### PR TITLE
fix(security): round 9 post-merge code review fixes

### DIFF
--- a/packages/mama-core/src/embedding-server/mobile/websocket-handler.js
+++ b/packages/mama-core/src/embedding-server/mobile/websocket-handler.js
@@ -267,7 +267,9 @@ async function handleClientMessage(clientId, message, clientInfo, messageRouter,
               const safeName = path.basename(att.filename || '');
               const inboundDir = path.join(os.homedir(), '.mama', 'workspace', 'media', 'inbound');
               const resolvedPath = path.join(inboundDir, safeName);
-              const rawMediaType = att.contentType || 'image/jpeg';
+              // Default to octet-stream for unknown types — prevents untyped attachments
+              // from being incorrectly treated as images and base64-encoded
+              const rawMediaType = att.contentType || 'application/octet-stream';
 
               if (ALLOWED_IMAGE_TYPES.has(rawMediaType)) {
                 // Only read file for images (to convert to base64)


### PR DESCRIPTION
## Summary

Post-merge security fixes from code review comments on PR #19.

### Changes

**websocket-handler.js**
- Default `contentType` to `application/octet-stream` instead of `image/jpeg`
- Prevents untyped attachments from being incorrectly treated as images

**graph-api.ts**
- Add auth guard to `handleMCPServersRequest` (was unauthenticated)
- Redact sensitive fields: `command`, `url`, `configPath`
- Wrap `decodeURIComponent` in try/catch for URIError (400 response)
- Validate `serverName` against `/^[a-z0-9_-]+$/i` pattern
- Replace `console.log/error` with DebugLogger

**message-router.ts**
- Add braces to all control flows in `resolveMediaPaths`
- Replace `console.log` with logger
- Log errors instead of silently ignoring in catch blocks

## Test plan

- [x] `pnpm typecheck` passes
- [x] Pre-commit hooks pass (lint, format, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)