### PR TITLE
feat(v0.17): Connector Framework — 13 connectors, truth-first 3-pass extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.17.0] - 2026-04-07
+
+### Added
+
+- **Connector Framework** — plugin-based architecture for connecting MAMA OS to external data sources. `IConnector` interface, `ConnectorRegistry` (dynamic loading), `PollingScheduler` (batch polling with state persistence), `RawStore` (per-connector SQLite evidence storage). Source role classification: truth, hub, deliverable, spoke, reference. Shared `gws-utils.ts` utility for Google Workspace CLI commands (Gmail, Calendar, Sheets, Drive)
+- **13 Connectors** — Slack (Web API), Telegram (Bot API), Discord (REST API), Chatwork (API), iMessage (local DB), Gmail (gws CLI), Calendar (gws CLI), Notion (API), Obsidian (local vault), Kagemusha (kagemusha.db reader), Sheets (gws CLI, truth source), Trello (REST API, truth source), Drive (gws CLI, deliverable tracking)
+- **Truth-first 3-pass extraction** — Pass 0: structured data (spreadsheet/kanban) → `ProjectTruth` snapshot (no LLM). Pass 1: cross-source activity merged by timestamp + truth context → LLM extraction. Pass 2: spoke channels linked to projects via context. Functions: `buildProjectTruth`, `buildActivityExtractionPrompt`, `buildSpokeExtractionPrompt`
+- **Batch polling** — `PollingScheduler.pollAll()` collects from all connectors, classifies by source role, and feeds unified 3-pass pipeline
+- **CLI: `mama connector`** — `add/remove/list/status` commands for managing connectors. Config at `~/.mama/connectors.json`
+- **Memory kinds: task, schedule** — `mama-core` MEMORY_KINDS extended to support project task tracking and schedule events from connectors
+- **DB migration 025** — adds `kind` CHECK constraint for `task` and `schedule` values in the decisions table
+
+### Changed
+
+- **search_decisions_and_contracts** — migrated from inline handler in `server.js` to `src/tools/search-decisions-and-contracts.js` (single source of truth)
+
 ## [0.16.1] - 2026-04-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,45 @@ Once saved:
 - Important function signature changes
 - Architecture pattern decisions
 
+## Connector Framework (v0.17)
+
+MAMA OS can connect to external data sources via a plugin-based connector framework.
+
+### Configuration
+
+```bash
+# Config file location
+~/.mama/connectors.json
+
+# CLI commands
+mama connector add <name>     # activate connector + authentication guide
+mama connector remove <name>  # deactivate connector
+mama connector list           # list all connectors + status
+mama connector status         # health + last poll time
+```
+
+### Key Source Files
+
+```
+packages/standalone/src/connectors/
+├── framework/              ← IConnector, ConnectorRegistry, PollingScheduler, RawStore
+├── slack/   telegram/   discord/   chatwork/   imessage/
+├── gmail/   calendar/   drive/   sheets/
+├── notion/  obsidian/  kagemusha/  trello/
+└── index.ts
+
+packages/standalone/src/memory/
+└── history-extractor.ts    ← 3-pass extraction: buildProjectTruth, buildActivityExtractionPrompt, buildSpokeExtractionPrompt
+```
+
+### Source Role Classification
+
+Connectors classify each channel by role: `truth` (spreadsheets/kanban), `hub` (project channels), `deliverable` (file storage), `spoke` (individual channels), `reference` (calendar/docs). The 3-pass memory extraction uses this classification to build project intelligence without requiring manual tagging.
+
+### Raw Data Storage
+
+Each connector writes to its own SQLite database at `~/.mama/connectors/<name>/raw.db`. Only structured facts flow into `mama-core`. Poll state persists at `~/.mama/connectors/poll-state.json`.
+
 ## Important Constraints
 
 1. **Never rewrite working code** - Check mcp-server/src/mama/ first

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ MAMA now outperforms SuperMemory while running **entirely locally** with open-so
 
 | Package                                          | Version | Description                                  |
 | ------------------------------------------------ | ------- | -------------------------------------------- |
-| [@jungjaehoon/mama-os](packages/standalone/)     | 0.16.1  | Always-on runtime with messenger gateways    |
+| [@jungjaehoon/mama-os](packages/standalone/)     | 0.17.0  | Always-on runtime with messenger gateways    |
 | [@jungjaehoon/mama-server](packages/mcp-server/) | 1.12.1  | MCP server for Claude Desktop/Code           |
 | [@jungjaehoon/mama-core](packages/mama-core/)    | 1.4.0   | Core library (memory engine, embeddings, DB) |
 | [mama plugin](packages/claude-code-plugin/)      | 1.9.0   | Claude Code plugin (marketplace)             |
@@ -199,38 +199,36 @@ Connects to Discord, Slack, Telegram. Web dashboard at `http://localhost:3847`.
 
 ### What Works Today
 
-| Feature                | Status     | Details                                                                         |
-| ---------------------- | ---------- | ------------------------------------------------------------------------------- |
-| **Knowledge Graph**    | Production | decisions + edges (supersedes/builds_on/debates/synthesizes) + truth projection |
-| **Hybrid Search**      | Production | FTS5 BM25 + vector cosine + RRF fusion, 93% on LongMemEval                      |
-| **Claude Code Plugin** | Production | Auto-save decisions via hooks, search via `/mama:search`                        |
-| **MCP Server**         | Production | `mama_save`, `mama_search`, `mama_suggest`, `ingest_conversation` + scopes      |
-| **Messenger Gateways** | Production | Telegram, Discord, Slack bots with memory integration                           |
-| **Always-On Daemon**   | Production | Cron scheduler, web dashboard at localhost:3847                                 |
-| **Evolution Engine**   | Production | Conservative supersede (overlap-based), builds_on for independent facts         |
+| Feature                 | Status     | Details                                                                                                                                                                                                                                                 |
+| ----------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Knowledge Graph**     | Production | decisions + edges (supersedes/builds_on/debates/synthesizes) + truth projection                                                                                                                                                                         |
+| **Hybrid Search**       | Production | FTS5 BM25 + vector cosine + RRF fusion, 93% on LongMemEval                                                                                                                                                                                              |
+| **Claude Code Plugin**  | Production | Auto-save decisions via hooks, search via `/mama:search`                                                                                                                                                                                                |
+| **MCP Server**          | Production | `mama_save`, `mama_search`, `mama_suggest`, `ingest_conversation` + scopes                                                                                                                                                                              |
+| **Messenger Gateways**  | Production | Telegram, Discord, Slack bots with memory integration                                                                                                                                                                                                   |
+| **Always-On Daemon**    | Production | Cron scheduler, web dashboard at localhost:3847                                                                                                                                                                                                         |
+| **Evolution Engine**    | Production | Conservative supersede (overlap-based), builds_on for independent facts                                                                                                                                                                                 |
+| **Connector Framework** | v0.17      | 13 data source connectors (Slack, Gmail, Notion, iMessage, Sheets, Trello, Drive, and more). Automatic project intelligence extraction via truth-first 3-pass pipeline. Hub/spoke/truth source role classification. Config at `~/.mama/connectors.json` |
 
 ### What's Not Built Yet
 
-| Feature                       | Target | Why It Matters                                        |
-| ----------------------------- | ------ | ----------------------------------------------------- |
-| **Noise Filtering**           | v0.17  | Reject greetings, internal prompts, duplicates        |
-| **Pattern Recognition**       | v0.17  | Detect recurring workflows from accumulated knowledge |
-| **Cross-Source Intelligence** | v0.17  | Code decisions + team chat + email = unified graph    |
-| **Workflow Recommendations**  | v0.18  | "Your team usually does X before Y" suggestions       |
-| **Memory Explorer UI**        | v0.18  | Visual graph of decision evolution                    |
-| **Enterprise Server Mode**    | v0.19  | Central server for team knowledge (vs personal local) |
-| **Domain Automation**         | v1.0   | Knowledge graph → automated workflow execution        |
+| Feature                      | Target | Why It Matters                                        |
+| ---------------------------- | ------ | ----------------------------------------------------- |
+| **Workflow Recommendations** | v0.18  | "Your team usually does X before Y" suggestions       |
+| **Memory Explorer UI**       | v0.18  | Visual graph of decision evolution                    |
+| **Enterprise Server Mode**   | v0.19  | Central server for team knowledge (vs personal local) |
+| **Domain Automation**        | v1.0   | Knowledge graph → automated workflow execution        |
 
 ### Roadmap
 
-| Phase    | Version | Focus                                                         |
-| -------- | ------- | ------------------------------------------------------------- |
-| **Done** | v0.15   | Search quality overhaul, FTS5, evolution engine (58% → 88%)   |
-| **Done** | v0.16   | event_date API, tool-use answer, memory agent v5 (88% → 93%)  |
-| **Next** | v0.17   | Connector framework, cross-source memory, pattern recognition |
-|          | v0.18   | Control tower UI, memory explorer, workflow recommendations   |
-|          | v0.19   | Stability, security audit, enterprise server mode             |
-|          | v1.0    | General release — domain automation                           |
+| Phase    | Version | Focus                                                                                   |
+| -------- | ------- | --------------------------------------------------------------------------------------- |
+| **Done** | v0.15   | Search quality overhaul, FTS5, evolution engine (58% → 88%)                             |
+| **Done** | v0.16   | event_date API, tool-use answer, memory agent v5 (88% → 93%)                            |
+| **Done** | v0.17   | Connector framework (13 connectors), truth-first 3-pass extraction, cross-source memory |
+| **Next** | v0.18   | Control tower UI, memory explorer, workflow recommendations                             |
+|          | v0.19   | Stability, security audit, enterprise server mode                                       |
+|          | v1.0    | General release — domain automation                                                     |
 
 ## Development
 

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -258,7 +258,7 @@ Each package has independent versioning:
 - **mama-core:** 1.4.0 (stable API)
 - **mama-server:** 1.12.1 (follows MAMA version)
 - **claude-code-plugin:** 1.9.0 (follows MAMA version)
-- **mama-os:** 0.16.1 (standalone agent)
+- **mama-os:** 0.17.0 (standalone agent)
 
 ## Distribution Strategy
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -10,8 +10,8 @@ MAMA is a pnpm workspace-based monorepo with four packages:
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.16.1  |
-| MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.12.1   |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.17.0  |
+| MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.12.1  |
 | MAMA Core          | `packages/mama-core/`          | Internal           | `@jungjaehoon/mama-core`   | 1.4.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.9.0   |
 
@@ -60,8 +60,8 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.16.1          |
-| `packages/mcp-server/package.json`                       | `version` | 1.12.1           |
+| `packages/standalone/package.json`                       | `version` | 0.17.0          |
+| `packages/mcp-server/package.json`                       | `version` | 1.12.1          |
 | `packages/mama-core/package.json`                        | `version` | 1.4.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.9.0           |
 | `packages/claude-code-plugin/.claude-plugin/plugin.json` | `version` | 1.8.3           |

--- a/docs/superpowers/plans/2026-04-07-v0.17-connector-framework.md
+++ b/docs/superpowers/plans/2026-04-07-v0.17-connector-framework.md
@@ -1,0 +1,3259 @@
+# v0.17 Connector Framework Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** MAMA OS가 Slack, Telegram, Discord, Chatwork, Gmail, Calendar, Notion, Obsidian에 직접 연결하여 프로젝트 인텔리전스 그래프를 구축한다.
+
+**Architecture:** Connector Framework (플러그인 로더 + 폴링 스케줄러) → 8개 Connector (IConnector 구현) → Memory Agent 2패스 추출 (hub/spoke) → mama-core 저장. 각 커넥터는 독립 raw.db에 원본 보관. 모노레포 내장 + 동적 로딩.
+
+**Tech Stack:** TypeScript, better-sqlite3, Commander.js (CLI), chokidar (Obsidian), gws CLI (Gmail/Calendar), Slack Web API, grammY (Telegram), discord.js, Notion SDK
+
+**Design Spec:** `docs/superpowers/specs/2026-04-07-v0.17-connector-framework-design.md`
+
+---
+
+## File Structure
+
+### New Files
+
+```
+packages/standalone/src/connectors/
+├── framework/
+│   ├── types.ts                    ← IConnector, NormalizedItem, ConnectorConfig, etc.
+│   ├── connector-registry.ts       ← Dynamic import + init/dispose lifecycle
+│   ├── polling-scheduler.ts        ← Per-connector timer + lastPollTime persistence
+│   ├── raw-store.ts                ← Per-connector SQLite raw.db management
+│   └── index.ts                    ← Re-exports
+├── slack/
+│   └── index.ts                    ← SlackConnector implements IConnector
+├── telegram/
+│   └── index.ts                    ← TelegramConnector implements IConnector
+├── discord/
+│   └── index.ts                    ← DiscordConnector implements IConnector
+├── chatwork/
+│   └── index.ts                    ← ChatworkConnector implements IConnector
+├── gmail/
+│   └── index.ts                    ← GmailConnector implements IConnector (gws CLI)
+├── calendar/
+│   └── index.ts                    ← CalendarConnector implements IConnector (gws CLI)
+├── notion/
+│   └── index.ts                    ← NotionConnector implements IConnector
+├── obsidian/
+│   └── index.ts                    ← ObsidianConnector implements IConnector (chokidar)
+├── kagemusha/
+│   └── index.ts                    ← KagemushaConnector (kagemusha.db reader)
+└── index.ts                        ← Re-exports all connectors
+
+packages/standalone/src/memory/
+└── history-extractor.ts            ← Memory Agent 2-pass extraction logic
+
+packages/standalone/src/cli/commands/
+└── connector.ts                    ← mama connector add/config/list/remove/status
+
+packages/standalone/tests/connectors/
+├── framework/
+│   ├── types.test.ts
+│   ├── connector-registry.test.ts
+│   ├── polling-scheduler.test.ts
+│   └── raw-store.test.ts
+├── slack.test.ts
+├── telegram.test.ts
+├── discord.test.ts
+├── chatwork.test.ts
+├── gmail.test.ts
+├── calendar.test.ts
+├── notion.test.ts
+├── obsidian.test.ts
+├── kagemusha.test.ts
+└── history-extractor.test.ts
+```
+
+### Modified Files
+
+```
+packages/mama-core/src/memory/types.ts                 ← Add 'task' and 'schedule' to MEMORY_KINDS
+packages/standalone/src/cli/index.ts                   ← Add 'connector' command
+packages/standalone/src/cli/config/types.ts            ← Add ConnectorsConfig to MAMAConfig
+packages/standalone/src/cli/commands/start.ts          ← Wire PollingScheduler into runAgentLoop
+packages/mcp-server/src/server.js                      ← Extract handleSearchDecisionsAndContracts
+packages/mcp-server/src/tools/search_decisions_and_contracts.js  ← New tool file
+```
+
+---
+
+## Task 0: Technical Debt — search_decisions_and_contracts 이관
+
+**Files:**
+
+- Create: `packages/mcp-server/src/tools/search_decisions_and_contracts.js`
+- Modify: `packages/mcp-server/src/server.js`
+
+- [ ] **Step 1: Read current inline handler**
+
+```bash
+cd <project-root>
+grep -n "handleSearchDecisionsAndContracts\|search_decisions_and_contracts" packages/mcp-server/src/server.js
+```
+
+Identify the function boundaries and understand the full handler logic.
+
+- [ ] **Step 2: Create the extracted tool file**
+
+Create `packages/mcp-server/src/tools/search_decisions_and_contracts.js` with the handler extracted from server.js. The function signature should match the existing pattern in `src/tools/`:
+
+```javascript
+// packages/mcp-server/src/tools/search_decisions_and_contracts.js
+export const definition = {
+  name: 'search_decisions_and_contracts',
+  description: '...',  // Copy from server.js inline definition
+  inputSchema: { ... } // Copy from server.js inline schema
+};
+
+export async function handler(params, { mama, embedder }) {
+  // Move the full handleSearchDecisionsAndContracts logic here
+  // Keep all existing logic intact — direct extraction, no refactoring
+}
+```
+
+- [ ] **Step 3: Update server.js to import from the new file**
+
+Replace the inline handler with an import:
+
+```javascript
+import {
+  handler as handleSearchDecisionsAndContracts,
+  definition as searchDecisionsAndContractsDef,
+} from './tools/search_decisions_and_contracts.js';
+```
+
+Remove the inline function body. Wire the imported handler into the tool dispatch.
+
+- [ ] **Step 4: Run existing tests**
+
+```bash
+cd <project-root> && pnpm test --filter @jungjaehoon/mama-server
+```
+
+Expected: All existing tests pass (no behavior change).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/mcp-server/src/tools/search_decisions_and_contracts.js packages/mcp-server/src/server.js
+git commit -m "refactor(mcp): extract search_decisions_and_contracts to src/tools/"
+```
+
+---
+
+## Task 0.5: mama-core — MEMORY_KINDS 확장 (task, schedule)
+
+**Files:**
+
+- Modify: `packages/mama-core/src/memory/types.ts`
+- Create: `packages/mama-core/tests/memory-kinds.test.ts`
+
+> DB 스키마 변경 없음. `kind`는 TEXT 컬럼으로 CHECK 제약 없이 저장됨.
+> TypeScript 타입만 확장하면 `saveMemory(kind: 'task')` 호출이 타입 안전해짐.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// packages/mama-core/tests/memory-kinds.test.ts
+import { describe, it, expect } from 'vitest';
+import { MEMORY_KINDS } from '../src/memory/types.js';
+import type { MemoryKind } from '../src/memory/types.js';
+
+describe('MEMORY_KINDS', () => {
+  it('includes task and schedule kinds for v0.17 connector extraction', () => {
+    expect(MEMORY_KINDS).toContain('task');
+    expect(MEMORY_KINDS).toContain('schedule');
+  });
+
+  it('task and schedule are valid MemoryKind values', () => {
+    const task: MemoryKind = 'task';
+    const schedule: MemoryKind = 'schedule';
+    expect(task).toBe('task');
+    expect(schedule).toBe('schedule');
+  });
+
+  it('preserves all existing kinds', () => {
+    expect(MEMORY_KINDS).toContain('decision');
+    expect(MEMORY_KINDS).toContain('preference');
+    expect(MEMORY_KINDS).toContain('constraint');
+    expect(MEMORY_KINDS).toContain('lesson');
+    expect(MEMORY_KINDS).toContain('fact');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd <project-root> && pnpm vitest run packages/mama-core/tests/memory-kinds.test.ts
+```
+
+Expected: FAIL — 'task' not in MEMORY_KINDS.
+
+- [ ] **Step 3: Add task and schedule to MEMORY_KINDS**
+
+In `packages/mama-core/src/memory/types.ts` line 4, change:
+
+```typescript
+export const MEMORY_KINDS = ['decision', 'preference', 'constraint', 'lesson', 'fact'] as const;
+```
+
+to:
+
+```typescript
+export const MEMORY_KINDS = [
+  'decision',
+  'preference',
+  'constraint',
+  'lesson',
+  'fact',
+  'task',
+  'schedule',
+] as const;
+```
+
+No other changes needed:
+
+- `is_static` check (api.ts:511) already safe: only `preference | constraint` are static
+- DB accepts any TEXT value in `kind` column
+- `evolveMemory` uses topic matching, not kind-based — no impact
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd <project-root> && pnpm vitest run packages/mama-core/tests/memory-kinds.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Run full mama-core tests + typecheck**
+
+```bash
+cd <project-root> && pnpm test --filter @jungjaehoon/mama-core && pnpm typecheck
+```
+
+Expected: All pass. No existing behavior changed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/mama-core/src/memory/types.ts packages/mama-core/tests/memory-kinds.test.ts
+git commit -m "feat(mama-core): add task and schedule memory kinds for v0.17 connectors"
+```
+
+---
+
+## Task 1: Connector Framework — Types
+
+**Files:**
+
+- Create: `packages/standalone/src/connectors/framework/types.ts`
+- Create: `packages/standalone/tests/connectors/framework/types.test.ts`
+
+- [ ] **Step 1: Write the type validation test**
+
+```typescript
+// packages/standalone/tests/connectors/framework/types.test.ts
+import { describe, it, expect } from 'vitest';
+import type {
+  IConnector,
+  NormalizedItem,
+  ConnectorConfig,
+  ChannelConfig,
+  AuthConfig,
+  AuthRequirement,
+  ConnectorHealth,
+} from '../../../src/connectors/framework/types.js';
+
+describe('Connector Framework Types', () => {
+  it('NormalizedItem has required fields', () => {
+    const item: NormalizedItem = {
+      source: 'slack',
+      sourceId: 'msg_123',
+      channel: 'product',
+      author: 'alice',
+      content: 'hello',
+      timestamp: new Date(),
+      type: 'message',
+    };
+    expect(item.source).toBe('slack');
+    expect(item.type).toBe('message');
+  });
+
+  it('NormalizedItem supports all types', () => {
+    const types: NormalizedItem['type'][] = ['message', 'email', 'event', 'document', 'note'];
+    expect(types).toHaveLength(5);
+  });
+
+  it('ChannelConfig supports hub/spoke/ignore roles', () => {
+    const hub: ChannelConfig = { role: 'hub' };
+    const spoke: ChannelConfig = { role: 'spoke' };
+    const ignore: ChannelConfig = { role: 'ignore', name: 'random' };
+    expect(hub.role).toBe('hub');
+    expect(spoke.role).toBe('spoke');
+    expect(ignore.role).toBe('ignore');
+  });
+
+  it('AuthConfig supports cli/token/none types', () => {
+    const cli: AuthConfig = { type: 'cli', cli: 'gws', cliAuthCommand: 'gws auth login' };
+    const token: AuthConfig = { type: 'token', tokenName: 'SLACK_BOT_TOKEN' };
+    const none: AuthConfig = { type: 'none' };
+    expect(cli.type).toBe('cli');
+    expect(token.type).toBe('token');
+    expect(none.type).toBe('none');
+  });
+
+  it('ConnectorConfig has required structure', () => {
+    const config: ConnectorConfig = {
+      enabled: true,
+      pollIntervalMinutes: 60,
+      channels: {
+        general: { role: 'hub', keywords: ['project-x'] },
+      },
+      auth: { type: 'token', tokenName: 'BOT_TOKEN' },
+    };
+    expect(config.pollIntervalMinutes).toBeGreaterThanOrEqual(60);
+    expect(config.channels.general.role).toBe('hub');
+  });
+
+  it('ConnectorHealth reports status', () => {
+    const healthy: ConnectorHealth = {
+      healthy: true,
+      lastPollTime: new Date(),
+      lastPollCount: 42,
+    };
+    const unhealthy: ConnectorHealth = {
+      healthy: false,
+      lastPollTime: null,
+      lastPollCount: 0,
+      error: 'auth failed',
+    };
+    expect(healthy.healthy).toBe(true);
+    expect(unhealthy.error).toBe('auth failed');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd <project-root> && pnpm vitest run tests/connectors/framework/types.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement types**
+
+```typescript
+// packages/standalone/src/connectors/framework/types.ts
+
+export interface NormalizedItem {
+  source: string;
+  sourceId: string;
+  channel: string;
+  author: string;
+  content: string;
+  timestamp: Date;
+  type: 'message' | 'email' | 'event' | 'document' | 'note';
+  metadata?: Record<string, unknown>;
+}
+
+export interface ChannelConfig {
+  role: 'hub' | 'spoke' | 'ignore';
+  name?: string;
+  keywords?: string[];
+  vaultPath?: string;
+  watchPatterns?: string[];
+}
+
+export interface AuthConfig {
+  type: 'cli' | 'token' | 'none';
+  cli?: string;
+  cliAuthCommand?: string;
+  tokenName?: string;
+  token?: string;
+}
+
+export interface AuthRequirement {
+  type: 'cli' | 'token' | 'none';
+  cli?: string;
+  cliAuthCommand?: string;
+  tokenName?: string;
+  description: string;
+}
+
+export interface ConnectorConfig {
+  enabled: boolean;
+  pollIntervalMinutes: number;
+  channels: Record<string, ChannelConfig>;
+  auth: AuthConfig;
+}
+
+export interface ConnectorHealth {
+  healthy: boolean;
+  lastPollTime: Date | null;
+  lastPollCount: number;
+  error?: string;
+}
+
+export interface IConnector {
+  readonly name: string;
+  readonly type: 'api' | 'local';
+
+  init(config: ConnectorConfig): Promise<void>;
+  dispose(): Promise<void>;
+  healthCheck(): Promise<ConnectorHealth>;
+
+  getAuthRequirements(): AuthRequirement[];
+  authenticate(credentials: Record<string, string>): Promise<boolean>;
+
+  poll(since: Date): Promise<NormalizedItem[]>;
+}
+
+export type ConnectorsConfig = Record<string, ConnectorConfig>;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd <project-root> && pnpm vitest run tests/connectors/framework/types.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/standalone/src/connectors/framework/types.ts packages/standalone/tests/connectors/framework/types.test.ts
+git commit -m "feat(connector): add IConnector interface and core types"
+```
+
+---
+
+## Task 2: Connector Framework — Raw Store
+
+**Files:**
+
+- Create: `packages/standalone/src/connectors/framework/raw-store.ts`
+- Create: `packages/standalone/tests/connectors/framework/raw-store.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// packages/standalone/tests/connectors/framework/raw-store.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { RawStore } from '../../../src/connectors/framework/raw-store.js';
+import type { NormalizedItem } from '../../../src/connectors/framework/types.js';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('RawStore', () => {
+  let tmpDir: string;
+  let store: RawStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'rawstore-'));
+    store = new RawStore(tmpDir);
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('saves and retrieves items for a connector', () => {
+    const items: NormalizedItem[] = [
+      {
+        source: 'slack',
+        sourceId: 'msg_1',
+        channel: 'general',
+        author: 'alice',
+        content: 'hello world',
+        timestamp: new Date('2026-04-07T10:00:00Z'),
+        type: 'message',
+      },
+    ];
+
+    store.save('slack', items);
+    const retrieved = store.query('slack', new Date('2026-04-07T09:00:00Z'));
+    expect(retrieved).toHaveLength(1);
+    expect(retrieved[0].sourceId).toBe('msg_1');
+    expect(retrieved[0].content).toBe('hello world');
+  });
+
+  it('deduplicates by sourceId', () => {
+    const item: NormalizedItem = {
+      source: 'slack',
+      sourceId: 'msg_1',
+      channel: 'general',
+      author: 'alice',
+      content: 'hello',
+      timestamp: new Date('2026-04-07T10:00:00Z'),
+      type: 'message',
+    };
+
+    store.save('slack', [item]);
+    store.save('slack', [item]); // duplicate
+    const retrieved = store.query('slack', new Date('2026-04-07T09:00:00Z'));
+    expect(retrieved).toHaveLength(1);
+  });
+
+  it('filters by since timestamp', () => {
+    const items: NormalizedItem[] = [
+      {
+        source: 'slack',
+        sourceId: 'msg_old',
+        channel: 'general',
+        author: 'alice',
+        content: 'old msg',
+        timestamp: new Date('2026-04-06T10:00:00Z'),
+        type: 'message',
+      },
+      {
+        source: 'slack',
+        sourceId: 'msg_new',
+        channel: 'general',
+        author: 'bob',
+        content: 'new msg',
+        timestamp: new Date('2026-04-07T10:00:00Z'),
+        type: 'message',
+      },
+    ];
+
+    store.save('slack', items);
+    const retrieved = store.query('slack', new Date('2026-04-07T00:00:00Z'));
+    expect(retrieved).toHaveLength(1);
+    expect(retrieved[0].sourceId).toBe('msg_new');
+  });
+
+  it('creates separate databases per connector', () => {
+    store.save('slack', [
+      {
+        source: 'slack',
+        sourceId: 's1',
+        channel: 'a',
+        author: 'x',
+        content: 'slack msg',
+        timestamp: new Date(),
+        type: 'message',
+      },
+    ]);
+    store.save('gmail', [
+      {
+        source: 'gmail',
+        sourceId: 'g1',
+        channel: 'inbox',
+        author: 'y',
+        content: 'email',
+        timestamp: new Date(),
+        type: 'email',
+      },
+    ]);
+
+    const slackItems = store.query('slack', new Date(0));
+    const gmailItems = store.query('gmail', new Date(0));
+    expect(slackItems).toHaveLength(1);
+    expect(gmailItems).toHaveLength(1);
+    expect(slackItems[0].source).toBe('slack');
+    expect(gmailItems[0].source).toBe('gmail');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd <project-root> && pnpm vitest run tests/connectors/framework/raw-store.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement RawStore**
+
+```typescript
+// packages/standalone/src/connectors/framework/raw-store.ts
+import Database from 'better-sqlite3';
+import { join } from 'path';
+import { mkdirSync } from 'fs';
+import type { NormalizedItem } from './types.js';
+
+const CREATE_TABLE = `
+CREATE TABLE IF NOT EXISTS raw_items (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  source_id TEXT NOT NULL UNIQUE,
+  source TEXT NOT NULL,
+  channel TEXT NOT NULL,
+  author TEXT NOT NULL,
+  content TEXT NOT NULL,
+  timestamp INTEGER NOT NULL,
+  type TEXT NOT NULL,
+  metadata TEXT,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000)
+)`;
+
+const CREATE_INDEX = `
+CREATE INDEX IF NOT EXISTS idx_raw_items_timestamp ON raw_items(timestamp)`;
+
+export class RawStore {
+  private dbs: Map<string, Database.Database> = new Map();
+
+  constructor(private basePath: string) {}
+
+  private getDb(connectorName: string): Database.Database {
+    let db = this.dbs.get(connectorName);
+    if (!db) {
+      const dir = join(this.basePath, connectorName);
+      mkdirSync(dir, { recursive: true });
+      db = new Database(join(dir, 'raw.db'));
+      db.pragma('journal_mode = WAL');
+      db.exec(CREATE_TABLE);
+      db.exec(CREATE_INDEX);
+      this.dbs.set(connectorName, db);
+    }
+    return db;
+  }
+
+  save(connectorName: string, items: NormalizedItem[]): void {
+    const db = this.getDb(connectorName);
+    const insert = db.prepare(`
+      INSERT OR IGNORE INTO raw_items (source_id, source, channel, author, content, timestamp, type, metadata)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    const tx = db.transaction(() => {
+      for (const item of items) {
+        insert.run(
+          item.sourceId,
+          item.source,
+          item.channel,
+          item.author,
+          item.content,
+          item.timestamp.getTime(),
+          item.type,
+          item.metadata ? JSON.stringify(item.metadata) : null
+        );
+      }
+    });
+    tx();
+  }
+
+  query(connectorName: string, since: Date): NormalizedItem[] {
+    const db = this.getDb(connectorName);
+    const rows = db
+      .prepare('SELECT * FROM raw_items WHERE timestamp > ? ORDER BY timestamp ASC')
+      .all(since.getTime()) as Array<Record<string, unknown>>;
+
+    return rows.map((row) => ({
+      source: row.source as string,
+      sourceId: row.source_id as string,
+      channel: row.channel as string,
+      author: row.author as string,
+      content: row.content as string,
+      timestamp: new Date(row.timestamp as number),
+      type: row.type as NormalizedItem['type'],
+      metadata: row.metadata ? JSON.parse(row.metadata as string) : undefined,
+    }));
+  }
+
+  close(): void {
+    for (const db of this.dbs.values()) {
+      db.close();
+    }
+    this.dbs.clear();
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd <project-root> && pnpm vitest run tests/connectors/framework/raw-store.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/standalone/src/connectors/framework/raw-store.ts packages/standalone/tests/connectors/framework/raw-store.test.ts
+git commit -m "feat(connector): add RawStore — per-connector SQLite storage"
+```
+
+---
+
+## Task 3: Connector Framework — Registry
+
+**Files:**
+
+- Create: `packages/standalone/src/connectors/framework/connector-registry.ts`
+- Create: `packages/standalone/tests/connectors/framework/connector-registry.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// packages/standalone/tests/connectors/framework/connector-registry.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { ConnectorRegistry } from '../../../src/connectors/framework/connector-registry.js';
+import type {
+  IConnector,
+  ConnectorConfig,
+  ConnectorsConfig,
+} from '../../../src/connectors/framework/types.js';
+
+// Mock connector for testing
+function createMockConnector(name: string): IConnector {
+  return {
+    name,
+    type: 'api' as const,
+    init: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn().mockResolvedValue(undefined),
+    healthCheck: vi.fn().mockResolvedValue({ healthy: true, lastPollTime: null, lastPollCount: 0 }),
+    getAuthRequirements: vi.fn().mockReturnValue([]),
+    authenticate: vi.fn().mockResolvedValue(true),
+    poll: vi.fn().mockResolvedValue([]),
+  };
+}
+
+describe('ConnectorRegistry', () => {
+  it('registers and retrieves a connector', () => {
+    const registry = new ConnectorRegistry();
+    const mock = createMockConnector('slack');
+    registry.register('slack', mock);
+
+    expect(registry.get('slack')).toBe(mock);
+    expect(registry.getActive().size).toBe(1);
+  });
+
+  it('lists all active connectors', () => {
+    const registry = new ConnectorRegistry();
+    registry.register('slack', createMockConnector('slack'));
+    registry.register('gmail', createMockConnector('gmail'));
+
+    const active = registry.getActive();
+    expect(active.size).toBe(2);
+    expect([...active.keys()]).toContain('slack');
+    expect([...active.keys()]).toContain('gmail');
+  });
+
+  it('returns undefined for unregistered connector', () => {
+    const registry = new ConnectorRegistry();
+    expect(registry.get('nonexistent')).toBeUndefined();
+  });
+
+  it('disposes all connectors', async () => {
+    const registry = new ConnectorRegistry();
+    const slack = createMockConnector('slack');
+    const gmail = createMockConnector('gmail');
+    registry.register('slack', slack);
+    registry.register('gmail', gmail);
+
+    await registry.disposeAll();
+
+    expect(slack.dispose).toHaveBeenCalled();
+    expect(gmail.dispose).toHaveBeenCalled();
+    expect(registry.getActive().size).toBe(0);
+  });
+
+  it('reports health for all connectors', async () => {
+    const registry = new ConnectorRegistry();
+    registry.register('slack', createMockConnector('slack'));
+    registry.register('gmail', createMockConnector('gmail'));
+
+    const health = await registry.healthCheckAll();
+    expect(health.slack.healthy).toBe(true);
+    expect(health.gmail.healthy).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd <project-root> && pnpm vitest run tests/connectors/framework/connector-registry.test.ts
+```
+
+Expected: FAIL
+
+- [ ] **Step 3: Implement ConnectorRegistry**
+
+```typescript
+// packages/standalone/src/connectors/framework/connector-registry.ts
+import type { IConnector, ConnectorHealth } from './types.js';
+
+export class ConnectorRegistry {
+  private connectors: Map<string, IConnector> = new Map();
+
+  register(name: string, connector: IConnector): void {
+    this.connectors.set(name, connector);
+  }
+
+  get(name: string): IConnector | undefined {
+    return this.connectors.get(name);
+  }
+
+  getActive(): Map<string, IConnector> {
+    return new Map(this.connectors);
+  }
+
+  async disposeAll(): Promise<void> {
+    for (const connector of this.connectors.values()) {
+      await connector.dispose();
+    }
+    this.connectors.clear();
+  }
+
+  async healthCheckAll(): Promise<Record<string, ConnectorHealth>> {
+    const result: Record<string, ConnectorHealth> = {};
+    for (const [name, connector] of this.connectors) {
+      result[name] = await connector.healthCheck();
+    }
+    return result;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd <project-root> && pnpm vitest run tests/connectors/framework/connector-registry.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/standalone/src/connectors/framework/connector-registry.ts packages/standalone/tests/connectors/framework/connector-registry.test.ts
+git commit -m "feat(connector): add ConnectorRegistry with lifecycle management"
+```
+
+---
+
+## Task 4: Connector Framework — Polling Scheduler
+
+**Files:**
+
+- Create: `packages/standalone/src/connectors/framework/polling-scheduler.ts`
+- Create: `packages/standalone/tests/connectors/framework/polling-scheduler.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// packages/standalone/tests/connectors/framework/polling-scheduler.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PollingScheduler } from '../../../src/connectors/framework/polling-scheduler.js';
+import { ConnectorRegistry } from '../../../src/connectors/framework/connector-registry.js';
+import { RawStore } from '../../../src/connectors/framework/raw-store.js';
+import type { IConnector, NormalizedItem } from '../../../src/connectors/framework/types.js';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+function createMockConnector(items: NormalizedItem[] = []): IConnector {
+  return {
+    name: 'test',
+    type: 'api' as const,
+    init: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn().mockResolvedValue(undefined),
+    healthCheck: vi.fn().mockResolvedValue({ healthy: true, lastPollTime: null, lastPollCount: 0 }),
+    getAuthRequirements: vi.fn().mockReturnValue([]),
+    authenticate: vi.fn().mockResolvedValue(true),
+    poll: vi.fn().mockResolvedValue(items),
+  };
+}
+
+describe('PollingScheduler', () => {
+  let tmpDir: string;
+  let rawStore: RawStore;
+  let scheduler: PollingScheduler;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'scheduler-'));
+    rawStore = new RawStore(tmpDir);
+  });
+
+  afterEach(async () => {
+    if (scheduler) await scheduler.stop();
+    rawStore.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('polls connector on start and saves to raw store', async () => {
+    const items: NormalizedItem[] = [
+      {
+        source: 'slack',
+        sourceId: 'msg_1',
+        channel: 'general',
+        author: 'alice',
+        content: 'hello',
+        timestamp: new Date(),
+        type: 'message',
+      },
+    ];
+    const connector = createMockConnector(items);
+    const registry = new ConnectorRegistry();
+    registry.register('slack', connector);
+
+    const onExtract = vi.fn();
+    scheduler = new PollingScheduler(rawStore, tmpDir, onExtract);
+    await scheduler.pollOnce('slack', connector);
+
+    expect(connector.poll).toHaveBeenCalled();
+    expect(onExtract).toHaveBeenCalledWith('slack', items);
+    const stored = rawStore.query('slack', new Date(0));
+    expect(stored).toHaveLength(1);
+  });
+
+  it('skips extraction when no items returned', async () => {
+    const connector = createMockConnector([]);
+    const registry = new ConnectorRegistry();
+    registry.register('slack', connector);
+
+    const onExtract = vi.fn();
+    scheduler = new PollingScheduler(rawStore, tmpDir, onExtract);
+    await scheduler.pollOnce('slack', connector);
+
+    expect(onExtract).not.toHaveBeenCalled();
+  });
+
+  it('persists and restores lastPollTime', async () => {
+    const connector = createMockConnector([]);
+    const onExtract = vi.fn();
+    scheduler = new PollingScheduler(rawStore, tmpDir, onExtract);
+
+    await scheduler.pollOnce('slack', connector);
+    const time1 = scheduler.getLastPollTime('slack');
+    expect(time1).toBeInstanceOf(Date);
+
+    // Create new scheduler — should restore state
+    const scheduler2 = new PollingScheduler(rawStore, tmpDir, onExtract);
+    const time2 = scheduler2.getLastPollTime('slack');
+    expect(time2?.getTime()).toBe(time1?.getTime());
+    await scheduler2.stop();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd <project-root> && pnpm vitest run tests/connectors/framework/polling-scheduler.test.ts
+```
+
+Expected: FAIL
+
+- [ ] **Step 3: Implement PollingScheduler**
+
+```typescript
+// packages/standalone/src/connectors/framework/polling-scheduler.ts
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import type { IConnector, NormalizedItem } from './types.js';
+import type { ConnectorRegistry } from './connector-registry.js';
+import type { RawStore } from './raw-store.js';
+
+type ExtractCallback = (connectorName: string, items: NormalizedItem[]) => Promise<void>;
+
+export class PollingScheduler {
+  private timers: Map<string, ReturnType<typeof setInterval>> = new Map();
+  private lastPollTimes: Map<string, Date>;
+  private statePath: string;
+
+  constructor(
+    private rawStore: RawStore,
+    private basePath: string,
+    private onExtract: ExtractCallback
+  ) {
+    this.statePath = join(basePath, 'poll-state.json');
+    this.lastPollTimes = this.loadState();
+  }
+
+  async start(
+    registry: ConnectorRegistry,
+    configs: Record<string, { pollIntervalMinutes: number }>
+  ): Promise<void> {
+    for (const [name, connector] of registry.getActive()) {
+      const interval = configs[name]?.pollIntervalMinutes ?? 60;
+      // Initial poll
+      await this.pollOnce(name, connector);
+      // Periodic polling
+      this.timers.set(
+        name,
+        setInterval(
+          () =>
+            this.pollOnce(name, connector).catch((err) =>
+              console.error(`[connector:${name}] poll error:`, err)
+            ),
+          interval * 60_000
+        )
+      );
+    }
+  }
+
+  async pollOnce(name: string, connector: IConnector): Promise<void> {
+    const since = this.lastPollTimes.get(name) ?? new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const items = await connector.poll(since);
+
+    if (items.length > 0) {
+      this.rawStore.save(name, items);
+      await this.onExtract(name, items);
+    }
+
+    this.lastPollTimes.set(name, new Date());
+    this.saveState();
+  }
+
+  getLastPollTime(name: string): Date | undefined {
+    return this.lastPollTimes.get(name);
+  }
+
+  async stop(): Promise<void> {
+    for (const timer of this.timers.values()) {
+      clearInterval(timer);
+    }
+    this.timers.clear();
+    this.saveState();
+  }
+
+  private loadState(): Map<string, Date> {
+    const map = new Map<string, Date>();
+    if (existsSync(this.statePath)) {
+      try {
+        const data = JSON.parse(readFileSync(this.statePath, 'utf-8'));
+        for (const [key, val] of Object.entries(data)) {
+          map.set(key, new Date(val as string));
+        }
+      } catch {
+        /* ignore corrupted state */
+      }
+    }
+    return map;
+  }
+
+  private saveState(): void {
+    const obj: Record<string, string> = {};
+    for (const [key, date] of this.lastPollTimes) {
+      obj[key] = date.toISOString();
+    }
+    writeFileSync(this.statePath, JSON.stringify(obj, null, 2));
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd <project-root> && pnpm vitest run tests/connectors/framework/polling-scheduler.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Create framework index and commit**
+
+```typescript
+// packages/standalone/src/connectors/framework/index.ts
+export type {
+  IConnector,
+  NormalizedItem,
+  ConnectorConfig,
+  ChannelConfig,
+  AuthConfig,
+  AuthRequirement,
+  ConnectorHealth,
+  ConnectorsConfig,
+} from './types.js';
+export { ConnectorRegistry } from './connector-registry.js';
+export { PollingScheduler } from './polling-scheduler.js';
+export { RawStore } from './raw-store.js';
+```
+
+```bash
+git add packages/standalone/src/connectors/framework/ packages/standalone/tests/connectors/framework/
+git commit -m "feat(connector): add PollingScheduler with state persistence"
+```
+
+---
+
+## Task 5: Slack Connector
+
+**Files:**
+
+- Create: `packages/standalone/src/connectors/slack/index.ts`
+- Create: `packages/standalone/tests/connectors/slack.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// packages/standalone/tests/connectors/slack.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { SlackConnector } from '../../src/connectors/slack/index.js';
+
+// Mock @slack/web-api
+vi.mock('@slack/web-api', () => ({
+  WebClient: vi.fn().mockImplementation(() => ({
+    conversations: {
+      history: vi.fn().mockResolvedValue({
+        messages: [
+          { ts: '1712480400.000100', user: 'U123', text: 'hello world', type: 'message' },
+          { ts: '1712480460.000200', user: 'U456', text: 'hi there', type: 'message' },
+        ],
+      }),
+    },
+    users: {
+      info: vi.fn().mockImplementation(({ user }) =>
+        Promise.resolve({
+          user: { real_name: user === 'U123' ? 'Alice' : 'Bob' },
+        })
+      ),
+    },
+  })),
+}));
+
+describe('SlackConnector', () => {
+  it('has correct name and type', () => {
+    const connector = new SlackConnector();
+    expect(connector.name).toBe('slack');
+    expect(connector.type).toBe('api');
+  });
+
+  it('declares token auth requirement', () => {
+    const connector = new SlackConnector();
+    const reqs = connector.getAuthRequirements();
+    expect(reqs).toHaveLength(1);
+    expect(reqs[0].type).toBe('token');
+    expect(reqs[0].tokenName).toBe('SLACK_BOT_TOKEN');
+  });
+
+  it('polls messages and returns NormalizedItems', async () => {
+    const connector = new SlackConnector();
+    await connector.init({
+      enabled: true,
+      pollIntervalMinutes: 60,
+      channels: { C001: { role: 'hub', name: 'general' } },
+      auth: { type: 'token', token: 'xoxb-test' },
+    });
+
+    const since = new Date('2026-04-06T00:00:00Z');
+    const items = await connector.poll(since);
+
+    expect(items.length).toBeGreaterThan(0);
+    expect(items[0].source).toBe('slack');
+    expect(items[0].type).toBe('message');
+    expect(items[0].content).toBe('hello world');
+  });
+
+  it('skips ignored channels', async () => {
+    const connector = new SlackConnector();
+    await connector.init({
+      enabled: true,
+      pollIntervalMinutes: 60,
+      channels: { C001: { role: 'ignore' } },
+      auth: { type: 'token', token: 'xoxb-test' },
+    });
+
+    const items = await connector.poll(new Date(0));
+    expect(items).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd <project-root> && pnpm vitest run tests/connectors/slack.test.ts
+```
+
+Expected: FAIL
+
+- [ ] **Step 3: Implement SlackConnector**
+
+```typescript
+// packages/standalone/src/connectors/slack/index.ts
+import type {
+  IConnector,
+  ConnectorConfig,
+  ConnectorHealth,
+  AuthRequirement,
+  NormalizedItem,
+} from '../framework/types.js';
+
+export class SlackConnector implements IConnector {
+  readonly name = 'slack';
+  readonly type = 'api' as const;
+  private client: any;
+  private config!: ConnectorConfig;
+  private userCache = new Map<string, string>();
+
+  async init(config: ConnectorConfig): Promise<void> {
+    this.config = config;
+    if (config.auth.token) {
+      const { WebClient } = await import('@slack/web-api');
+      this.client = new WebClient(config.auth.token);
+    }
+  }
+
+  async dispose(): Promise<void> {
+    this.client = null;
+    this.userCache.clear();
+  }
+
+  async healthCheck(): Promise<ConnectorHealth> {
+    if (!this.client) {
+      return { healthy: false, lastPollTime: null, lastPollCount: 0, error: 'Not initialized' };
+    }
+    return { healthy: true, lastPollTime: null, lastPollCount: 0 };
+  }
+
+  getAuthRequirements(): AuthRequirement[] {
+    return [
+      {
+        type: 'token',
+        tokenName: 'SLACK_BOT_TOKEN',
+        description: 'Slack Bot Token (xoxb-...). Create at https://api.slack.com/apps',
+      },
+    ];
+  }
+
+  async authenticate(credentials: Record<string, string>): Promise<boolean> {
+    const token = credentials.SLACK_BOT_TOKEN;
+    if (!token) return false;
+    const { WebClient } = await import('@slack/web-api');
+    this.client = new WebClient(token);
+    return true;
+  }
+
+  async poll(since: Date): Promise<NormalizedItem[]> {
+    if (!this.client) return [];
+    const items: NormalizedItem[] = [];
+    const oldest = String(since.getTime() / 1000);
+
+    for (const [channelId, channelConfig] of Object.entries(this.config.channels)) {
+      if (channelConfig.role === 'ignore') continue;
+
+      try {
+        const result = await this.client.conversations.history({
+          channel: channelId,
+          oldest,
+          limit: 200,
+        });
+
+        for (const msg of result.messages ?? []) {
+          if (!msg.text || msg.subtype === 'bot_message') continue;
+          const author = await this.resolveUser(msg.user);
+          items.push({
+            source: 'slack',
+            sourceId: `${channelId}:${msg.ts}`,
+            channel: channelConfig.name ?? channelId,
+            author,
+            content: msg.text,
+            timestamp: new Date(parseFloat(msg.ts) * 1000),
+            type: 'message',
+            metadata: { channelId, ts: msg.ts, threadTs: msg.thread_ts },
+          });
+        }
+      } catch (err) {
+        console.error(`[slack] Failed to poll channel ${channelId}:`, err);
+      }
+    }
+
+    return items.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+  }
+
+  private async resolveUser(userId: string): Promise<string> {
+    if (!userId) return 'unknown';
+    const cached = this.userCache.get(userId);
+    if (cached) return cached;
+    try {
+      const result = await this.client.users.info({ user: userId });
+      const name = result.user?.real_name ?? userId;
+      this.userCache.set(userId, name);
+      return name;
+    } catch {
+      return userId;
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd <project-root> && pnpm vitest run tests/connectors/slack.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/standalone/src/connectors/slack/ packages/standalone/tests/connectors/slack.test.ts
+git commit -m "feat(connector): add SlackConnector — conversations.history polling"
+```
+
+---
+
+## Task 6: Chatwork Connector
+
+**Files:**
+
+- Create: `packages/standalone/src/connectors/chatwork/index.ts`
+- Create: `packages/standalone/tests/connectors/chatwork.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// packages/standalone/tests/connectors/chatwork.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { ChatworkConnector } from '../../src/connectors/chatwork/index.js';
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('ChatworkConnector', () => {
+  it('has correct name and type', () => {
+    const connector = new ChatworkConnector();
+    expect(connector.name).toBe('chatwork');
+    expect(connector.type).toBe('api');
+  });
+
+  it('declares token auth requirement', () => {
+    const connector = new ChatworkConnector();
+    const reqs = connector.getAuthRequirements();
+    expect(reqs[0].tokenName).toBe('CHATWORK_API_TOKEN');
+  });
+
+  it('polls messages from configured rooms', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          {
+            message_id: '1001',
+            account: { name: 'Alice' },
+            body: '작업 시작합니다',
+            send_time: 1712480400,
+          },
+          {
+            message_id: '1002',
+            account: { name: 'Bob' },
+            body: '확인했습니다',
+            send_time: 1712480460,
+          },
+        ]),
+    });
+
+    const connector = new ChatworkConnector();
+    await connector.init({
+      enabled: true,
+      pollIntervalMinutes: 60,
+      channels: { ROOM001: { role: 'hub', name: 'project-alpha' } },
+      auth: { type: 'token', token: 'test-token' },
+    });
+
+    const items = await connector.poll(new Date('2026-04-06T00:00:00Z'));
+    expect(items).toHaveLength(2);
+    expect(items[0].source).toBe('chatwork');
+    expect(items[0].channel).toBe('project-alpha');
+    expect(items[0].author).toBe('Alice');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd <project-root> && pnpm vitest run tests/connectors/chatwork.test.ts
+```
+
+- [ ] **Step 3: Implement ChatworkConnector**
+
+```typescript
+// packages/standalone/src/connectors/chatwork/index.ts
+import type {
+  IConnector,
+  ConnectorConfig,
+  ConnectorHealth,
+  AuthRequirement,
+  NormalizedItem,
+} from '../framework/types.js';
+
+const CHATWORK_API = 'https://api.chatwork.com/v2';
+
+export class ChatworkConnector implements IConnector {
+  readonly name = 'chatwork';
+  readonly type = 'api' as const;
+  private config!: ConnectorConfig;
+  private token = '';
+
+  async init(config: ConnectorConfig): Promise<void> {
+    this.config = config;
+    this.token = config.auth.token ?? '';
+  }
+
+  async dispose(): Promise<void> {
+    this.token = '';
+  }
+
+  async healthCheck(): Promise<ConnectorHealth> {
+    if (!this.token)
+      return { healthy: false, lastPollTime: null, lastPollCount: 0, error: 'No token' };
+    return { healthy: true, lastPollTime: null, lastPollCount: 0 };
+  }
+
+  getAuthRequirements(): AuthRequirement[] {
+    return [
+      {
+        type: 'token',
+        tokenName: 'CHATWORK_API_TOKEN',
+        description:
+          'Chatwork API Token. Get from https://www.chatwork.com/service/packages/chatwork/subpackages/api/token.php',
+      },
+    ];
+  }
+
+  async authenticate(credentials: Record<string, string>): Promise<boolean> {
+    this.token = credentials.CHATWORK_API_TOKEN ?? '';
+    return !!this.token;
+  }
+
+  async poll(since: Date): Promise<NormalizedItem[]> {
+    if (!this.token) return [];
+    const items: NormalizedItem[] = [];
+
+    for (const [roomId, channelConfig] of Object.entries(this.config.channels)) {
+      if (channelConfig.role === 'ignore') continue;
+      try {
+        const res = await fetch(`${CHATWORK_API}/rooms/${roomId}/messages?force=1`, {
+          headers: { 'X-ChatWorkToken': this.token },
+        });
+        if (!res.ok) continue;
+        const messages = (await res.json()) as Array<{
+          message_id: string;
+          account: { name: string };
+          body: string;
+          send_time: number;
+        }>;
+
+        for (const msg of messages) {
+          const ts = new Date(msg.send_time * 1000);
+          if (ts <= since) continue;
+          items.push({
+            source: 'chatwork',
+            sourceId: `${roomId}:${msg.message_id}`,
+            channel: channelConfig.name ?? roomId,
+            author: msg.account.name,
+            content: msg.body,
+            timestamp: ts,
+            type: 'message',
+            metadata: { roomId },
+          });
+        }
+      } catch (err) {
+        console.error(`[chatwork] Failed to poll room ${roomId}:`, err);
+      }
+    }
+
+    return items.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+  }
+}
+```
+
+- [ ] **Step 4: Run test and commit**
+
+```bash
+cd <project-root> && pnpm vitest run tests/connectors/chatwork.test.ts
+git add packages/standalone/src/connectors/chatwork/ packages/standalone/tests/connectors/chatwork.test.ts
+git commit -m "feat(connector): add ChatworkConnector — rooms messages polling"
+```
+
+---
+
+## Task 7: Gmail Connector (gws CLI)
+
+**Files:**
+
+- Create: `packages/standalone/src/connectors/gmail/index.ts`
+- Create: `packages/standalone/tests/connectors/gmail.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// packages/standalone/tests/connectors/gmail.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { GmailConnector } from '../../src/connectors/gmail/index.js';
+import { execSync } from 'child_process';
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+describe('GmailConnector', () => {
+  it('has correct name and type', () => {
+    const connector = new GmailConnector();
+    expect(connector.name).toBe('gmail');
+    expect(connector.type).toBe('api');
+  });
+
+  it('declares cli auth requirement', () => {
+    const reqs = new GmailConnector().getAuthRequirements();
+    expect(reqs[0].type).toBe('cli');
+    expect(reqs[0].cli).toBe('gws');
+  });
+
+  it('polls emails via gws CLI', async () => {
+    const mockExecSync = vi.mocked(execSync);
+
+    // Mock message list
+    mockExecSync.mockReturnValueOnce(
+      Buffer.from(
+        JSON.stringify({
+          messages: [{ id: 'msg_abc', threadId: 'thread_1' }],
+        })
+      )
+    );
+
+    // Mock message detail
+    mockExecSync.mockReturnValueOnce(
+      Buffer.from(
+        JSON.stringify({
+          id: 'msg_abc',
+          internalDate: '1712480400000',
+          payload: {
+            headers: [
+              { name: 'Subject', value: '契約書の件' },
+              { name: 'From', value: 'client@example.com' },
+            ],
+          },
+          snippet: 'お世話になっております。契約書を修正しました。',
+        })
+      )
+    );
+
+    const connector = new GmailConnector();
+    await connector.init({
+      enabled: true,
+      pollIntervalMinutes: 120,
+      channels: { inbox: { role: 'hub' } },
+      auth: { type: 'cli', cli: 'gws' },
+    });
+
+    const items = await connector.poll(new Date('2026-04-06T00:00:00Z'));
+    expect(items).toHaveLength(1);
+    expect(items[0].source).toBe('gmail');
+    expect(items[0].type).toBe('email');
+    expect(items[0].content).toContain('契約書の件');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd <project-root> && pnpm vitest run tests/connectors/gmail.test.ts
+```
+
+- [ ] **Step 3: Implement GmailConnector**
+
+```typescript
+// packages/standalone/src/connectors/gmail/index.ts
+import { execSync } from 'child_process';
+import type {
+  IConnector,
+  ConnectorConfig,
+  ConnectorHealth,
+  AuthRequirement,
+  NormalizedItem,
+} from '../framework/types.js';
+
+export class GmailConnector implements IConnector {
+  readonly name = 'gmail';
+  readonly type = 'api' as const;
+  private config!: ConnectorConfig;
+
+  async init(config: ConnectorConfig): Promise<void> {
+    this.config = config;
+  }
+  async dispose(): Promise<void> {}
+
+  async healthCheck(): Promise<ConnectorHealth> {
+    try {
+      const result = this.gws('gmail users getProfile --params \'{"userId":"me"}\'');
+      return { healthy: !!result.emailAddress, lastPollTime: null, lastPollCount: 0 };
+    } catch (err) {
+      return { healthy: false, lastPollTime: null, lastPollCount: 0, error: String(err) };
+    }
+  }
+
+  getAuthRequirements(): AuthRequirement[] {
+    return [
+      {
+        type: 'cli',
+        cli: 'gws',
+        cliAuthCommand: 'gws auth login',
+        description: 'Google Workspace CLI. Run "gws auth login" to authenticate.',
+      },
+    ];
+  }
+
+  async authenticate(): Promise<boolean> {
+    try {
+      const status = this.gws('auth status');
+      return status.token_valid === true;
+    } catch {
+      return false;
+    }
+  }
+
+  async poll(since: Date): Promise<NormalizedItem[]> {
+    const items: NormalizedItem[] = [];
+    const afterDate = since.toISOString().split('T')[0].replace(/-/g, '/');
+
+    try {
+      const listResult = this.gws(
+        `gmail users messages list --params '{"userId":"me","q":"after:${afterDate}","maxResults":50}'`
+      );
+
+      for (const msg of listResult.messages ?? []) {
+        try {
+          const detail = this.gws(
+            `gmail users messages get --params '{"userId":"me","id":"${msg.id}","format":"metadata","metadataHeaders":["Subject","From"]}'`
+          );
+
+          const headers = detail.payload?.headers ?? [];
+          const subject = headers.find((h: any) => h.name === 'Subject')?.value ?? '(no subject)';
+          const from = headers.find((h: any) => h.name === 'From')?.value ?? 'unknown';
+          const ts = new Date(parseInt(detail.internalDate, 10));
+
+          if (ts <= since) continue;
+
+          items.push({
+            source: 'gmail',
+            sourceId: msg.id,
+            channel: 'inbox',
+            author: from,
+            content: `Subject: ${subject}\n\n${detail.snippet ?? ''}`,
+            timestamp: ts,
+            type: 'email',
+            metadata: { threadId: msg.threadId },
+          });
+        } catch {
+          /* skip individual message errors */
+        }
+      }
+    } catch (err) {
+      console.error('[gmail] Poll failed:', err);
+    }
+
+    return items.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+  }
+
+  private gws(command: string): any {
+    const output = execSync(`gws ${command}`, { encoding: 'utf-8', timeout: 30_000 });
+    // gws outputs "Using keyring backend: keyring\n" before JSON
+    const jsonStart = output.indexOf('{');
+    if (jsonStart === -1) return {};
+    return JSON.parse(output.slice(jsonStart));
+  }
+}
+```
+
+- [ ] **Step 4: Run test and commit**
+
+```bash
+cd <project-root> && pnpm vitest run tests/connectors/gmail.test.ts
+git add packages/standalone/src/connectors/gmail/ packages/standalone/tests/connectors/gmail.test.ts
+git commit -m "feat(connector): add GmailConnector — gws CLI wrapper"
+```
+
+---
+
+## Task 8: Calendar Connector (gws CLI)
+
+**Files:**
+
+- Create: `packages/standalone/src/connectors/calendar/index.ts`
+- Create: `packages/standalone/tests/connectors/calendar.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// packages/standalone/tests/connectors/calendar.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { CalendarConnector } from '../../src/connectors/calendar/index.js';
+import { execSync } from 'child_process';
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn().mockReturnValue(
+    Buffer.from(
+      JSON.stringify({
+        items: [
+          {
+            id: 'evt_1',
+            summary: 'Weekly Progress Meeting',
+            start: { dateTime: '2026-04-07T14:00:00+09:00' },
+            end: { dateTime: '2026-04-07T15:00:00+09:00' },
+            description: '週次進捗確認',
+            creator: { email: 'user@example.com' },
+          },
+        ],
+      })
+    )
+  ),
+}));
+
+describe('CalendarConnector', () => {
+  it('has correct name and type', () => {
+    const connector = new CalendarConnector();
+    expect(connector.name).toBe('calendar');
+    expect(connector.type).toBe('api');
+  });
+
+  it('polls events via gws CLI', async () => {
+    const connector = new CalendarConnector();
+    await connector.init({
+      enabled: true,
+      pollIntervalMinutes: 60,
+      channels: { primary: { role: 'hub' } },
+      auth: { type: 'cli', cli: 'gws' },
+    });
+
+    const items = await connector.poll(new Date('2026-04-06T00:00:00Z'));
+    expect(items).toHaveLength(1);
+    expect(items[0].source).toBe('calendar');
+    expect(items[0].type).toBe('event');
+    expect(items[0].content).toContain('Weekly Progress Meeting');
+  });
+});
+```
+
+- [ ] **Step 2: Implement CalendarConnector**
+
+```typescript
+// packages/standalone/src/connectors/calendar/index.ts
+import { execSync } from 'child_process';
+import type {
+  IConnector,
+  ConnectorConfig,
+  ConnectorHealth,
+  AuthRequirement,
+  NormalizedItem,
+} from '../framework/types.js';
+
+export class CalendarConnector implements IConnector {
+  readonly name = 'calendar';
+  readonly type = 'api' as const;
+  private config!: ConnectorConfig;
+
+  async init(config: ConnectorConfig): Promise<void> {
+    this.config = config;
+  }
+  async dispose(): Promise<void> {}
+
+  async healthCheck(): Promise<ConnectorHealth> {
+    return { healthy: true, lastPollTime: null, lastPollCount: 0 };
+  }
+
+  getAuthRequirements(): AuthRequirement[] {
+    return [
+      {
+        type: 'cli',
+        cli: 'gws',
+        cliAuthCommand: 'gws auth login',
+        description: 'Google Workspace CLI. Run "gws auth login" to authenticate.',
+      },
+    ];
+  }
+
+  async authenticate(): Promise<boolean> {
+    return true;
+  }
+
+  async poll(since: Date): Promise<NormalizedItem[]> {
+    const items: NormalizedItem[] = [];
+    const timeMin = since.toISOString();
+
+    for (const [calendarId, channelConfig] of Object.entries(this.config.channels)) {
+      if (channelConfig.role === 'ignore') continue;
+      try {
+        const output = execSync(
+          `gws calendar events list --params '{"calendarId":"${calendarId}","timeMin":"${timeMin}","maxResults":50,"singleEvents":true,"orderBy":"startTime"}'`,
+          { encoding: 'utf-8', timeout: 30_000 }
+        );
+        const jsonStart = output.indexOf('{');
+        if (jsonStart === -1) continue;
+        const result = JSON.parse(output.slice(jsonStart));
+
+        for (const event of result.items ?? []) {
+          const start = event.start?.dateTime ?? event.start?.date ?? '';
+          const end = event.end?.dateTime ?? event.end?.date ?? '';
+          items.push({
+            source: 'calendar',
+            sourceId: event.id,
+            channel: channelConfig.name ?? calendarId,
+            author: event.creator?.email ?? 'unknown',
+            content: `${event.summary ?? '(no title)'} | ${start} ~ ${end}${event.description ? '\n' + event.description : ''}`,
+            timestamp: new Date(start),
+            type: 'event',
+            metadata: { calendarId, htmlLink: event.htmlLink },
+          });
+        }
+      } catch (err) {
+        console.error(`[calendar] Poll failed for ${calendarId}:`, err);
+      }
+    }
+
+    return items.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+  }
+}
+```
+
+- [ ] **Step 3: Run test and commit**
+
+```bash
+cd <project-root> && pnpm vitest run tests/connectors/calendar.test.ts
+git add packages/standalone/src/connectors/calendar/ packages/standalone/tests/connectors/calendar.test.ts
+git commit -m "feat(connector): add CalendarConnector — gws CLI wrapper"
+```
+
+---
+
+## Task 9: Telegram Connector
+
+**Files:**
+
+- Create: `packages/standalone/src/connectors/telegram/index.ts`
+- Create: `packages/standalone/tests/connectors/telegram.test.ts`
+
+- [ ] **Step 1: Write test, implement, and commit**
+
+Follow the same pattern as SlackConnector. Key differences:
+
+- Uses grammY `bot.api.getUpdates({ offset, allowed_updates: ['message'] })`
+- NormalizedItem.author = `update.message.from.first_name`
+- sourceId = `${chatId}:${message_id}`
+- Tracks offset in connector state for sequential polling
+
+```bash
+git commit -m "feat(connector): add TelegramConnector — getUpdates polling"
+```
+
+---
+
+## Task 10: Discord Connector
+
+**Files:**
+
+- Create: `packages/standalone/src/connectors/discord/index.ts`
+- Create: `packages/standalone/tests/connectors/discord.test.ts`
+
+- [ ] **Step 1: Write test, implement, and commit**
+
+Follow the same pattern. Key differences:
+
+- Uses discord.js `channel.messages.fetch({ after: lastMessageId })`
+- Can reuse existing gateway's client if available, or create standalone
+- sourceId = `${channelId}:${messageId}`
+
+```bash
+git commit -m "feat(connector): add DiscordConnector — channel messages fetch"
+```
+
+---
+
+## Task 11: Notion Connector
+
+**Files:**
+
+- Create: `packages/standalone/src/connectors/notion/index.ts`
+- Create: `packages/standalone/tests/connectors/notion.test.ts`
+
+- [ ] **Step 1: Write test, implement, and commit**
+
+Key implementation:
+
+- Uses `@notionhq/client` — `notion.search({ filter: { property: 'object', value: 'page' }, sort: { timestamp: 'last_edited_time', direction: 'descending' } })`
+- Filters pages by `last_edited_time > since`
+- Fetches block children for content text extraction
+- NormalizedItem.type = 'document'
+- sourceId = page.id
+
+```bash
+git commit -m "feat(connector): add NotionConnector — page search + block extraction"
+```
+
+---
+
+## Task 12: Obsidian Connector
+
+**Files:**
+
+- Create: `packages/standalone/src/connectors/obsidian/index.ts`
+- Create: `packages/standalone/tests/connectors/obsidian.test.ts`
+
+- [ ] **Step 1: Write test, implement, and commit**
+
+Key implementation:
+
+- Uses `chokidar` for file watching (optional, for future real-time)
+- `poll(since)`: glob `**/*.md` in vaultPath, filter by `stat.mtime > since`
+- Reads file content via `readFileSync`
+- NormalizedItem.type = 'note'
+- sourceId = relative file path
+
+```bash
+git commit -m "feat(connector): add ObsidianConnector — local vault file polling"
+```
+
+---
+
+## Task 13: Kagemusha Connector
+
+**Files:**
+
+- Create: `packages/standalone/src/connectors/kagemusha/index.ts`
+- Create: `packages/standalone/tests/connectors/kagemusha.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// packages/standalone/tests/connectors/kagemusha.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { KagemushaConnector } from '../../src/connectors/kagemusha/index.js';
+import Database from 'better-sqlite3';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('KagemushaConnector', () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'kagemusha-'));
+    dbPath = join(tmpDir, 'kagemusha.db');
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE channel_messages (
+        id INTEGER PRIMARY KEY,
+        channel TEXT NOT NULL,
+        channel_id TEXT NOT NULL,
+        user_id TEXT NOT NULL,
+        role TEXT NOT NULL DEFAULT 'user',
+        content TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      )
+    `);
+    db.prepare(
+      'INSERT INTO channel_messages (channel, channel_id, user_id, content, created_at) VALUES (?, ?, ?, ?, ?)'
+    ).run('chatwork', 'ROOM001', 'Alice', '작업 시작합니다', Date.now());
+    db.prepare(
+      'INSERT INTO channel_messages (channel, channel_id, user_id, content, created_at) VALUES (?, ?, ?, ?, ?)'
+    ).run('kakao', 'Bob', 'Bob', '확인했습니다', Date.now());
+    db.close();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reads from kagemusha.db', async () => {
+    const connector = new KagemushaConnector();
+    await connector.init({
+      enabled: true,
+      pollIntervalMinutes: 60,
+      channels: {},
+      auth: { type: 'none' },
+    });
+    // Override db path for test
+    (connector as any).dbPath = dbPath;
+
+    const items = await connector.poll(new Date(0));
+    expect(items).toHaveLength(2);
+    expect(items[0].source).toBe('chatwork');
+    expect(items[1].source).toBe('kakao');
+  });
+});
+```
+
+- [ ] **Step 2: Implement KagemushaConnector**
+
+```typescript
+// packages/standalone/src/connectors/kagemusha/index.ts
+import Database from 'better-sqlite3';
+import { join } from 'path';
+import { homedir } from 'os';
+import type {
+  IConnector,
+  ConnectorConfig,
+  ConnectorHealth,
+  AuthRequirement,
+  NormalizedItem,
+} from '../framework/types.js';
+
+export class KagemushaConnector implements IConnector {
+  readonly name = 'kagemusha';
+  readonly type = 'local' as const;
+  private dbPath = join(homedir(), '.kagemusha', 'kagemusha.db');
+
+  async init(config: ConnectorConfig): Promise<void> {
+    // dbPath can be overridden via config metadata
+  }
+
+  async dispose(): Promise<void> {}
+
+  async healthCheck(): Promise<ConnectorHealth> {
+    try {
+      const db = new Database(this.dbPath, { readonly: true });
+      db.prepare('SELECT 1 FROM channel_messages LIMIT 1').get();
+      db.close();
+      return { healthy: true, lastPollTime: null, lastPollCount: 0 };
+    } catch (err) {
+      return { healthy: false, lastPollTime: null, lastPollCount: 0, error: String(err) };
+    }
+  }
+
+  getAuthRequirements(): AuthRequirement[] {
+    return [{ type: 'none', description: 'Local kagemusha.db — no authentication needed.' }];
+  }
+
+  async authenticate(): Promise<boolean> {
+    return true;
+  }
+
+  async poll(since: Date): Promise<NormalizedItem[]> {
+    try {
+      const db = new Database(this.dbPath, { readonly: true });
+      const rows = db
+        .prepare(
+          'SELECT * FROM channel_messages WHERE created_at > ? AND role = ? ORDER BY created_at ASC'
+        )
+        .all(since.getTime(), 'user') as Array<{
+        id: number;
+        channel: string;
+        channel_id: string;
+        user_id: string;
+        content: string;
+        created_at: number;
+      }>;
+      db.close();
+
+      return rows.map((row) => ({
+        source: row.channel,
+        sourceId: `${row.channel_id}:${row.id}`,
+        channel: row.channel_id,
+        author: row.user_id,
+        content: row.content,
+        timestamp: new Date(row.created_at),
+        type: 'message' as const,
+        metadata: { kagemushaId: row.id },
+      }));
+    } catch (err) {
+      console.error('[kagemusha] Poll failed:', err);
+      return [];
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Run test and commit**
+
+```bash
+cd <project-root> && pnpm vitest run tests/connectors/kagemusha.test.ts
+git add packages/standalone/src/connectors/kagemusha/ packages/standalone/tests/connectors/kagemusha.test.ts
+git commit -m "feat(connector): add KagemushaConnector — kagemusha.db reader"
+```
+
+---
+
+## Task 14: Connectors Index + Re-exports
+
+**Files:**
+
+- Create: `packages/standalone/src/connectors/index.ts`
+
+- [ ] **Step 1: Create index file**
+
+```typescript
+// packages/standalone/src/connectors/index.ts
+export * from './framework/index.js';
+export { SlackConnector } from './slack/index.js';
+export { TelegramConnector } from './telegram/index.js';
+export { DiscordConnector } from './discord/index.js';
+export { ChatworkConnector } from './chatwork/index.js';
+export { GmailConnector } from './gmail/index.js';
+export { CalendarConnector } from './calendar/index.js';
+export { NotionConnector } from './notion/index.js';
+export { ObsidianConnector } from './obsidian/index.js';
+export { KagemushaConnector } from './kagemusha/index.js';
+
+// Connector name → class mapping for dynamic loading
+export const CONNECTOR_MAP: Record<string, new () => import('./framework/types.js').IConnector> = {
+  slack: undefined as any, // Lazy-loaded to avoid pulling in all deps
+  telegram: undefined as any,
+  discord: undefined as any,
+  chatwork: undefined as any,
+  gmail: undefined as any,
+  calendar: undefined as any,
+  notion: undefined as any,
+  obsidian: undefined as any,
+  kagemusha: undefined as any,
+};
+
+export async function loadConnector(
+  name: string
+): Promise<import('./framework/types.js').IConnector> {
+  const mod = await import(`./${name}/index.js`);
+  const ConnectorClass = mod[Object.keys(mod).find((k) => k.endsWith('Connector'))!];
+  return new ConnectorClass();
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/standalone/src/connectors/index.ts
+git commit -m "feat(connector): add connectors index with dynamic loader"
+```
+
+---
+
+## Task 15: Memory Agent — History Extractor (2-Pass)
+
+**Files:**
+
+- Create: `packages/standalone/src/memory/history-extractor.ts`
+- Create: `packages/standalone/tests/connectors/history-extractor.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// packages/standalone/tests/connectors/history-extractor.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  classifyItemsByRole,
+  buildHubExtractionPrompt,
+  buildSpokeExtractionPrompt,
+} from '../../src/memory/history-extractor.js';
+import type { NormalizedItem, ChannelConfig } from '../../src/connectors/framework/types.js';
+
+describe('History Extractor', () => {
+  const hubItems: NormalizedItem[] = [
+    {
+      source: 'chatwork',
+      sourceId: 'cw:1',
+      channel: 'project-alpha',
+      author: 'Alice',
+      content: 'Task-3 납기 금요일로 확정합시다',
+      timestamp: new Date('2026-04-07T10:00:00Z'),
+      type: 'message',
+    },
+    {
+      source: 'chatwork',
+      sourceId: 'cw:2',
+      channel: 'project-alpha',
+      author: 'Bob',
+      content: '확인했습니다. 작업 시작하겠습니다',
+      timestamp: new Date('2026-04-07T10:05:00Z'),
+      type: 'message',
+    },
+  ];
+
+  const spokeItems: NormalizedItem[] = [
+    {
+      source: 'kakao',
+      sourceId: 'kk:1',
+      channel: 'Bob',
+      author: 'Bob',
+      content: '3화 라인 정리 중입니다',
+      timestamp: new Date('2026-04-07T12:00:00Z'),
+      type: 'message',
+    },
+  ];
+
+  const channelConfigs: Record<string, Record<string, ChannelConfig>> = {
+    chatwork: { project-alpha: { role: 'hub' } },
+    kakao: { Bob: { role: 'spoke' } },
+  };
+
+  it('classifies items into hub and spoke groups', () => {
+    const allItems = [...hubItems, ...spokeItems];
+    const { hub, spoke } = classifyItemsByRole(allItems, channelConfigs);
+
+    expect(hub).toHaveLength(2);
+    expect(spoke).toHaveLength(1);
+    expect(hub[0].channel).toBe('project-alpha');
+    expect(spoke[0].channel).toBe('Bob');
+  });
+
+  it('builds hub extraction prompt with channel context', () => {
+    const prompt = buildHubExtractionPrompt(hubItems);
+    expect(prompt).toContain('역사가');
+    expect(prompt).toContain('Task-3 납기 금요일');
+    expect(prompt).toContain('Alice');
+  });
+
+  it('builds spoke extraction prompt with hub context', () => {
+    const hubContext = [
+      {
+        project: 'project-alpha',
+        workUnit: 'Task-3',
+        assignedTo: 'Bob',
+        status: '작업 시작',
+      },
+    ];
+    const prompt = buildSpokeExtractionPrompt(spokeItems, hubContext);
+    expect(prompt).toContain('활성 프로젝트');
+    expect(prompt).toContain('project-alpha');
+    expect(prompt).toContain('3화 라인 정리');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd <project-root> && pnpm vitest run tests/connectors/history-extractor.test.ts
+```
+
+- [ ] **Step 3: Implement history-extractor.ts**
+
+```typescript
+// packages/standalone/src/memory/history-extractor.ts
+import type { NormalizedItem, ChannelConfig } from '../connectors/framework/types.js';
+
+export interface HubContextEntry {
+  project: string;
+  workUnit?: string;
+  assignedTo?: string;
+  status?: string;
+}
+
+export function classifyItemsByRole(
+  items: NormalizedItem[],
+  channelConfigs: Record<string, Record<string, ChannelConfig>>
+): { hub: NormalizedItem[]; spoke: NormalizedItem[] } {
+  const hub: NormalizedItem[] = [];
+  const spoke: NormalizedItem[] = [];
+
+  for (const item of items) {
+    const sourceConfigs = channelConfigs[item.source] ?? {};
+    const channelConfig = sourceConfigs[item.channel];
+    const role = channelConfig?.role ?? 'ignore';
+
+    if (role === 'hub') hub.push(item);
+    else if (role === 'spoke') spoke.push(item);
+    // 'ignore' items are dropped
+  }
+
+  return { hub, spoke };
+}
+
+export function buildHubExtractionPrompt(items: NormalizedItem[]): string {
+  const grouped = groupByChannel(items);
+  let prompt = `당신은 역사가입니다. 아래는 프로젝트 채널에서 수집된 내용입니다.
+
+기록할 가치가 있는 것만 추출하세요:
+- task: 새로 할당되거나 상태가 변한 작업
+- decision: 합의되거나 확정된 것
+- lesson: 문제-해결 경험
+- schedule: 납기, 미팅 변경
+
+일상 대화, 인사, 잡담은 무시하세요.
+
+각 항목을 JSON 배열로 반환하세요:
+[{
+  "project": "프로젝트명 (채널명 기반)",
+  "work_unit": "구체적 작업 단위 (있으면)",
+  "assigned_to": "담당자 (있으면)",
+  "kind": "task|decision|lesson|schedule",
+  "topic": "주제 키워드",
+  "summary": "1-2문장 요약",
+  "reasoning": "왜 기록할 가치가 있는지",
+  "event_date": "YYYY-MM-DD",
+  "confidence": 0.0-1.0
+}]
+
+추출할 것이 없으면 빈 배열 []을 반환하세요.
+
+---
+`;
+
+  for (const [channel, channelItems] of grouped) {
+    prompt += `\n### ${channel}\n`;
+    for (const item of channelItems) {
+      const time = item.timestamp.toISOString().slice(11, 16);
+      prompt += `${item.author}(${time}): ${item.content}\n`;
+    }
+  }
+
+  return prompt;
+}
+
+export function buildSpokeExtractionPrompt(
+  items: NormalizedItem[],
+  hubContext: HubContextEntry[]
+): string {
+  let prompt = `현재 활성 프로젝트 상황:\n`;
+  for (const ctx of hubContext) {
+    prompt += `- ${ctx.project}`;
+    if (ctx.workUnit) prompt += `/${ctx.workUnit}`;
+    if (ctx.assignedTo) prompt += ` → ${ctx.assignedTo}`;
+    if (ctx.status) prompt += `, ${ctx.status}`;
+    prompt += '\n';
+  }
+
+  prompt += `\n아래는 작업자 DM/메모에서 수집된 내용입니다.
+관련 프로젝트에 연결하세요. 어떤 프로젝트에도 해당하지 않는 일상 대화는 무시하세요.
+
+각 항목을 JSON 배열로 반환하세요 (hub와 동일한 형식).
+추출할 것이 없으면 빈 배열 []을 반환하세요.
+
+---
+`;
+
+  const grouped = groupByChannel(items);
+  for (const [channel, channelItems] of grouped) {
+    prompt += `\n### ${channel}\n`;
+    for (const item of channelItems) {
+      const time = item.timestamp.toISOString().slice(11, 16);
+      prompt += `${item.author}(${time}): ${item.content}\n`;
+    }
+  }
+
+  return prompt;
+}
+
+function groupByChannel(items: NormalizedItem[]): Map<string, NormalizedItem[]> {
+  const groups = new Map<string, NormalizedItem[]>();
+  for (const item of items) {
+    const key = `${item.source}:${item.channel}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(item);
+  }
+  return groups;
+}
+```
+
+- [ ] **Step 4: Run test and commit**
+
+```bash
+cd <project-root> && pnpm vitest run tests/connectors/history-extractor.test.ts
+git add packages/standalone/src/memory/history-extractor.ts packages/standalone/tests/connectors/history-extractor.test.ts
+git commit -m "feat(memory): add 2-pass history extractor with hub/spoke classification"
+```
+
+---
+
+## Task 16: CLI — mama connector command
+
+**Files:**
+
+- Create: `packages/standalone/src/cli/commands/connector.ts`
+- Modify: `packages/standalone/src/cli/index.ts`
+
+- [ ] **Step 1: Create connector CLI command**
+
+```typescript
+// packages/standalone/src/cli/commands/connector.ts
+import { Command } from 'commander';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { loadConnector } from '../../connectors/index.js';
+import type { ConnectorsConfig, ConnectorConfig } from '../../connectors/framework/types.js';
+
+const CONNECTORS_PATH = join(homedir(), '.mama', 'connectors.json');
+
+function loadConfig(): ConnectorsConfig {
+  if (!existsSync(CONNECTORS_PATH)) return {};
+  return JSON.parse(readFileSync(CONNECTORS_PATH, 'utf-8'));
+}
+
+function saveConfig(config: ConnectorsConfig): void {
+  writeFileSync(CONNECTORS_PATH, JSON.stringify(config, null, 2));
+}
+
+const AVAILABLE_CONNECTORS = [
+  'slack',
+  'telegram',
+  'discord',
+  'chatwork',
+  'gmail',
+  'calendar',
+  'notion',
+  'obsidian',
+  'kagemusha',
+];
+
+export function createConnectorCommand(): Command {
+  const cmd = new Command('connector').description('Manage data source connectors');
+
+  cmd
+    .command('list')
+    .description('List all connectors and their status')
+    .action(() => {
+      const config = loadConfig();
+      console.log('\nAvailable Connectors:\n');
+      for (const name of AVAILABLE_CONNECTORS) {
+        const c = config[name];
+        const status = c?.enabled ? '✓ enabled' : '  disabled';
+        console.log(`  ${status}  ${name}`);
+      }
+      console.log('');
+    });
+
+  cmd
+    .command('add <name>')
+    .description('Enable a connector')
+    .action(async (name: string) => {
+      if (!AVAILABLE_CONNECTORS.includes(name)) {
+        console.error(`Unknown connector: ${name}. Available: ${AVAILABLE_CONNECTORS.join(', ')}`);
+        return;
+      }
+      const connector = await loadConnector(name);
+      const reqs = connector.getAuthRequirements();
+
+      const config = loadConfig();
+      if (!config[name]) {
+        config[name] = {
+          enabled: true,
+          pollIntervalMinutes: 60,
+          channels: {},
+          auth: { type: reqs[0]?.type ?? 'none' },
+        };
+      } else {
+        config[name].enabled = true;
+      }
+      saveConfig(config);
+
+      console.log(`\n✓ ${name} connector enabled.`);
+      if (reqs.length > 0) {
+        console.log('\nAuthentication required:');
+        for (const req of reqs) {
+          console.log(`  ${req.description}`);
+          if (req.cliAuthCommand) console.log(`  Run: ${req.cliAuthCommand}`);
+          if (req.tokenName) console.log(`  Set: ${req.tokenName} in ~/.mama/connectors.json`);
+        }
+      }
+      console.log(`\nConfigure channels: mama connector config ${name}`);
+    });
+
+  cmd
+    .command('remove <name>')
+    .description('Disable a connector')
+    .action((name: string) => {
+      const config = loadConfig();
+      if (config[name]) {
+        config[name].enabled = false;
+        saveConfig(config);
+        console.log(`✓ ${name} connector disabled.`);
+      }
+    });
+
+  cmd
+    .command('status')
+    .description('Show connector health and last poll times')
+    .action(async () => {
+      const config = loadConfig();
+      console.log('\nConnector Status:\n');
+      for (const [name, c] of Object.entries(config)) {
+        if (!c.enabled) continue;
+        try {
+          const connector = await loadConnector(name);
+          await connector.init(c);
+          const health = await connector.healthCheck();
+          const statusIcon = health.healthy ? '✓' : '✗';
+          const lastPoll = health.lastPollTime ? health.lastPollTime.toISOString() : 'never';
+          console.log(
+            `  ${statusIcon} ${name} — last poll: ${lastPoll}${health.error ? ' — ' + health.error : ''}`
+          );
+          await connector.dispose();
+        } catch (err) {
+          console.log(`  ✗ ${name} — error: ${err}`);
+        }
+      }
+      console.log('');
+    });
+
+  return cmd;
+}
+```
+
+- [ ] **Step 2: Register in CLI index**
+
+Add to `packages/standalone/src/cli/index.ts`:
+
+```typescript
+import { createConnectorCommand } from './commands/connector.js';
+
+// After existing commands, before program.parse():
+program.addCommand(createConnectorCommand());
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/standalone/src/cli/commands/connector.ts packages/standalone/src/cli/index.ts
+git commit -m "feat(cli): add 'mama connector' command — add/remove/list/status"
+```
+
+---
+
+## Task 17: Wire Connectors into Bootstrap
+
+**Files:**
+
+- Modify: `packages/standalone/src/cli/config/types.ts`
+- Modify: `packages/standalone/src/cli/commands/start.ts`
+
+- [ ] **Step 1: Add ConnectorsConfig to MAMAConfig**
+
+In `packages/standalone/src/cli/config/types.ts`, add to the `MAMAConfig` interface:
+
+```typescript
+/** Connector settings (loaded from ~/.mama/connectors.json) */
+connectors?: ConnectorsConfig;
+```
+
+Import the type:
+
+```typescript
+import type { ConnectorsConfig } from '../../connectors/framework/types.js';
+```
+
+- [ ] **Step 2: Add connector initialization to runAgentLoop**
+
+In `packages/standalone/src/cli/commands/start.ts`, after gateway initialization (~line 1969) and before the API server setup, add:
+
+```typescript
+// === Connector Framework ===
+const connectorsConfigPath = join(homedir(), '.mama', 'connectors.json');
+if (existsSync(connectorsConfigPath)) {
+  const { ConnectorRegistry, PollingScheduler, RawStore } =
+    await import('../../connectors/framework/index.js');
+  const { loadConnector } = await import('../../connectors/index.js');
+
+  const connectorsConfig = JSON.parse(readFileSync(connectorsConfigPath, 'utf-8'));
+  const connectorRegistry = new ConnectorRegistry();
+  const rawStore = new RawStore(join(homedir(), '.mama', 'connectors'));
+
+  for (const [name, connConfig] of Object.entries(connectorsConfig)) {
+    const cc = connConfig as any;
+    if (!cc.enabled) continue;
+    try {
+      const connector = await loadConnector(name);
+      await connector.init(cc);
+      connectorRegistry.register(name, connector);
+      console.log(`[connector] ${name} initialized`);
+    } catch (err) {
+      console.error(`[connector] ${name} failed to init:`, err);
+    }
+  }
+
+  if (connectorRegistry.getActive().size > 0) {
+    const scheduler = new PollingScheduler(
+      rawStore,
+      join(homedir(), '.mama', 'connectors'),
+      async (connectorName, items) => {
+        // TODO Task 18: Wire to Memory Agent history extractor
+        console.log(`[connector:${connectorName}] polled ${items.length} items`);
+      }
+    );
+
+    const intervals: Record<string, { pollIntervalMinutes: number }> = {};
+    for (const [name, cc] of Object.entries(connectorsConfig)) {
+      intervals[name] = { pollIntervalMinutes: (cc as any).pollIntervalMinutes ?? 60 };
+    }
+    await scheduler.start(connectorRegistry, intervals);
+    console.log(`[connector] ${connectorRegistry.getActive().size} connectors active`);
+
+    // Add to graceful shutdown
+    gateways.push({ stop: () => scheduler.stop() } as any);
+  }
+}
+```
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+cd <project-root> && pnpm test
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/standalone/src/cli/config/types.ts packages/standalone/src/cli/commands/start.ts
+git commit -m "feat(connector): wire PollingScheduler into MAMA OS bootstrap"
+```
+
+---
+
+## Task 18: Wire Memory Agent History Extraction
+
+**Files:**
+
+- Modify: `packages/standalone/src/cli/commands/start.ts`
+
+- [ ] **Step 1: Connect history extractor to polling scheduler callback**
+
+Replace the TODO in Task 17's scheduler callback:
+
+```typescript
+const { classifyItemsByRole, buildHubExtractionPrompt, buildSpokeExtractionPrompt } =
+  await import('../../memory/history-extractor.js');
+
+// Build channel configs from connectors.json for role classification
+const allChannelConfigs: Record<string, Record<string, any>> = {};
+for (const [name, cc] of Object.entries(connectorsConfig)) {
+  allChannelConfigs[name] = (cc as any).channels ?? {};
+}
+
+let hubContext: any[] = []; // Accumulated from hub passes
+
+const scheduler = new PollingScheduler(
+  rawStore,
+  join(homedir(), '.mama', 'connectors'),
+  async (connectorName, items) => {
+    const { hub, spoke } = classifyItemsByRole(items, allChannelConfigs);
+
+    // Pass 1: Hub extraction
+    if (hub.length > 0) {
+      const prompt = buildHubExtractionPrompt(hub);
+      // Use memory agent to extract (reuse existing persistent process)
+      // The memory agent will call mama_save with appropriate scopes
+      try {
+        const result = await memoryAgentProcess.prompt(prompt);
+        // Parse JSON response to update hubContext
+        const match = result.match(/\[[\s\S]*\]/);
+        if (match) {
+          const extracted = JSON.parse(match[0]);
+          hubContext = [...hubContext, ...extracted];
+        }
+      } catch (err) {
+        console.error(`[connector:${connectorName}] hub extraction failed:`, err);
+      }
+    }
+
+    // Pass 2: Spoke extraction with hub context
+    if (spoke.length > 0 && hubContext.length > 0) {
+      const prompt = buildSpokeExtractionPrompt(spoke, hubContext);
+      try {
+        await memoryAgentProcess.prompt(prompt);
+      } catch (err) {
+        console.error(`[connector:${connectorName}] spoke extraction failed:`, err);
+      }
+    }
+  }
+);
+```
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+cd <project-root> && pnpm test
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/standalone/src/cli/commands/start.ts
+git commit -m "feat(connector): wire 2-pass history extraction to Memory Agent"
+```
+
+---
+
+## Task 19: Integration Test — End-to-End Connector Flow
+
+**Files:**
+
+- Create: `packages/standalone/tests/connectors/integration.test.ts`
+
+- [ ] **Step 1: Write integration test**
+
+```typescript
+// packages/standalone/tests/connectors/integration.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ConnectorRegistry } from '../../src/connectors/framework/connector-registry.js';
+import { PollingScheduler } from '../../src/connectors/framework/polling-scheduler.js';
+import { RawStore } from '../../src/connectors/framework/raw-store.js';
+import { classifyItemsByRole } from '../../src/memory/history-extractor.js';
+import type { IConnector, NormalizedItem } from '../../src/connectors/framework/types.js';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+function createMockHubConnector(): IConnector {
+  return {
+    name: 'chatwork',
+    type: 'api',
+    init: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn().mockResolvedValue(undefined),
+    healthCheck: vi.fn().mockResolvedValue({ healthy: true, lastPollTime: null, lastPollCount: 0 }),
+    getAuthRequirements: vi.fn().mockReturnValue([]),
+    authenticate: vi.fn().mockResolvedValue(true),
+    poll: vi.fn().mockResolvedValue([
+      {
+        source: 'chatwork',
+        sourceId: 'cw:1',
+        channel: 'project-alpha',
+        author: 'Alice',
+        content: 'Task-3 Bob님 부탁드립니다',
+        timestamp: new Date(),
+        type: 'message',
+      },
+    ] as NormalizedItem[]),
+  };
+}
+
+function createMockSpokeConnector(): IConnector {
+  return {
+    name: 'kakao',
+    type: 'api',
+    init: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn().mockResolvedValue(undefined),
+    healthCheck: vi.fn().mockResolvedValue({ healthy: true, lastPollTime: null, lastPollCount: 0 }),
+    getAuthRequirements: vi.fn().mockReturnValue([]),
+    authenticate: vi.fn().mockResolvedValue(true),
+    poll: vi.fn().mockResolvedValue([
+      {
+        source: 'kakao',
+        sourceId: 'kk:1',
+        channel: 'Bob',
+        author: 'Bob',
+        content: '3화 작업 시작합니다',
+        timestamp: new Date(),
+        type: 'message',
+      },
+    ] as NormalizedItem[]),
+  };
+}
+
+describe('Connector Integration', () => {
+  let tmpDir: string;
+  let rawStore: RawStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'integration-'));
+    rawStore = new RawStore(tmpDir);
+  });
+
+  afterEach(() => {
+    rawStore.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('full flow: register → poll → classify → extract', async () => {
+    const registry = new ConnectorRegistry();
+    registry.register('chatwork', createMockHubConnector());
+    registry.register('kakao', createMockSpokeConnector());
+
+    const collected: NormalizedItem[] = [];
+    const scheduler = new PollingScheduler(rawStore, tmpDir, async (name, items) => {
+      collected.push(...items);
+    });
+
+    // Poll both connectors
+    for (const [name, connector] of registry.getActive()) {
+      await scheduler.pollOnce(name, connector);
+    }
+
+    expect(collected).toHaveLength(2);
+
+    // Classify hub/spoke
+    const channelConfigs = {
+      chatwork: { project-alpha: { role: 'hub' as const } },
+      kakao: { Bob: { role: 'spoke' as const } },
+    };
+    const { hub, spoke } = classifyItemsByRole(collected, channelConfigs);
+    expect(hub).toHaveLength(1);
+    expect(spoke).toHaveLength(1);
+    expect(hub[0].content).toContain('Task-3');
+    expect(spoke[0].content).toContain('작업 시작');
+
+    // Verify raw store
+    const chatworkRaw = rawStore.query('chatwork', new Date(0));
+    const kakaoRaw = rawStore.query('kakao', new Date(0));
+    expect(chatworkRaw).toHaveLength(1);
+    expect(kakaoRaw).toHaveLength(1);
+
+    await scheduler.stop();
+  });
+});
+```
+
+- [ ] **Step 2: Run integration test**
+
+```bash
+cd <project-root> && pnpm vitest run tests/connectors/integration.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+cd <project-root> && pnpm test
+```
+
+Expected: All tests pass including new connector tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/standalone/tests/connectors/integration.test.ts
+git commit -m "test(connector): add end-to-end integration test"
+```
+
+---
+
+## Task 20: ~~Final — Version Bump + Changelog~~ (DONE — already committed)
+
+---
+
+# Phase 2: Truth-First 3-Pass Architecture
+
+> Tasks 0-20 completed the foundational 9 connectors + 2-pass extractor.
+> Tasks 21-28 extend to the full truth-first 3-pass architecture with 12 connectors.
+
+---
+
+## Task 21: Extend ChannelConfig roles + NormalizedItem types
+
+**Files:**
+
+- Modify: `packages/standalone/src/connectors/framework/types.ts`
+- Modify: `packages/standalone/tests/connectors/framework/types.test.ts`
+
+- [ ] **Step 1: Write failing tests for new roles and types**
+
+```typescript
+// Add to types.test.ts
+it('ChannelConfig supports truth/deliverable/reference roles', () => {
+  const truth: ChannelConfig = { role: 'truth', spreadsheetId: 'abc', sheetRange: 'A1:Z500' };
+  const deliverable: ChannelConfig = { role: 'deliverable', folderId: 'folder123' };
+  const reference: ChannelConfig = { role: 'reference' };
+  expect(truth.role).toBe('truth');
+  expect(deliverable.folderId).toBe('folder123');
+  expect(reference.role).toBe('reference');
+});
+
+it('NormalizedItem supports spreadsheet_row, kanban_card, file_change types', () => {
+  const types: NormalizedItem['type'][] = [
+    'message',
+    'email',
+    'event',
+    'document',
+    'note',
+    'spreadsheet_row',
+    'kanban_card',
+    'file_change',
+  ];
+  expect(types).toHaveLength(8);
+});
+```
+
+- [ ] **Step 2: Update types.ts**
+
+ChannelConfig.role: add `'truth' | 'deliverable' | 'reference'`
+ChannelConfig: add optional fields `spreadsheetId?, sheetRange?, boardId?, folderId?`
+NormalizedItem.type: add `'spreadsheet_row' | 'kanban_card' | 'file_change'`
+
+- [ ] **Step 3: Run tests, commit**
+
+```bash
+git commit -m "feat(connector): extend ChannelConfig roles + NormalizedItem types for 3-pass"
+```
+
+---
+
+## Task 22: Sheets Connector (Truth Source)
+
+**Files:**
+
+- Create: `packages/standalone/src/connectors/sheets/index.ts`
+- Create: `packages/standalone/tests/connectors/sheets.test.ts`
+
+**Key design:** Reads spreadsheet via `gws sheets spreadsheets values get`. Stores previous snapshot hash in connector state. On each poll, compares current vs previous and emits `spreadsheet_row` items for changed/new rows.
+
+```typescript
+class SheetsConnector implements IConnector {
+  name = 'sheets';
+  type = 'api';
+  private lastSnapshot: Map<string, string[][]> = new Map(); // channelName → rows
+
+  async poll(since: Date): Promise<NormalizedItem[]> {
+    for (const [name, cfg] of Object.entries(config.channels)) {
+      if (cfg.role === 'ignore') continue;
+      const params = JSON.stringify({
+        spreadsheetId: cfg.spreadsheetId,
+        range: cfg.sheetRange ?? 'A1:Z1000',
+      });
+      const result = this.execGws(`sheets spreadsheets values get --params '${params}'`);
+      const rows = result.values ?? [];
+      const headers = rows[0] ?? [];
+
+      // Compare with lastSnapshot → emit changed rows as NormalizedItem
+      const prev = this.lastSnapshot.get(name) ?? [];
+      for (let i = 1; i < rows.length; i++) {
+        const rowKey = rows[i][0] ?? String(i); // First column as key
+        const prevRow = prev[i];
+        if (!prevRow || JSON.stringify(prevRow) !== JSON.stringify(rows[i])) {
+          items.push({
+            source: 'sheets',
+            sourceId: `${cfg.spreadsheetId}:${rowKey}`,
+            channel: name,
+            author: 'spreadsheet',
+            content: headers.map((h, j) => `${h}: ${rows[i][j] ?? ''}`).join(' | '),
+            timestamp: new Date(),
+            type: 'spreadsheet_row',
+            metadata: { row: i, headers, values: rows[i] },
+          });
+        }
+      }
+      this.lastSnapshot.set(name, rows);
+    }
+  }
+}
+```
+
+- [ ] **Step 1: Write tests (mock execSync)**
+- [ ] **Step 2: Implement SheetsConnector**
+- [ ] **Step 3: Run tests, commit**
+
+---
+
+## Task 23: Trello Connector (Truth Source)
+
+**Files:**
+
+- Create: `packages/standalone/src/connectors/trello/index.ts`
+- Create: `packages/standalone/tests/connectors/trello.test.ts`
+
+**Key design:** Reads board lists + cards via Trello REST API. Tracks card position changes (which list a card is in). Emits `kanban_card` items for moved/changed cards.
+
+```typescript
+class TrelloConnector implements IConnector {
+  name = 'trello';
+  type = 'api';
+  private lastCardStates: Map<string, Map<string, string>> = new Map(); // board → cardId → listName
+
+  async poll(since: Date): Promise<NormalizedItem[]> {
+    for (const [name, cfg] of Object.entries(config.channels)) {
+      // GET /boards/{boardId}/lists?cards=open&card_fields=name,idMembers,dateLastActivity
+      const url = `https://api.trello.com/1/boards/${cfg.boardId}/lists?cards=open&card_fields=name,idMembers,dateLastActivity&key=${apiKey}&token=${token}`;
+      const lists = await fetch(url).then((r) => r.json());
+
+      const prevStates = this.lastCardStates.get(name) ?? new Map();
+      const currentStates = new Map<string, string>();
+
+      for (const list of lists) {
+        for (const card of list.cards ?? []) {
+          currentStates.set(card.id, list.name);
+          const prevList = prevStates.get(card.id);
+          if (prevList !== list.name) {
+            // Card moved or new
+            items.push({
+              source: 'trello',
+              sourceId: `${cfg.boardId}:${card.id}`,
+              channel: name,
+              author: 'trello',
+              content: `${card.name} | ${list.name}${prevList ? ` (from: ${prevList})` : ' (new)'}`,
+              timestamp: new Date(card.dateLastActivity),
+              type: 'kanban_card',
+              metadata: {
+                boardId: cfg.boardId,
+                listName: list.name,
+                prevListName: prevList,
+                cardName: card.name,
+              },
+            });
+          }
+        }
+      }
+      this.lastCardStates.set(name, currentStates);
+    }
+  }
+}
+```
+
+- [ ] **Step 1: Write tests (mock fetch)**
+- [ ] **Step 2: Implement TrelloConnector**
+- [ ] **Step 3: Run tests, commit**
+
+---
+
+## Task 24: Drive Connector (Deliverable Source)
+
+**Files:**
+
+- Create: `packages/standalone/src/connectors/drive/index.ts`
+- Create: `packages/standalone/tests/connectors/drive.test.ts`
+
+**Key design:** Uses `gws drive changes list` with pageToken for incremental change tracking. Filters by folderId. Emits `file_change` items.
+
+```typescript
+class DriveConnector implements IConnector {
+  name = 'drive';
+  type = 'api';
+  private pageTokens: Map<string, string> = new Map(); // channel → pageToken
+
+  async poll(since: Date): Promise<NormalizedItem[]> {
+    // Get or initialize pageToken
+    let pageToken = this.pageTokens.get('default');
+    if (!pageToken) {
+      const startToken = this.execGws("drive changes getStartPageToken --params '{}'");
+      pageToken = startToken.startPageToken;
+    }
+
+    const params = JSON.stringify({
+      pageToken,
+      pageSize: 100,
+      fields:
+        'changes(fileId,time,removed,file(name,mimeType,modifiedTime,lastModifyingUser,parents)),newStartPageToken',
+      includeRemoved: false,
+    });
+    const result = this.execGws(`drive changes list --params '${params}'`);
+
+    for (const change of result.changes ?? []) {
+      const file = change.file;
+      if (!file) continue;
+      // Filter by configured folder IDs
+      const matchedChannel = this.findChannelByParent(file.parents);
+      if (!matchedChannel) continue;
+
+      items.push({
+        source: 'drive',
+        sourceId: `${change.fileId}:${change.time}`,
+        channel: matchedChannel,
+        author: file.lastModifyingUser?.displayName ?? 'unknown',
+        content: `modified: ${file.name} (${file.mimeType})`,
+        timestamp: new Date(file.modifiedTime),
+        type: 'file_change',
+        metadata: { fileId: change.fileId, mimeType: file.mimeType, fileName: file.name },
+      });
+    }
+
+    this.pageTokens.set('default', result.newStartPageToken);
+  }
+}
+```
+
+- [ ] **Step 1: Write tests (mock execSync)**
+- [ ] **Step 2: Implement DriveConnector**
+- [ ] **Step 3: Run tests, commit**
+
+---
+
+## Task 25: Update connectors/index.ts
+
+**Files:**
+
+- Modify: `packages/standalone/src/connectors/index.ts`
+
+Add `'sheets', 'trello', 'drive'` to `AVAILABLE_CONNECTORS`.
+
+```bash
+git commit -m "feat(connector): add Sheets, Trello, Drive to available connectors"
+```
+
+---
+
+## Task 26: History Extractor — 3-Pass Refactor
+
+**Files:**
+
+- Modify: `packages/standalone/src/memory/history-extractor.ts`
+- Modify: `packages/standalone/tests/connectors/history-extractor.test.ts`
+
+**Changes:**
+
+1. `classifyItemsByRole` returns `{ truth, activity, spoke }` instead of `{ hub, spoke }`
+   - `truth`: role=truth items
+   - `activity`: role=hub + deliverable + reference, merged and sorted by timestamp
+   - `spoke`: role=spoke items
+
+2. Add `buildProjectTruth(truthItems)` — NO LLM needed
+   - Groups spreadsheet_row and kanban_card items by channel
+   - Returns `ProjectTruth` structure (project → work units → status → assigned)
+   - Pure data transformation
+
+3. Update `buildHubExtractionPrompt` → `buildActivityExtractionPrompt`
+   - Takes `activity: NormalizedItem[]` + `truth: ProjectTruth`
+   - Prompt includes project truth as context
+   - Instructs: "진실 대비 변경사항을 추출하세요"
+
+4. `buildSpokeExtractionPrompt` — keep, add ProjectTruth to context
+
+```typescript
+interface ProjectTruth {
+  projects: Record<
+    string,
+    {
+      workUnits: Record<
+        string,
+        {
+          status: string;
+          assigned?: string;
+          column?: string; // Trello column
+          metadata?: Record<string, string>;
+        }
+      >;
+    }
+  >;
+}
+
+function buildProjectTruth(truthItems: NormalizedItem[]): ProjectTruth {
+  // Parse spreadsheet_row items → project state
+  // Parse kanban_card items → card positions
+  // No LLM needed — structured data transformation
+}
+```
+
+- [ ] **Step 1: Write failing tests for new classification and ProjectTruth**
+- [ ] **Step 2: Refactor classifyItemsByRole return type**
+- [ ] **Step 3: Implement buildProjectTruth**
+- [ ] **Step 4: Update buildActivityExtractionPrompt with truth context**
+- [ ] **Step 5: Fix existing tests, run all, commit**
+
+```bash
+git commit -m "feat(connector): 3-pass history extractor with truth-first architecture"
+```
+
+---
+
+## Task 27: PollingScheduler — pollAll() Batch Mode
+
+**Files:**
+
+- Modify: `packages/standalone/src/connectors/framework/polling-scheduler.ts`
+- Modify: `packages/standalone/tests/connectors/framework/polling-scheduler.test.ts`
+
+**Add `pollAll()` method** alongside existing `pollOnce()`:
+
+```typescript
+type BatchExtractCallback = (classified: {
+  truth: NormalizedItem[];
+  activity: NormalizedItem[];
+  spoke: NormalizedItem[];
+}) => void | Promise<void>;
+
+class PollingScheduler {
+  // ... existing pollOnce/start/stop ...
+
+  async pollAll(
+    registry: ConnectorRegistry,
+    channelConfigs: Record<string, Record<string, ChannelConfig>>,
+    onBatchExtract: BatchExtractCallback
+  ): Promise<void> {
+    const allItems: NormalizedItem[] = [];
+
+    for (const [name, connector] of registry.getActive()) {
+      const since = this.lastPollTime.get(name) ?? oneDayAgo();
+      const items = await connector.poll(since);
+      if (items.length > 0) {
+        this.rawStore.save(name, items);
+        allItems.push(...items);
+      }
+      this.lastPollTime.set(name, new Date());
+    }
+
+    if (allItems.length > 0) {
+      const classified = classifyItemsByRole(allItems, channelConfigs);
+      await onBatchExtract(classified);
+    }
+
+    this.saveState();
+  }
+
+  // New: start with batch mode (single unified interval)
+  startBatch(
+    registry: ConnectorRegistry,
+    channelConfigs: Record<string, Record<string, ChannelConfig>>,
+    intervalMinutes: number,
+    onBatchExtract: BatchExtractCallback
+  ): void {
+    // Initial poll
+    this.pollAll(registry, channelConfigs, onBatchExtract);
+    // Periodic
+    this.batchTimer = setInterval(
+      () => this.pollAll(registry, channelConfigs, onBatchExtract),
+      intervalMinutes * 60_000
+    );
+  }
+}
+```
+
+- [ ] **Step 1: Write failing tests**
+- [ ] **Step 2: Implement pollAll + startBatch**
+- [ ] **Step 3: Run tests, commit**
+
+```bash
+git commit -m "feat(connector): add pollAll batch mode to PollingScheduler"
+```
+
+---
+
+## Task 28: Rewire start.ts — 3-Pass Extraction
+
+**Files:**
+
+- Modify: `packages/standalone/src/cli/commands/start.ts`
+
+Replace current per-connector callback with batch 3-pass:
+
+```typescript
+const {
+  classifyItemsByRole,
+  buildProjectTruth,
+  buildActivityExtractionPrompt,
+  buildSpokeExtractionPrompt,
+} = await import('../../memory/history-extractor.js');
+
+connectorScheduler.startBatch(
+  connectorRegistry,
+  allChannelConfigs,
+  60, // unified polling interval
+  async ({ truth, activity, spoke }) => {
+    // Pass 0: Truth → ProjectTruth (no LLM)
+    const projectTruth = buildProjectTruth(truth);
+    console.log(
+      `[connector] truth snapshot: ${Object.keys(projectTruth.projects).length} projects`
+    );
+
+    // Pass 1: Activity + Truth → LLM extraction
+    if (activity.length > 0) {
+      const prompt = buildActivityExtractionPrompt(activity, projectTruth);
+      console.log(
+        `[connector] activity extraction: ${activity.length} items, ${prompt.length} chars`
+      );
+      // TODO: Wire to memoryAgentProcess.prompt(prompt)
+    }
+
+    // Pass 2: Spoke + context → LLM extraction
+    if (spoke.length > 0) {
+      const prompt = buildSpokeExtractionPrompt(spoke, [
+        /* hubContext from Pass 1 */
+      ]);
+      console.log(`[connector] spoke extraction: ${spoke.length} items`);
+      // TODO: Wire to memoryAgentProcess.prompt(prompt)
+    }
+  }
+);
+```
+
+- [ ] **Step 1: Update start.ts connector block**
+- [ ] **Step 2: Run full test suite + typecheck**
+- [ ] **Step 3: Update CHANGELOG.md**
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(connector): wire 3-pass truth-first extraction pipeline"
+```

--- a/docs/superpowers/specs/2026-04-07-v0.17-connector-framework-design.md
+++ b/docs/superpowers/specs/2026-04-07-v0.17-connector-framework-design.md
@@ -1,0 +1,540 @@
+# MAMA OS v0.17 — Connector Framework & Project Intelligence
+
+**Date:** 2026-04-07
+**Status:** Revised (v2)
+**Scope:** Connector Framework + 12 Connectors + 3-Pass Memory Agent + CLI
+
+---
+
+## 1. Overview
+
+v0.17의 핵심 목표는 **"연결"** — MAMA OS가 다양한 데이터 소스에 직접 연결하여 프로젝트 인텔리전스 그래프를 구축한다.
+
+### 핵심 원칙
+
+- **Connector = 연결만** — 인증 + 데이터 파이프 제공. 추출/판단 로직 없음
+- **Memory Agent = 역사가** — 기록할 가치가 있는 것만 추출하여 mama-core에 구조화 저장
+- **Truth-First 3패스** — 진실의 원천(관리 문서, 칸반)을 먼저 읽고, 활동을 진실 대비로 분석하고, 작업자 채널을 프로젝트에 연결
+- **크로스소스 타임라인** — 모든 소스를 시간순으로 합쳐서 하나의 프로젝트 흐름으로 인식
+- **플러그인 아키텍처** — 필요한 커넥터만 활성화, 동적 로딩
+- **각 커넥터별 독립 DB** — raw 데이터는 소스별 DB에 보관, mama-core는 구조화된 지식
+
+### 설계 원칙이 도출된 배경
+
+| 문제                                                  | 해결                                                     |
+| ----------------------------------------------------- | -------------------------------------------------------- |
+| 운영 에이전트가 기록까지 하면 인지 예산 경쟁          | Memory Agent를 별도 프로세스로 분리 — 역사만 기록        |
+| 채널 중심 설계로 프로젝트 추적 불가 (1채널=N프로젝트) | 소스 역할 분류 (truth/hub/spoke) + keyword 매칭          |
+| 프로젝트가 여러 채널에 걸침                           | 크로스소스 시간순 합침 + 프로젝트 스코핑                 |
+| 결과물(파일)과 대화가 분리되어 흐름 추적 불가         | Drive를 deliverable 역할로 채널 활동과 합침              |
+| 프로젝트 상태의 기준이 불명확                         | 관리 문서/칸반을 truth 역할로 지정, Pass 0에서 먼저 처리 |
+| Haiku 등 별도 필터 레이어 비용                        | Memory Agent 프롬프트 품질로 노이즈 필터링               |
+
+---
+
+## 2. Source Role Classification
+
+모든 데이터 소스는 **역할**에 따라 분류된다. 역할이 Memory Agent의 처리 순서와 방식을 결정한다.
+
+```
+truth (진실의 원천) — 프로젝트 상태의 기준
+  관리 스프레드시트, 칸반 보드 등
+  → Pass 0에서 가장 먼저 읽어 프로젝트 스냅샷 생성
+
+hub (프로젝트 활동) — 이벤트/지시/피드백 발생
+  프로젝트 그룹 채널, 클라이언트 메일 등
+  → Pass 1에서 진실 대비 변경 감지
+
+deliverable (결과물) — 산출물 흐름 추적
+  공유 드라이브 폴더의 파일 업로드/수정
+  → Pass 1에서 hub 활동과 시간순으로 합쳐서 처리
+
+spoke (작업자) — hub에 연결되는 개인 채널
+  작업자 DM, 개인 메모
+  → Pass 2에서 프로젝트에 연결
+
+reference (참고) — 일정/문서 보충
+  캘린더, 위키/문서 도구
+  → Pass 1에서 보충 정보로 포함
+
+monitor (감시) — 외부 시스템이 이미 수집한 데이터
+  다른 에이전트의 DB 등
+  → 별도 커넥터로 raw 데이터 재활용
+```
+
+---
+
+## 3. Architecture
+
+### 3.1 전체 구조
+
+```
+MAMA OS Core
+├── mama-core (메모리 엔진 — mama-memory.db)
+├── Connector Framework
+│   ├── ConnectorRegistry (동적 로딩)
+│   ├── PollingScheduler (배치 폴링 + 시간순 합침)
+│   └── RawStore (커넥터별 SQLite)
+├── Memory Agent (3패스 추출 + 프로젝트 스코핑)
+└── CLI (mama connector add/config/list/status)
+
+Connectors (모노레포 내장, 동적 로딩, 12개)
+├── Truth: Sheets, Trello
+├── Hub: Slack, Chatwork, Gmail, Telegram, Discord
+├── Deliverable: Drive
+├── Reference: Calendar, Notion
+├── Spoke: Obsidian
+└── Monitor: Kagemusha
+```
+
+### 3.2 데이터 흐름
+
+```
+PollingScheduler.pollAll()
+│
+├── 1. 모든 활성 커넥터 폴링 → NormalizedItem[]
+├── 2. 역할별 분류 (truth / hub+deliverable+reference / spoke)
+├── 3. hub+deliverable+reference를 시간순으로 합침
+│
+└── Memory Agent 3패스 호출
+    ├── Pass 0: truth 소스 → ProjectTruth 스냅샷
+    ├── Pass 1: 합쳐진 활동 + ProjectTruth → 변경 추출
+    └── Pass 2: spoke + Pass 0+1 컨텍스트 → 프로젝트 연결
+        └── mama-core saveMemory (scope, kind, event_date)
+```
+
+### 3.3 파일 구조
+
+```
+packages/standalone/src/connectors/
+├── framework/
+│   ├── types.ts              ← IConnector, NormalizedItem, ChannelConfig (role 포함)
+│   ├── connector-registry.ts ← 동적 로딩 + lifecycle
+│   ├── polling-scheduler.ts  ← 배치 폴링 + 시간순 합침
+│   ├── raw-store.ts          ← 커넥터별 SQLite
+│   └── index.ts
+├── slack/index.ts
+├── chatwork/index.ts
+├── telegram/index.ts
+├── discord/index.ts
+├── gmail/index.ts
+├── calendar/index.ts
+├── drive/index.ts            ← 신규
+├── sheets/index.ts           ← 신규
+├── trello/index.ts           ← 신규
+├── notion/index.ts
+├── obsidian/index.ts
+├── kagemusha/index.ts
+└── index.ts
+
+packages/standalone/src/memory/
+└── history-extractor.ts      ← 3패스 추출 로직
+```
+
+### 3.4 런타임 디렉토리
+
+```
+~/.mama/
+├── mama-memory.db              ← mama-core (구조화된 지식)
+├── connectors.json             ← 전체 설정 (역할, 주기, 인증)
+└── connectors/
+    ├── slack/raw.db
+    ├── chatwork/raw.db
+    ├── drive/raw.db
+    ├── sheets/raw.db
+    ├── trello/raw.db
+    ├── ...
+    └── poll-state.json         ← 폴링 상태 영속
+```
+
+---
+
+## 4. Core Interfaces
+
+### 4.1 IConnector
+
+```typescript
+interface IConnector {
+  readonly name: string;
+  readonly type: 'api' | 'local';
+
+  init(config: ConnectorConfig): Promise<void>;
+  dispose(): Promise<void>;
+  healthCheck(): Promise<ConnectorHealth>;
+
+  getAuthRequirements(): AuthRequirement[];
+  authenticate(credentials: Record<string, string>): Promise<boolean>;
+
+  poll(since: Date): Promise<NormalizedItem[]>;
+}
+```
+
+### 4.2 NormalizedItem
+
+```typescript
+interface NormalizedItem {
+  source: string; // 'slack', 'gmail', 'drive', 'sheets', 'trello', ...
+  sourceId: string; // 원본 ID
+  channel: string; // 출처 채널/폴더/보드 이름
+  author: string;
+  content: string; // 텍스트 내용
+  timestamp: Date;
+  type:
+    | 'message'
+    | 'email'
+    | 'event'
+    | 'document'
+    | 'note'
+    | 'spreadsheet_row'
+    | 'kanban_card'
+    | 'file_change';
+  metadata?: Record<string, unknown>;
+}
+```
+
+### 4.3 ChannelConfig
+
+```typescript
+interface ChannelConfig {
+  role: 'truth' | 'hub' | 'deliverable' | 'spoke' | 'reference' | 'ignore';
+  name?: string;
+  keywords?: string[];
+  // truth 전용
+  spreadsheetId?: string;
+  sheetRange?: string;
+  boardId?: string;
+  // deliverable 전용
+  folderId?: string;
+  // spoke 전용
+  vaultPath?: string;
+  watchPatterns?: string[];
+}
+```
+
+### 4.4 ConnectorConfig
+
+```typescript
+interface ConnectorConfig {
+  enabled: boolean;
+  pollIntervalMinutes: number; // 최소 60
+  channels: Record<string, ChannelConfig>;
+  auth: AuthConfig;
+}
+
+interface AuthConfig {
+  type: 'cli' | 'token' | 'none';
+  cli?: string; // 'gws'
+  cliAuthCommand?: string; // 'gws auth login'
+  tokenName?: string; // 'SLACK_BOT_TOKEN'
+  token?: string;
+}
+
+type ConnectorsConfig = Record<string, ConnectorConfig>;
+```
+
+### 4.5 ConnectorHealth / AuthRequirement
+
+```typescript
+interface ConnectorHealth {
+  healthy: boolean;
+  lastPollTime: Date | null;
+  lastPollCount: number;
+  error?: string;
+}
+
+interface AuthRequirement {
+  type: 'cli' | 'token' | 'none';
+  cli?: string;
+  cliAuthCommand?: string;
+  tokenName?: string;
+  description: string;
+}
+```
+
+---
+
+## 5. PollingScheduler — 배치 모드
+
+```typescript
+class PollingScheduler {
+  // 모든 활성 커넥터를 한번에 폴링하고 역할별로 분류
+  async pollAll(): Promise<void> {
+    const allItems: Map<string, NormalizedItem[]> = new Map();
+
+    // 1. 모든 커넥터 폴링
+    for (const [name, connector] of registry.getActive()) {
+      const since = this.lastPollTime.get(name) ?? oneDayAgo();
+      const items = await connector.poll(since);
+      if (items.length > 0) {
+        this.rawStore.save(name, items);
+        allItems.set(name, items);
+      }
+      this.lastPollTime.set(name, new Date());
+    }
+
+    // 2. 역할별 분류 + 시간순 합침
+    const classified = classifyByRole(allItems, channelConfigs);
+    // classified = { truth: [...], activity: [...sorted by time], spoke: [...] }
+
+    // 3. Memory Agent 3패스 호출
+    await memoryAgent.extractThreePass(classified);
+
+    this.persistState();
+  }
+}
+```
+
+---
+
+## 6. Memory Agent — 3패스 추출
+
+### 6.1 Pass 0: Truth Snapshot
+
+```
+입력: truth 역할의 NormalizedItem[] (스프레드시트 행, 칸반 카드)
+출력: ProjectTruth — 프로젝트별 작업 단위 × 상태 × 담당자
+
+Memory Agent는 관리 문서의 현재 상태를 구조화된 스냅샷으로 변환:
+  Project A:
+    Work Unit 1: status=진행중, assigned=Worker1
+    Work Unit 2: status=대기, assigned=미정
+  Project B:
+    Work Unit 3: status=피드백, assigned=Worker2
+```
+
+### 6.2 Pass 1: Activity Extraction
+
+```
+입력:
+  - ProjectTruth (Pass 0 결과)
+  - hub + deliverable + reference의 NormalizedItem[] (시간순 합침)
+
+Memory Agent 프롬프트:
+  "현재 프로젝트 진실: {Pass 0 결과}
+   아래는 이번 기간의 크로스채널 활동입니다.
+   진실 대비 변경사항을 추출하세요."
+
+추출 대상:
+  - 상태 변경 (진행→제출 등)
+  - 결과물 업로드 (파일 변경)
+  - 결정/합의
+  - 일정 변경
+  - 교훈/문제-해결
+```
+
+### 6.3 Pass 2: Spoke Connection
+
+```
+입력:
+  - Pass 0+1 결과 (활성 프로젝트 + 최근 변경)
+  - spoke 역할의 NormalizedItem[]
+
+Memory Agent 프롬프트:
+  "활성 프로젝트: {Pass 0+1 결과}
+   아래 작업자 DM/메모를 관련 프로젝트에 연결하세요.
+   일상 대화는 무시하세요."
+```
+
+### 6.4 mama-core 저장
+
+```
+각 추출 항목 → saveMemory({
+  topic: "project_name/work_unit",
+  kind: "task" | "decision" | "lesson" | "schedule",
+  summary: "상태 변경 내용",
+  scopes: [{kind:'project', id:'project_name'}],
+  event_date: "YYYY-MM-DD",
+  details: "evidence 포함",
+})
+
+builds_on 에지로 같은 work_unit의 이전 노드에 연결 → 타임라인 형성
+```
+
+---
+
+## 7. Connectors 상세
+
+### 7.1 Truth Connectors
+
+**SheetsConnector**
+
+| 항목                | 값                                             |
+| ------------------- | ---------------------------------------------- |
+| API                 | `gws sheets spreadsheets values get` (gws CLI) |
+| 인증                | gws CLI (`gws auth login`)                     |
+| poll                | 설정된 range 전체 읽기, 이전 스냅샷과 diff     |
+| NormalizedItem.type | `spreadsheet_row`                              |
+| content             | 행 데이터를 key:value 형태로 포매팅            |
+| 참고                | 변경 감지: 셀 값 해시 비교 (이전 폴링 대비)    |
+
+**TrelloConnector**
+
+| 항목                | 값                                                          |
+| ------------------- | ----------------------------------------------------------- |
+| API                 | Trello REST API (`/boards/{id}/lists`, `/lists/{id}/cards`) |
+| 인증                | API Key + Token                                             |
+| poll                | 보드의 리스트/카드 전체 읽기, 이전 대비 카드 이동/변경 감지 |
+| NormalizedItem.type | `kanban_card`                                               |
+| content             | `{cardName}                                                 | {listName} | assigned: {members}` |
+
+### 7.2 Hub Connectors
+
+**SlackConnector** — `conversations.history` API, Bot Token 인증
+**ChatworkConnector** — `/rooms/{id}/messages` REST, API Token 인증
+**GmailConnector** — `gws gmail` CLI, `--params` JSON 형식
+**TelegramConnector** — Bot API `getUpdates`, offset 기반
+**DiscordConnector** — REST API `GET /channels/{id}/messages`, Bot Token
+
+### 7.3 Deliverable Connector
+
+**DriveConnector**
+
+| 항목                | 값                                                         |
+| ------------------- | ---------------------------------------------------------- |
+| API                 | `gws drive changes list` + `gws drive files get` (gws CLI) |
+| 인증                | gws CLI (`gws auth login`)                                 |
+| poll                | `changes.list(pageToken)` 으로 증분 변경 추적              |
+| NormalizedItem.type | `file_change`                                              |
+| content             | `{action}: {fileName} (by {author})`                       |
+| metadata            | fileId, mimeType, webViewLink                              |
+| 참고                | pageToken 영속 저장, 폴더별 필터링                         |
+
+### 7.4 Reference Connectors
+
+**CalendarConnector** — `gws calendar events list`, type=`event`
+**NotionConnector** — `POST /search` + block children, type=`document`
+
+### 7.5 Spoke / Monitor
+
+**ObsidianConnector** — 로컬 `.md` 파일 mtime 감시, type=`note`
+**KagemushaConnector** — `channel_messages` 테이블 읽기, type=`message`
+
+---
+
+## 8. CLI
+
+```bash
+mama connector list              # 전체 커넥터 + 상태
+mama connector add <name>        # 활성화 + 인증 안내
+mama connector remove <name>     # 비활성화
+mama connector status            # health + 마지막 폴링
+```
+
+설정: `~/.mama/connectors.json`
+
+---
+
+## 9. Configuration Example
+
+```json
+{
+  "sheets": {
+    "enabled": true,
+    "pollIntervalMinutes": 60,
+    "channels": {
+      "management": {
+        "role": "truth",
+        "spreadsheetId": "<SPREADSHEET_ID>",
+        "sheetRange": "A1:Z500"
+      }
+    },
+    "auth": { "type": "cli", "cli": "gws" }
+  },
+  "trello": {
+    "enabled": true,
+    "pollIntervalMinutes": 60,
+    "channels": {
+      "project-a": { "role": "truth", "boardId": "<BOARD_ID>" }
+    },
+    "auth": { "type": "token", "tokenName": "TRELLO_TOKEN" }
+  },
+  "chatwork": {
+    "enabled": true,
+    "pollIntervalMinutes": 60,
+    "channels": {
+      "<ROOM_ID>": { "role": "hub", "name": "Project A Channel" }
+    },
+    "auth": { "type": "token", "tokenName": "CHATWORK_API_TOKEN" }
+  },
+  "drive": {
+    "enabled": true,
+    "pollIntervalMinutes": 60,
+    "channels": {
+      "project-a": { "role": "deliverable", "folderId": "<FOLDER_ID>" }
+    },
+    "auth": { "type": "cli", "cli": "gws" }
+  },
+  "slack": {
+    "enabled": true,
+    "pollIntervalMinutes": 60,
+    "channels": {
+      "<CHANNEL_ID>": { "role": "hub", "name": "Project B" }
+    },
+    "auth": { "type": "token", "tokenName": "SLACK_BOT_TOKEN" }
+  },
+  "gmail": {
+    "enabled": true,
+    "pollIntervalMinutes": 120,
+    "channels": {
+      "inbox": { "role": "hub" }
+    },
+    "auth": { "type": "cli", "cli": "gws" }
+  },
+  "calendar": {
+    "enabled": true,
+    "pollIntervalMinutes": 60,
+    "channels": {
+      "primary": { "role": "reference" }
+    },
+    "auth": { "type": "cli", "cli": "gws" }
+  },
+  "notion": {
+    "enabled": true,
+    "pollIntervalMinutes": 120,
+    "channels": {
+      "workspace": { "role": "reference" }
+    },
+    "auth": { "type": "token", "tokenName": "NOTION_TOKEN" }
+  },
+  "obsidian": {
+    "enabled": true,
+    "pollIntervalMinutes": 60,
+    "channels": {
+      "vault": { "role": "spoke", "vaultPath": "~/Documents/Obsidian/Main" }
+    },
+    "auth": { "type": "none" }
+  }
+}
+```
+
+---
+
+## 10. mama-core 변경
+
+- `MEMORY_KINDS`에 `task`, `schedule` 추가 (DB 스키마 변경 없음)
+- `NormalizedItem.type`에 `spreadsheet_row`, `kanban_card`, `file_change` 추가
+
+---
+
+## 11. 제외 사항
+
+| 항목                   | 이유                         | 예상 버전 |
+| ---------------------- | ---------------------------- | --------- |
+| Haiku 필터 레이어      | Memory Agent 프롬프트로 충분 | 불필요    |
+| npm 패키지 분리        | 모노레포로 충분              | v0.18+    |
+| Web UI (Control Tower) | 연결 우선                    | v0.18+    |
+| Watchdog/Auto-restart  | 안정성은 연결 후             | v0.19     |
+
+---
+
+## 12. 성공 기준
+
+1. `mama connector add slack` → 인증 → 채널 설정 → 폴링 시작까지 작동
+2. 12개 커넥터 모두 `poll()` → `NormalizedItem[]` 반환
+3. Truth 소스 (관리 시트, 칸반)에서 프로젝트 상태 스냅샷 생성
+4. 크로스소스 시간순 합침 후 Memory Agent가 프로젝트 변경 추출
+5. Spoke 채널이 hub 프로젝트에 올바르게 연결
+6. Drive 파일 변경이 채널 활동과 같은 타임라인에 포함
+7. 프로젝트 단위 질의 가능: 특정 작업의 크로스채널 타임라인 응답
+8. 각 커넥터의 `raw.db`에 원본 데이터 보관
+9. 기존 테스트 전체 통과 + 신규 커넥터 테스트 추가

--- a/packages/mama-core/db/migrations/025-extend-kind-check.sql
+++ b/packages/mama-core/db/migrations/025-extend-kind-check.sql
@@ -1,0 +1,59 @@
+-- v0.17: Extend kind CHECK constraint to include 'task' and 'schedule'.
+-- Only runs if the old CHECK exists (idempotent).
+-- Uses a temp table approach since SQLite cannot ALTER CHECK constraints.
+
+-- Drop the old column constraint by recreating the table
+-- This is safe because we explicitly list all columns
+
+CREATE TABLE IF NOT EXISTS decisions_v17 (
+  id TEXT PRIMARY KEY,
+  topic TEXT NOT NULL,
+  decision TEXT NOT NULL,
+  reasoning TEXT,
+  outcome TEXT,
+  failure_reason TEXT,
+  limitation TEXT,
+  user_involvement TEXT,
+  session_id TEXT,
+  supersedes TEXT,
+  superseded_by TEXT,
+  refined_from TEXT,
+  confidence REAL DEFAULT 0.5 CHECK (confidence >= 0.0 AND confidence <= 1.0),
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000),
+  updated_at INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000),
+  needs_validation INTEGER DEFAULT 0 CHECK (needs_validation IN (0, 1)),
+  validation_attempts INTEGER DEFAULT 0,
+  last_validated_at INTEGER,
+  usage_count INTEGER DEFAULT 0,
+  trust_context TEXT,
+  usage_success INTEGER DEFAULT 0,
+  usage_failure INTEGER DEFAULT 0,
+  time_saved INTEGER DEFAULT 0,
+  evidence TEXT,
+  alternatives TEXT,
+  risks TEXT,
+  event_date TEXT,
+  kind TEXT DEFAULT 'decision'
+    CHECK (kind IN ('decision', 'preference', 'constraint', 'lesson', 'fact', 'task', 'schedule')),
+  status TEXT DEFAULT 'active'
+    CHECK (status IN ('active', 'superseded', 'contradicted', 'stale')),
+  summary TEXT,
+  is_static INTEGER DEFAULT 0
+);
+
+INSERT OR IGNORE INTO decisions_v17 (
+  id, topic, decision, reasoning, outcome, failure_reason, limitation,
+  user_involvement, session_id, supersedes, superseded_by, refined_from,
+  confidence, created_at, updated_at, needs_validation, validation_attempts,
+  last_validated_at, usage_count, trust_context, usage_success, usage_failure,
+  time_saved, evidence, alternatives, risks, event_date, kind, status, summary, is_static
+) SELECT
+  id, topic, decision, reasoning, outcome, failure_reason, limitation,
+  user_involvement, session_id, supersedes, superseded_by, refined_from,
+  confidence, created_at, updated_at, needs_validation, validation_attempts,
+  last_validated_at, usage_count, trust_context, usage_success, usage_failure,
+  time_saved, evidence, alternatives, risks, event_date, kind, status, summary, is_static
+FROM decisions;
+
+DROP TABLE decisions;
+ALTER TABLE decisions_v17 RENAME TO decisions;

--- a/packages/mama-core/src/memory/types.ts
+++ b/packages/mama-core/src/memory/types.ts
@@ -1,7 +1,15 @@
 export const MEMORY_SCOPE_KINDS = ['global', 'user', 'channel', 'project'] as const;
 export type MemoryScopeKind = (typeof MEMORY_SCOPE_KINDS)[number];
 
-export const MEMORY_KINDS = ['decision', 'preference', 'constraint', 'lesson', 'fact'] as const;
+export const MEMORY_KINDS = [
+  'decision',
+  'preference',
+  'constraint',
+  'lesson',
+  'fact',
+  'task',
+  'schedule',
+] as const;
 export type MemoryKind = (typeof MEMORY_KINDS)[number];
 
 export const MEMORY_STATUSES = ['active', 'superseded', 'contradicted', 'stale'] as const;

--- a/packages/mama-core/tests/unit/memory-kinds.test.ts
+++ b/packages/mama-core/tests/unit/memory-kinds.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { MEMORY_KINDS } from '../../src/memory/types.js';
+import type { MemoryKind } from '../../src/memory/types.js';
+
+describe('MEMORY_KINDS', () => {
+  it('includes task and schedule kinds for v0.17 connector extraction', () => {
+    expect(MEMORY_KINDS).toContain('task');
+    expect(MEMORY_KINDS).toContain('schedule');
+  });
+
+  it('task and schedule are valid MemoryKind values', () => {
+    const task: MemoryKind = 'task';
+    const schedule: MemoryKind = 'schedule';
+    expect(task).toBe('task');
+    expect(schedule).toBe('schedule');
+  });
+
+  it('preserves all existing kinds', () => {
+    expect(MEMORY_KINDS).toContain('decision');
+    expect(MEMORY_KINDS).toContain('preference');
+    expect(MEMORY_KINDS).toContain('constraint');
+    expect(MEMORY_KINDS).toContain('lesson');
+    expect(MEMORY_KINDS).toContain('fact');
+  });
+});

--- a/packages/mcp-server/src/server.js
+++ b/packages/mcp-server/src/server.js
@@ -26,7 +26,6 @@ const {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } = require('@modelcontextprotocol/sdk/types.js');
-const path = require('path');
 
 // Import all MAMA tools from src/tools/ — single source of truth for tool definitions
 const { createMemoryTools } = require('./tools/index.js');
@@ -35,8 +34,6 @@ const mama = require('@jungjaehoon/mama-core/mama-api');
 
 // Import core modules from mama-core
 const { initDB } = require('@jungjaehoon/mama-core/db-manager');
-const { generateEmbedding } = require('@jungjaehoon/mama-core/embeddings');
-const { vectorSearch } = require('@jungjaehoon/mama-core/memory-store');
 const embeddingServer = require('@jungjaehoon/mama-core/embedding-server');
 const http = require('http');
 
@@ -369,24 +366,11 @@ After failure → save a NEW decision with same topic to create evolution histor
           required: ['id', 'outcome'],
         },
       },
-      // 4. SEARCH_DECISIONS_AND_CONTRACTS — PreToolUse hook RPC
+      // 4. SEARCH_DECISIONS_AND_CONTRACTS — PreToolUse hook RPC (defined in src/tools/)
       {
-        name: 'search_decisions_and_contracts',
-        description: 'Search decisions and contracts for PreToolUse hook injection.',
-        inputSchema: {
-          type: 'object',
-          properties: {
-            query: { type: 'string', description: 'Search query for decisions.' },
-            filePath: { type: 'string', description: 'File path context.' },
-            toolName: { type: 'string', description: 'Tool name (Edit/Write/apply_patch).' },
-            decisionLimit: { type: 'number', description: 'Max decisions (default: 5).' },
-            contractLimit: { type: 'number', description: 'Max contracts (default: 3).' },
-            similarityThreshold: {
-              type: 'number',
-              description: 'Similarity threshold (default: 0.7).',
-            },
-          },
-        },
+        name: memoryTools.search_decisions_and_contracts.name,
+        description: memoryTools.search_decisions_and_contracts.description,
+        inputSchema: memoryTools.search_decisions_and_contracts.inputSchema,
       },
     ];
 
@@ -589,74 +573,6 @@ After failure → save a NEW decision with same topic to create evolution histor
       success: true,
       count: limited.length,
       results: limited,
-    };
-  }
-
-  /**
-   * Handle PreToolUse search for decisions + contracts
-   */
-  async handleSearchDecisionsAndContracts(args = {}) {
-    const {
-      query = '',
-      filePath = '',
-      toolName = '',
-      decisionLimit = 5,
-      contractLimit = 3,
-      similarityThreshold = 0.7,
-    } = args;
-
-    await initDB();
-
-    let decisionResults = [];
-    let contractResults = [];
-
-    // Decision search
-    if (decisionLimit > 0 && query) {
-      try {
-        const queryEmbedding = await generateEmbedding(query);
-        const results = await vectorSearch(queryEmbedding, decisionLimit, similarityThreshold);
-        if (Array.isArray(results)) {
-          decisionResults = results.slice(0, decisionLimit);
-        }
-      } catch (err) {
-        console.error('[MAMA MCP] Decision search failed:', err.message);
-      }
-    }
-
-    // Contract search (file-specific)
-    const contractTools = ['Edit', 'Write', 'apply_patch'];
-    const codeExtensions = ['.js', '.ts', '.jsx', '.tsx', '.py', '.go', '.rs', '.java'];
-    const ext = filePath ? path.extname(filePath) : '';
-
-    if (
-      contractLimit > 0 &&
-      filePath &&
-      contractTools.includes(toolName) &&
-      codeExtensions.includes(ext)
-    ) {
-      const basename = path.basename(filePath, ext);
-      const keywords = basename.split(/[-_]/).filter(Boolean);
-      const contractQuery = `contract api ${keywords.join(' ')}`.trim();
-
-      if (contractQuery) {
-        try {
-          const contractEmbedding = await generateEmbedding(contractQuery);
-          const contractMatches = await vectorSearch(contractEmbedding, 10, similarityThreshold);
-          if (Array.isArray(contractMatches)) {
-            contractResults = contractMatches
-              .filter((r) => r.topic && r.topic.startsWith('contract_'))
-              .slice(0, contractLimit);
-          }
-        } catch (err) {
-          console.error('[MAMA MCP] Contract search failed:', err.message);
-        }
-      }
-    }
-
-    return {
-      success: true,
-      decisionResults,
-      contractResults,
     };
   }
 

--- a/packages/mcp-server/src/tools/index.js
+++ b/packages/mcp-server/src/tools/index.js
@@ -29,6 +29,7 @@ const { saveCheckpointTool, loadCheckpointTool } = require('./checkpoint-tools.j
 const { searchNarrativeTool } = require('./search-narrative.js');
 const { generateQualityReportTool, getRestartMetricsTool } = require('./quality-metrics-tools.js');
 const { ingestConversationTool } = require('./ingest-conversation.js');
+const { searchDecisionsAndContractsTool } = require('./search-decisions-and-contracts.js');
 
 /**
  * Create all MAMA memory tools
@@ -50,6 +51,7 @@ function createMemoryTools() {
     generate_quality_report: generateQualityReportTool,
     get_restart_metrics: getRestartMetricsTool,
     ingest_conversation: ingestConversationTool,
+    search_decisions_and_contracts: searchDecisionsAndContractsTool,
   };
 }
 
@@ -67,4 +69,5 @@ module.exports = {
   generateQualityReportTool,
   getRestartMetricsTool,
   ingestConversationTool,
+  searchDecisionsAndContractsTool,
 };

--- a/packages/mcp-server/src/tools/search-decisions-and-contracts.js
+++ b/packages/mcp-server/src/tools/search-decisions-and-contracts.js
@@ -1,0 +1,109 @@
+/**
+ * MCP Tool: search_decisions_and_contracts
+ *
+ * PreToolUse hook RPC — searches decisions and contract-specific memories
+ * for file-aware context injection before Edit/Write/apply_patch tool calls.
+ *
+ * @module search-decisions-and-contracts
+ */
+
+const path = require('path');
+const { initDB } = require('@jungjaehoon/mama-core/db-manager');
+const { generateEmbedding } = require('@jungjaehoon/mama-core/embeddings');
+const { vectorSearch } = require('@jungjaehoon/mama-core/memory-store');
+
+/**
+ * search_decisions_and_contracts tool definition
+ */
+const searchDecisionsAndContractsTool = {
+  name: 'search_decisions_and_contracts',
+  description: 'Search decisions and contracts for PreToolUse hook injection.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: { type: 'string', description: 'Search query for decisions.' },
+      filePath: { type: 'string', description: 'File path context.' },
+      toolName: { type: 'string', description: 'Tool name (Edit/Write/apply_patch).' },
+      decisionLimit: { type: 'number', description: 'Max decisions (default: 5).' },
+      contractLimit: { type: 'number', description: 'Max contracts (default: 3).' },
+      similarityThreshold: {
+        type: 'number',
+        description: 'Similarity threshold (default: 0.7).',
+      },
+    },
+  },
+
+  async handler(args = {}) {
+    try {
+      const {
+        query = '',
+        filePath = '',
+        toolName = '',
+        decisionLimit = 5,
+        contractLimit = 3,
+        similarityThreshold = 0.7,
+      } = args;
+
+      await initDB();
+
+      let decisionResults = [];
+      let contractResults = [];
+
+      // Decision search
+      if (decisionLimit > 0 && query) {
+        try {
+          const queryEmbedding = await generateEmbedding(query);
+          const results = await vectorSearch(queryEmbedding, decisionLimit, similarityThreshold);
+          if (Array.isArray(results)) {
+            decisionResults = results.slice(0, decisionLimit);
+          }
+        } catch (err) {
+          console.error('[MAMA MCP] Decision search failed:', err.message);
+        }
+      }
+
+      // Contract search (file-specific)
+      const contractTools = ['Edit', 'Write', 'apply_patch'];
+      const codeExtensions = ['.js', '.ts', '.jsx', '.tsx', '.py', '.go', '.rs', '.java'];
+      const ext = filePath ? path.extname(filePath) : '';
+
+      if (
+        contractLimit > 0 &&
+        filePath &&
+        contractTools.includes(toolName) &&
+        codeExtensions.includes(ext)
+      ) {
+        const basename = path.basename(filePath, ext);
+        const keywords = basename.split(/[-_]/).filter(Boolean);
+        const contractQuery = `contract api ${keywords.join(' ')}`.trim();
+
+        if (contractQuery) {
+          try {
+            const contractEmbedding = await generateEmbedding(contractQuery);
+            const contractMatches = await vectorSearch(contractEmbedding, 10, similarityThreshold);
+            if (Array.isArray(contractMatches)) {
+              contractResults = contractMatches
+                .filter((r) => r.topic && r.topic.startsWith('contract_'))
+                .slice(0, contractLimit);
+            }
+          } catch (err) {
+            console.error('[MAMA MCP] Contract search failed:', err.message);
+          }
+        }
+      }
+
+      return {
+        success: true,
+        decisionResults,
+        contractResults,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  },
+};
+
+module.exports = { searchDecisionsAndContractsTool };

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "MAMA OS - Your AI Operating System. Control + Visibility for AI-Powered Automation",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/standalone/src/agent/gateway-tools.md
+++ b/packages/standalone/src/agent/gateway-tools.md
@@ -5,7 +5,6 @@ Call tools via JSON block:
 ```tool_call
 {"name": "tool_name", "input": {"param1": "value1"}}
 ```
-
 ## MAMA Memory
 
 - **mama_save**() — Save decision (topic, decision, reasoning) or checkpoint (summary, next_steps?)
@@ -66,7 +65,6 @@ Call tools via JSON block:
 ## Code-Act Sandbox
 
 - **code_act**() — Execute JavaScript in sandboxed QuickJS
-
 ## Sending Media to Webchat
 
 To display images in webchat, you MUST include the full file path in your response text.

--- a/packages/standalone/src/cli/commands/connector.ts
+++ b/packages/standalone/src/cli/commands/connector.ts
@@ -1,0 +1,175 @@
+/**
+ * mama connector command
+ *
+ * Manage data source connectors (list, add, remove, status).
+ * Config file: ~/.mama/connectors.json
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { Command } from 'commander';
+
+import { AVAILABLE_CONNECTORS, loadConnector } from '../../connectors/index.js';
+import type { ConnectorsConfig, ConnectorConfig } from '../../connectors/index.js';
+
+const CONNECTORS_CONFIG_PATH = join(homedir(), '.mama', 'connectors.json');
+
+function loadConnectorsConfig(): ConnectorsConfig {
+  if (!existsSync(CONNECTORS_CONFIG_PATH)) return {};
+  try {
+    return JSON.parse(readFileSync(CONNECTORS_CONFIG_PATH, 'utf-8')) as ConnectorsConfig;
+  } catch {
+    return {};
+  }
+}
+
+function saveConnectorsConfig(config: ConnectorsConfig): void {
+  const dir = join(homedir(), '.mama');
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(CONNECTORS_CONFIG_PATH, JSON.stringify(config, null, 2), 'utf-8');
+}
+
+export function createConnectorCommand(): Command {
+  const cmd = new Command('connector').description('Manage data source connectors');
+
+  // ── list ────────────────────────────────────────────────────────────────────
+  cmd
+    .command('list')
+    .description('List all connectors and their status')
+    .action(() => {
+      const config = loadConnectorsConfig();
+
+      console.log('\nAvailable connectors:\n');
+      for (const name of AVAILABLE_CONNECTORS) {
+        const connectorCfg = config[name];
+        const enabled = connectorCfg?.enabled ?? false;
+        const status = enabled ? '✓ enabled ' : '✗ disabled';
+        const interval = connectorCfg?.pollIntervalMinutes
+          ? ` (poll: ${connectorCfg.pollIntervalMinutes}m)`
+          : '';
+        console.log(`  ${status}  ${name}${interval}`);
+      }
+      console.log('');
+    });
+
+  // ── add ─────────────────────────────────────────────────────────────────────
+  cmd
+    .command('add <name>')
+    .description('Enable a connector')
+    .action(async (name: string) => {
+      if (!(AVAILABLE_CONNECTORS as readonly string[]).includes(name)) {
+        console.error(`Unknown connector: ${name}`);
+        console.error(`Available: ${AVAILABLE_CONNECTORS.join(', ')}`);
+        process.exitCode = 1;
+        return;
+      }
+
+      const config = loadConnectorsConfig();
+
+      // Build a default enabled config if not present
+      if (!config[name]) {
+        config[name] = {
+          enabled: true,
+          pollIntervalMinutes: 60,
+          channels: {},
+          auth: { type: 'none' },
+        } satisfies ConnectorConfig;
+      } else {
+        config[name]!.enabled = true;
+      }
+
+      saveConnectorsConfig(config);
+      console.log(`\n✓ Connector '${name}' enabled.\n`);
+
+      // Show auth requirements
+      try {
+        const connector = await loadConnector(name, config[name]);
+        const reqs = connector.getAuthRequirements();
+        if (reqs.length > 0) {
+          console.log('Auth requirements:');
+          for (const req of reqs) {
+            console.log(`  • ${req.description}`);
+            if (req.type === 'token' && req.tokenName) {
+              console.log(`    Set env: ${req.tokenName}`);
+            }
+            if (req.type === 'cli' && req.cliAuthCommand) {
+              console.log(`    Run: ${req.cliAuthCommand}`);
+            }
+          }
+          console.log('');
+        }
+      } catch {
+        // Auth requirements display is best-effort
+      }
+    });
+
+  // ── remove ──────────────────────────────────────────────────────────────────
+  cmd
+    .command('remove <name>')
+    .description('Disable a connector')
+    .action((name: string) => {
+      if (!(AVAILABLE_CONNECTORS as readonly string[]).includes(name)) {
+        console.error(`Unknown connector: ${name}`);
+        console.error(`Available: ${AVAILABLE_CONNECTORS.join(', ')}`);
+        process.exitCode = 1;
+        return;
+      }
+
+      const config = loadConnectorsConfig();
+
+      if (!config[name]) {
+        console.log(`Connector '${name}' is already disabled (no config found).`);
+        return;
+      }
+
+      config[name]!.enabled = false;
+      saveConnectorsConfig(config);
+      console.log(`\n✓ Connector '${name}' disabled.\n`);
+    });
+
+  // ── status ──────────────────────────────────────────────────────────────────
+  cmd
+    .command('status')
+    .description('Show connector health and last poll times')
+    .action(async () => {
+      const config = loadConnectorsConfig();
+      const enabledNames = AVAILABLE_CONNECTORS.filter((name) => config[name]?.enabled === true);
+
+      if (enabledNames.length === 0) {
+        console.log('\nNo connectors enabled. Run: mama connector add <name>\n');
+        return;
+      }
+
+      console.log('\nConnector health:\n');
+
+      await Promise.all(
+        enabledNames.map(async (name) => {
+          let connector: Awaited<ReturnType<typeof loadConnector>> | undefined;
+          try {
+            connector = await loadConnector(name, config[name]);
+            await connector.init();
+            const health = await connector.healthCheck();
+
+            const statusIcon = health.healthy ? '✓' : '✗';
+            const lastPoll = health.lastPollTime ? health.lastPollTime.toLocaleString() : 'never';
+            console.log(`  ${statusIcon} ${name}`);
+            console.log(`      last poll: ${lastPoll}  items: ${health.lastPollCount}`);
+            if (health.error) {
+              console.log(`      error: ${health.error}`);
+            }
+          } catch (err) {
+            console.log(`  ✗ ${name}`);
+            console.log(`      error: ${err instanceof Error ? err.message : String(err)}`);
+          } finally {
+            await connector?.dispose();
+          }
+        })
+      );
+
+      console.log('');
+    });
+
+  return cmd;
+}

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -1326,6 +1326,9 @@ export async function runAgentLoop(
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const mamaCore = require('@jungjaehoon/mama-core');
 
+  // Connector extraction function — set when Claude CLI extraction process is ready
+  let connectorExtractionFn: ((prompt: string) => Promise<string>) | null = null;
+
   // Set extraction backend to Claude CLI persistent session (no API key needed)
   if (mamaCore.setExtractionFn) {
     const { PersistentClaudeProcess } = await import('../../agent/persistent-cli-process.js');
@@ -1389,6 +1392,13 @@ export async function runAgentLoop(
       const result = await proc.sendMessage(prompt);
       return parseExtractionResponse(result.response);
     });
+
+    // Expose extraction for connector pipeline
+    connectorExtractionFn = async (prompt: string): Promise<string> => {
+      const proc = await getExtractionProcess();
+      const result = await proc.sendMessage(prompt);
+      return result.response;
+    };
   }
 
   const mamaApi = (
@@ -2283,6 +2293,174 @@ export async function runAgentLoop(
     },
   });
   tokenKeepAlive.start();
+
+  // === Connector Framework ===
+  const connectorsConfigPath = join(homedir(), '.mama', 'connectors.json');
+  if (existsSync(connectorsConfigPath)) {
+    const { ConnectorRegistry, PollingScheduler, RawStore } =
+      await import('../../connectors/framework/index.js');
+    const { loadConnector } = await import('../../connectors/index.js');
+    const {
+      buildProjectTruth, buildActivityExtractionPrompt, buildSpokeExtractionPrompt, groupByChannel,
+    } = await import('../../memory/history-extractor.js');
+    const { saveMemory, MEMORY_KINDS } = await import('@jungjaehoon/mama-core');
+    type MemoryKind = import('@jungjaehoon/mama-core').MemoryKind;
+    type ConnectorsJson = import('../../connectors/framework/types.js').ConnectorsConfig;
+    type ChannelConfigMap = import('../../connectors/framework/types.js').ChannelConfig;
+    type NormalizedItem = import('../../connectors/framework/types.js').NormalizedItem;
+
+    let connectorsConfig: ConnectorsJson;
+    try {
+      connectorsConfig = JSON.parse(readFileSync(connectorsConfigPath, 'utf-8')) as ConnectorsJson;
+    } catch (err) {
+      console.error(`[connector] failed to parse connectors.json:`, err);
+      connectorsConfig = {} as ConnectorsJson;
+    }
+    const connectorRegistry = new ConnectorRegistry();
+    const rawStore = new RawStore(join(homedir(), '.mama', 'connectors'));
+
+    // Build channel configs for role classification
+    // For kagemusha connector, channels are keyed as "source:channelId" (e.g., "chatwork:ROOM_ID")
+    // but items have source=row.channel (e.g., "chatwork") and channel=row.channel_id (e.g., "chatwork:ROOM_ID")
+    // So we need to distribute kagemusha channel configs by their source prefix
+    const allChannelConfigs: Record<string, Record<string, ChannelConfigMap>> = {};
+    for (const [name, cc] of Object.entries(connectorsConfig)) {
+      if (name === 'kagemusha') {
+        // Distribute kagemusha channels by source prefix
+        for (const [channelKey, channelCfg] of Object.entries(cc.channels ?? {})) {
+          const [source] = channelKey.split(':');
+          if (!allChannelConfigs[source]) allChannelConfigs[source] = {};
+          allChannelConfigs[source][channelKey] = channelCfg;
+        }
+      } else {
+        allChannelConfigs[name] = cc.channels ?? {};
+      }
+    }
+
+    for (const [name, connConfig] of Object.entries(connectorsConfig)) {
+      if (!connConfig.enabled) continue;
+      try {
+        const connector = await loadConnector(name, connConfig);
+        await connector.init();
+        connectorRegistry.register(name, connector);
+        console.log(`[connector] ${name} initialized`);
+      } catch (err) {
+        console.error(`[connector] ${name} failed to init:`, err);
+      }
+    }
+
+    if (connectorRegistry.getActive().size > 0) {
+      const connectorScheduler = new PollingScheduler(
+        rawStore,
+        join(homedir(), '.mama', 'connectors')
+      );
+
+      const validKinds = new Set<string>(MEMORY_KINDS);
+
+      const extractAndSave = async (
+        label: string,
+        groups: Map<string, NormalizedItem[]>,
+        buildPrompt: (items: NormalizedItem[]) => string
+      ): Promise<void> => {
+        for (const [channelKey, channelItems] of groups) {
+          const prompt = buildPrompt(channelItems);
+          if (prompt.length > 20000) {
+            console.log(
+              `[connector] ${label}:${channelKey} skipped (prompt too large: ${prompt.length})`
+            );
+            continue;
+          }
+          try {
+            if (!connectorExtractionFn) throw new Error('Extraction not available');
+            const responseText = await connectorExtractionFn(prompt);
+            const jsonMatch = responseText.match(/\[[\s\S]*\]/);
+            if (jsonMatch) {
+              const extracted = JSON.parse(jsonMatch[0]) as Array<{
+                project?: string;
+                work_unit?: string;
+                kind?: string;
+                topic?: string;
+                summary?: string;
+                reasoning?: string;
+                event_date?: string;
+                confidence?: number;
+              }>;
+              for (const item of extracted) {
+                if (!item.topic || !item.summary) continue;
+                const projectName = item.project ?? 'unknown';
+                const topicStr = item.work_unit
+                  ? `${projectName}/${item.work_unit}`
+                      .toLowerCase()
+                      .replace(/[^a-z0-9가-힣_/]+/g, '_')
+                  : `${projectName}/${item.topic}`.toLowerCase().replace(/[^a-z0-9가-힣_/]+/g, '_');
+                await saveMemory({
+                  topic: topicStr,
+                  kind: (validKinds.has(item.kind ?? '') ? item.kind : 'fact') as MemoryKind,
+                  summary: item.summary,
+                  details: item.reasoning ?? item.summary,
+                  confidence: Math.max(0, Math.min(1, item.confidence ?? 0.7)),
+                  scopes: [{ kind: 'project', id: projectName }],
+                  source: { package: 'standalone', source_type: 'connector' },
+                  eventDate: item.event_date ?? new Date().toISOString().split('T')[0],
+                });
+              }
+              console.log(`[connector] ${label}:${channelKey}: ${extracted.length} memories saved`);
+            }
+          } catch (err) {
+            console.error(`[connector] ${label}:${channelKey} extraction failed:`, err);
+          }
+        }
+      };
+
+      connectorScheduler.startBatch(
+        connectorRegistry,
+        allChannelConfigs,
+        60, // unified polling interval (minutes)
+        async ({ truth, activity, spoke }) => {
+          // Pass 0: Truth → ProjectTruth (no LLM)
+          const projectTruth = buildProjectTruth(truth);
+          if (truth.length > 0) {
+            console.log(
+              `[connector] truth snapshot: ${Object.keys(projectTruth.projects).length} projects`
+            );
+          }
+
+          // Pass 1: Activity extraction with truth context
+          if (activity.length > 0) {
+            const activityGroups = groupByChannel(activity);
+            console.log(
+              `[connector] activity: ${activity.length} items in ${activityGroups.size} channels`
+            );
+            await extractAndSave('activity', activityGroups, (items) =>
+              buildActivityExtractionPrompt(items, projectTruth)
+            );
+          }
+
+          // Pass 2: Spoke extraction with project context
+          if (spoke.length > 0) {
+            const hubContext = Object.entries(projectTruth.projects).flatMap(([proj, p]) =>
+              Object.entries(p.workUnits).map(([wu, state]) => ({
+                project: proj,
+                workUnit: wu,
+                assignedTo: state.assigned,
+                status: state.status,
+              }))
+            );
+            const spokeGroups = groupByChannel(spoke);
+            console.log(`[connector] spoke: ${spoke.length} items in ${spokeGroups.size} channels`);
+            await extractAndSave('spoke', spokeGroups, (items) =>
+              buildSpokeExtractionPrompt(items, hubContext, projectTruth)
+            );
+          }
+        }
+      );
+
+      console.log(`[connector] ${connectorRegistry.getActive().size} connectors active`);
+
+      // Add to graceful shutdown
+      gateways.push({ stop: () => Promise.resolve(connectorScheduler.stop()) });
+    }
+  }
 
   // Start API server
   const skillRegistry = new SkillRegistry();

--- a/packages/standalone/src/cli/index.ts
+++ b/packages/standalone/src/cli/index.ts
@@ -14,6 +14,7 @@ import { startCommand, runAgentLoop } from './commands/start.js';
 import { stopCommand } from './commands/stop.js';
 import { statusCommand } from './commands/status.js';
 import { runCommand } from './commands/run.js';
+import { createConnectorCommand } from './commands/connector.js';
 import { initConfig } from './config/config-manager.js';
 import { readFileSync } from 'fs';
 import { join } from 'path';
@@ -100,6 +101,8 @@ program
   .action(async (prompt, options) => {
     await runCommand({ prompt, verbose: options.verbose });
   });
+
+program.addCommand(createConnectorCommand());
 
 // Hidden daemon command (used internally for background process)
 program

--- a/packages/standalone/src/connectors/calendar/index.ts
+++ b/packages/standalone/src/connectors/calendar/index.ts
@@ -1,0 +1,161 @@
+/**
+ * CalendarConnector — polls Google Calendar via the gws CLI tool.
+ * Uses child_process.execSync to call gws CLI commands.
+ * Skips "Using keyring backend:" prefix lines before parsing JSON.
+ */
+
+import { execSync } from 'child_process';
+
+import type {
+  AuthRequirement,
+  ConnectorConfig,
+  ConnectorHealth,
+  IConnector,
+  NormalizedItem,
+} from '../framework/types.js';
+import { execGws } from '../framework/gws-utils.js';
+
+interface CalendarEvent {
+  id: string;
+  summary?: string;
+  description?: string;
+  start?: {
+    dateTime?: string;
+    date?: string;
+  };
+  end?: {
+    dateTime?: string;
+    date?: string;
+  };
+  organizer?: {
+    email?: string;
+    displayName?: string;
+  };
+  status?: string;
+}
+
+interface CalendarEventList {
+  items?: CalendarEvent[];
+}
+
+export class CalendarConnector implements IConnector {
+  readonly name = 'calendar';
+  readonly type = 'api' as const;
+
+  private lastPollTime: Date | null = null;
+  private lastPollCount = 0;
+  private lastError: string | undefined = undefined;
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  constructor(_config: ConnectorConfig) {
+    // config reserved for future channel-scoped filtering
+  }
+
+  async init(): Promise<void> {
+    // Verify gws CLI is available
+    try {
+      execSync('gws --version', { stdio: 'pipe' });
+    } catch {
+      throw new Error('gws CLI not found. Install it and run: gws auth login');
+    }
+  }
+
+  async dispose(): Promise<void> {
+    // No resources to clean up
+  }
+
+  async healthCheck(): Promise<ConnectorHealth> {
+    return {
+      healthy: this.lastError === undefined,
+      lastPollTime: this.lastPollTime,
+      lastPollCount: this.lastPollCount,
+      error: this.lastError,
+    };
+  }
+
+  getAuthRequirements(): AuthRequirement[] {
+    return [
+      {
+        type: 'cli',
+        cli: 'gws',
+        cliAuthCommand: 'gws auth login',
+        description: 'Google Workspace CLI authentication. Run: gws auth login',
+      },
+    ];
+  }
+
+  async authenticate(): Promise<boolean> {
+    try {
+      execSync('gws auth status', { stdio: 'pipe' });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private getEventTime(ev: CalendarEvent): string {
+    return ev.start?.dateTime ?? ev.start?.date ?? '';
+  }
+
+  private getEventEndTime(ev: CalendarEvent): string {
+    return ev.end?.dateTime ?? ev.end?.date ?? '';
+  }
+
+  async poll(since: Date): Promise<NormalizedItem[]> {
+    const items: NormalizedItem[] = [];
+    let hadError = false;
+
+    try {
+      const timeMin = since.toISOString();
+      const params = JSON.stringify({
+        calendarId: 'primary',
+        timeMin,
+        singleEvents: true,
+        orderBy: 'startTime',
+        maxResults: 50,
+      });
+      const result = execGws(`calendar events list --params '${params}'`) as CalendarEventList;
+
+      const events = result.items ?? [];
+
+      for (const ev of events) {
+        const start = this.getEventTime(ev);
+        const end = this.getEventEndTime(ev);
+        const summary = ev.summary ?? '(No title)';
+        const description = ev.description ?? '';
+        const organizer = ev.organizer?.displayName ?? ev.organizer?.email ?? 'unknown';
+
+        // Determine timestamp from start time
+        const startMs = start ? new Date(start).getTime() : Date.now();
+        const timestamp = new Date(startMs);
+
+        items.push({
+          source: 'calendar',
+          sourceId: ev.id,
+          channel: 'calendar',
+          author: organizer,
+          content: `${summary} | ${start} ~ ${end}\n${description}`,
+          timestamp,
+          type: 'event',
+          metadata: {
+            summary,
+            start,
+            end,
+            status: ev.status,
+            organizer: ev.organizer,
+          },
+        });
+      }
+    } catch (err) {
+      hadError = true;
+      this.lastError = err instanceof Error ? err.message : String(err);
+    }
+
+    this.lastPollTime = new Date();
+    this.lastPollCount = items.length;
+    // lastError was set in catch blocks; clear only if no error occurred this pass
+    if (!hadError) this.lastError = undefined;
+
+    return items;
+  }
+}

--- a/packages/standalone/src/connectors/chatwork/index.ts
+++ b/packages/standalone/src/connectors/chatwork/index.ts
@@ -1,0 +1,164 @@
+/**
+ * ChatworkConnector — polls Chatwork rooms via native fetch.
+ * No SDK dependency; uses X-ChatWorkToken header for auth.
+ */
+
+import type {
+  AuthRequirement,
+  ConnectorConfig,
+  ConnectorHealth,
+  IConnector,
+  NormalizedItem,
+} from '../framework/types.js';
+
+interface ChatworkMessage {
+  message_id: string;
+  account: {
+    account_id: number;
+    name: string;
+    avatar_image_url: string;
+  };
+  body: string;
+  send_time: number;
+  update_time: number;
+}
+
+export class ChatworkConnector implements IConnector {
+  readonly name = 'chatwork';
+  readonly type = 'api' as const;
+
+  private config: ConnectorConfig;
+  private token: string | null = null;
+  private readonly baseUrl = 'https://api.chatwork.com/v2';
+  private lastPollTime: Date | null = null;
+  private lastPollCount = 0;
+  private lastError: string | undefined = undefined;
+
+  /**
+   * Per-room last seen message ID for incremental polling.
+   * NOTE: The Chatwork API has no cursor-based pagination. The `force=0` mode
+   * returns messages since the server-tracked read cursor (up to 100 per call).
+   * We additionally track the last seen message_id client-side so we can skip
+   * already-processed messages on the first poll after restart.
+   * Limitation: if a room receives >100 messages between polls, the oldest
+   * messages in that batch will be missed — this is a Chatwork API constraint.
+   */
+  private lastMessageIds: Map<string, string> = new Map();
+
+  constructor(config: ConnectorConfig) {
+    this.config = config;
+  }
+
+  async init(): Promise<void> {
+    const token =
+      this.config.auth.token ?? process.env[this.config.auth.tokenName ?? 'CHATWORK_API_TOKEN'];
+    if (!token) {
+      throw new Error('Chatwork API token not found. Set CHATWORK_API_TOKEN environment variable.');
+    }
+    this.token = token;
+  }
+
+  async dispose(): Promise<void> {
+    this.token = null;
+  }
+
+  async healthCheck(): Promise<ConnectorHealth> {
+    return {
+      healthy: this.token !== null && this.lastError === undefined,
+      lastPollTime: this.lastPollTime,
+      lastPollCount: this.lastPollCount,
+      error: this.lastError,
+    };
+  }
+
+  getAuthRequirements(): AuthRequirement[] {
+    return [
+      {
+        type: 'token',
+        tokenName: 'CHATWORK_API_TOKEN',
+        description:
+          'Chatwork API token from https://www.chatwork.com/service/packages/chatwork/subpackages/api/token.php',
+      },
+    ];
+  }
+
+  async authenticate(): Promise<boolean> {
+    try {
+      if (!this.token) return false;
+      const res = await fetch(`${this.baseUrl}/me`, {
+        headers: { 'X-ChatWorkToken': this.token },
+      });
+      return res.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  async poll(since: Date): Promise<NormalizedItem[]> {
+    if (!this.token) throw new Error('ChatworkConnector not initialized');
+
+    const items: NormalizedItem[] = [];
+    let hadError = false;
+    const sinceEpoch = Math.floor(since.getTime() / 1000);
+
+    for (const [roomId, channelCfg] of Object.entries(this.config.channels)) {
+      if (channelCfg.role === 'ignore') continue;
+
+      try {
+        // Use force=0 to rely on the server-side read cursor rather than
+        // force-fetching all messages. This avoids clobbering the server cursor
+        // and correctly returns only new messages since the last acknowledged read.
+        // Limitation: up to 100 messages per call — busy rooms may drop messages
+        // between polls if the interval is too long relative to message volume.
+        const lastMsgId = this.lastMessageIds.get(roomId);
+        const res = await fetch(`${this.baseUrl}/rooms/${roomId}/messages?force=0`, {
+          headers: { 'X-ChatWorkToken': this.token },
+        });
+
+        if (!res.ok) {
+          hadError = true;
+          this.lastError = `Room ${roomId}: HTTP ${res.status}`;
+          continue;
+        }
+
+        const messages = (await res.json()) as ChatworkMessage[];
+
+        let maxMsgId = lastMsgId ?? '';
+        for (const msg of messages) {
+          if (msg.send_time <= sinceEpoch) continue;
+          // Skip messages we've already processed (client-side guard)
+          if (lastMsgId && msg.message_id <= lastMsgId) continue;
+
+          if (msg.message_id > maxMsgId) maxMsgId = msg.message_id;
+
+          items.push({
+            source: 'chatwork',
+            sourceId: `${roomId}:${msg.message_id}`,
+            channel: channelCfg.name ?? roomId,
+            author: msg.account.name,
+            content: msg.body,
+            timestamp: new Date(msg.send_time * 1000),
+            type: 'message',
+            metadata: {
+              roomId,
+              messageId: msg.message_id,
+              accountId: msg.account.account_id,
+            },
+          });
+        }
+
+        if (maxMsgId) this.lastMessageIds.set(roomId, maxMsgId);
+      } catch (err) {
+        hadError = true;
+        this.lastError = err instanceof Error ? err.message : String(err);
+      }
+    }
+
+    this.lastPollTime = new Date();
+    this.lastPollCount = items.length;
+    // lastError was set in catch blocks; clear only if no error occurred this pass
+    if (!hadError) this.lastError = undefined;
+
+    return items;
+  }
+}

--- a/packages/standalone/src/connectors/discord/index.ts
+++ b/packages/standalone/src/connectors/discord/index.ts
@@ -1,0 +1,179 @@
+/**
+ * DiscordConnector — polls Discord channels via native fetch using REST API.
+ * Uses Authorization: Bot token header. Tracks lastMessageId per channel.
+ */
+
+import type {
+  AuthRequirement,
+  ConnectorConfig,
+  ConnectorHealth,
+  IConnector,
+  NormalizedItem,
+} from '../framework/types.js';
+
+interface DiscordMessage {
+  id: string;
+  content: string;
+  timestamp: string;
+  author: {
+    id: string;
+    username: string;
+    bot?: boolean;
+  };
+}
+
+export class DiscordConnector implements IConnector {
+  readonly name = 'discord';
+  readonly type = 'api' as const;
+
+  private config: ConnectorConfig;
+  private token: string | null = null;
+  private readonly baseUrl = 'https://discord.com/api/v10';
+  private lastMessageIdPerChannel = new Map<string, string>();
+  private lastPollTime: Date | null = null;
+  private lastPollCount = 0;
+  private lastError: string | undefined = undefined;
+
+  constructor(config: ConnectorConfig) {
+    this.config = config;
+  }
+
+  async init(): Promise<void> {
+    const token =
+      this.config.auth.token ?? process.env[this.config.auth.tokenName ?? 'DISCORD_BOT_TOKEN'];
+    if (!token) {
+      throw new Error('Discord bot token not found. Set DISCORD_BOT_TOKEN environment variable.');
+    }
+    this.token = token;
+  }
+
+  async dispose(): Promise<void> {
+    this.token = null;
+    this.lastMessageIdPerChannel.clear();
+  }
+
+  async healthCheck(): Promise<ConnectorHealth> {
+    return {
+      healthy: this.token !== null && this.lastError === undefined,
+      lastPollTime: this.lastPollTime,
+      lastPollCount: this.lastPollCount,
+      error: this.lastError,
+    };
+  }
+
+  getAuthRequirements(): AuthRequirement[] {
+    return [
+      {
+        type: 'token',
+        tokenName: 'DISCORD_BOT_TOKEN',
+        description:
+          'Discord Bot token from the Discord Developer Portal. Add the bot to your server with MESSAGE_CONTENT intent.',
+      },
+    ];
+  }
+
+  async authenticate(): Promise<boolean> {
+    try {
+      if (!this.token) return false;
+      const res = await fetch(`${this.baseUrl}/users/@me`, {
+        headers: { Authorization: `Bot ${this.token}` },
+      });
+      return res.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  async poll(since: Date): Promise<NormalizedItem[]> {
+    if (!this.token) throw new Error('DiscordConnector not initialized');
+
+    const items: NormalizedItem[] = [];
+    let hadError = false;
+
+    for (const [channelId, channelCfg] of Object.entries(this.config.channels)) {
+      if (channelCfg.role === 'ignore') continue;
+
+      try {
+        let afterId = this.lastMessageIdPerChannel.get(channelId);
+        let hasMore = true;
+        while (hasMore) {
+          const url = new URL(`${this.baseUrl}/channels/${channelId}/messages`);
+          url.searchParams.set('limit', '100');
+          if (afterId) url.searchParams.set('after', afterId);
+
+          const controller = new AbortController();
+          const timeout = setTimeout(() => controller.abort(), 30_000);
+          let res: Response;
+          try {
+            res = await fetch(url.toString(), {
+              headers: { Authorization: `Bot ${this.token}` },
+              signal: controller.signal,
+            });
+          } finally {
+            clearTimeout(timeout);
+          }
+
+          if (!res.ok) {
+            hadError = true;
+            this.lastError = `Channel ${channelId}: HTTP ${res.status}`;
+            break;
+          }
+
+          const messages = (await res.json()) as DiscordMessage[];
+
+          // Discord returns newest-first; reverse to get ascending order
+          const sorted = [...messages].reverse();
+
+          for (const msg of sorted) {
+            // Skip bot messages
+            if (msg.author.bot) continue;
+            if (!msg.content) continue;
+
+            const timestamp = new Date(msg.timestamp);
+
+            // Filter by since date
+            if (timestamp <= since) continue;
+
+            // Track the newest message id for next poll
+            const current = this.lastMessageIdPerChannel.get(channelId);
+            if (!current || msg.id > current) {
+              this.lastMessageIdPerChannel.set(channelId, msg.id);
+            }
+
+            items.push({
+              source: 'discord',
+              sourceId: `${channelId}:${msg.id}`,
+              channel: channelCfg.name ?? channelId,
+              author: msg.author.username,
+              content: msg.content,
+              timestamp,
+              type: 'message',
+              metadata: {
+                channelId,
+                messageId: msg.id,
+                authorId: msg.author.id,
+              },
+            });
+          }
+
+          hasMore = messages.length === 100;
+          if (sorted.length > 0) {
+            afterId = sorted[sorted.length - 1].id;
+          }
+        }
+      } catch (err) {
+        hadError = true;
+        this.lastError = err instanceof Error ? err.message : String(err);
+      }
+    }
+
+    items.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+
+    this.lastPollTime = new Date();
+    this.lastPollCount = items.length;
+    // lastError was set in catch blocks; clear only if no error occurred this pass
+    if (!hadError) this.lastError = undefined;
+
+    return items;
+  }
+}

--- a/packages/standalone/src/connectors/drive/index.ts
+++ b/packages/standalone/src/connectors/drive/index.ts
@@ -1,0 +1,213 @@
+/**
+ * DriveConnector — polls Google Drive changes via the gws CLI tool.
+ * Uses child_process.execSync to call gws CLI commands.
+ * Emits file_change NormalizedItems for files modified in configured folders.
+ */
+
+import { execSync } from 'child_process';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+import type {
+  AuthRequirement,
+  ConnectorConfig,
+  ConnectorHealth,
+  IConnector,
+  NormalizedItem,
+} from '../framework/types.js';
+import { execGws } from '../framework/gws-utils.js';
+
+interface DriveFile {
+  name: string;
+  mimeType: string;
+  modifiedTime: string;
+  lastModifyingUser?: {
+    displayName: string;
+  };
+  parents?: string[];
+}
+
+interface DriveChange {
+  fileId: string;
+  time: string;
+  removed?: boolean;
+  file?: DriveFile;
+}
+
+interface DriveChangeList {
+  changes: DriveChange[];
+  newStartPageToken?: string;
+}
+
+interface StartPageTokenResult {
+  startPageToken: string;
+}
+
+export class DriveConnector implements IConnector {
+  readonly name = 'drive';
+  readonly type = 'api' as const;
+
+  private config: ConnectorConfig;
+  private lastPollTime: Date | null = null;
+  private lastPollCount = 0;
+  private lastError: string | undefined = undefined;
+
+  /** Stored page tokens per poll session (single global token for Drive changes API) */
+  private pageTokens: Map<string, string> = new Map();
+
+  private readonly stateFilePath = join(homedir(), '.mama', 'connectors', 'drive', 'drive-state.json');
+
+  constructor(config: ConnectorConfig) {
+    this.config = config;
+  }
+
+  async init(): Promise<void> {
+    try {
+      execSync('gws --version', { stdio: 'pipe' });
+    } catch {
+      throw new Error('gws CLI not found. Install it and run: gws auth login');
+    }
+    this.loadState();
+  }
+
+  private loadState(): void {
+    if (existsSync(this.stateFilePath)) {
+      try {
+        const data = JSON.parse(readFileSync(this.stateFilePath, 'utf-8'));
+        for (const [k, v] of Object.entries(data.pageTokens ?? {})) {
+          this.pageTokens.set(k, v as string);
+        }
+      } catch { /* ignore corrupt state */ }
+    }
+  }
+
+  private saveState(): void {
+    const dir = join(homedir(), '.mama', 'connectors', 'drive');
+    mkdirSync(dir, { recursive: true });
+    const obj: Record<string, string> = {};
+    for (const [k, v] of this.pageTokens) obj[k] = v;
+    writeFileSync(this.stateFilePath, JSON.stringify({ pageTokens: obj }));
+  }
+
+  async dispose(): Promise<void> {
+    this.pageTokens.clear();
+  }
+
+  async healthCheck(): Promise<ConnectorHealth> {
+    return {
+      healthy: this.lastError === undefined,
+      lastPollTime: this.lastPollTime,
+      lastPollCount: this.lastPollCount,
+      error: this.lastError,
+    };
+  }
+
+  getAuthRequirements(): AuthRequirement[] {
+    return [
+      {
+        type: 'cli',
+        cli: 'gws',
+        cliAuthCommand: 'gws auth login',
+        description: 'Google Workspace CLI authentication. Run: gws auth login',
+      },
+    ];
+  }
+
+  async authenticate(): Promise<boolean> {
+    try {
+      execSync('gws auth status', { stdio: 'pipe' });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Find which channel config matches based on a file's parent folder IDs.
+   * Returns [channelKey, channelName] or null if no match.
+   */
+  private findChannelByParent(parents: string[]): [string, string] | null {
+    for (const [channelKey, channelCfg] of Object.entries(this.config.channels)) {
+      if (channelCfg.role === 'ignore') continue;
+      if (!channelCfg.folderId) continue;
+      if (parents.includes(channelCfg.folderId)) {
+        return [channelKey, channelCfg.name ?? channelKey];
+      }
+    }
+    return null;
+  }
+
+  async poll(_since: Date): Promise<NormalizedItem[]> {
+    const items: NormalizedItem[] = [];
+    let hadError = false;
+
+    try {
+      // Get or initialize the page token
+      let pageToken = this.pageTokens.get('drive');
+      if (!pageToken) {
+        const tokenResult = execGws(
+          `drive changes getStartPageToken --params '{}'`
+        ) as StartPageTokenResult;
+        pageToken = tokenResult.startPageToken;
+        this.pageTokens.set('drive', pageToken);
+      }
+
+      const params = JSON.stringify({
+        pageToken,
+        pageSize: 100,
+        fields:
+          'changes(fileId,time,removed,file(name,mimeType,modifiedTime,lastModifyingUser,parents)),newStartPageToken',
+        includeRemoved: false,
+      });
+
+      const changeList = execGws(`drive changes list --params '${params}'`) as DriveChangeList;
+
+      for (const change of changeList.changes) {
+        if (!change.file) continue;
+
+        const file = change.file;
+        const parents = file.parents ?? [];
+        const channelMatch = this.findChannelByParent(parents);
+        if (!channelMatch) continue;
+
+        const [, channelName] = channelMatch;
+        const author = file.lastModifyingUser?.displayName ?? 'unknown';
+
+        items.push({
+          source: 'drive',
+          sourceId: `${change.fileId}:${change.time}`,
+          channel: channelName,
+          author,
+          content: `modified: ${file.name} (${file.mimeType})`,
+          timestamp: new Date(change.time),
+          type: 'file_change',
+          metadata: {
+            fileId: change.fileId,
+            fileName: file.name,
+            mimeType: file.mimeType,
+            modifiedTime: file.modifiedTime,
+            parents,
+          },
+        });
+      }
+
+      // Store the new page token for the next poll and persist to disk
+      if (changeList.newStartPageToken) {
+        this.pageTokens.set('drive', changeList.newStartPageToken);
+      }
+      this.saveState();
+    } catch (err) {
+      hadError = true;
+      this.lastError = err instanceof Error ? err.message : String(err);
+      throw err;
+    }
+
+    this.lastPollTime = new Date();
+    this.lastPollCount = items.length;
+    // lastError was set in catch blocks; clear only if no error occurred this pass
+    if (!hadError) this.lastError = undefined;
+
+    return items;
+  }
+}

--- a/packages/standalone/src/connectors/framework/connector-registry.ts
+++ b/packages/standalone/src/connectors/framework/connector-registry.ts
@@ -1,0 +1,46 @@
+/**
+ * ConnectorRegistry — in-memory registry for all active connectors.
+ */
+
+import type { ConnectorHealth, IConnector } from './types.js';
+
+export class ConnectorRegistry {
+  private connectors = new Map<string, IConnector>();
+
+  register(name: string, connector: IConnector): void {
+    this.connectors.set(name, connector);
+  }
+
+  get(name: string): IConnector | undefined {
+    return this.connectors.get(name);
+  }
+
+  getActive(): Map<string, IConnector> {
+    return new Map(this.connectors);
+  }
+
+  async disposeAll(): Promise<void> {
+    const disposePromises = Array.from(this.connectors.values()).map((c) => c.dispose());
+    await Promise.all(disposePromises);
+    this.connectors.clear();
+  }
+
+  async healthCheckAll(): Promise<Record<string, ConnectorHealth>> {
+    const results: Record<string, ConnectorHealth> = {};
+    await Promise.all(
+      Array.from(this.connectors.entries()).map(async ([name, connector]) => {
+        try {
+          results[name] = await connector.healthCheck();
+        } catch (err) {
+          results[name] = {
+            healthy: false,
+            lastPollTime: null,
+            lastPollCount: 0,
+            error: err instanceof Error ? err.message : String(err),
+          };
+        }
+      })
+    );
+    return results;
+  }
+}

--- a/packages/standalone/src/connectors/framework/gws-utils.ts
+++ b/packages/standalone/src/connectors/framework/gws-utils.ts
@@ -1,0 +1,27 @@
+import { execSync } from 'child_process';
+
+export function parseGwsOutput(raw: string): unknown {
+  const lines = raw.split('\n');
+  const jsonStart = lines.findIndex(
+    (line) => line.trimStart().startsWith('{') || line.trimStart().startsWith('[')
+  );
+  if (jsonStart === -1) {
+    throw new Error('No JSON found in gws CLI output');
+  }
+  return JSON.parse(lines.slice(jsonStart).join('\n'));
+}
+
+/**
+ * Execute a gws CLI command and parse the JSON output.
+ * Note: args are constructed internally by connectors using JSON.stringify
+ * for parameter values — no user-supplied input is interpolated directly.
+ */
+export function execGws(args: string, options?: { maxBuffer?: number }): unknown {
+  const raw = execSync(`gws ${args}`, {
+    encoding: 'utf8',
+    stdio: 'pipe',
+    maxBuffer: options?.maxBuffer,
+    timeout: 60_000,
+  });
+  return parseGwsOutput(raw);
+}

--- a/packages/standalone/src/connectors/framework/index.ts
+++ b/packages/standalone/src/connectors/framework/index.ts
@@ -1,0 +1,14 @@
+export type {
+  IConnector,
+  NormalizedItem,
+  ConnectorConfig,
+  ChannelConfig,
+  AuthConfig,
+  AuthRequirement,
+  ConnectorHealth,
+  ConnectorsConfig,
+} from './types.js';
+export { ConnectorRegistry } from './connector-registry.js';
+export { PollingScheduler } from './polling-scheduler.js';
+export { RawStore } from './raw-store.js';
+export { parseGwsOutput, execGws } from './gws-utils.js';

--- a/packages/standalone/src/connectors/framework/polling-scheduler.ts
+++ b/packages/standalone/src/connectors/framework/polling-scheduler.ts
@@ -1,0 +1,136 @@
+/**
+ * PollingScheduler — drives periodic collection from all registered connectors.
+ * Persists lastPollTime to basePath/poll-state.json for crash recovery.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+import type { ConnectorRegistry } from './connector-registry.js';
+import type { ChannelConfig, NormalizedItem } from './types.js';
+import type { RawStore } from './raw-store.js';
+import { classifyItemsByRole } from '../../memory/history-extractor.js';
+import type { ClassifiedItems } from '../../memory/history-extractor.js';
+
+type BatchExtractCallback = (classified: ClassifiedItems) => void | Promise<void>;
+
+interface PollState {
+  [connectorName: string]: string; // ISO timestamp
+}
+
+export class PollingScheduler {
+  private readonly rawStore: RawStore;
+  private lastPollTimes = new Map<string, Date>();
+  private timers = new Map<string, ReturnType<typeof setInterval>>();
+  private readonly stateFile: string;
+  private isBatchRunning = false;
+
+  constructor(rawStore: RawStore, basePath: string) {
+    this.rawStore = rawStore;
+    this.stateFile = join(basePath, 'poll-state.json');
+    this.restoreState();
+  }
+
+  private restoreState(): void {
+    if (!existsSync(this.stateFile)) return;
+    try {
+      const raw = readFileSync(this.stateFile, 'utf8');
+      const state = JSON.parse(raw) as PollState;
+      for (const [name, iso] of Object.entries(state)) {
+        this.lastPollTimes.set(name, new Date(iso));
+      }
+    } catch {
+      // Corrupt state file — start fresh
+    }
+  }
+
+  persistState(): void {
+    const state: PollState = {};
+    for (const [name, date] of this.lastPollTimes.entries()) {
+      state[name] = date.toISOString();
+    }
+    writeFileSync(this.stateFile, JSON.stringify(state, null, 2), 'utf8');
+  }
+
+  async pollAll(
+    registry: ConnectorRegistry,
+    channelConfigs: Record<string, Record<string, ChannelConfig>>,
+    onBatchExtract: BatchExtractCallback
+  ): Promise<void> {
+    if (this.isBatchRunning) {
+      console.log('[connector] pollAll: skipping — previous batch still running');
+      return;
+    }
+    this.isBatchRunning = true;
+    try {
+      console.log(`[connector] pollAll: ${registry.getActive().size} connectors`);
+      const allItems: NormalizedItem[] = [];
+
+      for (const [name, connector] of registry.getActive()) {
+        const since = this.lastPollTimes.get(name) ?? new Date(Date.now() - 24 * 60 * 60 * 1000);
+        try {
+          const items = await connector.poll(since);
+          console.log(
+            `[connector:${name}] polled ${items.length} items (since: ${since.toISOString()})`
+          );
+          if (items.length > 0) {
+            this.rawStore.save(name, items);
+            allItems.push(...items);
+          }
+          // Only advance the cursor after a successful poll+save
+          this.lastPollTimes.set(name, new Date());
+        } catch (err) {
+          console.error(`[connector:${name}] poll error:`, err);
+        }
+      }
+
+      console.log(`[connector] pollAll total: ${allItems.length} items`);
+      if (allItems.length > 0) {
+        const classified = classifyItemsByRole(allItems, channelConfigs, 'hub');
+        console.log(
+          `[connector] classified: truth=${classified.truth.length} activity=${classified.activity.length} spoke=${classified.spoke.length}`
+        );
+        await onBatchExtract(classified);
+      }
+
+      this.persistState();
+    } finally {
+      this.isBatchRunning = false;
+    }
+  }
+
+  startBatch(
+    registry: ConnectorRegistry,
+    channelConfigs: Record<string, Record<string, ChannelConfig>>,
+    intervalMinutes: number,
+    onBatchExtract: BatchExtractCallback
+  ): void {
+    // Initial poll (fire-and-forget)
+    this.pollAll(registry, channelConfigs, onBatchExtract).catch((err) =>
+      console.error('[connector] initial batch poll error:', err)
+    );
+    // Periodic
+    this.timers.set(
+      '__batch__',
+      setInterval(
+        () =>
+          this.pollAll(registry, channelConfigs, onBatchExtract).catch((err) =>
+            console.error('[connector] batch poll error:', err)
+          ),
+        intervalMinutes * 60_000
+      )
+    );
+  }
+
+  getLastPollTime(name: string): Date | undefined {
+    return this.lastPollTimes.get(name);
+  }
+
+  stop(): void {
+    for (const timer of this.timers.values()) {
+      clearInterval(timer);
+    }
+    this.timers.clear();
+    this.rawStore?.close();
+  }
+}

--- a/packages/standalone/src/connectors/framework/raw-store.ts
+++ b/packages/standalone/src/connectors/framework/raw-store.ts
@@ -1,0 +1,107 @@
+/**
+ * RawStore — per-connector SQLite evidence storage.
+ * Creates basePath/<connectorName>/raw.db for each connector.
+ * Uses the project's existing Database wrapper (sqlite.ts).
+ */
+
+import { mkdirSync } from 'fs';
+import { join } from 'path';
+
+import Database from '../../sqlite.js';
+import type { NormalizedItem } from './types.js';
+
+interface RawRow {
+  source_id: string;
+  source: string;
+  channel: string;
+  author: string;
+  content: string;
+  timestamp: number;
+  type: string;
+  metadata: string | null;
+}
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS raw_items (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  source_id TEXT NOT NULL UNIQUE,
+  source TEXT NOT NULL,
+  channel TEXT NOT NULL,
+  author TEXT NOT NULL,
+  content TEXT NOT NULL,
+  timestamp INTEGER NOT NULL,
+  type TEXT NOT NULL,
+  metadata TEXT,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000)
+);
+CREATE INDEX IF NOT EXISTS idx_raw_items_timestamp ON raw_items(timestamp);
+`;
+
+export class RawStore {
+  private dbs = new Map<string, Database>();
+  private readonly basePath: string;
+
+  constructor(basePath: string) {
+    this.basePath = basePath;
+  }
+
+  private getDb(connectorName: string): Database {
+    const existing = this.dbs.get(connectorName);
+    if (existing) return existing;
+
+    const dir = join(this.basePath, connectorName);
+    mkdirSync(dir, { recursive: true });
+    const db = new Database(join(dir, 'raw.db'));
+    db.exec(SCHEMA);
+    this.dbs.set(connectorName, db);
+    return db;
+  }
+
+  save(connectorName: string, items: NormalizedItem[]): void {
+    if (items.length === 0) return;
+    const db = this.getDb(connectorName);
+    const stmt = db.prepare(`
+      INSERT OR IGNORE INTO raw_items
+        (source_id, source, channel, author, content, timestamp, type, metadata)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    for (const item of items) {
+      stmt.run(
+        item.sourceId,
+        item.source,
+        item.channel,
+        item.author,
+        item.content,
+        item.timestamp.getTime(),
+        item.type,
+        item.metadata !== undefined ? JSON.stringify(item.metadata) : null
+      );
+    }
+  }
+
+  query(connectorName: string, since: Date): NormalizedItem[] {
+    const db = this.getDb(connectorName);
+    const rows = db
+      .prepare('SELECT * FROM raw_items WHERE timestamp >= ? ORDER BY timestamp ASC')
+      .all(since.getTime()) as RawRow[];
+
+    return rows.map((row) => ({
+      source: row.source,
+      sourceId: row.source_id,
+      channel: row.channel,
+      author: row.author,
+      content: row.content,
+      timestamp: new Date(row.timestamp),
+      type: row.type as NormalizedItem['type'],
+      metadata:
+        row.metadata !== null ? (JSON.parse(row.metadata) as Record<string, unknown>) : undefined,
+    }));
+  }
+
+  close(): void {
+    for (const db of this.dbs.values()) {
+      db.close();
+    }
+    this.dbs.clear();
+  }
+}

--- a/packages/standalone/src/connectors/framework/types.ts
+++ b/packages/standalone/src/connectors/framework/types.ts
@@ -1,0 +1,86 @@
+/**
+ * Core types for the Connector Framework.
+ * All connectors implement IConnector and produce NormalizedItem records.
+ */
+
+export interface NormalizedItem {
+  source: string;
+  sourceId: string;
+  channel: string;
+  author: string;
+  content: string;
+  timestamp: Date;
+  type:
+    | 'message'
+    | 'email'
+    | 'event'
+    | 'document'
+    | 'note'
+    | 'spreadsheet_row'
+    | 'kanban_card'
+    | 'file_change';
+  metadata?: Record<string, unknown>;
+}
+
+export interface ChannelConfig {
+  role: 'truth' | 'hub' | 'deliverable' | 'spoke' | 'reference' | 'ignore';
+  name?: string;
+  keywords?: string[];
+  /** Truth: spreadsheet ID for Sheets connector */
+  spreadsheetId?: string;
+  /** Truth: header range (e.g., "Sheet!A1:Z1") */
+  sheetRange?: string;
+  /** Truth: data range separate from header (e.g., "Sheet!A100:Z200") */
+  dataRange?: string;
+  /** Truth: Trello board ID */
+  boardId?: string;
+  /** Deliverable: Drive folder ID */
+  folderId?: string;
+  /** Spoke: Obsidian vault path */
+  vaultPath?: string;
+  /** Spoke: file watch patterns */
+  watchPatterns?: string[];
+}
+
+export interface AuthConfig {
+  type: 'cli' | 'token' | 'none';
+  cli?: string;
+  cliAuthCommand?: string;
+  tokenName?: string;
+  token?: string;
+}
+
+export interface AuthRequirement {
+  type: 'cli' | 'token' | 'none';
+  cli?: string;
+  cliAuthCommand?: string;
+  tokenName?: string;
+  description: string;
+}
+
+export interface ConnectorConfig {
+  enabled: boolean;
+  pollIntervalMinutes: number;
+  channels: Record<string, ChannelConfig>;
+  auth: AuthConfig;
+}
+
+export interface ConnectorHealth {
+  healthy: boolean;
+  lastPollTime: Date | null;
+  lastPollCount: number;
+  error?: string;
+}
+
+export interface IConnector {
+  name: string;
+  type: 'api' | 'local';
+  init(): Promise<void>;
+  dispose(): Promise<void>;
+  healthCheck(): Promise<ConnectorHealth>;
+  getAuthRequirements(): AuthRequirement[];
+  authenticate(): Promise<boolean>;
+  poll(since: Date): Promise<NormalizedItem[]>;
+}
+
+export type ConnectorsConfig = Record<string, ConnectorConfig>;

--- a/packages/standalone/src/connectors/gmail/index.ts
+++ b/packages/standalone/src/connectors/gmail/index.ts
@@ -1,0 +1,161 @@
+/**
+ * GmailConnector — polls Gmail via the gws CLI tool.
+ * Uses child_process.execSync to call gws CLI commands.
+ * Skips "Using keyring backend:" prefix lines before parsing JSON.
+ */
+
+import { execSync } from 'child_process';
+
+import type {
+  AuthRequirement,
+  ConnectorConfig,
+  ConnectorHealth,
+  IConnector,
+  NormalizedItem,
+} from '../framework/types.js';
+import { execGws } from '../framework/gws-utils.js';
+
+interface GmailMessage {
+  id: string;
+  threadId: string;
+  snippet: string;
+  payload?: {
+    headers?: Array<{ name: string; value: string }>;
+  };
+  internalDate?: string;
+}
+
+interface GmailMessageList {
+  messages?: Array<{ id: string; threadId: string }>;
+}
+
+export class GmailConnector implements IConnector {
+  readonly name = 'gmail';
+  readonly type = 'api' as const;
+
+  private lastPollTime: Date | null = null;
+  private lastPollCount = 0;
+  private lastError: string | undefined = undefined;
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  constructor(_config: ConnectorConfig) {
+    // config reserved for future channel-scoped filtering
+  }
+
+  async init(): Promise<void> {
+    // Verify gws CLI is available
+    try {
+      execSync('gws --version', { stdio: 'pipe' });
+    } catch {
+      throw new Error('gws CLI not found. Install it and run: gws auth login');
+    }
+  }
+
+  async dispose(): Promise<void> {
+    // No resources to clean up
+  }
+
+  async healthCheck(): Promise<ConnectorHealth> {
+    return {
+      healthy: this.lastError === undefined,
+      lastPollTime: this.lastPollTime,
+      lastPollCount: this.lastPollCount,
+      error: this.lastError,
+    };
+  }
+
+  getAuthRequirements(): AuthRequirement[] {
+    return [
+      {
+        type: 'cli',
+        cli: 'gws',
+        cliAuthCommand: 'gws auth login',
+        description: 'Google Workspace CLI authentication. Run: gws auth login',
+      },
+    ];
+  }
+
+  async authenticate(): Promise<boolean> {
+    try {
+      execSync('gws auth status', { stdio: 'pipe' });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private getHeader(msg: GmailMessage, name: string): string {
+    const headers = msg.payload?.headers ?? [];
+    return headers.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value ?? '';
+  }
+
+  async poll(since: Date): Promise<NormalizedItem[]> {
+    const items: NormalizedItem[] = [];
+    let hadError = false;
+
+    try {
+      const afterEpoch = Math.floor(since.getTime() / 1000);
+      const listParams = JSON.stringify({
+        userId: 'me',
+        q: `after:${afterEpoch}`,
+        maxResults: 25,
+      });
+      const listResult = execGws(
+        `gmail users messages list --params '${listParams}'`
+      ) as GmailMessageList;
+
+      const messageRefs = listResult.messages ?? [];
+
+      for (const ref of messageRefs) {
+        try {
+          const getParams = JSON.stringify({
+            userId: 'me',
+            id: ref.id,
+            format: 'metadata',
+            metadataHeaders: ['Subject', 'From', 'Date'],
+          });
+          const msg = execGws(`gmail users messages get --params '${getParams}'`) as GmailMessage;
+
+          const subject = this.getHeader(msg, 'Subject');
+          const from = this.getHeader(msg, 'From');
+          const snippet = msg.snippet ?? '';
+
+          const internalDateMs = msg.internalDate ? parseInt(msg.internalDate, 10) : Date.now();
+          const timestamp = new Date(internalDateMs);
+
+          // Only include messages after since
+          if (timestamp <= since) continue;
+
+          items.push({
+            source: 'gmail',
+            sourceId: msg.id,
+            channel: 'inbox',
+            author: from,
+            content: `Subject: ${subject}\n\n${snippet}`,
+            timestamp,
+            type: 'email',
+            metadata: {
+              threadId: msg.threadId,
+              subject,
+              from,
+            },
+          });
+        } catch (err) {
+          // Skip individual message fetch errors
+          hadError = true;
+          this.lastError = err instanceof Error ? err.message : String(err);
+        }
+      }
+    } catch (err) {
+      hadError = true;
+      this.lastError = err instanceof Error ? err.message : String(err);
+    }
+
+    this.lastPollTime = new Date();
+    this.lastPollCount = items.length;
+    // lastError was set in catch blocks; clear only if no error occurred this pass
+    if (!hadError) this.lastError = undefined;
+
+    return items;
+  }
+}

--- a/packages/standalone/src/connectors/imessage/index.ts
+++ b/packages/standalone/src/connectors/imessage/index.ts
@@ -1,0 +1,151 @@
+/**
+ * iMessageConnector — reads messages from macOS iMessage SQLite database.
+ * Queries ~/Library/Messages/chat.db for messages newer than the given timestamp.
+ * Uses better-sqlite3 via the standalone's Database wrapper.
+ *
+ * iMessage timestamps use Core Data format: nanoseconds since 2001-01-01.
+ * Conversion: unix_ms = (date / 1_000_000) + 978_307_200_000
+ */
+
+import { homedir } from 'os';
+import { join } from 'path';
+
+import Database from '../../sqlite.js';
+import type { SQLiteDatabase } from '../../sqlite.js';
+
+import type {
+  AuthRequirement,
+  ConnectorConfig,
+  ConnectorHealth,
+  IConnector,
+  NormalizedItem,
+} from '../framework/types.js';
+
+interface MessageRow {
+  ROWID: number;
+  date: number;
+  text: string;
+  is_from_me: number;
+  sender: string | null;
+  chat_id: string | null;
+  display_name: string | null;
+}
+
+export class IMessageConnector implements IConnector {
+  readonly name = 'imessage';
+  readonly type = 'local' as const;
+
+  private db: SQLiteDatabase | null = null;
+  private dbPath: string;
+  private lastPollTime: Date | null = null;
+  private lastPollCount = 0;
+  private lastError: string | undefined = undefined;
+
+  constructor(_config: ConnectorConfig, dbPath?: string) {
+    this.dbPath = dbPath ?? join(homedir(), 'Library', 'Messages', 'chat.db');
+  }
+
+  async init(): Promise<void> {
+    try {
+      this.db = new Database(this.dbPath);
+    } catch (err) {
+      throw new Error(
+        `iMessageConnector: failed to open database at ${this.dbPath}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  async dispose(): Promise<void> {
+    if (this.db) {
+      this.db.close();
+      this.db = null;
+    }
+  }
+
+  async healthCheck(): Promise<ConnectorHealth> {
+    return {
+      healthy: this.db !== null && this.lastError === undefined,
+      lastPollTime: this.lastPollTime,
+      lastPollCount: this.lastPollCount,
+      error: this.lastError,
+    };
+  }
+
+  getAuthRequirements(): AuthRequirement[] {
+    return [
+      {
+        type: 'none',
+        description:
+          'No authentication required. Requires Full Disk Access for Terminal in System Settings > Privacy & Security.',
+      },
+    ];
+  }
+
+  async authenticate(): Promise<boolean> {
+    return this.db !== null;
+  }
+
+  async poll(since: Date): Promise<NormalizedItem[]> {
+    if (!this.db) throw new Error('iMessageConnector not initialized');
+
+    const items: NormalizedItem[] = [];
+    let hadError = false;
+
+    try {
+      // iMessage date is nanoseconds since 2001-01-01 (Core Data epoch).
+      // Values exceed Number.MAX_SAFE_INTEGER, so we convert in SQL instead.
+      // Unix seconds = date / 1_000_000_000 + 978_307_200
+      const sinceUnixSec = Math.floor(since.getTime() / 1000);
+
+      const rows = this.db
+        .prepare(
+          `SELECT m.ROWID,
+                  (m.date / 1000000000 + 978307200) as date,
+                  m.text, m.is_from_me,
+                  h.id as sender,
+                  c.chat_identifier as chat_id,
+                  c.display_name
+           FROM message m
+           LEFT JOIN handle h ON m.handle_id = h.ROWID
+           LEFT JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
+           LEFT JOIN chat c ON c.ROWID = cmj.chat_id
+           WHERE (m.date / 1000000000 + 978307200) > ?
+             AND m.text IS NOT NULL AND m.text != ''
+           ORDER BY m.date ASC`
+        )
+        .all(sinceUnixSec) as MessageRow[];
+
+      for (const row of rows) {
+        // date is already Unix seconds (converted in SQL)
+        const unixMs = row.date * 1000;
+        const author = row.is_from_me ? 'me' : (row.sender ?? 'unknown');
+        const channel = row.display_name || row.chat_id || row.sender || 'unknown';
+
+        items.push({
+          source: 'imessage',
+          sourceId: `imessage:${row.ROWID}`,
+          channel,
+          author,
+          content: row.text,
+          timestamp: new Date(unixMs),
+          type: 'message',
+          metadata: {
+            isFromMe: row.is_from_me === 1,
+            chatId: row.chat_id,
+            sender: row.sender,
+          },
+        });
+      }
+    } catch (err) {
+      hadError = true;
+      this.lastError = err instanceof Error ? err.message : String(err);
+    }
+
+    this.lastPollTime = new Date();
+    this.lastPollCount = items.length;
+    // lastError was set in catch blocks; clear only if no error occurred this pass
+    if (!hadError) this.lastError = undefined;
+
+    return items;
+  }
+}

--- a/packages/standalone/src/connectors/index.ts
+++ b/packages/standalone/src/connectors/index.ts
@@ -1,0 +1,43 @@
+export * from './framework/index.js';
+
+export const AVAILABLE_CONNECTORS = [
+  'slack',
+  'telegram',
+  'discord',
+  'chatwork',
+  'gmail',
+  'calendar',
+  'notion',
+  'obsidian',
+  'kagemusha',
+  'sheets',
+  'trello',
+  'drive',
+  'imessage',
+] as const;
+
+export type AvailableConnector = (typeof AVAILABLE_CONNECTORS)[number];
+
+/**
+ * Dynamic connector loader — avoids importing all connector deps at startup.
+ * Optionally accepts a ConnectorConfig; if omitted, a minimal disabled config is used
+ * (useful for CLI introspection like healthCheck or getAuthRequirements).
+ */
+export async function loadConnector(
+  name: string,
+  config?: import('./framework/types.js').ConnectorConfig
+): Promise<import('./framework/types.js').IConnector> {
+  const mod = await import(`./${name}/index.js`);
+  // Find the export that ends with 'Connector'
+  const connectorKey = Object.keys(mod).find((k) => k.endsWith('Connector'));
+  if (!connectorKey) throw new Error(`No connector class found in module: ${name}`);
+
+  const effectiveConfig: import('./framework/types.js').ConnectorConfig = config ?? {
+    enabled: false,
+    pollIntervalMinutes: 5,
+    channels: {},
+    auth: { type: 'none' },
+  };
+
+  return new mod[connectorKey](effectiveConfig);
+}

--- a/packages/standalone/src/connectors/kagemusha/index.ts
+++ b/packages/standalone/src/connectors/kagemusha/index.ts
@@ -1,0 +1,129 @@
+/**
+ * KagemushaConnector — reads messages from the Kagemusha local SQLite database.
+ * Queries channel_messages table for user messages newer than the given timestamp.
+ * Uses the standalone's node:sqlite wrapper (Database from ../../sqlite.js).
+ */
+
+import { homedir } from 'os';
+import { join } from 'path';
+
+import Database from '../../sqlite.js';
+import type { SQLiteDatabase } from '../../sqlite.js';
+
+import type {
+  AuthRequirement,
+  ConnectorConfig,
+  ConnectorHealth,
+  IConnector,
+  NormalizedItem,
+} from '../framework/types.js';
+
+interface ChannelMessage {
+  id: number | string;
+  channel: string;
+  channel_id: string;
+  user_id: string;
+  role: string;
+  content: string;
+  created_at: string;
+}
+
+export class KagemushaConnector implements IConnector {
+  readonly name = 'kagemusha';
+  readonly type = 'local' as const;
+
+  private db: SQLiteDatabase | null = null;
+  private dbPath: string;
+  private lastPollTime: Date | null = null;
+  private lastPollCount = 0;
+  private lastError: string | undefined = undefined;
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  constructor(_config: ConnectorConfig, dbPath?: string) {
+    this.dbPath = dbPath ?? join(homedir(), '.kagemusha', 'kagemusha.db');
+  }
+
+  async init(): Promise<void> {
+    try {
+      this.db = new Database(this.dbPath);
+    } catch (err) {
+      throw new Error(
+        `KagemushaConnector: failed to open database at ${this.dbPath}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  async dispose(): Promise<void> {
+    if (this.db) {
+      this.db.close();
+      this.db = null;
+    }
+  }
+
+  async healthCheck(): Promise<ConnectorHealth> {
+    return {
+      healthy: this.db !== null && this.lastError === undefined,
+      lastPollTime: this.lastPollTime,
+      lastPollCount: this.lastPollCount,
+      error: this.lastError,
+    };
+  }
+
+  getAuthRequirements(): AuthRequirement[] {
+    return [
+      {
+        type: 'none',
+        description:
+          'No authentication required. Kagemusha database must exist at ~/.kagemusha/kagemusha.db.',
+      },
+    ];
+  }
+
+  async authenticate(): Promise<boolean> {
+    return this.db !== null;
+  }
+
+  async poll(since: Date): Promise<NormalizedItem[]> {
+    if (!this.db) throw new Error('KagemushaConnector not initialized');
+
+    const items: NormalizedItem[] = [];
+    let hadError = false;
+
+    try {
+      const sinceMs = since.getTime();
+      const rows = this.db
+        .prepare(
+          `SELECT * FROM channel_messages WHERE created_at > ? AND role = 'user' ORDER BY created_at ASC LIMIT 5000`
+        )
+        .all(sinceMs) as ChannelMessage[];
+
+      for (const row of rows) {
+        items.push({
+          source: row.channel,
+          sourceId: `${row.channel_id}:${row.id}`,
+          channel: row.channel_id,
+          author: row.user_id,
+          content: row.content,
+          timestamp: new Date(Number(row.created_at)),
+          type: 'message',
+          metadata: {
+            channel: row.channel,
+            channelId: row.channel_id,
+            userId: row.user_id,
+            role: row.role,
+          },
+        });
+      }
+    } catch (err) {
+      hadError = true;
+      this.lastError = err instanceof Error ? err.message : String(err);
+    }
+
+    this.lastPollTime = new Date();
+    this.lastPollCount = items.length;
+    // lastError was set in catch blocks; clear only if no error occurred this pass
+    if (!hadError) this.lastError = undefined;
+
+    return items;
+  }
+}

--- a/packages/standalone/src/connectors/notion/index.ts
+++ b/packages/standalone/src/connectors/notion/index.ts
@@ -1,0 +1,249 @@
+/**
+ * NotionConnector — polls Notion pages via native fetch.
+ * Uses POST /search to find recently edited pages, then fetches block children for content.
+ */
+
+import type {
+  AuthRequirement,
+  ConnectorConfig,
+  ConnectorHealth,
+  IConnector,
+  NormalizedItem,
+} from '../framework/types.js';
+
+interface NotionRichText {
+  plain_text: string;
+}
+
+interface NotionTitleProperty {
+  title: NotionRichText[];
+}
+
+interface NotionPage {
+  id: string;
+  last_edited_time: string;
+  properties: Record<string, NotionTitleProperty | unknown>;
+}
+
+interface NotionSearchResponse {
+  results: NotionPage[];
+  has_more: boolean;
+  next_cursor: string | null;
+}
+
+interface NotionBlock {
+  type: string;
+  [key: string]: unknown;
+}
+
+interface NotionBlockChildrenResponse {
+  results: NotionBlock[];
+  has_more: boolean;
+  next_cursor: string | null;
+}
+
+export class NotionConnector implements IConnector {
+  readonly name = 'notion';
+  readonly type = 'api' as const;
+
+  private config: ConnectorConfig;
+  private token: string | null = null;
+  private readonly baseUrl = 'https://api.notion.com/v1';
+  private readonly notionVersion = '2022-06-28';
+  private lastPollTime: Date | null = null;
+  private lastPollCount = 0;
+  private lastError: string | undefined = undefined;
+
+  constructor(config: ConnectorConfig) {
+    this.config = config;
+  }
+
+  async init(): Promise<void> {
+    const token =
+      this.config.auth.token ?? process.env[this.config.auth.tokenName ?? 'NOTION_TOKEN'];
+    if (!token) {
+      throw new Error('Notion token not found. Set NOTION_TOKEN environment variable.');
+    }
+    this.token = token;
+  }
+
+  async dispose(): Promise<void> {
+    this.token = null;
+  }
+
+  async healthCheck(): Promise<ConnectorHealth> {
+    return {
+      healthy: this.token !== null && this.lastError === undefined,
+      lastPollTime: this.lastPollTime,
+      lastPollCount: this.lastPollCount,
+      error: this.lastError,
+    };
+  }
+
+  getAuthRequirements(): AuthRequirement[] {
+    return [
+      {
+        type: 'token',
+        tokenName: 'NOTION_TOKEN',
+        description:
+          'Notion Internal Integration Token. Create an integration at https://www.notion.so/my-integrations and share your pages with it.',
+      },
+    ];
+  }
+
+  async authenticate(): Promise<boolean> {
+    try {
+      if (!this.token) return false;
+      const res = await fetch(`${this.baseUrl}/users/me`, {
+        headers: this.authHeaders(),
+      });
+      return res.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  private authHeaders(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.token}`,
+      'Notion-Version': this.notionVersion,
+      'Content-Type': 'application/json',
+    };
+  }
+
+  private extractTitle(page: NotionPage): string {
+    for (const value of Object.values(page.properties)) {
+      const prop = value as NotionTitleProperty;
+      if (Array.isArray(prop.title)) {
+        return prop.title.map((t) => t.plain_text).join('');
+      }
+    }
+    return page.id;
+  }
+
+  private extractBlockText(block: NotionBlock): string {
+    const blockContent = block[block.type] as Record<string, unknown> | undefined;
+    if (!blockContent) return '';
+    const richText = blockContent['rich_text'] as NotionRichText[] | undefined;
+    if (!Array.isArray(richText)) return '';
+    return richText.map((t) => t.plain_text).join('');
+  }
+
+  private async fetchBlockChildren(pageId: string): Promise<string> {
+    const texts: string[] = [];
+    let startCursor: string | undefined;
+    let hasMore = true;
+
+    while (hasMore) {
+      const url = `${this.baseUrl}/blocks/${pageId}/children?page_size=100${startCursor ? `&start_cursor=${startCursor}` : ''}`;
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 30_000);
+      try {
+        const res = await fetch(url, {
+          headers: this.authHeaders(),
+          signal: controller.signal,
+        });
+        if (!res.ok) break;
+        const data = (await res.json()) as NotionBlockChildrenResponse;
+
+        for (const block of data.results ?? []) {
+          const text = this.extractBlockText(block);
+          if (text) texts.push(text);
+        }
+
+        hasMore = data.has_more ?? false;
+        startCursor = data.next_cursor ?? undefined;
+      } catch {
+        break;
+      } finally {
+        clearTimeout(timeout);
+      }
+    }
+
+    return texts.join('\n');
+  }
+
+  async poll(since: Date): Promise<NormalizedItem[]> {
+    if (!this.token) throw new Error('NotionConnector not initialized');
+
+    const items: NormalizedItem[] = [];
+    let hadError = false;
+
+    try {
+      let startCursor: string | undefined;
+      let hasMore = true;
+
+      while (hasMore) {
+        const searchBody: Record<string, unknown> = {
+          filter: { property: 'object', value: 'page' },
+          sort: { direction: 'descending', timestamp: 'last_edited_time' },
+          page_size: 100,
+        };
+        if (startCursor) searchBody.start_cursor = startCursor;
+
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 30_000);
+        let res: Response;
+        try {
+          res = await fetch(`${this.baseUrl}/search`, {
+            method: 'POST',
+            headers: this.authHeaders(),
+            body: JSON.stringify(searchBody),
+            signal: controller.signal,
+          });
+        } finally {
+          clearTimeout(timeout);
+        }
+
+        if (!res.ok) {
+          hadError = true;
+          this.lastError = `Notion search HTTP ${res.status}`;
+          this.lastPollTime = new Date();
+          this.lastPollCount = 0;
+          return items;
+        }
+
+        const data = (await res.json()) as NotionSearchResponse;
+
+        for (const page of data.results) {
+          const lastEdited = new Date(page.last_edited_time);
+          if (lastEdited <= since) continue;
+
+          const title = this.extractTitle(page);
+          const blockText = await this.fetchBlockChildren(page.id);
+          const content = blockText ? `${title}\n\n${blockText}` : title;
+
+          items.push({
+            source: 'notion',
+            sourceId: page.id,
+            channel: 'notion',
+            author: '',
+            content,
+            timestamp: lastEdited,
+            type: 'document',
+            metadata: {
+              pageId: page.id,
+              title,
+              lastEditedTime: page.last_edited_time,
+            },
+          });
+        }
+
+        hasMore = data.has_more ?? false;
+        startCursor = data.next_cursor ?? undefined;
+      }
+    } catch (err) {
+      hadError = true;
+      this.lastError = err instanceof Error ? err.message : String(err);
+    }
+
+    items.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+
+    this.lastPollTime = new Date();
+    this.lastPollCount = items.length;
+    // lastError was set in catch blocks; clear only if no error occurred this pass
+    if (!hadError) this.lastError = undefined;
+
+    return items;
+  }
+}

--- a/packages/standalone/src/connectors/obsidian/index.ts
+++ b/packages/standalone/src/connectors/obsidian/index.ts
@@ -1,0 +1,159 @@
+/**
+ * ObsidianConnector — polls an Obsidian vault by scanning *.md files on the local filesystem.
+ * Uses statSync for mtime checks and readFileSync for content.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative } from 'path';
+
+import type {
+  AuthRequirement,
+  ConnectorConfig,
+  ConnectorHealth,
+  IConnector,
+  NormalizedItem,
+} from '../framework/types.js';
+
+export class ObsidianConnector implements IConnector {
+  readonly name = 'obsidian';
+  readonly type = 'local' as const;
+
+  private config: ConnectorConfig;
+  private lastPollTime: Date | null = null;
+  private lastPollCount = 0;
+  private lastError: string | undefined = undefined;
+
+  constructor(config: ConnectorConfig) {
+    this.config = config;
+  }
+
+  async init(): Promise<void> {
+    const vaultPath = this.getVaultPath();
+    if (!vaultPath) {
+      throw new Error('Obsidian vault path not configured. Set vaultPath in channel config.');
+    }
+    try {
+      statSync(vaultPath);
+    } catch {
+      throw new Error(`Obsidian vault path does not exist: ${vaultPath}`);
+    }
+  }
+
+  async dispose(): Promise<void> {
+    // No resources to clean up
+  }
+
+  async healthCheck(): Promise<ConnectorHealth> {
+    return {
+      healthy: this.lastError === undefined,
+      lastPollTime: this.lastPollTime,
+      lastPollCount: this.lastPollCount,
+      error: this.lastError,
+    };
+  }
+
+  getAuthRequirements(): AuthRequirement[] {
+    return [
+      {
+        type: 'none',
+        description: 'No authentication required. Configure vaultPath in channel settings.',
+      },
+    ];
+  }
+
+  async authenticate(): Promise<boolean> {
+    const vaultPath = this.getVaultPath();
+    if (!vaultPath) return false;
+    try {
+      statSync(vaultPath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private getVaultPath(): string | undefined {
+    for (const channelCfg of Object.values(this.config.channels)) {
+      if (channelCfg.vaultPath) {
+        return channelCfg.vaultPath;
+      }
+    }
+    return undefined;
+  }
+
+  private collectMdFiles(dir: string): string[] {
+    const results: string[] = [];
+    try {
+      const entries = readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        // Skip hidden directories (e.g., .obsidian, .git)
+        if (entry.name.startsWith('.')) continue;
+        const fullPath = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          results.push(...this.collectMdFiles(fullPath));
+        } else if (entry.isFile() && entry.name.endsWith('.md')) {
+          results.push(fullPath);
+        }
+      }
+    } catch {
+      // Skip unreadable directories
+    }
+    return results;
+  }
+
+  async poll(since: Date): Promise<NormalizedItem[]> {
+    const vaultPath = this.getVaultPath();
+    if (!vaultPath) throw new Error('ObsidianConnector: vaultPath not configured');
+
+    const items: NormalizedItem[] = [];
+    let hadError = false;
+
+    try {
+      const mdFiles = this.collectMdFiles(vaultPath);
+
+      for (const filePath of mdFiles) {
+        try {
+          const stat = statSync(filePath);
+          if (stat.mtime <= since) continue;
+
+          const relPath = relative(vaultPath, filePath);
+          const parts = relPath.split(/[/\\]/);
+          const channelName = parts.length > 1 ? (parts[0] ?? 'vault') : 'vault';
+
+          const content = readFileSync(filePath, 'utf8');
+
+          items.push({
+            source: 'obsidian',
+            sourceId: relPath,
+            channel: channelName,
+            author: '',
+            content,
+            timestamp: stat.mtime,
+            type: 'note',
+            metadata: {
+              filePath,
+              relPath,
+              mtime: stat.mtime.toISOString(),
+            },
+          });
+        } catch (err) {
+          // Skip individual file errors
+          hadError = true;
+          this.lastError = err instanceof Error ? err.message : String(err);
+        }
+      }
+    } catch (err) {
+      hadError = true;
+      this.lastError = err instanceof Error ? err.message : String(err);
+    }
+
+    items.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+
+    this.lastPollTime = new Date();
+    this.lastPollCount = items.length;
+    // lastError was set in catch blocks; clear only if no error occurred this pass
+    if (!hadError) this.lastError = undefined;
+
+    return items;
+  }
+}

--- a/packages/standalone/src/connectors/sheets/index.ts
+++ b/packages/standalone/src/connectors/sheets/index.ts
@@ -1,0 +1,221 @@
+/**
+ * SheetsConnector — polls Google Sheets via the gws CLI tool.
+ * Uses child_process.execSync to call gws CLI commands.
+ * Emits spreadsheet_row NormalizedItems for changed/new rows.
+ */
+
+import { execSync } from 'child_process';
+
+import type {
+  AuthRequirement,
+  ConnectorConfig,
+  ConnectorHealth,
+  IConnector,
+  NormalizedItem,
+} from '../framework/types.js';
+import { execGws } from '../framework/gws-utils.js';
+
+interface SheetValues {
+  values?: string[][];
+}
+
+export class SheetsConnector implements IConnector {
+  readonly name = 'sheets';
+  readonly type = 'api' as const;
+
+  private config: ConnectorConfig;
+  private lastPollTime: Date | null = null;
+  private lastPollCount = 0;
+  private lastError: string | undefined = undefined;
+
+  /** Snapshot of previous rows per channel: channelName → rows (excluding header) */
+  private lastSnapshot: Map<string, string[][]> = new Map();
+
+  constructor(config: ConnectorConfig) {
+    this.config = config;
+  }
+
+  async init(): Promise<void> {
+    try {
+      execSync('gws --version', { stdio: 'pipe' });
+    } catch {
+      throw new Error('gws CLI not found. Install it and run: gws auth login');
+    }
+  }
+
+  async dispose(): Promise<void> {
+    this.lastSnapshot.clear();
+  }
+
+  async healthCheck(): Promise<ConnectorHealth> {
+    return {
+      healthy: this.lastError === undefined,
+      lastPollTime: this.lastPollTime,
+      lastPollCount: this.lastPollCount,
+      error: this.lastError,
+    };
+  }
+
+  getAuthRequirements(): AuthRequirement[] {
+    return [
+      {
+        type: 'cli',
+        cli: 'gws',
+        cliAuthCommand: 'gws auth login',
+        description: 'Google Workspace CLI authentication. Run: gws auth login',
+      },
+    ];
+  }
+
+  async authenticate(): Promise<boolean> {
+    try {
+      execSync('gws auth status', { stdio: 'pipe' });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async poll(_since: Date): Promise<NormalizedItem[]> {
+    const items: NormalizedItem[] = [];
+    let hadError = false;
+
+    for (const [channelKey, channelCfg] of Object.entries(this.config.channels)) {
+      if (channelCfg.role === 'ignore') continue;
+      if (!channelCfg.spreadsheetId) continue;
+      const headerRange = channelCfg.sheetRange;
+      const dataRange = channelCfg.dataRange;
+      if (!headerRange) continue;
+
+      const channelName = channelCfg.name ?? channelKey;
+
+      try {
+        let headers: string[];
+        let effectiveRows: string[][];
+
+        if (dataRange) {
+          // Separate header and data ranges (for large sheets)
+          const headerParams = JSON.stringify({
+            spreadsheetId: channelCfg.spreadsheetId,
+            range: headerRange,
+          });
+          const headerResult = execGws(
+            `sheets spreadsheets values get --params '${headerParams}'`,
+            { maxBuffer: 50 * 1024 * 1024 }
+          ) as SheetValues;
+          headers = (headerResult.values ?? [])[0] ?? [];
+          if (headers.length === 0) continue;
+
+          const dataParams = JSON.stringify({
+            spreadsheetId: channelCfg.spreadsheetId,
+            range: dataRange,
+          });
+          const dataResult = execGws(`sheets spreadsheets values get --params '${dataParams}'`, {
+            maxBuffer: 50 * 1024 * 1024,
+          }) as SheetValues;
+          effectiveRows = dataResult.values ?? [];
+        } else {
+          // Single range: first row is header, rest is data
+          const params = JSON.stringify({
+            spreadsheetId: channelCfg.spreadsheetId,
+            range: headerRange,
+          });
+          const result = execGws(`sheets spreadsheets values get --params '${params}'`, {
+            maxBuffer: 50 * 1024 * 1024,
+          }) as SheetValues;
+          const allRows = result.values ?? [];
+          if (allRows.length === 0) continue;
+          headers = allRows[0] ?? [];
+          if (headers.length === 0) continue;
+          effectiveRows = allRows.slice(1);
+        }
+
+        const isFirstPoll = !this.lastSnapshot.has(channelName);
+        const previousRows = this.lastSnapshot.get(channelName) ?? [];
+
+        // Build a map from row key (first column) to row data for the previous snapshot
+        const prevMap = new Map<string, string[]>();
+        for (const row of previousRows) {
+          const rowKey = row.find((c) => c && c.trim()) ?? '';
+          if (rowKey) prevMap.set(rowKey, row);
+        }
+
+        // For truth sources: first poll returns ALL populated rows as current state
+        // Subsequent polls return only changed rows
+        const activeRows = isFirstPoll
+          ? effectiveRows.filter((row) => {
+              // Only include rows with at least one non-empty column
+              const nonEmpty = row.filter((c) => c && c.trim()).length;
+              return nonEmpty >= 1;
+            })
+          : effectiveRows;
+
+        for (const row of activeRows) {
+          // Find row key: first non-empty column (A column may be empty in some sheets)
+          const rowKey = row.find((c) => c && c.trim()) ?? '';
+          if (!rowKey) continue;
+
+          if (isFirstPoll) {
+            // First poll: emit all populated rows as truth snapshot
+            const content = headers.map((header, i) => `${header}: ${row[i] ?? ''}`).join(' | ');
+            items.push({
+              source: 'sheets',
+              sourceId: `${channelCfg.spreadsheetId}:${rowKey}`,
+              channel: channelName,
+              author: 'spreadsheet',
+              content,
+              timestamp: new Date(),
+              type: 'spreadsheet_row',
+              metadata: {
+                spreadsheetId: channelCfg.spreadsheetId,
+                sheetRange: channelCfg.sheetRange,
+                rowKey,
+                headers,
+                values: row,
+              },
+            });
+          } else {
+            // Subsequent polls: only emit changed rows
+            const prevRow = prevMap.get(rowKey);
+            const rowChanged =
+              prevRow === undefined ||
+              headers.some((_, i) => (row[i] ?? '') !== (prevRow[i] ?? ''));
+
+            if (rowChanged) {
+              const content = headers.map((header, i) => `${header}: ${row[i] ?? ''}`).join(' | ');
+              items.push({
+                source: 'sheets',
+                sourceId: `${channelCfg.spreadsheetId}:${rowKey}`,
+                channel: channelName,
+                author: 'spreadsheet',
+                content,
+                timestamp: new Date(),
+                type: 'spreadsheet_row',
+                metadata: {
+                  spreadsheetId: channelCfg.spreadsheetId,
+                  sheetRange: channelCfg.sheetRange,
+                  rowKey,
+                  headers,
+                  values: row,
+                },
+              });
+            }
+          }
+        }
+
+        // Update snapshot with current data rows
+        this.lastSnapshot.set(channelName, effectiveRows);
+      } catch (err) {
+        hadError = true;
+        this.lastError = err instanceof Error ? err.message : String(err);
+      }
+    }
+
+    this.lastPollTime = new Date();
+    this.lastPollCount = items.length;
+    // lastError was set in catch blocks; clear only if no error occurred this pass
+    if (!hadError) this.lastError = undefined;
+
+    return items;
+  }
+}

--- a/packages/standalone/src/connectors/slack/index.ts
+++ b/packages/standalone/src/connectors/slack/index.ts
@@ -1,0 +1,157 @@
+/**
+ * SlackConnector — polls Slack channels via the Web API.
+ * Uses dynamic import for @slack/web-api to keep it optional at module load time.
+ */
+
+import type { WebClient } from '@slack/web-api';
+
+import type {
+  AuthRequirement,
+  ConnectorConfig,
+  ConnectorHealth,
+  IConnector,
+  NormalizedItem,
+} from '../framework/types.js';
+
+export class SlackConnector implements IConnector {
+  readonly name = 'slack';
+  readonly type = 'api' as const;
+
+  private config: ConnectorConfig;
+  private client: WebClient | null = null;
+  private userCache = new Map<string, string>();
+  private lastPollTime: Date | null = null;
+  private lastPollCount = 0;
+  private lastError: string | undefined = undefined;
+
+  constructor(config: ConnectorConfig) {
+    this.config = config;
+  }
+
+  async init(): Promise<void> {
+    const token =
+      this.config.auth.token ?? process.env[this.config.auth.tokenName ?? 'SLACK_BOT_TOKEN'];
+    if (!token) {
+      throw new Error('Slack bot token not found. Set SLACK_BOT_TOKEN environment variable.');
+    }
+    const { WebClient } = await import('@slack/web-api');
+    this.client = new WebClient(token);
+  }
+
+  async dispose(): Promise<void> {
+    this.client = null;
+    this.userCache.clear();
+  }
+
+  async healthCheck(): Promise<ConnectorHealth> {
+    return {
+      healthy: this.client !== null && this.lastError === undefined,
+      lastPollTime: this.lastPollTime,
+      lastPollCount: this.lastPollCount,
+      error: this.lastError,
+    };
+  }
+
+  getAuthRequirements(): AuthRequirement[] {
+    return [
+      {
+        type: 'token',
+        tokenName: 'SLACK_BOT_TOKEN',
+        description: 'Slack Bot OAuth token with channels:history and users:read scopes.',
+      },
+    ];
+  }
+
+  async authenticate(): Promise<boolean> {
+    try {
+      if (!this.client) return false;
+      await this.client.auth.test();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async resolveUserName(userId: string): Promise<string> {
+    if (this.userCache.has(userId)) {
+      return this.userCache.get(userId)!;
+    }
+    if (!this.client) return userId;
+    try {
+      const result = await this.client.users.info({ user: userId });
+      const name: string = result.user?.real_name ?? result.user?.name ?? userId;
+      this.userCache.set(userId, name);
+      return name;
+    } catch {
+      this.userCache.set(userId, userId);
+      return userId;
+    }
+  }
+
+  async poll(since: Date): Promise<NormalizedItem[]> {
+    if (!this.client) throw new Error('SlackConnector not initialized');
+
+    const items: NormalizedItem[] = [];
+    let hadError = false;
+
+    for (const [channelId, channelCfg] of Object.entries(this.config.channels)) {
+      if (channelCfg.role === 'ignore') continue;
+
+      const sinceTs = (since.getTime() / 1000).toFixed(6);
+
+      try {
+        let cursor: string | undefined;
+        do {
+          const result = await this.client.conversations.history({
+            channel: channelId,
+            oldest: sinceTs,
+            limit: 200,
+            cursor,
+          });
+
+          const messages = result.messages ?? [];
+
+          for (const msg of messages) {
+            // Skip bot messages
+            if (msg.bot_id || msg.subtype === 'bot_message') continue;
+            // Skip messages without user or text
+            if (!msg.user || !msg.text) continue;
+
+            const authorName = await this.resolveUserName(msg.user as string);
+            const timestamp = new Date(parseFloat(msg.ts as string) * 1000);
+
+            items.push({
+              source: 'slack',
+              sourceId: `${channelId}:${msg.ts as string}`,
+              channel: channelCfg.name ?? channelId,
+              author: authorName,
+              content: msg.text as string,
+              timestamp,
+              type: 'message',
+              metadata: {
+                channelId,
+                ts: msg.ts as string,
+                threadTs: msg.thread_ts as string | undefined,
+              },
+            });
+          }
+
+          cursor = result.response_metadata?.next_cursor || undefined;
+        } while (cursor);
+      } catch (err) {
+        hadError = true;
+        this.lastError = err instanceof Error ? err.message : String(err);
+      }
+    }
+
+    // Sort ascending by timestamp
+    items.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+
+    this.lastPollTime = new Date();
+    this.lastPollCount = items.length;
+    // lastError was set in catch blocks; clear only if no error occurred this pass
+    if (!hadError) this.lastError = undefined;
+
+    return items;
+  }
+}

--- a/packages/standalone/src/connectors/telegram/index.ts
+++ b/packages/standalone/src/connectors/telegram/index.ts
@@ -1,0 +1,185 @@
+/**
+ * TelegramConnector — polls Telegram channels via native fetch using Bot API getUpdates.
+ * Tracks offset state for sequential polling.
+ */
+
+import type {
+  AuthRequirement,
+  ConnectorConfig,
+  ConnectorHealth,
+  IConnector,
+  NormalizedItem,
+} from '../framework/types.js';
+
+interface TelegramUser {
+  id: number;
+  first_name: string;
+  last_name?: string;
+  username?: string;
+}
+
+interface TelegramMessage {
+  message_id: number;
+  from?: TelegramUser;
+  date: number;
+  text?: string;
+  chat: {
+    id: number;
+    type: string;
+    title?: string;
+  };
+}
+
+interface TelegramUpdate {
+  update_id: number;
+  message?: TelegramMessage;
+}
+
+interface TelegramGetUpdatesResponse {
+  ok: boolean;
+  result: TelegramUpdate[];
+}
+
+export class TelegramConnector implements IConnector {
+  readonly name = 'telegram';
+  readonly type = 'api' as const;
+
+  private config: ConnectorConfig;
+  private token: string | null = null;
+  private readonly baseUrl = 'https://api.telegram.org';
+  private offset: number = 0;
+  private lastPollTime: Date | null = null;
+  private lastPollCount = 0;
+  private lastError: string | undefined = undefined;
+
+  constructor(config: ConnectorConfig) {
+    this.config = config;
+  }
+
+  async init(): Promise<void> {
+    const token =
+      this.config.auth.token ?? process.env[this.config.auth.tokenName ?? 'TELEGRAM_BOT_TOKEN'];
+    if (!token) {
+      throw new Error('Telegram bot token not found. Set TELEGRAM_BOT_TOKEN environment variable.');
+    }
+    this.token = token;
+  }
+
+  async dispose(): Promise<void> {
+    this.token = null;
+  }
+
+  async healthCheck(): Promise<ConnectorHealth> {
+    return {
+      healthy: this.token !== null && this.lastError === undefined,
+      lastPollTime: this.lastPollTime,
+      lastPollCount: this.lastPollCount,
+      error: this.lastError,
+    };
+  }
+
+  getAuthRequirements(): AuthRequirement[] {
+    return [
+      {
+        type: 'token',
+        tokenName: 'TELEGRAM_BOT_TOKEN',
+        description:
+          'Telegram Bot token from @BotFather. Create a bot with /newbot and copy the token.',
+      },
+    ];
+  }
+
+  async authenticate(): Promise<boolean> {
+    try {
+      if (!this.token) return false;
+      const res = await fetch(`${this.baseUrl}/bot${this.token}/getMe`);
+      if (!res.ok) return false;
+      const data = (await res.json()) as { ok: boolean };
+      return data.ok === true;
+    } catch {
+      return false;
+    }
+  }
+
+  async poll(since: Date): Promise<NormalizedItem[]> {
+    if (!this.token) throw new Error('TelegramConnector not initialized');
+
+    const items: NormalizedItem[] = [];
+    let hadError = false;
+    const sinceEpoch = Math.floor(since.getTime() / 1000);
+
+    try {
+      const url = `${this.baseUrl}/bot${this.token}/getUpdates?offset=${this.offset}&limit=100&timeout=0`;
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 30_000);
+      let res: Response;
+      try {
+        res = await fetch(url, { signal: controller.signal });
+      } finally {
+        clearTimeout(timeout);
+      }
+
+      if (!res.ok) {
+        hadError = true;
+        this.lastError = `getUpdates HTTP ${res.status}`;
+        this.lastPollTime = new Date();
+        this.lastPollCount = 0;
+        return items;
+      }
+
+      const data = (await res.json()) as TelegramGetUpdatesResponse;
+
+      if (!data.ok) {
+        hadError = true;
+        this.lastError = 'Telegram API returned ok=false';
+        this.lastPollTime = new Date();
+        this.lastPollCount = 0;
+        return items;
+      }
+
+      for (const update of data.result) {
+        // Advance offset so we don't re-fetch this update
+        if (update.update_id >= this.offset) {
+          this.offset = update.update_id + 1;
+        }
+
+        const msg = update.message;
+        if (!msg) continue;
+        if (!msg.text) continue;
+
+        // Filter by date > since
+        if (msg.date <= sinceEpoch) continue;
+
+        const chatId = String(msg.chat.id);
+        const author = msg.from?.first_name ?? 'unknown';
+
+        items.push({
+          source: 'telegram',
+          sourceId: `${chatId}:${msg.message_id}`,
+          channel: msg.chat.title ?? chatId,
+          author,
+          content: msg.text,
+          timestamp: new Date(msg.date * 1000),
+          type: 'message',
+          metadata: {
+            chatId,
+            messageId: msg.message_id,
+            updateId: update.update_id,
+          },
+        });
+      }
+    } catch (err) {
+      hadError = true;
+      this.lastError = err instanceof Error ? err.message : String(err);
+    }
+
+    items.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+
+    this.lastPollTime = new Date();
+    this.lastPollCount = items.length;
+    // lastError was set in catch blocks; clear only if no error occurred this pass
+    if (!hadError) this.lastError = undefined;
+
+    return items;
+  }
+}

--- a/packages/standalone/src/connectors/trello/index.ts
+++ b/packages/standalone/src/connectors/trello/index.ts
@@ -1,0 +1,222 @@
+/**
+ * TrelloConnector — polls Trello boards via native fetch.
+ * Auth token format: "apiKey:token" stored in config.auth.token or TRELLO_TOKEN env var.
+ * Emits kanban_card NormalizedItems for moved/new cards.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+import type {
+  AuthRequirement,
+  ConnectorConfig,
+  ConnectorHealth,
+  IConnector,
+  NormalizedItem,
+} from '../framework/types.js';
+
+interface TrelloCard {
+  id: string;
+  name: string;
+  idMembers: string[];
+  dateLastActivity: string;
+}
+
+interface TrelloList {
+  id: string;
+  name: string;
+  cards: TrelloCard[];
+}
+
+export class TrelloConnector implements IConnector {
+  readonly name = 'trello';
+  readonly type = 'api' as const;
+
+  private config: ConnectorConfig;
+  private apiKey: string | null = null;
+  private token: string | null = null;
+  private readonly baseUrl = 'https://api.trello.com/1';
+  private lastPollTime: Date | null = null;
+  private lastPollCount = 0;
+  private lastError: string | undefined = undefined;
+
+  /** boardId → (cardId → listName) */
+  private lastCardStates: Map<string, Map<string, string>> = new Map();
+
+  private readonly stateFilePath = join(homedir(), '.mama', 'connectors', 'trello', 'trello-state.json');
+
+  constructor(config: ConnectorConfig) {
+    this.config = config;
+  }
+
+  private loadState(): void {
+    if (existsSync(this.stateFilePath)) {
+      try {
+        const data = JSON.parse(readFileSync(this.stateFilePath, 'utf-8'));
+        for (const [board, cards] of Object.entries(data.lastCardStates ?? {})) {
+          this.lastCardStates.set(board, new Map(Object.entries(cards as Record<string, string>)));
+        }
+      } catch { /* ignore corrupt state */ }
+    }
+  }
+
+  private saveState(): void {
+    const dir = join(homedir(), '.mama', 'connectors', 'trello');
+    mkdirSync(dir, { recursive: true });
+    const obj: Record<string, Record<string, string>> = {};
+    for (const [board, cards] of this.lastCardStates) {
+      obj[board] = Object.fromEntries(cards);
+    }
+    writeFileSync(this.stateFilePath, JSON.stringify({ lastCardStates: obj }));
+  }
+
+  async init(): Promise<void> {
+    const rawToken =
+      this.config.auth.token ?? process.env[this.config.auth.tokenName ?? 'TRELLO_TOKEN'];
+    if (!rawToken) {
+      throw new Error(
+        'Trello token not found. Set TRELLO_TOKEN environment variable (format: apiKey:token).'
+      );
+    }
+    const parts = rawToken.split(':');
+    if (parts.length < 2) {
+      throw new Error('Trello token format invalid. Expected "apiKey:token".');
+    }
+    this.apiKey = parts[0] ?? null;
+    this.token = parts.slice(1).join(':');
+    this.loadState();
+  }
+
+  async dispose(): Promise<void> {
+    this.apiKey = null;
+    this.token = null;
+    this.lastCardStates.clear();
+  }
+
+  async healthCheck(): Promise<ConnectorHealth> {
+    return {
+      healthy: this.token !== null && this.lastError === undefined,
+      lastPollTime: this.lastPollTime,
+      lastPollCount: this.lastPollCount,
+      error: this.lastError,
+    };
+  }
+
+  getAuthRequirements(): AuthRequirement[] {
+    return [
+      {
+        type: 'token',
+        tokenName: 'TRELLO_TOKEN',
+        description:
+          'Trello API credentials in format "apiKey:token". Get from https://trello.com/app-key',
+      },
+    ];
+  }
+
+  async authenticate(): Promise<boolean> {
+    try {
+      if (!this.apiKey || !this.token) return false;
+      const url = `${this.baseUrl}/members/me?key=${this.apiKey}&token=${this.token}`;
+      const res = await fetch(url);
+      return res.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  async poll(_since: Date): Promise<NormalizedItem[]> {
+    if (!this.apiKey || !this.token) throw new Error('TrelloConnector not initialized');
+
+    const items: NormalizedItem[] = [];
+    let hadError = false;
+
+    for (const [channelKey, channelCfg] of Object.entries(this.config.channels)) {
+      if (channelCfg.role === 'ignore') continue;
+      if (!channelCfg.boardId) continue;
+
+      const channelName = channelCfg.name ?? channelKey;
+      const boardId = channelCfg.boardId;
+
+      try {
+        const url =
+          `${this.baseUrl}/boards/${boardId}/lists` +
+          `?cards=open&card_fields=name,idMembers,dateLastActivity` +
+          `&key=${this.apiKey}&token=${this.token}`;
+
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 30_000);
+        let res: Response;
+        try {
+          res = await fetch(url, { signal: controller.signal });
+        } finally {
+          clearTimeout(timeout);
+        }
+
+        if (!res.ok) {
+          hadError = true;
+          this.lastError = `Board ${boardId}: HTTP ${res.status}`;
+          continue;
+        }
+
+        const lists = (await res.json()) as TrelloList[];
+
+        // Get or init previous card states for this board
+        if (!this.lastCardStates.has(boardId)) {
+          this.lastCardStates.set(boardId, new Map());
+        }
+        const prevCardState = this.lastCardStates.get(boardId)!;
+        const newCardState = new Map<string, string>();
+
+        for (const list of lists) {
+          for (const card of list.cards) {
+            newCardState.set(card.id, list.name);
+
+            const prevList = prevCardState.get(card.id);
+            const isNew = prevList === undefined;
+            const isMoved = prevList !== undefined && prevList !== list.name;
+
+            if (isNew || isMoved) {
+              let content = `${card.name} | ${list.name}`;
+              if (isMoved) {
+                content += ` (from: ${prevList})`;
+              }
+
+              items.push({
+                source: 'trello',
+                sourceId: `${boardId}:${card.id}:${Date.now()}`,
+                channel: channelName,
+                author: 'trello',
+                content,
+                timestamp: new Date(card.dateLastActivity),
+                type: 'kanban_card',
+                metadata: {
+                  boardId,
+                  cardId: card.id,
+                  listName: list.name,
+                  prevListName: prevList,
+                  cardName: card.name,
+                  members: card.idMembers,
+                },
+              });
+            }
+          }
+        }
+
+        // Update card state snapshot for this board
+        this.lastCardStates.set(boardId, newCardState);
+      } catch (err) {
+        hadError = true;
+        this.lastError = err instanceof Error ? err.message : String(err);
+      }
+    }
+
+    this.saveState();
+    this.lastPollTime = new Date();
+    this.lastPollCount = items.length;
+    // lastError was set in catch blocks; clear only if no error occurred this pass
+    if (!hadError) this.lastError = undefined;
+
+    return items;
+  }
+}

--- a/packages/standalone/src/memory/history-extractor.ts
+++ b/packages/standalone/src/memory/history-extractor.ts
@@ -1,0 +1,292 @@
+/**
+ * history-extractor.ts
+ *
+ * 3-pass Memory Agent history extraction utilities.
+ * Pass 0: truth channels → build ground-truth project state (no LLM)
+ * Pass 1: activity channels (hub + deliverable + reference) → extract decisions/tasks with full context
+ * Pass 2: spoke channels → connect to hub projects
+ */
+
+import type { NormalizedItem, ChannelConfig } from '../connectors/framework/types.js';
+
+export interface HubContextEntry {
+  project: string;
+  workUnit?: string;
+  assignedTo?: string;
+  status?: string;
+}
+
+export interface ClassifiedItems {
+  truth: NormalizedItem[]; // role=truth
+  activity: NormalizedItem[]; // role=hub + deliverable + reference, sorted by timestamp
+  spoke: NormalizedItem[]; // role=spoke
+}
+
+export interface ProjectTruth {
+  projects: Record<
+    string,
+    {
+      workUnits: Record<
+        string,
+        {
+          status: string;
+          assigned?: string;
+          column?: string;
+          metadata?: Record<string, string>;
+        }
+      >;
+    }
+  >;
+}
+
+/**
+ * Classify NormalizedItems into truth, activity, and spoke groups based on channel configs.
+ * Items with role 'ignore' or no matching config are dropped.
+ * Activity items (hub + deliverable + reference) are sorted by timestamp ascending.
+ *
+ * @param items - Normalized items to classify
+ * @param channelConfigs - Keyed by source (e.g. 'chatwork'), then by channel name
+ */
+export function classifyItemsByRole(
+  items: NormalizedItem[],
+  channelConfigs: Record<string, Record<string, ChannelConfig>>,
+  defaultRole: ChannelConfig['role'] = 'ignore'
+): ClassifiedItems {
+  const truth: NormalizedItem[] = [];
+  const activity: NormalizedItem[] = [];
+  const spoke: NormalizedItem[] = [];
+
+  for (const item of items) {
+    const sourceConfigs = channelConfigs[item.source];
+    let channelCfg = sourceConfigs?.[item.channel];
+    // Fallback: search by name field when direct key lookup fails
+    if (!channelCfg && sourceConfigs) {
+      for (const cfg of Object.values(sourceConfigs)) {
+        if (cfg.name === item.channel) {
+          channelCfg = cfg;
+          break;
+        }
+      }
+    }
+    const role = channelCfg?.role ?? defaultRole;
+    if (role === 'ignore') continue;
+
+    if (role === 'truth') {
+      truth.push(item);
+    } else if (role === 'hub' || role === 'deliverable' || role === 'reference') {
+      activity.push(item);
+    } else if (role === 'spoke') {
+      spoke.push(item);
+    }
+  }
+
+  // Sort activity items by timestamp ascending
+  activity.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+
+  return { truth, activity, spoke };
+}
+
+/**
+ * Build ground-truth project state from truth-role items (Pass 0).
+ * No LLM needed — directly parses structured data from kanban_card and spreadsheet_row items.
+ *
+ * @param truthItems - NormalizedItems with role=truth
+ */
+export function buildProjectTruth(truthItems: NormalizedItem[]): ProjectTruth {
+  const projects: ProjectTruth['projects'] = {};
+
+  for (const item of truthItems) {
+    if (!projects[item.channel]) {
+      projects[item.channel] = { workUnits: {} };
+    }
+
+    if (item.type === 'kanban_card') {
+      // Parse from metadata: cardName, listName, prevListName
+      const cardName = (item.metadata?.cardName as string) ?? item.sourceId;
+      const listName = (item.metadata?.listName as string) ?? 'unknown';
+      const assigned = item.metadata?.members as string;
+      projects[item.channel].workUnits[cardName] = {
+        status: listName,
+        column: listName,
+        assigned,
+      };
+    } else if (item.type === 'spreadsheet_row') {
+      const headers = (item.metadata?.headers as string[]) ?? [];
+      const values = (item.metadata?.values as string[]) ?? [];
+      const meta: Record<string, string> = {};
+      for (let i = 0; i < headers.length; i++) {
+        const h = headers[i]?.replace(/\n/g, '').trim() ?? '';
+        meta[h] = values[i]?.trim() ?? '';
+      }
+      // Spreadsheet schema example: 클라이언트, 프로젝트, 명칭, 제출기한, Trello
+      const client = meta['클라이언트'] ?? meta['client'] ?? '';
+      const project = meta['프로젝트'] ?? meta['project'] ?? item.channel;
+      const name = meta['명칭'] ?? meta['name'] ?? meta['LIST_NO'] ?? '';
+      const deadline = meta['제출기한'] ?? meta['deadline'] ?? meta['Due'] ?? '';
+      const trello = meta['Trello'] ?? '';
+      const projectKey = client ? `${client}/${project}` : project;
+      if (!projects[projectKey]) {
+        projects[projectKey] = { workUnits: {} };
+      }
+      projects[projectKey].workUnits[name || item.sourceId] = {
+        status: deadline ? `납기:${deadline}` : 'active',
+        assigned: meta['담당'] ?? meta['담당자'] ?? meta['assigned'],
+        metadata: { ...meta, trello },
+      };
+    }
+  }
+
+  return { projects };
+}
+
+/**
+ * Format a single NormalizedItem as a prompt line: "author(HH:MM): content"
+ */
+function formatItemLine(item: NormalizedItem): string {
+  const hh = String(item.timestamp.getHours()).padStart(2, '0');
+  const mm = String(item.timestamp.getMinutes()).padStart(2, '0');
+  return `${item.author}(${hh}:${mm}): ${item.content}`;
+}
+
+/**
+ * Group items by "${source}:${channel}" key.
+ */
+export function groupByChannel(items: NormalizedItem[]): Map<string, NormalizedItem[]> {
+  const groups = new Map<string, NormalizedItem[]>();
+  for (const item of items) {
+    const key = `${item.source}:${item.channel}`;
+    const existing = groups.get(key) ?? [];
+    existing.push(item);
+    groups.set(key, existing);
+  }
+  return groups;
+}
+
+/**
+ * Build an LLM prompt for activity channel extraction (Pass 1).
+ * Includes truth context as a header so the agent can identify changes relative to ground truth.
+ *
+ * @param activity - Activity NormalizedItems (hub + deliverable + reference)
+ * @param truth - Ground-truth project state from Pass 0
+ */
+export function buildActivityExtractionPrompt(
+  activity: NormalizedItem[],
+  truth: ProjectTruth
+): string {
+  let prompt = '당신은 프로젝트 역사가입니다.\n\n';
+  prompt += '현재 프로젝트 상태 (관리 문서/칸반 기준):\n';
+
+  const truthEntries = Object.entries(truth.projects);
+  if (truthEntries.length === 0) {
+    prompt += '(없음)\n';
+  } else {
+    for (const [projectName, project] of truthEntries) {
+      for (const [workUnit, state] of Object.entries(project.workUnits)) {
+        prompt += `- ${projectName}/${workUnit}: ${state.status}`;
+        if (state.assigned) prompt += `, 담당: ${state.assigned}`;
+        prompt += '\n';
+      }
+    }
+  }
+
+  prompt += '\n아래는 이번 기간의 크로스채널 활동입니다.\n';
+  prompt += '진실 대비 변경사항을 추출하세요:\n';
+  prompt += '- 상태 변경 (진행→제출 등)\n';
+  prompt += '- 결과물 업로드 (파일 변경)\n';
+  prompt += '- 결정/합의\n';
+  prompt += '- 일정 변경\n';
+  prompt += '- 교훈/문제-해결\n\n';
+  prompt += '일상 대화, 인사, 잡담은 무시하세요.\n\n';
+  prompt +=
+    'JSON 배열로 반환: [{project, work_unit, kind, topic, summary, reasoning, event_date, confidence}]\n';
+  prompt += '추출할 것이 없으면 빈 배열 []을 반환하세요.\n\n---\n';
+
+  // Add activity items grouped by source:channel
+  const grouped = groupByChannel(activity);
+  for (const [channel, channelItems] of grouped) {
+    prompt += `\n### ${channel}\n`;
+    for (const item of channelItems) {
+      const time = item.timestamp.toISOString().slice(11, 16);
+      prompt += `${item.author}(${time}): ${item.content}\n`;
+    }
+  }
+
+  return prompt;
+}
+
+/**
+ * Build an LLM prompt for spoke channel extraction (Pass 2).
+ * Includes hub context so the agent can connect spoke messages to known projects.
+ * Optionally includes project truth for richer context.
+ *
+ * @param items - Spoke NormalizedItems
+ * @param hubContext - Active project context from Pass 1
+ * @param truth - Optional ground-truth project state for richer context
+ */
+export function buildSpokeExtractionPrompt(
+  items: NormalizedItem[],
+  hubContext: HubContextEntry[],
+  truth?: ProjectTruth
+): string {
+  const groups = groupByChannel(items);
+
+  const channelSections: string[] = [];
+  for (const [channelKey, channelItems] of groups.entries()) {
+    const lines = channelItems.map(formatItemLine).join('\n');
+    channelSections.push(`### 채널: ${channelKey}\n${lines}`);
+  }
+
+  const messagesBlock = channelSections.join('\n\n');
+
+  const hubContextLines = hubContext
+    .map((entry) => {
+      const parts: string[] = [`- 프로젝트: ${entry.project}`];
+      if (entry.workUnit) parts.push(`  작업: ${entry.workUnit}`);
+      if (entry.assignedTo) parts.push(`  담당: ${entry.assignedTo}`);
+      if (entry.status) parts.push(`  상태: ${entry.status}`);
+      return parts.join('\n');
+    })
+    .join('\n');
+
+  let prompt = `당신은 역사가입니다.\n\n`;
+
+  // Include truth context if provided
+  if (truth && Object.keys(truth.projects).length > 0) {
+    prompt += '프로젝트 진실 상태 (관리 문서/칸반 기준):\n';
+    for (const [projectName, project] of Object.entries(truth.projects)) {
+      for (const [workUnit, state] of Object.entries(project.workUnits)) {
+        prompt += `- ${projectName}/${workUnit}: ${state.status}`;
+        if (state.assigned) prompt += `, 담당: ${state.assigned}`;
+        prompt += '\n';
+      }
+    }
+    prompt += '\n';
+  }
+
+  prompt += `현재 활성 프로젝트 상황:\n${hubContextLines || '(없음)'}
+
+아래 스포크 채널 메시지에서 중요한 작업, 결정, 교훈, 일정을 추출하세요.
+가능한 경우 위의 허브 프로젝트와 연결하세요.
+허브 프로젝트와 무관한 일상적인 잡담은 무시하세요.
+
+출력 형식: JSON 배열로만 응답하세요. 다른 텍스트 없이 JSON만 출력하세요.
+각 항목의 스키마:
+[
+  {
+    "project": "프로젝트명 (허브 컨텍스트에서 연결 가능한 경우 해당 프로젝트명 사용)",
+    "work_unit": "작업 단위 또는 기능명 (선택)",
+    "assigned_to": "담당자 이름 (선택)",
+    "kind": "task | decision | lesson | schedule",
+    "topic": "한 줄 제목",
+    "summary": "요약 (2-3문장)",
+    "reasoning": "이 항목을 추출한 이유 및 허브 프로젝트와의 연결 근거",
+    "event_date": "YYYY-MM-DD 형식 (메시지에서 날짜를 추론할 수 있는 경우, 없으면 null)",
+    "confidence": 0.0~1.0
+  }
+]
+
+메시지:
+${messagesBlock}`;
+
+  return prompt;
+}

--- a/packages/standalone/tests/connectors/calendar.test.ts
+++ b/packages/standalone/tests/connectors/calendar.test.ts
@@ -1,0 +1,333 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CalendarConnector } from '../../src/connectors/calendar/index.js';
+import type { ConnectorConfig } from '../../src/connectors/framework/types.js';
+
+// Mock child_process
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+import { execSync } from 'child_process';
+const mockExecSync = vi.mocked(execSync);
+
+function makeConfig(overrides: Partial<ConnectorConfig> = {}): ConnectorConfig {
+  return {
+    enabled: true,
+    pollIntervalMinutes: 15,
+    channels: {},
+    auth: {
+      type: 'cli',
+      cli: 'gws',
+      cliAuthCommand: 'gws auth login',
+    },
+    ...overrides,
+  };
+}
+
+function makeEventListJson(events: Record<string, unknown>[]): string {
+  return JSON.stringify({ items: events });
+}
+
+function makeEvent(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'evt001',
+    summary: 'Team Standup',
+    description: 'Daily standup meeting',
+    start: { dateTime: '2024-01-15T09:00:00+09:00' },
+    end: { dateTime: '2024-01-15T09:30:00+09:00' },
+    organizer: { email: 'organizer@example.com', displayName: 'Organizer Name' },
+    status: 'confirmed',
+    ...overrides,
+  };
+}
+
+describe('CalendarConnector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecSync.mockReturnValue('' as unknown as ReturnType<typeof execSync>);
+  });
+
+  describe('name and type', () => {
+    it('has name "calendar"', () => {
+      const connector = new CalendarConnector(makeConfig());
+      expect(connector.name).toBe('calendar');
+    });
+
+    it('has type "api"', () => {
+      const connector = new CalendarConnector(makeConfig());
+      expect(connector.type).toBe('api');
+    });
+  });
+
+  describe('getAuthRequirements', () => {
+    it('returns cli auth requirement for gws', () => {
+      const connector = new CalendarConnector(makeConfig());
+      const reqs = connector.getAuthRequirements();
+      expect(reqs).toHaveLength(1);
+      expect(reqs[0]?.type).toBe('cli');
+      expect(reqs[0]?.cli).toBe('gws');
+      expect(reqs[0]?.cliAuthCommand).toBe('gws auth login');
+    });
+  });
+
+  describe('init', () => {
+    it('initializes when gws CLI is available', async () => {
+      mockExecSync.mockReturnValue('gws version 1.0.0' as unknown as ReturnType<typeof execSync>);
+      const connector = new CalendarConnector(makeConfig());
+      await expect(connector.init()).resolves.toBeUndefined();
+    });
+
+    it('throws when gws CLI is not found', async () => {
+      mockExecSync.mockImplementation(() => {
+        throw new Error('command not found: gws');
+      });
+      const connector = new CalendarConnector(makeConfig());
+      await expect(connector.init()).rejects.toThrow(/gws/i);
+    });
+  });
+
+  describe('authenticate', () => {
+    it('returns true when gws auth status succeeds', async () => {
+      mockExecSync.mockReturnValue('' as unknown as ReturnType<typeof execSync>);
+      const connector = new CalendarConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(true);
+    });
+
+    it('returns false when gws auth status throws', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockImplementationOnce(() => {
+          throw new Error('not authenticated');
+        });
+      const connector = new CalendarConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(false);
+    });
+  });
+
+  describe('poll', () => {
+    it('returns empty array when no events', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(makeEventListJson([]) as unknown as ReturnType<typeof execSync>);
+      const connector = new CalendarConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toEqual([]);
+    });
+
+    it('returns normalized event items', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeEventListJson([makeEvent()]) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new CalendarConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(1);
+      expect(items[0]?.source).toBe('calendar');
+      expect(items[0]?.type).toBe('event');
+    });
+
+    it('sets sourceId to event.id', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeEventListJson([makeEvent({ id: 'unique-evt-id' })]) as unknown as ReturnType<
+            typeof execSync
+          >
+        );
+      const connector = new CalendarConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.sourceId).toBe('unique-evt-id');
+    });
+
+    it('formats content as "summary | start ~ end\\ndescription"', async () => {
+      const event = makeEvent({
+        summary: 'Team Meeting',
+        description: 'Weekly sync',
+        start: { dateTime: '2024-01-15T10:00:00Z' },
+        end: { dateTime: '2024-01-15T11:00:00Z' },
+      });
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(makeEventListJson([event]) as unknown as ReturnType<typeof execSync>);
+      const connector = new CalendarConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.content).toBe(
+        'Team Meeting | 2024-01-15T10:00:00Z ~ 2024-01-15T11:00:00Z\nWeekly sync'
+      );
+    });
+
+    it('uses organizer displayName as author', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeEventListJson([
+            makeEvent({
+              organizer: { email: 'org@example.com', displayName: 'Jane Doe' },
+            }),
+          ]) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new CalendarConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.author).toBe('Jane Doe');
+    });
+
+    it('falls back to organizer email when displayName is absent', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeEventListJson([
+            makeEvent({
+              organizer: { email: 'org@example.com' },
+            }),
+          ]) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new CalendarConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.author).toBe('org@example.com');
+    });
+
+    it('uses date (all-day) when dateTime is absent', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeEventListJson([
+            makeEvent({
+              start: { date: '2024-01-15' },
+              end: { date: '2024-01-16' },
+            }),
+          ]) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new CalendarConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.content).toContain('2024-01-15');
+      expect(items[0]?.content).toContain('2024-01-16');
+    });
+
+    it('handles empty description gracefully', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeEventListJson([makeEvent({ description: undefined })]) as unknown as ReturnType<
+            typeof execSync
+          >
+        );
+      const connector = new CalendarConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.content).toMatch(/Team Standup \|/);
+      expect(items[0]?.content).toMatch(/\n$/);
+    });
+
+    it('passes timeMin as ISO string to gws CLI', async () => {
+      const since = new Date('2024-01-10T00:00:00.000Z');
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(makeEventListJson([]) as unknown as ReturnType<typeof execSync>);
+      const connector = new CalendarConnector(makeConfig());
+      await connector.init();
+      await connector.poll(since);
+
+      const calls = mockExecSync.mock.calls;
+      const listCall = calls.find((c: unknown[]) => String(c[0]).includes('calendar events list'));
+      expect(listCall).toBeDefined();
+      expect(String(listCall?.[0])).toContain('2024-01-10T00:00:00.000Z');
+    });
+
+    it('passes singleEvents=true and orderBy=startTime', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(makeEventListJson([]) as unknown as ReturnType<typeof execSync>);
+      const connector = new CalendarConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+
+      const calls = mockExecSync.mock.calls;
+      const listCall = calls.find((c: unknown[]) => String(c[0]).includes('calendar events list'));
+      const cmd = String(listCall?.[0]);
+      expect(cmd).toContain('"singleEvents":true');
+      expect(cmd).toContain('"orderBy":"startTime"');
+    });
+
+    it('handles prefix lines like "Using keyring backend: ..." before JSON', async () => {
+      const prefixed = 'Using keyring backend: SecretService\n' + makeEventListJson([makeEvent()]);
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(prefixed as unknown as ReturnType<typeof execSync>);
+      const connector = new CalendarConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(1);
+    });
+
+    it('sets channel to "calendar"', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeEventListJson([makeEvent()]) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new CalendarConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.channel).toBe('calendar');
+    });
+
+    it('includes metadata with start, end, status, organizer', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeEventListJson([makeEvent()]) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new CalendarConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.metadata).toHaveProperty('status', 'confirmed');
+      expect(items[0]?.metadata).toHaveProperty('start');
+      expect(items[0]?.metadata).toHaveProperty('end');
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('reflects lastPollTime and lastPollCount after poll', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeEventListJson([makeEvent()]) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new CalendarConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      const health = await connector.healthCheck();
+      expect(health.lastPollTime).not.toBeNull();
+      expect(health.lastPollCount).toBe(1);
+    });
+
+    it('is healthy when no errors occurred', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(makeEventListJson([]) as unknown as ReturnType<typeof execSync>);
+      const connector = new CalendarConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      const health = await connector.healthCheck();
+      expect(health.healthy).toBe(true);
+    });
+  });
+
+  describe('dispose', () => {
+    it('resolves without error', async () => {
+      const connector = new CalendarConnector(makeConfig());
+      await expect(connector.dispose()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/standalone/tests/connectors/chatwork.test.ts
+++ b/packages/standalone/tests/connectors/chatwork.test.ts
@@ -1,0 +1,323 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ChatworkConnector } from '../../src/connectors/chatwork/index.js';
+import type { ConnectorConfig } from '../../src/connectors/framework/types.js';
+
+function makeConfig(overrides: Partial<ConnectorConfig> = {}): ConnectorConfig {
+  return {
+    enabled: true,
+    pollIntervalMinutes: 5,
+    channels: {
+      '12345': { role: 'hub', name: 'project-room' },
+      '67890': { role: 'spoke', name: 'general-room' },
+      '99999': { role: 'ignore', name: 'noise-room' },
+    },
+    auth: {
+      type: 'token',
+      tokenName: 'CHATWORK_API_TOKEN',
+      token: 'test-chatwork-token',
+    },
+    ...overrides,
+  };
+}
+
+function makeChatworkMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    message_id: '1001',
+    account: {
+      account_id: 42,
+      name: 'Alice',
+      avatar_image_url: 'https://example.com/alice.png',
+    },
+    body: 'Hello from Chatwork',
+    send_time: 1700000001,
+    update_time: 1700000001,
+    ...overrides,
+  };
+}
+
+describe('ChatworkConnector', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('name and type', () => {
+    it('has name "chatwork"', () => {
+      const connector = new ChatworkConnector(makeConfig());
+      expect(connector.name).toBe('chatwork');
+    });
+
+    it('has type "api"', () => {
+      const connector = new ChatworkConnector(makeConfig());
+      expect(connector.type).toBe('api');
+    });
+  });
+
+  describe('getAuthRequirements', () => {
+    it('returns token auth requirement with CHATWORK_API_TOKEN', () => {
+      const connector = new ChatworkConnector(makeConfig());
+      const reqs = connector.getAuthRequirements();
+      expect(reqs).toHaveLength(1);
+      expect(reqs[0]?.type).toBe('token');
+      expect(reqs[0]?.tokenName).toBe('CHATWORK_API_TOKEN');
+    });
+  });
+
+  describe('init', () => {
+    it('initializes successfully with a token', async () => {
+      const connector = new ChatworkConnector(makeConfig());
+      await expect(connector.init()).resolves.toBeUndefined();
+    });
+
+    it('throws when token is missing', async () => {
+      const connector = new ChatworkConnector(
+        makeConfig({ auth: { type: 'token', tokenName: 'CHATWORK_API_TOKEN' } })
+      );
+      const originalEnv = process.env['CHATWORK_API_TOKEN'];
+      delete process.env['CHATWORK_API_TOKEN'];
+      await expect(connector.init()).rejects.toThrow(/token/i);
+      if (originalEnv !== undefined) process.env['CHATWORK_API_TOKEN'] = originalEnv;
+    });
+  });
+
+  describe('authenticate', () => {
+    it('returns true when /me responds with 200', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+      const connector = new ChatworkConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(true);
+    });
+
+    it('returns false when /me responds with non-200', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+      const connector = new ChatworkConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(false);
+    });
+
+    it('returns false when not initialized', async () => {
+      const connector = new ChatworkConnector(makeConfig());
+      expect(await connector.authenticate()).toBe(false);
+    });
+
+    it('returns false when fetch throws', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+      const connector = new ChatworkConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(false);
+    });
+  });
+
+  describe('poll', () => {
+    it('returns empty array when no messages', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: vi.fn().mockResolvedValue([]),
+        })
+      );
+      const connector = new ChatworkConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toEqual([]);
+    });
+
+    it('skips channels with role "ignore"', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue([]),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new ChatworkConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+
+      const calledUrls = mockFetch.mock.calls.map((c: unknown[]) => String(c[0]));
+      expect(calledUrls.some((u) => u.includes('12345'))).toBe(true);
+      expect(calledUrls.some((u) => u.includes('67890'))).toBe(true);
+      expect(calledUrls.some((u) => u.includes('99999'))).toBe(false);
+    });
+
+    it('filters messages by send_time > since', async () => {
+      const since = new Date('2024-01-01T00:00:00.000Z'); // epoch 1704067200
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: vi.fn().mockResolvedValue([
+            makeChatworkMessage({ message_id: '1', send_time: 1704067199 }), // before
+            makeChatworkMessage({ message_id: '2', send_time: 1704067201 }), // after
+          ]),
+        })
+      );
+      const connector = new ChatworkConnector(
+        makeConfig({ channels: { '12345': { role: 'hub', name: 'project' } } })
+      );
+      await connector.init();
+      const items = await connector.poll(since);
+      expect(items).toHaveLength(1);
+      expect(items[0]?.sourceId).toBe('12345:2');
+    });
+
+    it('sets correct sourceId as "roomId:messageId"', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: vi.fn().mockResolvedValue([makeChatworkMessage({ message_id: '9876' })]),
+        })
+      );
+      const connector = new ChatworkConnector(
+        makeConfig({ channels: { '12345': { role: 'hub', name: 'project' } } })
+      );
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.sourceId).toBe('12345:9876');
+    });
+
+    it('sets source to "chatwork"', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: vi.fn().mockResolvedValue([makeChatworkMessage()]),
+        })
+      );
+      const connector = new ChatworkConnector(
+        makeConfig({ channels: { '12345': { role: 'hub', name: 'project' } } })
+      );
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.source).toBe('chatwork');
+    });
+
+    it('sets type to "message"', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: vi.fn().mockResolvedValue([makeChatworkMessage()]),
+        })
+      );
+      const connector = new ChatworkConnector(
+        makeConfig({ channels: { '12345': { role: 'hub', name: 'project' } } })
+      );
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.type).toBe('message');
+    });
+
+    it('sets author from account.name', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: vi.fn().mockResolvedValue([
+            makeChatworkMessage({
+              account: { account_id: 1, name: 'Charlie', avatar_image_url: '' },
+            }),
+          ]),
+        })
+      );
+      const connector = new ChatworkConnector(
+        makeConfig({ channels: { '12345': { role: 'hub', name: 'project' } } })
+      );
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.author).toBe('Charlie');
+    });
+
+    it('sets content from body', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: vi.fn().mockResolvedValue([makeChatworkMessage({ body: 'Important update' })]),
+        })
+      );
+      const connector = new ChatworkConnector(
+        makeConfig({ channels: { '12345': { role: 'hub', name: 'project' } } })
+      );
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.content).toBe('Important update');
+    });
+
+    it('uses channel name from config', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: vi.fn().mockResolvedValue([makeChatworkMessage()]),
+        })
+      );
+      const connector = new ChatworkConnector(
+        makeConfig({ channels: { '12345': { role: 'hub', name: 'my-project' } } })
+      );
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.channel).toBe('my-project');
+    });
+
+    it('sends X-ChatWorkToken header', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue([]),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new ChatworkConnector(
+        makeConfig({ channels: { '12345': { role: 'hub' } } })
+      );
+      await connector.init();
+      await connector.poll(new Date(0));
+
+      const callHeaders = mockFetch.mock.calls[0]?.[1]?.headers as Record<string, string>;
+      expect(callHeaders?.['X-ChatWorkToken']).toBe('test-chatwork-token');
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('returns healthy after successful poll', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: vi.fn().mockResolvedValue([]),
+        })
+      );
+      const connector = new ChatworkConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      const health = await connector.healthCheck();
+      expect(health.healthy).toBe(true);
+    });
+
+    it('tracks lastPollTime', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: vi.fn().mockResolvedValue([]),
+        })
+      );
+      const connector = new ChatworkConnector(makeConfig());
+      await connector.init();
+      const before = new Date();
+      await connector.poll(new Date(0));
+      const health = await connector.healthCheck();
+      expect(health.lastPollTime).not.toBeNull();
+      expect(health.lastPollTime!.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    });
+  });
+
+  describe('dispose', () => {
+    it('clears the token so authenticate returns false', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+      const connector = new ChatworkConnector(makeConfig());
+      await connector.init();
+      await connector.dispose();
+      expect(await connector.authenticate()).toBe(false);
+    });
+  });
+});

--- a/packages/standalone/tests/connectors/discord.test.ts
+++ b/packages/standalone/tests/connectors/discord.test.ts
@@ -1,0 +1,295 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DiscordConnector } from '../../src/connectors/discord/index.js';
+import type { ConnectorConfig } from '../../src/connectors/framework/types.js';
+
+function makeConfig(overrides: Partial<ConnectorConfig> = {}): ConnectorConfig {
+  return {
+    enabled: true,
+    pollIntervalMinutes: 5,
+    channels: {
+      '111222333444555': { role: 'hub', name: 'project-channel' },
+      '999888777666555': { role: 'spoke', name: 'general' },
+      '000111222333444': { role: 'ignore', name: 'noise' },
+    },
+    auth: {
+      type: 'token',
+      tokenName: 'DISCORD_BOT_TOKEN',
+      token: 'test-discord-token',
+    },
+    ...overrides,
+  };
+}
+
+function makeMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '987654321098765432',
+    content: 'Hello from Discord',
+    timestamp: '2023-11-14T22:13:21.000Z',
+    author: {
+      id: '123456789012345678',
+      username: 'alice',
+      bot: false,
+    },
+    ...overrides,
+  };
+}
+
+function makeOkResponse(messages: unknown[]) {
+  return {
+    ok: true,
+    json: vi.fn().mockResolvedValue(messages),
+  };
+}
+
+describe('DiscordConnector', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('name and type', () => {
+    it('has name "discord"', () => {
+      const connector = new DiscordConnector(makeConfig());
+      expect(connector.name).toBe('discord');
+    });
+
+    it('has type "api"', () => {
+      const connector = new DiscordConnector(makeConfig());
+      expect(connector.type).toBe('api');
+    });
+  });
+
+  describe('getAuthRequirements', () => {
+    it('returns token auth requirement with DISCORD_BOT_TOKEN', () => {
+      const connector = new DiscordConnector(makeConfig());
+      const reqs = connector.getAuthRequirements();
+      expect(reqs).toHaveLength(1);
+      expect(reqs[0]?.type).toBe('token');
+      expect(reqs[0]?.tokenName).toBe('DISCORD_BOT_TOKEN');
+    });
+  });
+
+  describe('init', () => {
+    it('initializes successfully with a token', async () => {
+      const connector = new DiscordConnector(makeConfig());
+      await expect(connector.init()).resolves.toBeUndefined();
+    });
+
+    it('throws when token is missing', async () => {
+      const connector = new DiscordConnector(
+        makeConfig({ auth: { type: 'token', tokenName: 'DISCORD_BOT_TOKEN' } })
+      );
+      const originalEnv = process.env['DISCORD_BOT_TOKEN'];
+      delete process.env['DISCORD_BOT_TOKEN'];
+      await expect(connector.init()).rejects.toThrow(/token/i);
+      if (originalEnv !== undefined) process.env['DISCORD_BOT_TOKEN'] = originalEnv;
+    });
+  });
+
+  describe('authenticate', () => {
+    it('returns true when /users/@me responds with 200', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+      const connector = new DiscordConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(true);
+    });
+
+    it('returns false when response is not ok', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+      const connector = new DiscordConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(false);
+    });
+
+    it('returns false when not initialized', async () => {
+      const connector = new DiscordConnector(makeConfig());
+      expect(await connector.authenticate()).toBe(false);
+    });
+
+    it('returns false when fetch throws', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+      const connector = new DiscordConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(false);
+    });
+
+    it('sends Authorization: Bot header', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new DiscordConnector(makeConfig());
+      await connector.init();
+      await connector.authenticate();
+      const headers = mockFetch.mock.calls[0]?.[1]?.headers as Record<string, string>;
+      expect(headers?.['Authorization']).toBe('Bot test-discord-token');
+    });
+  });
+
+  describe('poll', () => {
+    it('returns empty array when no messages', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeOkResponse([])));
+      const connector = new DiscordConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toEqual([]);
+    });
+
+    it('skips channels with role "ignore"', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(makeOkResponse([]));
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new DiscordConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+
+      const calledUrls = mockFetch.mock.calls.map((c: unknown[]) => String(c[0]));
+      expect(calledUrls.some((u) => u.includes('111222333444555'))).toBe(true);
+      expect(calledUrls.some((u) => u.includes('999888777666555'))).toBe(true);
+      expect(calledUrls.some((u) => u.includes('000111222333444'))).toBe(false);
+    });
+
+    it('filters messages by timestamp > since', async () => {
+      const since = new Date('2024-01-01T00:00:00.000Z');
+      vi.stubGlobal(
+        'fetch',
+        vi
+          .fn()
+          .mockResolvedValue(
+            makeOkResponse([
+              makeMessage({ id: '1', timestamp: '2023-12-31T23:59:59.000Z' }),
+              makeMessage({ id: '2', timestamp: '2024-01-01T00:00:01.000Z' }),
+            ])
+          )
+      );
+      const connector = new DiscordConnector(
+        makeConfig({ channels: { '111222333444555': { role: 'hub', name: 'proj' } } })
+      );
+      await connector.init();
+      const items = await connector.poll(since);
+      expect(items).toHaveLength(1);
+      expect(items[0]?.sourceId).toBe('111222333444555:2');
+    });
+
+    it('sets sourceId as "channelId:messageId"', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(makeOkResponse([makeMessage({ id: '42' })]))
+      );
+      const connector = new DiscordConnector(
+        makeConfig({ channels: { '111222333444555': { role: 'hub', name: 'proj' } } })
+      );
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.sourceId).toBe('111222333444555:42');
+    });
+
+    it('sets source to "discord"', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeOkResponse([makeMessage()])));
+      const connector = new DiscordConnector(
+        makeConfig({ channels: { '111222333444555': { role: 'hub', name: 'proj' } } })
+      );
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.source).toBe('discord');
+    });
+
+    it('sets author from username', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi
+          .fn()
+          .mockResolvedValue(
+            makeOkResponse([makeMessage({ author: { id: '1', username: 'bob', bot: false } })])
+          )
+      );
+      const connector = new DiscordConnector(
+        makeConfig({ channels: { '111222333444555': { role: 'hub', name: 'proj' } } })
+      );
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.author).toBe('bob');
+    });
+
+    it('sets type to "message"', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeOkResponse([makeMessage()])));
+      const connector = new DiscordConnector(
+        makeConfig({ channels: { '111222333444555': { role: 'hub', name: 'proj' } } })
+      );
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.type).toBe('message');
+    });
+
+    it('skips bot messages', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi
+          .fn()
+          .mockResolvedValue(
+            makeOkResponse([makeMessage({ author: { id: '1', username: 'mybot', bot: true } })])
+          )
+      );
+      const connector = new DiscordConnector(
+        makeConfig({ channels: { '111222333444555': { role: 'hub', name: 'proj' } } })
+      );
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(0);
+    });
+
+    it('skips messages without content', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(makeOkResponse([makeMessage({ content: '' })]))
+      );
+      const connector = new DiscordConnector(
+        makeConfig({ channels: { '111222333444555': { role: 'hub', name: 'proj' } } })
+      );
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(0);
+    });
+
+    it('sends Authorization: Bot header', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(makeOkResponse([]));
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new DiscordConnector(
+        makeConfig({ channels: { '111222333444555': { role: 'hub' } } })
+      );
+      await connector.init();
+      await connector.poll(new Date(0));
+      const headers = mockFetch.mock.calls[0]?.[1]?.headers as Record<string, string>;
+      expect(headers?.['Authorization']).toBe('Bot test-discord-token');
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('returns healthy after successful poll', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeOkResponse([])));
+      const connector = new DiscordConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      const health = await connector.healthCheck();
+      expect(health.healthy).toBe(true);
+    });
+
+    it('tracks lastPollTime after poll', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeOkResponse([])));
+      const connector = new DiscordConnector(makeConfig());
+      await connector.init();
+      const before = new Date();
+      await connector.poll(new Date(0));
+      const health = await connector.healthCheck();
+      expect(health.lastPollTime).not.toBeNull();
+      expect(health.lastPollTime!.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    });
+  });
+
+  describe('dispose', () => {
+    it('clears token so authenticate returns false', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+      const connector = new DiscordConnector(makeConfig());
+      await connector.init();
+      await connector.dispose();
+      expect(await connector.authenticate()).toBe(false);
+    });
+  });
+});

--- a/packages/standalone/tests/connectors/drive.test.ts
+++ b/packages/standalone/tests/connectors/drive.test.ts
@@ -1,0 +1,447 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DriveConnector } from '../../src/connectors/drive/index.js';
+import type { ConnectorConfig } from '../../src/connectors/framework/types.js';
+
+// Mock child_process
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+// Mock fs to prevent state file I/O from interfering with tests
+vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn().mockReturnValue('{}'),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+import { execSync } from 'child_process';
+const mockExecSync = vi.mocked(execSync);
+
+function makeConfig(overrides: Partial<ConnectorConfig> = {}): ConnectorConfig {
+  return {
+    enabled: true,
+    pollIntervalMinutes: 5,
+    channels: {
+      docs: {
+        role: 'deliverable',
+        name: 'project-docs',
+        folderId: 'folder-abc123',
+      },
+    },
+    auth: {
+      type: 'cli',
+      cli: 'gws',
+      cliAuthCommand: 'gws auth login',
+    },
+    ...overrides,
+  };
+}
+
+function makeStartPageToken(token: string): string {
+  return JSON.stringify({ startPageToken: token });
+}
+
+function makeChangeList(
+  changes: Array<{
+    fileId: string;
+    time: string;
+    fileName?: string;
+    mimeType?: string;
+    modifiedTime?: string;
+    displayName?: string;
+    parents?: string[];
+    removed?: boolean;
+  }>,
+  newStartPageToken?: string
+): string {
+  const changeObjects = changes.map((c) => ({
+    fileId: c.fileId,
+    time: c.time,
+    removed: c.removed ?? false,
+    file: c.removed
+      ? undefined
+      : {
+          name: c.fileName ?? 'test-file.docx',
+          mimeType: c.mimeType ?? 'application/vnd.google-apps.document',
+          modifiedTime: c.modifiedTime ?? c.time,
+          lastModifyingUser: { displayName: c.displayName ?? 'Alice' },
+          parents: c.parents ?? ['folder-abc123'],
+        },
+  }));
+  return JSON.stringify({
+    changes: changeObjects,
+    newStartPageToken: newStartPageToken ?? 'next-token-456',
+  });
+}
+
+describe('DriveConnector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecSync.mockReturnValue('' as unknown as ReturnType<typeof execSync>);
+  });
+
+  describe('name and type', () => {
+    it('has name "drive"', () => {
+      const connector = new DriveConnector(makeConfig());
+      expect(connector.name).toBe('drive');
+    });
+
+    it('has type "api"', () => {
+      const connector = new DriveConnector(makeConfig());
+      expect(connector.type).toBe('api');
+    });
+  });
+
+  describe('getAuthRequirements', () => {
+    it('returns cli auth requirement for gws', () => {
+      const connector = new DriveConnector(makeConfig());
+      const reqs = connector.getAuthRequirements();
+      expect(reqs).toHaveLength(1);
+      expect(reqs[0]?.type).toBe('cli');
+      expect(reqs[0]?.cli).toBe('gws');
+      expect(reqs[0]?.cliAuthCommand).toBe('gws auth login');
+    });
+  });
+
+  describe('init', () => {
+    it('initializes when gws CLI is available', async () => {
+      mockExecSync.mockReturnValue('gws version 1.0.0' as unknown as ReturnType<typeof execSync>);
+      const connector = new DriveConnector(makeConfig());
+      await expect(connector.init()).resolves.toBeUndefined();
+    });
+
+    it('throws when gws CLI is not found', async () => {
+      mockExecSync.mockImplementation(() => {
+        throw new Error('command not found: gws');
+      });
+      const connector = new DriveConnector(makeConfig());
+      await expect(connector.init()).rejects.toThrow(/gws/i);
+    });
+  });
+
+  describe('authenticate', () => {
+    it('returns true when gws auth status succeeds', async () => {
+      mockExecSync.mockReturnValue('' as unknown as ReturnType<typeof execSync>);
+      const connector = new DriveConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(true);
+    });
+
+    it('returns false when gws auth status throws', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockImplementationOnce(() => {
+          throw new Error('not authenticated');
+        });
+      const connector = new DriveConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(false);
+    });
+  });
+
+  describe('poll', () => {
+    it('fetches start page token on first poll', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>) // init
+        .mockReturnValueOnce(
+          makeStartPageToken('token-001') as unknown as ReturnType<typeof execSync>
+        ) // getStartPageToken
+        .mockReturnValueOnce(makeChangeList([]) as unknown as ReturnType<typeof execSync>); // changes list
+      const connector = new DriveConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      // Verify getStartPageToken was called
+      const calls = mockExecSync.mock.calls.map((c) => String(c[0]));
+      expect(calls.some((c) => c.includes('getStartPageToken'))).toBe(true);
+    });
+
+    it('reuses stored page token on subsequent polls', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>) // init
+        .mockReturnValueOnce(
+          makeStartPageToken('token-001') as unknown as ReturnType<typeof execSync>
+        ) // getStartPageToken (first poll)
+        .mockReturnValueOnce(
+          makeChangeList([], 'token-002') as unknown as ReturnType<typeof execSync>
+        ) // changes list (first poll)
+        .mockReturnValueOnce(makeChangeList([]) as unknown as ReturnType<typeof execSync>); // changes list (second poll — no getStartPageToken)
+      const connector = new DriveConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      await connector.poll(new Date(0));
+      const calls = mockExecSync.mock.calls.map((c) => String(c[0]));
+      // getStartPageToken should only be called once
+      expect(calls.filter((c) => c.includes('getStartPageToken'))).toHaveLength(1);
+    });
+
+    it('returns empty array when no changes', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeStartPageToken('token-001') as unknown as ReturnType<typeof execSync>
+        )
+        .mockReturnValueOnce(makeChangeList([]) as unknown as ReturnType<typeof execSync>);
+      const connector = new DriveConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toEqual([]);
+    });
+
+    it('emits file_change items for files in configured folder', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeStartPageToken('token-001') as unknown as ReturnType<typeof execSync>
+        )
+        .mockReturnValueOnce(
+          makeChangeList([
+            {
+              fileId: 'file-111',
+              time: '2024-06-15T10:00:00.000Z',
+              fileName: 'Report.docx',
+              parents: ['folder-abc123'],
+            },
+          ]) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new DriveConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(1);
+      expect(items[0]?.type).toBe('file_change');
+    });
+
+    it('sets source to "drive"', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeStartPageToken('token-001') as unknown as ReturnType<typeof execSync>
+        )
+        .mockReturnValueOnce(
+          makeChangeList([
+            { fileId: 'file-111', time: '2024-01-01T00:00:00.000Z' },
+          ]) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new DriveConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.source).toBe('drive');
+    });
+
+    it('sets sourceId as "fileId:changeTime"', async () => {
+      const time = '2024-06-15T10:00:00.000Z';
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeStartPageToken('token-001') as unknown as ReturnType<typeof execSync>
+        )
+        .mockReturnValueOnce(
+          makeChangeList([{ fileId: 'file-xyz', time }]) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new DriveConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.sourceId).toBe(`file-xyz:${time}`);
+    });
+
+    it('formats content as "modified: {fileName} ({mimeType})"', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeStartPageToken('token-001') as unknown as ReturnType<typeof execSync>
+        )
+        .mockReturnValueOnce(
+          makeChangeList([
+            {
+              fileId: 'file-111',
+              time: '2024-01-01T00:00:00.000Z',
+              fileName: 'Budget.xlsx',
+              mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            },
+          ]) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new DriveConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.content).toBe(
+        'modified: Budget.xlsx (application/vnd.openxmlformats-officedocument.spreadsheetml.sheet)'
+      );
+    });
+
+    it('sets author from lastModifyingUser.displayName', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeStartPageToken('token-001') as unknown as ReturnType<typeof execSync>
+        )
+        .mockReturnValueOnce(
+          makeChangeList([
+            { fileId: 'file-111', time: '2024-01-01T00:00:00.000Z', displayName: 'Bob Smith' },
+          ]) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new DriveConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.author).toBe('Bob Smith');
+    });
+
+    it('sets channel from matched folder config name', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeStartPageToken('token-001') as unknown as ReturnType<typeof execSync>
+        )
+        .mockReturnValueOnce(
+          makeChangeList([
+            { fileId: 'file-111', time: '2024-01-01T00:00:00.000Z' },
+          ]) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new DriveConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.channel).toBe('project-docs');
+    });
+
+    it('filters out changes not in any configured folder', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeStartPageToken('token-001') as unknown as ReturnType<typeof execSync>
+        )
+        .mockReturnValueOnce(
+          makeChangeList([
+            {
+              fileId: 'file-other',
+              time: '2024-01-01T00:00:00.000Z',
+              parents: ['some-other-folder'],
+            },
+          ]) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new DriveConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toEqual([]);
+    });
+
+    it('matches file to correct channel when multiple folders configured', async () => {
+      const config = makeConfig({
+        channels: {
+          docs: { role: 'deliverable', name: 'project-docs', folderId: 'folder-abc123' },
+          assets: { role: 'deliverable', name: 'project-assets', folderId: 'folder-def456' },
+        },
+      });
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeStartPageToken('token-001') as unknown as ReturnType<typeof execSync>
+        )
+        .mockReturnValueOnce(
+          makeChangeList([
+            { fileId: 'file-1', time: '2024-01-01T00:00:00.000Z', parents: ['folder-def456'] },
+          ]) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new DriveConnector(config);
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.channel).toBe('project-assets');
+    });
+
+    it('updates page token after each poll', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeStartPageToken('token-001') as unknown as ReturnType<typeof execSync>
+        )
+        .mockReturnValueOnce(
+          makeChangeList([], 'token-002') as unknown as ReturnType<typeof execSync>
+        )
+        .mockReturnValueOnce(
+          makeChangeList([], 'token-003') as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new DriveConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      await connector.poll(new Date(0));
+      // Check second poll used token-002 (set from first poll's newStartPageToken)
+      const secondPollParams = String(mockExecSync.mock.calls[3]?.[0]);
+      expect(secondPollParams).toContain('token-002');
+    });
+
+    it('skips changes with no file object', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeStartPageToken('token-001') as unknown as ReturnType<typeof execSync>
+        )
+        .mockReturnValueOnce(
+          makeChangeList([
+            { fileId: 'file-removed', time: '2024-01-01T00:00:00.000Z', removed: true },
+          ]) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new DriveConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toEqual([]);
+    });
+
+    it('handles "Using keyring backend:" prefix before JSON', async () => {
+      const prefix = 'Using keyring backend: SecretService\n';
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          (prefix + makeStartPageToken('token-001')) as unknown as ReturnType<typeof execSync>
+        )
+        .mockReturnValueOnce(
+          (prefix +
+            makeChangeList([
+              { fileId: 'file-111', time: '2024-01-01T00:00:00.000Z' },
+            ])) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new DriveConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(1);
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('reflects lastPollTime and lastPollCount after poll', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeStartPageToken('token-001') as unknown as ReturnType<typeof execSync>
+        )
+        .mockReturnValueOnce(makeChangeList([]) as unknown as ReturnType<typeof execSync>);
+      const connector = new DriveConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      const health = await connector.healthCheck();
+      expect(health.lastPollTime).not.toBeNull();
+      expect(health.lastPollCount).toBe(0);
+    });
+  });
+
+  describe('dispose', () => {
+    it('clears page token so next poll fetches a fresh start token', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeStartPageToken('token-001') as unknown as ReturnType<typeof execSync>
+        )
+        .mockReturnValueOnce(makeChangeList([]) as unknown as ReturnType<typeof execSync>)
+        // After dispose: init again + getStartPageToken again
+        .mockReturnValueOnce(
+          makeStartPageToken('token-fresh') as unknown as ReturnType<typeof execSync>
+        )
+        .mockReturnValueOnce(makeChangeList([]) as unknown as ReturnType<typeof execSync>);
+      const connector = new DriveConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      await connector.dispose();
+      await connector.poll(new Date(0));
+      const calls = mockExecSync.mock.calls.map((c) => String(c[0]));
+      expect(calls.filter((c) => c.includes('getStartPageToken'))).toHaveLength(2);
+    });
+  });
+});

--- a/packages/standalone/tests/connectors/framework/connector-registry.test.ts
+++ b/packages/standalone/tests/connectors/framework/connector-registry.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ConnectorRegistry } from '../../../src/connectors/framework/connector-registry.js';
+import type { ConnectorHealth, IConnector } from '../../../src/connectors/framework/types.js';
+
+function makeMockConnector(name: string, healthy = true): IConnector {
+  return {
+    name,
+    type: 'api',
+    init: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn().mockResolvedValue(undefined),
+    healthCheck: vi.fn().mockResolvedValue({
+      healthy,
+      lastPollTime: null,
+      lastPollCount: 0,
+    } satisfies ConnectorHealth),
+    getAuthRequirements: vi.fn().mockReturnValue([]),
+    authenticate: vi.fn().mockResolvedValue(true),
+    poll: vi.fn().mockResolvedValue([]),
+  };
+}
+
+describe('ConnectorRegistry', () => {
+  describe('register and get', () => {
+    it('registers a connector and retrieves it by name', () => {
+      const registry = new ConnectorRegistry();
+      const connector = makeMockConnector('slack');
+      registry.register('slack', connector);
+
+      expect(registry.get('slack')).toBe(connector);
+    });
+
+    it('returns undefined for unknown connector names', () => {
+      const registry = new ConnectorRegistry();
+      expect(registry.get('nonexistent')).toBeUndefined();
+    });
+
+    it('overwrites a connector if registered again with the same name', () => {
+      const registry = new ConnectorRegistry();
+      const first = makeMockConnector('slack');
+      const second = makeMockConnector('slack');
+
+      registry.register('slack', first);
+      registry.register('slack', second);
+
+      expect(registry.get('slack')).toBe(second);
+    });
+  });
+
+  describe('getActive', () => {
+    it('returns all registered connectors', () => {
+      const registry = new ConnectorRegistry();
+      registry.register('slack', makeMockConnector('slack'));
+      registry.register('notion', makeMockConnector('notion'));
+
+      const active = registry.getActive();
+      expect(active.size).toBe(2);
+      expect(active.has('slack')).toBe(true);
+      expect(active.has('notion')).toBe(true);
+    });
+
+    it('returns an empty map when no connectors are registered', () => {
+      const registry = new ConnectorRegistry();
+      expect(registry.getActive().size).toBe(0);
+    });
+
+    it('returns a snapshot — mutation does not affect the registry', () => {
+      const registry = new ConnectorRegistry();
+      registry.register('slack', makeMockConnector('slack'));
+
+      const active = registry.getActive();
+      active.delete('slack');
+
+      // Original registry still has it
+      expect(registry.get('slack')).toBeDefined();
+    });
+  });
+
+  describe('disposeAll', () => {
+    it('calls dispose on all registered connectors', async () => {
+      const registry = new ConnectorRegistry();
+      const slack = makeMockConnector('slack');
+      const notion = makeMockConnector('notion');
+
+      registry.register('slack', slack);
+      registry.register('notion', notion);
+
+      await registry.disposeAll();
+
+      expect(slack.dispose).toHaveBeenCalledOnce();
+      expect(notion.dispose).toHaveBeenCalledOnce();
+    });
+
+    it('clears the registry after disposing', async () => {
+      const registry = new ConnectorRegistry();
+      registry.register('slack', makeMockConnector('slack'));
+
+      await registry.disposeAll();
+
+      expect(registry.getActive().size).toBe(0);
+    });
+
+    it('resolves even when no connectors are registered', async () => {
+      const registry = new ConnectorRegistry();
+      await expect(registry.disposeAll()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('healthCheckAll', () => {
+    it('returns health for all connectors', async () => {
+      const registry = new ConnectorRegistry();
+      registry.register('slack', makeMockConnector('slack', true));
+      registry.register('broken', makeMockConnector('broken', false));
+
+      const health = await registry.healthCheckAll();
+
+      expect(health['slack']?.healthy).toBe(true);
+      expect(health['broken']?.healthy).toBe(false);
+    });
+
+    it('marks connector as unhealthy if healthCheck throws', async () => {
+      const registry = new ConnectorRegistry();
+      const connector = makeMockConnector('crash');
+      (connector.healthCheck as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('timeout'));
+
+      registry.register('crash', connector);
+
+      const health = await registry.healthCheckAll();
+      expect(health['crash']?.healthy).toBe(false);
+      expect(health['crash']?.error).toBe('timeout');
+    });
+
+    it('returns empty object when no connectors are registered', async () => {
+      const registry = new ConnectorRegistry();
+      const health = await registry.healthCheckAll();
+      expect(Object.keys(health)).toHaveLength(0);
+    });
+  });
+});

--- a/packages/standalone/tests/connectors/framework/polling-scheduler.test.ts
+++ b/packages/standalone/tests/connectors/framework/polling-scheduler.test.ts
@@ -1,0 +1,245 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ConnectorRegistry } from '../../../src/connectors/framework/connector-registry.js';
+import { PollingScheduler } from '../../../src/connectors/framework/polling-scheduler.js';
+import { RawStore } from '../../../src/connectors/framework/raw-store.js';
+import type { IConnector, NormalizedItem } from '../../../src/connectors/framework/types.js';
+
+function makeItem(sourceId: string, timestamp: Date): NormalizedItem {
+  return {
+    source: 'test',
+    sourceId,
+    channel: 'general',
+    author: 'bot',
+    content: 'test content',
+    timestamp,
+    type: 'message',
+  };
+}
+
+function makeMockConnector(name: string, items: NormalizedItem[] = []): IConnector {
+  return {
+    name,
+    type: 'api',
+    init: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn().mockResolvedValue(undefined),
+    healthCheck: vi.fn().mockResolvedValue({ healthy: true, lastPollTime: null, lastPollCount: 0 }),
+    getAuthRequirements: vi.fn().mockReturnValue([]),
+    authenticate: vi.fn().mockResolvedValue(true),
+    poll: vi.fn().mockResolvedValue(items),
+  };
+}
+
+describe('PollingScheduler', () => {
+  let tmpDir: string;
+  let rawStore: RawStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'poll-sched-test-'));
+    rawStore = new RawStore(tmpDir);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    // rawStore may have been closed by scheduler.stop(), so guard
+    try {
+      rawStore.close();
+    } catch {
+      /* already closed */
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.useRealTimers();
+  });
+
+  describe('pollAll (batch mode)', () => {
+    it('collects from all connectors and calls batch callback', async () => {
+      const onExtract = vi.fn().mockResolvedValue(undefined);
+      const scheduler = new PollingScheduler(rawStore, tmpDir);
+      const registry = new ConnectorRegistry();
+
+      const slackItem = makeItem('slack-1', new Date('2026-04-07T10:00:00Z'));
+      slackItem.source = 'slack';
+      slackItem.channel = 'general';
+      const notionItem = makeItem('notion-1', new Date('2026-04-07T11:00:00Z'));
+      notionItem.source = 'notion';
+      notionItem.channel = 'tasks';
+
+      const slackConnector = makeMockConnector('slack', [slackItem]);
+      const notionConnector = makeMockConnector('notion', [notionItem]);
+      registry.register('slack', slackConnector);
+      registry.register('notion', notionConnector);
+
+      const channelConfigs = {
+        slack: { general: { role: 'hub' as const } },
+        notion: { tasks: { role: 'hub' as const } },
+      };
+
+      await scheduler.pollAll(registry, channelConfigs, onExtract);
+
+      expect(onExtract).toHaveBeenCalledOnce();
+      const classified = onExtract.mock.calls[0]?.[0] as {
+        truth: unknown[];
+        activity: unknown[];
+        spoke: unknown[];
+      };
+      expect(classified.activity).toHaveLength(2);
+      expect(classified.truth).toHaveLength(0);
+      expect(classified.spoke).toHaveLength(0);
+    });
+
+    it('skips callback when no items from any connector', async () => {
+      const onExtract = vi.fn().mockResolvedValue(undefined);
+      const scheduler = new PollingScheduler(rawStore, tmpDir);
+      const registry = new ConnectorRegistry();
+
+      const slackConnector = makeMockConnector('slack', []);
+      const notionConnector = makeMockConnector('notion', []);
+      registry.register('slack', slackConnector);
+      registry.register('notion', notionConnector);
+
+      await scheduler.pollAll(registry, {}, onExtract);
+
+      expect(onExtract).not.toHaveBeenCalled();
+    });
+
+    it('saves all items to raw store', async () => {
+      const scheduler = new PollingScheduler(rawStore, tmpDir);
+      const registry = new ConnectorRegistry();
+
+      const ts = new Date('2026-04-07T10:00:00Z');
+      const slackItem = makeItem('slack-stored', ts);
+      slackItem.source = 'slack';
+      slackItem.channel = 'general';
+      const notionItem = makeItem('notion-stored', ts);
+      notionItem.source = 'notion';
+      notionItem.channel = 'tasks';
+
+      registry.register('slack', makeMockConnector('slack', [slackItem]));
+      registry.register('notion', makeMockConnector('notion', [notionItem]));
+
+      await scheduler.pollAll(registry, {}, vi.fn());
+
+      const slackItems = rawStore.query('slack', new Date(0));
+      const notionItems = rawStore.query('notion', new Date(0));
+      expect(slackItems).toHaveLength(1);
+      expect(notionItems).toHaveLength(1);
+      expect(slackItems[0]?.sourceId).toBe('slack-stored');
+      expect(notionItems[0]?.sourceId).toBe('notion-stored');
+    });
+
+    it('startBatch fires initial poll and sets interval', async () => {
+      const onBatchExtract = vi.fn().mockResolvedValue(undefined);
+      const scheduler = new PollingScheduler(rawStore, tmpDir);
+      const registry = new ConnectorRegistry();
+
+      const item = makeItem('batch-1', new Date());
+      item.source = 'slack';
+      item.channel = 'general';
+      registry.register('slack', makeMockConnector('slack', [item]));
+
+      const channelConfigs = { slack: { general: { role: 'hub' as const } } };
+
+      scheduler.startBatch(registry, channelConfigs, 1, onBatchExtract);
+
+      // Allow the initial fire-and-forget poll to resolve
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(onBatchExtract).toHaveBeenCalledOnce();
+
+      // Advance 1 minute — should trigger another batch poll
+      await vi.advanceTimersByTimeAsync(60 * 1000);
+      expect(onBatchExtract.mock.calls.length).toBeGreaterThan(1);
+
+      scheduler.stop();
+    });
+
+    it('stop() clears the batch timer', async () => {
+      const onBatchExtract = vi.fn().mockResolvedValue(undefined);
+      const scheduler = new PollingScheduler(rawStore, tmpDir);
+      const registry = new ConnectorRegistry();
+
+      const item = makeItem('batch-stop', new Date());
+      item.source = 'slack';
+      item.channel = 'general';
+      registry.register('slack', makeMockConnector('slack', [item]));
+
+      const channelConfigs = { slack: { general: { role: 'hub' as const } } };
+
+      scheduler.startBatch(registry, channelConfigs, 1, onBatchExtract);
+      await vi.advanceTimersByTimeAsync(0);
+
+      scheduler.stop();
+      const callsAtStop = onBatchExtract.mock.calls.length;
+
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000); // advance 5 minutes
+      expect(onBatchExtract.mock.calls.length).toBe(callsAtStop);
+    });
+  });
+
+  describe('state persistence', () => {
+    it('writes poll-state.json after pollAll', async () => {
+      const scheduler = new PollingScheduler(rawStore, tmpDir);
+      const registry = new ConnectorRegistry();
+
+      const item = makeItem('state-msg', new Date());
+      item.source = 'slack';
+      item.channel = 'general';
+      registry.register('slack', makeMockConnector('slack', [item]));
+
+      await scheduler.pollAll(registry, {}, vi.fn());
+
+      const stateFile = join(tmpDir, 'poll-state.json');
+      expect(existsSync(stateFile)).toBe(true);
+
+      const state = JSON.parse(readFileSync(stateFile, 'utf8')) as Record<string, string>;
+      expect(state['slack']).toBeDefined();
+      expect(new Date(state['slack']!)).toBeInstanceOf(Date);
+    });
+
+    it('restores lastPollTime from poll-state.json on construction', async () => {
+      const scheduler1 = new PollingScheduler(rawStore, tmpDir);
+      const registry = new ConnectorRegistry();
+
+      const item = makeItem('persist-msg', new Date());
+      item.source = 'slack';
+      item.channel = 'general';
+      registry.register('slack', makeMockConnector('slack', [item]));
+
+      await scheduler1.pollAll(registry, {}, vi.fn());
+      const savedTime = scheduler1.getLastPollTime('slack');
+
+      // Second scheduler reads it back (need a new rawStore since stop closes it)
+      const rawStore2 = new RawStore(tmpDir);
+      const scheduler2 = new PollingScheduler(rawStore2, tmpDir);
+      const restoredTime = scheduler2.getLastPollTime('slack');
+
+      expect(restoredTime).toBeDefined();
+      expect(restoredTime!.getTime()).toBe(savedTime!.getTime());
+      rawStore2.close();
+    });
+  });
+
+  describe('getLastPollTime', () => {
+    it('returns undefined before first poll', () => {
+      const scheduler = new PollingScheduler(rawStore, tmpDir);
+      expect(scheduler.getLastPollTime('unknown')).toBeUndefined();
+    });
+
+    it('returns a Date after polling', async () => {
+      const scheduler = new PollingScheduler(rawStore, tmpDir);
+      const registry = new ConnectorRegistry();
+
+      const item = makeItem('time-msg', new Date());
+      item.source = 'slack';
+      item.channel = 'general';
+      registry.register('slack', makeMockConnector('slack', [item]));
+
+      await scheduler.pollAll(registry, {}, vi.fn());
+
+      expect(scheduler.getLastPollTime('slack')).toBeInstanceOf(Date);
+    });
+  });
+});

--- a/packages/standalone/tests/connectors/framework/raw-store.test.ts
+++ b/packages/standalone/tests/connectors/framework/raw-store.test.ts
@@ -1,0 +1,169 @@
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { RawStore } from '../../../src/connectors/framework/raw-store.js';
+import type { NormalizedItem } from '../../../src/connectors/framework/types.js';
+
+function makeItem(overrides: Partial<NormalizedItem> = {}): NormalizedItem {
+  return {
+    source: 'slack',
+    sourceId: `msg-${Math.random().toString(36).slice(2)}`,
+    channel: 'general',
+    author: 'alice',
+    content: 'hello world',
+    timestamp: new Date('2026-04-07T10:00:00Z'),
+    type: 'message',
+    ...overrides,
+  };
+}
+
+describe('RawStore', () => {
+  let tmpDir: string;
+  let store: RawStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'raw-store-test-'));
+    store = new RawStore(tmpDir);
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('save and query', () => {
+    it('saves items and retrieves them', () => {
+      const item = makeItem({ timestamp: new Date('2026-04-07T10:00:00Z') });
+      store.save('slack', [item]);
+
+      const results = store.query('slack', new Date('2026-04-07T00:00:00Z'));
+      expect(results).toHaveLength(1);
+      expect(results[0]?.sourceId).toBe(item.sourceId);
+      expect(results[0]?.content).toBe('hello world');
+      expect(results[0]?.type).toBe('message');
+    });
+
+    it('saves items with metadata', () => {
+      const item = makeItem({
+        metadata: { threadId: 'T001', reactions: ['👍'] },
+      });
+      store.save('slack', [item]);
+
+      const results = store.query('slack', new Date(0));
+      expect(results[0]?.metadata).toEqual({ threadId: 'T001', reactions: ['👍'] });
+    });
+
+    it('returns items ordered by timestamp ascending', () => {
+      const t1 = new Date('2026-04-07T08:00:00Z');
+      const t2 = new Date('2026-04-07T09:00:00Z');
+      const t3 = new Date('2026-04-07T10:00:00Z');
+
+      store.save('slack', [
+        makeItem({ sourceId: 'c', timestamp: t3 }),
+        makeItem({ sourceId: 'a', timestamp: t1 }),
+        makeItem({ sourceId: 'b', timestamp: t2 }),
+      ]);
+
+      const results = store.query('slack', new Date(0));
+      expect(results.map((r) => r.sourceId)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('returns an empty array when no items match since filter', () => {
+      store.save('slack', [makeItem({ timestamp: new Date('2026-04-07T10:00:00Z') })]);
+      const results = store.query('slack', new Date('2026-04-07T11:00:00Z'));
+      expect(results).toHaveLength(0);
+    });
+
+    it('handles empty items array without error', () => {
+      expect(() => store.save('slack', [])).not.toThrow();
+      expect(store.query('slack', new Date(0))).toHaveLength(0);
+    });
+  });
+
+  describe('deduplication', () => {
+    it('deduplicates items by sourceId (INSERT OR IGNORE)', () => {
+      const item = makeItem({ sourceId: 'fixed-id', content: 'original' });
+      const duplicate = makeItem({ sourceId: 'fixed-id', content: 'duplicate' });
+
+      store.save('slack', [item]);
+      store.save('slack', [duplicate]);
+
+      const results = store.query('slack', new Date(0));
+      expect(results).toHaveLength(1);
+      expect(results[0]?.content).toBe('original');
+    });
+
+    it('saves only unique items in a single batch', () => {
+      const item1 = makeItem({ sourceId: 'same-id', content: 'first' });
+      const item2 = makeItem({ sourceId: 'same-id', content: 'second' });
+
+      store.save('slack', [item1, item2]);
+
+      const results = store.query('slack', new Date(0));
+      expect(results).toHaveLength(1);
+    });
+  });
+
+  describe('timestamp filtering', () => {
+    it('includes items exactly at the since boundary', () => {
+      const since = new Date('2026-04-07T10:00:00Z');
+      store.save('slack', [makeItem({ sourceId: 'exact', timestamp: since })]);
+
+      const results = store.query('slack', since);
+      expect(results).toHaveLength(1);
+    });
+
+    it('excludes items before the since boundary', () => {
+      const before = new Date('2026-04-07T09:59:59Z');
+      const after = new Date('2026-04-07T10:00:01Z');
+      store.save('slack', [
+        makeItem({ sourceId: 'before', timestamp: before }),
+        makeItem({ sourceId: 'after', timestamp: after }),
+      ]);
+
+      const results = store.query('slack', new Date('2026-04-07T10:00:00Z'));
+      expect(results).toHaveLength(1);
+      expect(results[0]?.sourceId).toBe('after');
+    });
+  });
+
+  describe('separate DBs per connector', () => {
+    it('keeps items isolated between connectors', () => {
+      store.save('slack', [makeItem({ sourceId: 'slack-1', source: 'slack' })]);
+      store.save('notion', [makeItem({ sourceId: 'notion-1', source: 'notion' })]);
+
+      const slackResults = store.query('slack', new Date(0));
+      const notionResults = store.query('notion', new Date(0));
+
+      expect(slackResults).toHaveLength(1);
+      expect(slackResults[0]?.source).toBe('slack');
+
+      expect(notionResults).toHaveLength(1);
+      expect(notionResults[0]?.source).toBe('notion');
+    });
+
+    it('creates separate db files per connector', () => {
+      store.save('connA', [makeItem({ sourceId: 'a1' })]);
+      store.save('connB', [makeItem({ sourceId: 'b1' })]);
+
+      // No cross-contamination
+      expect(store.query('connA', new Date(0))).toHaveLength(1);
+      expect(store.query('connB', new Date(0))).toHaveLength(1);
+      expect(store.query('connA', new Date(0))[0]?.sourceId).toBe('a1');
+      expect(store.query('connB', new Date(0))[0]?.sourceId).toBe('b1');
+    });
+  });
+
+  describe('timestamp round-trip', () => {
+    it('stores and retrieves timestamps as Date objects', () => {
+      const ts = new Date('2026-04-07T15:30:00.000Z');
+      store.save('slack', [makeItem({ timestamp: ts })]);
+
+      const results = store.query('slack', new Date(0));
+      expect(results[0]?.timestamp).toBeInstanceOf(Date);
+      expect(results[0]?.timestamp.getTime()).toBe(ts.getTime());
+    });
+  });
+});

--- a/packages/standalone/tests/connectors/framework/types.test.ts
+++ b/packages/standalone/tests/connectors/framework/types.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  AuthConfig,
+  AuthRequirement,
+  ChannelConfig,
+  ConnectorConfig,
+  ConnectorHealth,
+  ConnectorsConfig,
+  IConnector,
+  NormalizedItem,
+} from '../../../src/connectors/framework/types.js';
+
+describe('Connector Framework — Types', () => {
+  describe('NormalizedItem', () => {
+    it('accepts a minimal valid item', () => {
+      const item: NormalizedItem = {
+        source: 'slack',
+        sourceId: 'msg-001',
+        channel: 'general',
+        author: 'alice',
+        content: 'hello world',
+        timestamp: new Date('2026-04-07T10:00:00Z'),
+        type: 'message',
+      };
+      expect(item.source).toBe('slack');
+      expect(item.type).toBe('message');
+      expect(item.metadata).toBeUndefined();
+    });
+
+    it('accepts all supported item types', () => {
+      const types: NormalizedItem['type'][] = [
+        'message',
+        'email',
+        'event',
+        'document',
+        'note',
+        'spreadsheet_row',
+        'kanban_card',
+        'file_change',
+      ];
+      for (const type of types) {
+        const item: NormalizedItem = {
+          source: 'test',
+          sourceId: `id-${type}`,
+          channel: 'ch',
+          author: 'bot',
+          content: 'content',
+          timestamp: new Date(),
+          type,
+        };
+        expect(item.type).toBe(type);
+      }
+    });
+
+    it('accepts optional metadata', () => {
+      const item: NormalizedItem = {
+        source: 'notion',
+        sourceId: 'page-1',
+        channel: 'docs',
+        author: 'system',
+        content: 'doc content',
+        timestamp: new Date(),
+        type: 'document',
+        metadata: { pageId: 'abc123', tags: ['api', 'v2'] },
+      };
+      expect(item.metadata).toEqual({ pageId: 'abc123', tags: ['api', 'v2'] });
+    });
+  });
+
+  describe('ChannelConfig', () => {
+    it('accepts hub role', () => {
+      const cfg: ChannelConfig = { role: 'hub', name: 'main' };
+      expect(cfg.role).toBe('hub');
+    });
+
+    it('accepts spoke role with keywords', () => {
+      const cfg: ChannelConfig = {
+        role: 'spoke',
+        keywords: ['bug', 'fix'],
+        watchPatterns: ['**/*.ts'],
+      };
+      expect(cfg.keywords).toHaveLength(2);
+    });
+
+    it('accepts ignore role', () => {
+      const cfg: ChannelConfig = { role: 'ignore' };
+      expect(cfg.role).toBe('ignore');
+    });
+
+    it('accepts truth role with spreadsheet/board config', () => {
+      const sheet: ChannelConfig = {
+        role: 'truth',
+        spreadsheetId: 'abc123',
+        sheetRange: 'A1:Z500',
+      };
+      const board: ChannelConfig = { role: 'truth', boardId: 'board456' };
+      expect(sheet.spreadsheetId).toBe('abc123');
+      expect(board.boardId).toBe('board456');
+    });
+
+    it('accepts deliverable role with folderId', () => {
+      const cfg: ChannelConfig = { role: 'deliverable', folderId: 'folder789' };
+      expect(cfg.folderId).toBe('folder789');
+    });
+
+    it('accepts reference role', () => {
+      const cfg: ChannelConfig = { role: 'reference' };
+      expect(cfg.role).toBe('reference');
+    });
+  });
+
+  describe('AuthConfig', () => {
+    it('accepts none type', () => {
+      const cfg: AuthConfig = { type: 'none' };
+      expect(cfg.type).toBe('none');
+    });
+
+    it('accepts cli type with cli fields', () => {
+      const cfg: AuthConfig = {
+        type: 'cli',
+        cli: 'gh',
+        cliAuthCommand: 'gh auth login',
+      };
+      expect(cfg.cli).toBe('gh');
+    });
+
+    it('accepts token type', () => {
+      const cfg: AuthConfig = {
+        type: 'token',
+        tokenName: 'SLACK_TOKEN',
+        token: 'xoxb-secret',
+      };
+      expect(cfg.tokenName).toBe('SLACK_TOKEN');
+    });
+  });
+
+  describe('AuthRequirement', () => {
+    it('requires description field', () => {
+      const req: AuthRequirement = {
+        type: 'token',
+        tokenName: 'NOTION_TOKEN',
+        description: 'Create an integration token at notion.so/my-integrations',
+      };
+      expect(req.description).toBeTruthy();
+    });
+  });
+
+  describe('ConnectorConfig', () => {
+    it('accepts a full config', () => {
+      const cfg: ConnectorConfig = {
+        enabled: true,
+        pollIntervalMinutes: 15,
+        channels: {
+          general: { role: 'hub' },
+          random: { role: 'ignore' },
+        },
+        auth: { type: 'none' },
+      };
+      expect(cfg.enabled).toBe(true);
+      expect(Object.keys(cfg.channels)).toHaveLength(2);
+    });
+  });
+
+  describe('ConnectorHealth', () => {
+    it('represents a healthy state', () => {
+      const h: ConnectorHealth = {
+        healthy: true,
+        lastPollTime: new Date(),
+        lastPollCount: 42,
+      };
+      expect(h.healthy).toBe(true);
+      expect(h.error).toBeUndefined();
+    });
+
+    it('represents an unhealthy state with error', () => {
+      const h: ConnectorHealth = {
+        healthy: false,
+        lastPollTime: null,
+        lastPollCount: 0,
+        error: 'connection refused',
+      };
+      expect(h.healthy).toBe(false);
+      expect(h.error).toBe('connection refused');
+    });
+  });
+
+  describe('ConnectorsConfig', () => {
+    it('is a record of ConnectorConfig keyed by connector name', () => {
+      const cfg: ConnectorsConfig = {
+        slack: {
+          enabled: true,
+          pollIntervalMinutes: 5,
+          channels: { general: { role: 'hub' } },
+          auth: { type: 'token', tokenName: 'SLACK_TOKEN' },
+        },
+        notion: {
+          enabled: false,
+          pollIntervalMinutes: 60,
+          channels: {},
+          auth: { type: 'token', tokenName: 'NOTION_TOKEN' },
+        },
+      };
+      expect(Object.keys(cfg)).toHaveLength(2);
+      expect(cfg['slack']?.enabled).toBe(true);
+    });
+  });
+
+  describe('IConnector shape', () => {
+    it('can be implemented as a mock object satisfying the interface', () => {
+      const mock: IConnector = {
+        name: 'test',
+        type: 'api',
+        init: async () => undefined,
+        dispose: async () => undefined,
+        healthCheck: async () => ({
+          healthy: true,
+          lastPollTime: null,
+          lastPollCount: 0,
+        }),
+        getAuthRequirements: () => [],
+        authenticate: async () => true,
+        poll: async (_since: Date) => [],
+      };
+      expect(mock.name).toBe('test');
+      expect(mock.type).toBe('api');
+    });
+  });
+});

--- a/packages/standalone/tests/connectors/gmail.test.ts
+++ b/packages/standalone/tests/connectors/gmail.test.ts
@@ -1,0 +1,274 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GmailConnector } from '../../src/connectors/gmail/index.js';
+import type { ConnectorConfig } from '../../src/connectors/framework/types.js';
+
+// Mock child_process
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+import { execSync } from 'child_process';
+const mockExecSync = vi.mocked(execSync);
+
+function makeConfig(overrides: Partial<ConnectorConfig> = {}): ConnectorConfig {
+  return {
+    enabled: true,
+    pollIntervalMinutes: 10,
+    channels: {},
+    auth: {
+      type: 'cli',
+      cli: 'gws',
+      cliAuthCommand: 'gws auth login',
+    },
+    ...overrides,
+  };
+}
+
+function makeMessageListJson(messageIds: string[]): string {
+  const messages = messageIds.map((id) => ({ id, threadId: `thread-${id}` }));
+  return JSON.stringify({ messages });
+}
+
+function makeMessageJson(overrides: Record<string, unknown> = {}): string {
+  const msg = {
+    id: 'msg001',
+    threadId: 'thread001',
+    snippet: 'This is a brief snippet of the email.',
+    internalDate: '1700000001000',
+    payload: {
+      headers: [
+        { name: 'Subject', value: 'Test Subject' },
+        { name: 'From', value: 'sender@example.com' },
+      ],
+    },
+    ...overrides,
+  };
+  return JSON.stringify(msg);
+}
+
+describe('GmailConnector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: gws --version succeeds
+    mockExecSync.mockReturnValue('' as unknown as ReturnType<typeof execSync>);
+  });
+
+  describe('name and type', () => {
+    it('has name "gmail"', () => {
+      const connector = new GmailConnector(makeConfig());
+      expect(connector.name).toBe('gmail');
+    });
+
+    it('has type "api"', () => {
+      const connector = new GmailConnector(makeConfig());
+      expect(connector.type).toBe('api');
+    });
+  });
+
+  describe('getAuthRequirements', () => {
+    it('returns cli auth requirement for gws', () => {
+      const connector = new GmailConnector(makeConfig());
+      const reqs = connector.getAuthRequirements();
+      expect(reqs).toHaveLength(1);
+      expect(reqs[0]?.type).toBe('cli');
+      expect(reqs[0]?.cli).toBe('gws');
+      expect(reqs[0]?.cliAuthCommand).toBe('gws auth login');
+    });
+  });
+
+  describe('init', () => {
+    it('initializes when gws CLI is available', async () => {
+      mockExecSync.mockReturnValue('gws version 1.0.0' as unknown as ReturnType<typeof execSync>);
+      const connector = new GmailConnector(makeConfig());
+      await expect(connector.init()).resolves.toBeUndefined();
+    });
+
+    it('throws when gws CLI is not found', async () => {
+      mockExecSync.mockImplementation(() => {
+        throw new Error('command not found: gws');
+      });
+      const connector = new GmailConnector(makeConfig());
+      await expect(connector.init()).rejects.toThrow(/gws/i);
+    });
+  });
+
+  describe('authenticate', () => {
+    it('returns true when gws auth status succeeds', async () => {
+      mockExecSync.mockReturnValue('' as unknown as ReturnType<typeof execSync>);
+      const connector = new GmailConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(true);
+    });
+
+    it('returns false when gws auth status throws', async () => {
+      // First call (init --version) succeeds, second call (auth status) fails
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockImplementationOnce(() => {
+          throw new Error('not authenticated');
+        });
+      const connector = new GmailConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(false);
+    });
+  });
+
+  describe('poll', () => {
+    it('returns empty array when no messages', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>) // init
+        .mockReturnValueOnce(makeMessageListJson([]) as unknown as ReturnType<typeof execSync>); // list
+      const connector = new GmailConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toEqual([]);
+    });
+
+    it('fetches and returns normalized email items', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>) // init
+        .mockReturnValueOnce(
+          makeMessageListJson(['msg001']) as unknown as ReturnType<typeof execSync>
+        ) // list
+        .mockReturnValueOnce(makeMessageJson() as unknown as ReturnType<typeof execSync>); // get
+      const connector = new GmailConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(1);
+      expect(items[0]?.source).toBe('gmail');
+      expect(items[0]?.type).toBe('email');
+    });
+
+    it('sets sourceId to message id', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeMessageListJson(['abc123']) as unknown as ReturnType<typeof execSync>
+        )
+        .mockReturnValueOnce(
+          makeMessageJson({ id: 'abc123' }) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new GmailConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.sourceId).toBe('abc123');
+    });
+
+    it('formats content as "Subject: {subject}\\n\\n{snippet}"', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeMessageListJson(['msg001']) as unknown as ReturnType<typeof execSync>
+        )
+        .mockReturnValueOnce(
+          makeMessageJson({
+            snippet: 'Check out this update',
+            payload: {
+              headers: [
+                { name: 'Subject', value: 'Weekly Update' },
+                { name: 'From', value: 'boss@company.com' },
+              ],
+            },
+          }) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new GmailConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.content).toBe('Subject: Weekly Update\n\nCheck out this update');
+    });
+
+    it('sets author from From header', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeMessageListJson(['msg001']) as unknown as ReturnType<typeof execSync>
+        )
+        .mockReturnValueOnce(
+          makeMessageJson({
+            payload: {
+              headers: [
+                { name: 'Subject', value: 'Hello' },
+                { name: 'From', value: 'alice@example.com' },
+              ],
+            },
+          }) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new GmailConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.author).toBe('alice@example.com');
+    });
+
+    it('skips prefix lines like "Using keyring backend: ..." before JSON', async () => {
+      const prefixedOutput =
+        'Using keyring backend: SecretService\n' + makeMessageListJson(['msg001']);
+      const msgOutput = 'Using keyring backend: SecretService\n' + makeMessageJson();
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(prefixedOutput as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(msgOutput as unknown as ReturnType<typeof execSync>);
+      const connector = new GmailConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(1);
+    });
+
+    it('filters out messages at or before since timestamp', async () => {
+      const since = new Date('2024-01-01T00:00:00.000Z'); // 1704067200000 ms
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeMessageListJson(['old001', 'new001']) as unknown as ReturnType<typeof execSync>
+        )
+        .mockReturnValueOnce(
+          makeMessageJson({ id: 'old001', internalDate: '1704067200000' }) as unknown as ReturnType<
+            typeof execSync
+          >
+        ) // exactly at since
+        .mockReturnValueOnce(
+          makeMessageJson({ id: 'new001', internalDate: '1704067201000' }) as unknown as ReturnType<
+            typeof execSync
+          >
+        ); // after
+      const connector = new GmailConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(since);
+      expect(items).toHaveLength(1);
+      expect(items[0]?.sourceId).toBe('new001');
+    });
+
+    it('continues polling other messages if one fetch fails', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeMessageListJson(['bad001', 'good001']) as unknown as ReturnType<typeof execSync>
+        )
+        .mockImplementationOnce(() => {
+          throw new Error('not found');
+        }) // bad001 fails
+        .mockReturnValueOnce(
+          makeMessageJson({ id: 'good001' }) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new GmailConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(1);
+      expect(items[0]?.sourceId).toBe('good001');
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('reflects lastPollTime and lastPollCount after poll', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(makeMessageListJson([]) as unknown as ReturnType<typeof execSync>);
+      const connector = new GmailConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      const health = await connector.healthCheck();
+      expect(health.lastPollTime).not.toBeNull();
+      expect(health.lastPollCount).toBe(0);
+    });
+  });
+});

--- a/packages/standalone/tests/connectors/history-extractor.test.ts
+++ b/packages/standalone/tests/connectors/history-extractor.test.ts
@@ -1,0 +1,502 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  classifyItemsByRole,
+  buildSpokeExtractionPrompt,
+  buildProjectTruth,
+  buildActivityExtractionPrompt,
+} from '../../src/memory/history-extractor.js';
+import type { NormalizedItem, ChannelConfig } from '../../src/connectors/framework/types.js';
+import type { HubContextEntry, ProjectTruth } from '../../src/memory/history-extractor.js';
+
+function makeItem(overrides: Partial<NormalizedItem> = {}): NormalizedItem {
+  return {
+    source: 'chatwork',
+    sourceId: 'cw:001',
+    channel: 'general',
+    author: 'Alice',
+    content: 'Hello world',
+    timestamp: new Date('2025-01-15T09:30:00Z'),
+    type: 'message',
+    ...overrides,
+  };
+}
+
+describe('History Extractor', () => {
+  describe('classifyItemsByRole', () => {
+    it('classifies items into truth, activity, and spoke groups', () => {
+      const items: NormalizedItem[] = [
+        makeItem({ source: 'chatwork', channel: 'general' }),
+        makeItem({ source: 'chatwork', channel: 'dev', content: 'PR merged' }),
+        makeItem({ source: 'slack', channel: 'announcements', content: 'Release done' }),
+        makeItem({
+          source: 'trello',
+          channel: 'board',
+          content: 'Card moved',
+          type: 'kanban_card',
+        }),
+        makeItem({
+          source: 'sheets',
+          channel: 'tasks',
+          content: 'Row updated',
+          type: 'spreadsheet_row',
+        }),
+      ];
+
+      const channelConfigs: Record<string, Record<string, ChannelConfig>> = {
+        chatwork: {
+          general: { role: 'hub' },
+          dev: { role: 'spoke' },
+        },
+        slack: {
+          announcements: { role: 'hub' },
+        },
+        trello: {
+          board: { role: 'truth' },
+        },
+        sheets: {
+          tasks: { role: 'truth' },
+        },
+      };
+
+      const result = classifyItemsByRole(items, channelConfigs);
+
+      expect(result.truth).toHaveLength(2);
+      expect(result.activity).toHaveLength(2);
+      expect(result.spoke).toHaveLength(1);
+      expect(result.truth.map((i) => i.channel)).toContain('board');
+      expect(result.truth.map((i) => i.channel)).toContain('tasks');
+      expect(result.activity.map((i) => i.channel)).toContain('general');
+      expect(result.activity.map((i) => i.channel)).toContain('announcements');
+      expect(result.spoke[0]?.channel).toBe('dev');
+    });
+
+    it('places hub items into activity', () => {
+      const items: NormalizedItem[] = [makeItem({ source: 'chatwork', channel: 'hub-channel' })];
+      const channelConfigs: Record<string, Record<string, ChannelConfig>> = {
+        chatwork: { 'hub-channel': { role: 'hub' } },
+      };
+      const result = classifyItemsByRole(items, channelConfigs);
+      expect(result.activity).toHaveLength(1);
+      expect(result.truth).toHaveLength(0);
+      expect(result.spoke).toHaveLength(0);
+    });
+
+    it('places deliverable items into activity', () => {
+      const items: NormalizedItem[] = [
+        makeItem({ source: 'drive', channel: 'deliverables', type: 'file_change' }),
+      ];
+      const channelConfigs: Record<string, Record<string, ChannelConfig>> = {
+        drive: { deliverables: { role: 'deliverable' } },
+      };
+      const result = classifyItemsByRole(items, channelConfigs);
+      expect(result.activity).toHaveLength(1);
+    });
+
+    it('places reference items into activity', () => {
+      const items: NormalizedItem[] = [
+        makeItem({ source: 'notion', channel: 'wiki', type: 'document' }),
+      ];
+      const channelConfigs: Record<string, Record<string, ChannelConfig>> = {
+        notion: { wiki: { role: 'reference' } },
+      };
+      const result = classifyItemsByRole(items, channelConfigs);
+      expect(result.activity).toHaveLength(1);
+    });
+
+    it('sorts activity items by timestamp ascending', () => {
+      const items: NormalizedItem[] = [
+        makeItem({
+          source: 'chatwork',
+          channel: 'general',
+          timestamp: new Date('2025-01-15T12:00:00Z'),
+          content: 'later',
+        }),
+        makeItem({
+          source: 'chatwork',
+          channel: 'general',
+          timestamp: new Date('2025-01-15T09:00:00Z'),
+          content: 'earlier',
+        }),
+        makeItem({
+          source: 'chatwork',
+          channel: 'general',
+          timestamp: new Date('2025-01-15T10:30:00Z'),
+          content: 'middle',
+        }),
+      ];
+      const channelConfigs: Record<string, Record<string, ChannelConfig>> = {
+        chatwork: { general: { role: 'hub' } },
+      };
+      const result = classifyItemsByRole(items, channelConfigs);
+      expect(result.activity[0]?.content).toBe('earlier');
+      expect(result.activity[1]?.content).toBe('middle');
+      expect(result.activity[2]?.content).toBe('later');
+    });
+
+    it('drops items with ignore role or no config', () => {
+      const items: NormalizedItem[] = [
+        makeItem({ source: 'chatwork', channel: 'noise' }), // ignore role
+        makeItem({ source: 'chatwork', channel: 'unknown-channel' }), // no config
+        makeItem({ source: 'unknown-source', channel: 'anything' }), // no source config
+        makeItem({ source: 'chatwork', channel: 'hub-channel' }), // should be kept
+      ];
+
+      const channelConfigs: Record<string, Record<string, ChannelConfig>> = {
+        chatwork: {
+          noise: { role: 'ignore' },
+          'hub-channel': { role: 'hub' },
+        },
+      };
+
+      const result = classifyItemsByRole(items, channelConfigs);
+
+      expect(result.activity).toHaveLength(1);
+      expect(result.spoke).toHaveLength(0);
+      expect(result.truth).toHaveLength(0);
+      expect(result.activity[0]?.channel).toBe('hub-channel');
+    });
+
+    it('returns empty arrays when all items are dropped', () => {
+      const items: NormalizedItem[] = [makeItem({ source: 'chatwork', channel: 'noise' })];
+      const channelConfigs: Record<string, Record<string, ChannelConfig>> = {
+        chatwork: { noise: { role: 'ignore' } },
+      };
+
+      const result = classifyItemsByRole(items, channelConfigs);
+      expect(result.truth).toHaveLength(0);
+      expect(result.activity).toHaveLength(0);
+      expect(result.spoke).toHaveLength(0);
+    });
+
+    it('handles empty items array', () => {
+      const result = classifyItemsByRole([], { chatwork: { general: { role: 'hub' } } });
+      expect(result.truth).toHaveLength(0);
+      expect(result.activity).toHaveLength(0);
+      expect(result.spoke).toHaveLength(0);
+    });
+  });
+
+  describe('buildProjectTruth', () => {
+    it('builds project truth from kanban_card items', () => {
+      const items: NormalizedItem[] = [
+        makeItem({
+          source: 'trello',
+          channel: 'MyProject',
+          sourceId: 'card-1',
+          type: 'kanban_card',
+          metadata: {
+            cardName: 'Login Feature',
+            listName: 'In Progress',
+            members: 'Alice',
+          },
+        }),
+        makeItem({
+          source: 'trello',
+          channel: 'MyProject',
+          sourceId: 'card-2',
+          type: 'kanban_card',
+          metadata: {
+            cardName: 'Sign Up Page',
+            listName: 'Done',
+            members: 'Bob',
+          },
+        }),
+      ];
+
+      const truth = buildProjectTruth(items);
+
+      expect(truth.projects['MyProject']).toBeDefined();
+      const wu = truth.projects['MyProject']!.workUnits;
+      expect(wu['Login Feature']?.status).toBe('In Progress');
+      expect(wu['Login Feature']?.column).toBe('In Progress');
+      expect(wu['Login Feature']?.assigned).toBe('Alice');
+      expect(wu['Sign Up Page']?.status).toBe('Done');
+      expect(wu['Sign Up Page']?.assigned).toBe('Bob');
+    });
+
+    it('uses sourceId as fallback for kanban_card when cardName is missing', () => {
+      const items: NormalizedItem[] = [
+        makeItem({
+          source: 'trello',
+          channel: 'Project',
+          sourceId: 'card-99',
+          type: 'kanban_card',
+          metadata: { listName: 'Backlog' },
+        }),
+      ];
+
+      const truth = buildProjectTruth(items);
+      expect(truth.projects['Project']!.workUnits['card-99']).toBeDefined();
+    });
+
+    it('builds project truth from spreadsheet_row items', () => {
+      const items: NormalizedItem[] = [
+        makeItem({
+          source: 'sheets',
+          channel: 'TaskSheet',
+          sourceId: 'row-1',
+          type: 'spreadsheet_row',
+          metadata: {
+            headers: ['DB_NO', '클라이언트', '프로젝트', '명칭', '제출기한', '담당'],
+            values: ['101', 'ClientA', 'ProjectX', 'TaskAlpha', '2026-04-20', 'Carol'],
+          },
+        }),
+      ];
+
+      const truth = buildProjectTruth(items);
+
+      expect(truth.projects['ClientA/ProjectX']).toBeDefined();
+      const wu = truth.projects['ClientA/ProjectX']!.workUnits['TaskAlpha'];
+      expect(wu?.status).toBe('납기:2026-04-20');
+      expect(wu?.assigned).toBe('Carol');
+      expect(wu?.metadata?.['클라이언트']).toBe('ClientA');
+    });
+
+    it('handles Korean column names for spreadsheet_row', () => {
+      const items: NormalizedItem[] = [
+        makeItem({
+          source: 'sheets',
+          channel: 'KoreanSheet',
+          sourceId: 'row-1',
+          type: 'spreadsheet_row',
+          metadata: {
+            headers: ['DB_NO', '클라이언트', '프로젝트', '명칭', '제출기한', '담당자'],
+            values: ['202', 'ClientA', 'project_beta', 'feature_dev', '2026-05-01', 'Lee'],
+          },
+        }),
+      ];
+
+      const truth = buildProjectTruth(items);
+      const wu = truth.projects['ClientA/project_beta']!.workUnits['feature_dev'];
+      expect(wu?.status).toBe('납기:2026-05-01');
+      expect(wu?.assigned).toBe('Lee');
+    });
+
+    it('uses sourceId as fallback for spreadsheet_row when values is empty', () => {
+      const items: NormalizedItem[] = [
+        makeItem({
+          source: 'sheets',
+          channel: 'Sheet',
+          sourceId: 'row-42',
+          type: 'spreadsheet_row',
+          metadata: { headers: [], values: [] },
+        }),
+      ];
+
+      const truth = buildProjectTruth(items);
+      expect(truth.projects['Sheet']!.workUnits['row-42']).toBeDefined();
+      expect(truth.projects['Sheet']!.workUnits['row-42']?.status).toBe('active');
+    });
+
+    it('groups work units by channel', () => {
+      const items: NormalizedItem[] = [
+        makeItem({
+          source: 'trello',
+          channel: 'ProjectA',
+          sourceId: 'card-1',
+          type: 'kanban_card',
+          metadata: { cardName: 'Task A', listName: 'Todo' },
+        }),
+        makeItem({
+          source: 'trello',
+          channel: 'ProjectB',
+          sourceId: 'card-2',
+          type: 'kanban_card',
+          metadata: { cardName: 'Task B', listName: 'Done' },
+        }),
+      ];
+
+      const truth = buildProjectTruth(items);
+      expect(Object.keys(truth.projects)).toHaveLength(2);
+      expect(truth.projects['ProjectA']!.workUnits['Task A']).toBeDefined();
+      expect(truth.projects['ProjectB']!.workUnits['Task B']).toBeDefined();
+    });
+
+    it('returns empty projects for empty input', () => {
+      const truth = buildProjectTruth([]);
+      expect(truth.projects).toEqual({});
+    });
+
+    it('skips non-truth item types (message, email, etc.)', () => {
+      const items: NormalizedItem[] = [
+        makeItem({ source: 'chatwork', channel: 'general', type: 'message' }),
+        makeItem({ source: 'chatwork', channel: 'general', type: 'email' }),
+      ];
+      const truth = buildProjectTruth(items);
+      // Projects are still created by channel, but no workUnits are added
+      expect(truth.projects['general']?.workUnits).toEqual({});
+    });
+  });
+
+  describe('buildActivityExtractionPrompt', () => {
+    it('builds activity extraction prompt with truth context header', () => {
+      const activity: NormalizedItem[] = [
+        makeItem({
+          source: 'chatwork',
+          channel: 'general',
+          author: 'Alice',
+          content: 'Login feature is now submitted for review',
+          timestamp: new Date('2025-01-15T09:30:00Z'),
+        }),
+      ];
+
+      const truth: ProjectTruth = {
+        projects: {
+          MyProject: {
+            workUnits: {
+              'Login Feature': { status: 'In Progress', column: 'In Progress', assigned: 'Alice' },
+            },
+          },
+        },
+      };
+
+      const prompt = buildActivityExtractionPrompt(activity, truth);
+
+      expect(prompt).toContain('당신은 프로젝트 역사가입니다');
+      expect(prompt).toContain('현재 프로젝트 상태');
+      expect(prompt).toContain('MyProject/Login Feature: In Progress');
+      expect(prompt).toContain('담당: Alice');
+      expect(prompt).toContain('chatwork:general');
+      expect(prompt).toContain('Alice');
+      expect(prompt).toContain('Login feature is now submitted for review');
+      expect(prompt).toContain('JSON');
+      expect(prompt).toContain('project');
+      expect(prompt).toContain('confidence');
+    });
+
+    it('shows (없음) when truth has no projects', () => {
+      const activity: NormalizedItem[] = [makeItem({ source: 'chatwork', channel: 'general' })];
+      const truth: ProjectTruth = { projects: {} };
+      const prompt = buildActivityExtractionPrompt(activity, truth);
+      expect(prompt).toContain('(없음)');
+    });
+
+    it('includes activity items grouped by source:channel', () => {
+      const activity: NormalizedItem[] = [
+        makeItem({ source: 'chatwork', channel: 'general', content: 'msg1' }),
+        makeItem({ source: 'slack', channel: 'general', content: 'msg2' }),
+        makeItem({ source: 'chatwork', channel: 'general', content: 'msg3' }),
+      ];
+      const truth: ProjectTruth = { projects: {} };
+
+      const prompt = buildActivityExtractionPrompt(activity, truth);
+
+      expect(prompt).toContain('chatwork:general');
+      expect(prompt).toContain('slack:general');
+      expect(prompt).toContain('msg1');
+      expect(prompt).toContain('msg2');
+      expect(prompt).toContain('msg3');
+    });
+
+    it('returns a prompt even for empty activity', () => {
+      const truth: ProjectTruth = { projects: {} };
+      const prompt = buildActivityExtractionPrompt([], truth);
+      expect(typeof prompt).toBe('string');
+      expect(prompt).toContain('당신은 프로젝트 역사가입니다');
+    });
+  });
+
+  describe('buildSpokeExtractionPrompt', () => {
+    it('builds spoke extraction prompt with hub context', () => {
+      const items: NormalizedItem[] = [
+        makeItem({
+          source: 'telegram',
+          channel: 'team-chat',
+          author: 'Carol',
+          content: 'PostgreSQL migration is on track',
+          timestamp: new Date('2025-01-15T11:00:00Z'),
+        }),
+      ];
+
+      const hubContext: HubContextEntry[] = [
+        {
+          project: 'DataPlatform',
+          workUnit: 'DB Migration',
+          assignedTo: 'Alice',
+          status: 'in-progress',
+        },
+      ];
+
+      const prompt = buildSpokeExtractionPrompt(items, hubContext);
+
+      expect(prompt).toContain('당신은 역사가입니다');
+      expect(prompt).toContain('현재 활성 프로젝트 상황:');
+      expect(prompt).toContain('DataPlatform');
+      expect(prompt).toContain('DB Migration');
+      expect(prompt).toContain('Alice');
+      expect(prompt).toContain('in-progress');
+      expect(prompt).toContain('telegram:team-chat');
+      expect(prompt).toContain('Carol');
+      expect(prompt).toContain('PostgreSQL migration is on track');
+      // Should include HH:MM format
+      expect(prompt).toMatch(/Carol\(\d{2}:\d{2}\)/);
+      // Should request JSON output with same schema
+      expect(prompt).toContain('JSON');
+      expect(prompt).toContain('confidence');
+    });
+
+    it('handles empty hub context gracefully', () => {
+      const items: NormalizedItem[] = [
+        makeItem({ source: 'telegram', channel: 'dm', content: 'quick update' }),
+      ];
+
+      const prompt = buildSpokeExtractionPrompt(items, []);
+
+      expect(prompt).toContain('현재 활성 프로젝트 상황:');
+      expect(prompt).toContain('(없음)');
+      expect(prompt).toContain('quick update');
+    });
+
+    it('includes hub context entries without optional fields', () => {
+      const hubContext: HubContextEntry[] = [{ project: 'SimpleProject' }];
+      const prompt = buildSpokeExtractionPrompt([], hubContext);
+      expect(prompt).toContain('SimpleProject');
+    });
+
+    it('includes truth context in prompt when provided', () => {
+      const items: NormalizedItem[] = [
+        makeItem({ source: 'telegram', channel: 'team', content: 'task done' }),
+      ];
+      const hubContext: HubContextEntry[] = [{ project: 'MyProject' }];
+      const truth: ProjectTruth = {
+        projects: {
+          MyProject: {
+            workUnits: {
+              'Feature X': { status: 'In Review', column: 'In Review', assigned: 'Dave' },
+            },
+          },
+        },
+      };
+
+      const prompt = buildSpokeExtractionPrompt(items, hubContext, truth);
+
+      expect(prompt).toContain('프로젝트 진실 상태');
+      expect(prompt).toContain('MyProject/Feature X: In Review');
+      expect(prompt).toContain('담당: Dave');
+    });
+
+    it('omits truth context section when truth is undefined', () => {
+      const items: NormalizedItem[] = [
+        makeItem({ source: 'telegram', channel: 'team', content: 'msg' }),
+      ];
+      const hubContext: HubContextEntry[] = [{ project: 'P' }];
+
+      const prompt = buildSpokeExtractionPrompt(items, hubContext, undefined);
+
+      expect(prompt).not.toContain('프로젝트 진실 상태');
+    });
+
+    it('omits truth context section when truth has no projects', () => {
+      const items: NormalizedItem[] = [
+        makeItem({ source: 'telegram', channel: 'team', content: 'msg' }),
+      ];
+      const hubContext: HubContextEntry[] = [{ project: 'P' }];
+      const truth: ProjectTruth = { projects: {} };
+
+      const prompt = buildSpokeExtractionPrompt(items, hubContext, truth);
+
+      expect(prompt).not.toContain('프로젝트 진실 상태');
+    });
+  });
+});

--- a/packages/standalone/tests/connectors/integration.test.ts
+++ b/packages/standalone/tests/connectors/integration.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ConnectorRegistry } from '../../src/connectors/framework/connector-registry.js';
+import { PollingScheduler } from '../../src/connectors/framework/polling-scheduler.js';
+import { RawStore } from '../../src/connectors/framework/raw-store.js';
+import { classifyItemsByRole } from '../../src/memory/history-extractor.js';
+import type { IConnector, NormalizedItem } from '../../src/connectors/framework/types.js';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+function createMockConnector(name: string, items: NormalizedItem[]): IConnector {
+  return {
+    name,
+    type: 'api',
+    init: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn().mockResolvedValue(undefined),
+    healthCheck: vi.fn().mockResolvedValue({ healthy: true, lastPollTime: null, lastPollCount: 0 }),
+    getAuthRequirements: vi.fn().mockReturnValue([]),
+    authenticate: vi.fn().mockResolvedValue(true),
+    poll: vi.fn().mockResolvedValue(items),
+  };
+}
+
+describe('Connector Integration', () => {
+  let tmpDir: string;
+  let rawStore: RawStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'integration-'));
+    rawStore = new RawStore(tmpDir);
+  });
+
+  afterEach(() => {
+    try {
+      rawStore.close();
+    } catch {
+      /* already closed */
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('full flow: register → poll → raw store → classify', async () => {
+    const hubItems: NormalizedItem[] = [
+      {
+        source: 'chatwork',
+        sourceId: 'cw:1',
+        channel: 'project_alpha',
+        author: 'Alice',
+        content: 'Task 3 assigned to Bob',
+        timestamp: new Date(),
+        type: 'message',
+      },
+    ];
+    const spokeItems: NormalizedItem[] = [
+      {
+        source: 'kakao',
+        sourceId: 'kk:1',
+        channel: 'Bob',
+        author: 'Bob',
+        content: '3화 작업 시작합니다',
+        timestamp: new Date(),
+        type: 'message',
+      },
+    ];
+
+    const registry = new ConnectorRegistry();
+    registry.register('chatwork', createMockConnector('chatwork', hubItems));
+    registry.register('kakao', createMockConnector('kakao', spokeItems));
+
+    const channelConfigs = {
+      chatwork: { project_alpha: { role: 'hub' as const } },
+      kakao: { Bob: { role: 'spoke' as const } },
+    };
+
+    const collected: NormalizedItem[] = [];
+    const scheduler = new PollingScheduler(rawStore, tmpDir);
+
+    await scheduler.pollAll(registry, channelConfigs, async (classified) => {
+      collected.push(...classified.activity, ...classified.spoke);
+    });
+
+    expect(collected).toHaveLength(2);
+
+    // Classify manually to verify
+    const { activity, spoke } = classifyItemsByRole(collected, channelConfigs);
+    expect(activity).toHaveLength(1);
+    expect(spoke).toHaveLength(1);
+
+    // Verify raw store persistence
+    const chatworkRaw = rawStore.query('chatwork', new Date(0));
+    const kakaoRaw = rawStore.query('kakao', new Date(0));
+    expect(chatworkRaw).toHaveLength(1);
+    expect(kakaoRaw).toHaveLength(1);
+
+    scheduler.stop();
+  });
+
+  it('handles empty poll gracefully', async () => {
+    const registry = new ConnectorRegistry();
+    registry.register('slack', createMockConnector('slack', []));
+
+    const onExtract = vi.fn();
+    const scheduler = new PollingScheduler(rawStore, tmpDir);
+
+    await scheduler.pollAll(registry, {}, onExtract);
+
+    expect(onExtract).not.toHaveBeenCalled();
+    scheduler.stop();
+  });
+
+  it('deduplicates across polls', async () => {
+    const items: NormalizedItem[] = [
+      {
+        source: 'slack',
+        sourceId: 'same-id',
+        channel: 'general',
+        author: 'alice',
+        content: 'hello',
+        timestamp: new Date(),
+        type: 'message',
+      },
+    ];
+
+    const connector = createMockConnector('slack', items);
+    const registry = new ConnectorRegistry();
+    registry.register('slack', connector);
+
+    const scheduler = new PollingScheduler(rawStore, tmpDir);
+
+    await scheduler.pollAll(registry, {}, vi.fn());
+    await scheduler.pollAll(registry, {}, vi.fn());
+
+    // Raw store should deduplicate
+    const stored = rawStore.query('slack', new Date(0));
+    expect(stored).toHaveLength(1);
+
+    scheduler.stop();
+  });
+});

--- a/packages/standalone/tests/connectors/kagemusha.test.ts
+++ b/packages/standalone/tests/connectors/kagemusha.test.ts
@@ -1,0 +1,276 @@
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import Database from '../../src/sqlite.js';
+import { KagemushaConnector } from '../../src/connectors/kagemusha/index.js';
+import type { ConnectorConfig } from '../../src/connectors/framework/types.js';
+
+let tempDir: string;
+let tempDbPath: string;
+
+function makeConfig(overrides: Partial<ConnectorConfig> = {}): ConnectorConfig {
+  return {
+    enabled: true,
+    pollIntervalMinutes: 5,
+    channels: {},
+    auth: { type: 'none' },
+    ...overrides,
+  };
+}
+
+function createTestDb(dbPath: string): Database {
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS channel_messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      channel TEXT NOT NULL,
+      channel_id TEXT NOT NULL,
+      user_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    )
+  `);
+  return db;
+}
+
+describe('KagemushaConnector', () => {
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'kagemusha-test-'));
+    tempDbPath = join(tempDir, 'kagemusha.db');
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('name and type', () => {
+    it('has name "kagemusha"', () => {
+      const connector = new KagemushaConnector(makeConfig(), tempDbPath);
+      expect(connector.name).toBe('kagemusha');
+    });
+
+    it('has type "local"', () => {
+      const connector = new KagemushaConnector(makeConfig(), tempDbPath);
+      expect(connector.type).toBe('local');
+    });
+  });
+
+  describe('getAuthRequirements', () => {
+    it('returns "none" auth requirement', () => {
+      const connector = new KagemushaConnector(makeConfig(), tempDbPath);
+      const reqs = connector.getAuthRequirements();
+      expect(reqs).toHaveLength(1);
+      expect(reqs[0]?.type).toBe('none');
+    });
+  });
+
+  describe('init', () => {
+    it('initializes successfully when db file exists', async () => {
+      createTestDb(tempDbPath).close();
+      const connector = new KagemushaConnector(makeConfig(), tempDbPath);
+      await expect(connector.init()).resolves.toBeUndefined();
+      await connector.dispose();
+    });
+
+    it('throws when db file does not exist', async () => {
+      const connector = new KagemushaConnector(makeConfig(), '/nonexistent/path/kagemusha.db');
+      await expect(connector.init()).rejects.toThrow(/failed to open/i);
+    });
+  });
+
+  describe('authenticate', () => {
+    it('returns true after init', async () => {
+      createTestDb(tempDbPath).close();
+      const connector = new KagemushaConnector(makeConfig(), tempDbPath);
+      await connector.init();
+      expect(await connector.authenticate()).toBe(true);
+      await connector.dispose();
+    });
+
+    it('returns false before init', async () => {
+      const connector = new KagemushaConnector(makeConfig(), tempDbPath);
+      expect(await connector.authenticate()).toBe(false);
+    });
+  });
+
+  describe('poll', () => {
+    it('returns empty array when no messages after since', async () => {
+      createTestDb(tempDbPath).close();
+      const connector = new KagemushaConnector(makeConfig(), tempDbPath);
+      await connector.init();
+      const items = await connector.poll(new Date('2030-01-01T00:00:00.000Z'));
+      expect(items).toEqual([]);
+      await connector.dispose();
+    });
+
+    it('returns user messages newer than since', async () => {
+      const db = createTestDb(tempDbPath);
+      db.prepare(
+        `INSERT INTO channel_messages (channel, channel_id, user_id, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)`
+      ).run('chatwork', 'room-123', 'user-alice', 'user', 'Hello', 1705309200000);
+      db.close();
+
+      const connector = new KagemushaConnector(makeConfig(), tempDbPath);
+      await connector.init();
+      const items = await connector.poll(new Date('2024-01-01T00:00:00.000Z'));
+      expect(items).toHaveLength(1);
+      expect(items[0]?.content).toBe('Hello');
+      await connector.dispose();
+    });
+
+    it('excludes non-user messages (role != user)', async () => {
+      const db = createTestDb(tempDbPath);
+      db.prepare(
+        `INSERT INTO channel_messages (channel, channel_id, user_id, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)`
+      ).run('chatwork', 'room-123', 'assistant', 'assistant', 'AI response', 1705309200000);
+      db.close();
+
+      const connector = new KagemushaConnector(makeConfig(), tempDbPath);
+      await connector.init();
+      const items = await connector.poll(new Date('2024-01-01T00:00:00.000Z'));
+      expect(items).toHaveLength(0);
+      await connector.dispose();
+    });
+
+    it('excludes messages before since', async () => {
+      const db = createTestDb(tempDbPath);
+      db.prepare(
+        `INSERT INTO channel_messages (channel, channel_id, user_id, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)`
+      ).run('slack', 'channel-abc', 'user-bob', 'user', 'Old message', 1704067199000);
+      db.close();
+
+      const connector = new KagemushaConnector(makeConfig(), tempDbPath);
+      await connector.init();
+      const items = await connector.poll(new Date('2024-01-01T00:00:00.000Z'));
+      expect(items).toHaveLength(0);
+      await connector.dispose();
+    });
+
+    it('sets sourceId as "channelId:id"', async () => {
+      const db = createTestDb(tempDbPath);
+      db.prepare(
+        `INSERT INTO channel_messages (channel, channel_id, user_id, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)`
+      ).run('chatwork', 'room-999', 'user-alice', 'user', 'Test', '2024-06-01T00:00:00.000Z');
+      db.close();
+
+      const connector = new KagemushaConnector(makeConfig(), tempDbPath);
+      await connector.init();
+      const items = await connector.poll(new Date('2024-01-01T00:00:00.000Z'));
+      // id is auto-incremented, starts at 1
+      expect(items[0]?.sourceId).toBe('room-999:1');
+      await connector.dispose();
+    });
+
+    it('sets source from row.channel', async () => {
+      const db = createTestDb(tempDbPath);
+      db.prepare(
+        `INSERT INTO channel_messages (channel, channel_id, user_id, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)`
+      ).run('kakao', 'kakao-room-1', 'user-carol', 'user', 'Hi', '2024-06-01T00:00:00.000Z');
+      db.close();
+
+      const connector = new KagemushaConnector(makeConfig(), tempDbPath);
+      await connector.init();
+      const items = await connector.poll(new Date('2024-01-01T00:00:00.000Z'));
+      expect(items[0]?.source).toBe('kakao');
+      await connector.dispose();
+    });
+
+    it('sets channel from row.channel_id', async () => {
+      const db = createTestDb(tempDbPath);
+      db.prepare(
+        `INSERT INTO channel_messages (channel, channel_id, user_id, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)`
+      ).run('slack', 'C01234ABCDE', 'user-dave', 'user', 'Hey', '2024-06-01T00:00:00.000Z');
+      db.close();
+
+      const connector = new KagemushaConnector(makeConfig(), tempDbPath);
+      await connector.init();
+      const items = await connector.poll(new Date('2024-01-01T00:00:00.000Z'));
+      expect(items[0]?.channel).toBe('C01234ABCDE');
+      await connector.dispose();
+    });
+
+    it('sets author from row.user_id', async () => {
+      const db = createTestDb(tempDbPath);
+      db.prepare(
+        `INSERT INTO channel_messages (channel, channel_id, user_id, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)`
+      ).run('chatwork', 'room-1', 'user-eve', 'user', 'Hello', '2024-06-01T00:00:00.000Z');
+      db.close();
+
+      const connector = new KagemushaConnector(makeConfig(), tempDbPath);
+      await connector.init();
+      const items = await connector.poll(new Date('2024-01-01T00:00:00.000Z'));
+      expect(items[0]?.author).toBe('user-eve');
+      await connector.dispose();
+    });
+
+    it('sets type to "message"', async () => {
+      const db = createTestDb(tempDbPath);
+      db.prepare(
+        `INSERT INTO channel_messages (channel, channel_id, user_id, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)`
+      ).run('slack', 'C1', 'user-1', 'user', 'msg', '2024-06-01T00:00:00.000Z');
+      db.close();
+
+      const connector = new KagemushaConnector(makeConfig(), tempDbPath);
+      await connector.init();
+      const items = await connector.poll(new Date('2024-01-01T00:00:00.000Z'));
+      expect(items[0]?.type).toBe('message');
+      await connector.dispose();
+    });
+
+    it('returns messages ordered by created_at ascending', async () => {
+      const db = createTestDb(tempDbPath);
+      const stmt = db.prepare(
+        `INSERT INTO channel_messages (channel, channel_id, user_id, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)`
+      );
+      stmt.run('slack', 'C1', 'u1', 'user', 'second', '2024-06-01T00:00:02.000Z');
+      stmt.run('slack', 'C1', 'u1', 'user', 'first', '2024-06-01T00:00:01.000Z');
+      stmt.run('slack', 'C1', 'u1', 'user', 'third', '2024-06-01T00:00:03.000Z');
+      db.close();
+
+      const connector = new KagemushaConnector(makeConfig(), tempDbPath);
+      await connector.init();
+      const items = await connector.poll(new Date('2024-01-01T00:00:00.000Z'));
+      expect(items[0]?.content).toBe('first');
+      expect(items[1]?.content).toBe('second');
+      expect(items[2]?.content).toBe('third');
+      await connector.dispose();
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('returns healthy after successful poll', async () => {
+      createTestDb(tempDbPath).close();
+      const connector = new KagemushaConnector(makeConfig(), tempDbPath);
+      await connector.init();
+      await connector.poll(new Date(0));
+      const health = await connector.healthCheck();
+      expect(health.healthy).toBe(true);
+      await connector.dispose();
+    });
+
+    it('tracks lastPollTime after poll', async () => {
+      createTestDb(tempDbPath).close();
+      const connector = new KagemushaConnector(makeConfig(), tempDbPath);
+      await connector.init();
+      const before = new Date();
+      await connector.poll(new Date(0));
+      const health = await connector.healthCheck();
+      expect(health.lastPollTime).not.toBeNull();
+      expect(health.lastPollTime!.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      await connector.dispose();
+    });
+  });
+
+  describe('dispose', () => {
+    it('closes the database and authenticate returns false', async () => {
+      createTestDb(tempDbPath).close();
+      const connector = new KagemushaConnector(makeConfig(), tempDbPath);
+      await connector.init();
+      await connector.dispose();
+      expect(await connector.authenticate()).toBe(false);
+    });
+  });
+});

--- a/packages/standalone/tests/connectors/notion.test.ts
+++ b/packages/standalone/tests/connectors/notion.test.ts
@@ -1,0 +1,278 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { NotionConnector } from '../../src/connectors/notion/index.js';
+import type { ConnectorConfig } from '../../src/connectors/framework/types.js';
+
+function makeConfig(overrides: Partial<ConnectorConfig> = {}): ConnectorConfig {
+  return {
+    enabled: true,
+    pollIntervalMinutes: 10,
+    channels: {},
+    auth: {
+      type: 'token',
+      tokenName: 'NOTION_TOKEN',
+      token: 'test-notion-token',
+    },
+    ...overrides,
+  };
+}
+
+function makePage(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'page-abc-123',
+    last_edited_time: '2024-01-15T10:00:00.000Z',
+    properties: {
+      title: {
+        title: [{ plain_text: 'My Page Title' }],
+      },
+    },
+    ...overrides,
+  };
+}
+
+function makeBlockChildrenResponse(blocks: unknown[]) {
+  return {
+    ok: true,
+    json: vi.fn().mockResolvedValue({ results: blocks }),
+  };
+}
+
+function makeSearchResponse(pages: unknown[]) {
+  return {
+    ok: true,
+    json: vi.fn().mockResolvedValue({ results: pages, has_more: false, next_cursor: null }),
+  };
+}
+
+function makeParagraphBlock(text: string) {
+  return {
+    type: 'paragraph',
+    paragraph: {
+      rich_text: [{ plain_text: text }],
+    },
+  };
+}
+
+describe('NotionConnector', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('name and type', () => {
+    it('has name "notion"', () => {
+      const connector = new NotionConnector(makeConfig());
+      expect(connector.name).toBe('notion');
+    });
+
+    it('has type "api"', () => {
+      const connector = new NotionConnector(makeConfig());
+      expect(connector.type).toBe('api');
+    });
+  });
+
+  describe('getAuthRequirements', () => {
+    it('returns token auth requirement with NOTION_TOKEN', () => {
+      const connector = new NotionConnector(makeConfig());
+      const reqs = connector.getAuthRequirements();
+      expect(reqs).toHaveLength(1);
+      expect(reqs[0]?.type).toBe('token');
+      expect(reqs[0]?.tokenName).toBe('NOTION_TOKEN');
+    });
+  });
+
+  describe('init', () => {
+    it('initializes successfully with a token', async () => {
+      const connector = new NotionConnector(makeConfig());
+      await expect(connector.init()).resolves.toBeUndefined();
+    });
+
+    it('throws when token is missing', async () => {
+      const connector = new NotionConnector(
+        makeConfig({ auth: { type: 'token', tokenName: 'NOTION_TOKEN' } })
+      );
+      const originalEnv = process.env['NOTION_TOKEN'];
+      delete process.env['NOTION_TOKEN'];
+      await expect(connector.init()).rejects.toThrow(/token/i);
+      if (originalEnv !== undefined) process.env['NOTION_TOKEN'] = originalEnv;
+    });
+  });
+
+  describe('authenticate', () => {
+    it('returns true when /users/me responds with 200', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+      const connector = new NotionConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(true);
+    });
+
+    it('returns false when response is not ok', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+      const connector = new NotionConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(false);
+    });
+
+    it('returns false when not initialized', async () => {
+      const connector = new NotionConnector(makeConfig());
+      expect(await connector.authenticate()).toBe(false);
+    });
+
+    it('returns false when fetch throws', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+      const connector = new NotionConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(false);
+    });
+
+    it('sends Authorization: Bearer and Notion-Version headers', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new NotionConnector(makeConfig());
+      await connector.init();
+      await connector.authenticate();
+      const headers = mockFetch.mock.calls[0]?.[1]?.headers as Record<string, string>;
+      expect(headers?.['Authorization']).toBe('Bearer test-notion-token');
+      expect(headers?.['Notion-Version']).toBe('2022-06-28');
+    });
+  });
+
+  describe('poll', () => {
+    it('returns empty array when no pages returned', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeSearchResponse([])));
+      const connector = new NotionConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toEqual([]);
+    });
+
+    it('filters pages by last_edited_time > since', async () => {
+      const since = new Date('2024-01-01T00:00:00.000Z');
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          makeSearchResponse([
+            makePage({ id: 'old-page', last_edited_time: '2023-12-31T23:59:59.000Z' }),
+            makePage({ id: 'new-page', last_edited_time: '2024-01-01T00:00:01.000Z' }),
+          ])
+        )
+        // Block children fetch for new-page
+        .mockResolvedValueOnce(makeBlockChildrenResponse([]));
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new NotionConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(since);
+      expect(items).toHaveLength(1);
+      expect(items[0]?.sourceId).toBe('new-page');
+    });
+
+    it('sets sourceId to page.id', async () => {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(makeSearchResponse([makePage({ id: 'abc-123' })]))
+        .mockResolvedValueOnce(makeBlockChildrenResponse([]));
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new NotionConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.sourceId).toBe('abc-123');
+    });
+
+    it('sets source to "notion"', async () => {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(makeSearchResponse([makePage()]))
+        .mockResolvedValueOnce(makeBlockChildrenResponse([]));
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new NotionConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.source).toBe('notion');
+    });
+
+    it('sets type to "document"', async () => {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(makeSearchResponse([makePage()]))
+        .mockResolvedValueOnce(makeBlockChildrenResponse([]));
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new NotionConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.type).toBe('document');
+    });
+
+    it('includes title and block text in content', async () => {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(makeSearchResponse([makePage()]))
+        .mockResolvedValueOnce(
+          makeBlockChildrenResponse([makeParagraphBlock('Some block content')])
+        );
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new NotionConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.content).toContain('My Page Title');
+      expect(items[0]?.content).toContain('Some block content');
+    });
+
+    it('fetches block children with Authorization header', async () => {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce(makeSearchResponse([makePage({ id: 'page-xyz' })]))
+        .mockResolvedValueOnce(makeBlockChildrenResponse([]));
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new NotionConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      // Second call is block children
+      const secondUrl = String(mockFetch.mock.calls[1]?.[0]);
+      expect(secondUrl).toContain('blocks/page-xyz/children');
+      const headers = mockFetch.mock.calls[1]?.[1]?.headers as Record<string, string>;
+      expect(headers?.['Authorization']).toBe('Bearer test-notion-token');
+    });
+
+    it('uses POST for search with correct filter', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(makeSearchResponse([]));
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new NotionConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      expect(mockFetch.mock.calls[0]?.[1]?.method).toBe('POST');
+      const body = JSON.parse(mockFetch.mock.calls[0]?.[1]?.body as string);
+      expect(body.filter).toEqual({ property: 'object', value: 'page' });
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('returns healthy after successful poll', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeSearchResponse([])));
+      const connector = new NotionConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      const health = await connector.healthCheck();
+      expect(health.healthy).toBe(true);
+    });
+
+    it('tracks lastPollTime after poll', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeSearchResponse([])));
+      const connector = new NotionConnector(makeConfig());
+      await connector.init();
+      const before = new Date();
+      await connector.poll(new Date(0));
+      const health = await connector.healthCheck();
+      expect(health.lastPollTime).not.toBeNull();
+      expect(health.lastPollTime!.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    });
+  });
+
+  describe('dispose', () => {
+    it('clears token so authenticate returns false', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+      const connector = new NotionConnector(makeConfig());
+      await connector.init();
+      await connector.dispose();
+      expect(await connector.authenticate()).toBe(false);
+    });
+  });
+});

--- a/packages/standalone/tests/connectors/obsidian.test.ts
+++ b/packages/standalone/tests/connectors/obsidian.test.ts
@@ -1,0 +1,227 @@
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { ObsidianConnector } from '../../src/connectors/obsidian/index.js';
+import type { ConnectorConfig } from '../../src/connectors/framework/types.js';
+
+let tempDir: string;
+
+function makeConfig(vaultPath?: string, overrides: Partial<ConnectorConfig> = {}): ConnectorConfig {
+  return {
+    enabled: true,
+    pollIntervalMinutes: 5,
+    channels: vaultPath ? { vault: { role: 'hub', name: 'vault', vaultPath } } : {},
+    auth: { type: 'none' },
+    ...overrides,
+  };
+}
+
+function createMdFile(filePath: string, content: string, mtime: Date): void {
+  mkdirSync(join(filePath, '..'), { recursive: true });
+  writeFileSync(filePath, content, 'utf8');
+  utimesSync(filePath, mtime, mtime);
+}
+
+describe('ObsidianConnector', () => {
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'obsidian-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('name and type', () => {
+    it('has name "obsidian"', () => {
+      const connector = new ObsidianConnector(makeConfig(tempDir));
+      expect(connector.name).toBe('obsidian');
+    });
+
+    it('has type "local"', () => {
+      const connector = new ObsidianConnector(makeConfig(tempDir));
+      expect(connector.type).toBe('local');
+    });
+  });
+
+  describe('getAuthRequirements', () => {
+    it('returns "none" auth requirement', () => {
+      const connector = new ObsidianConnector(makeConfig(tempDir));
+      const reqs = connector.getAuthRequirements();
+      expect(reqs).toHaveLength(1);
+      expect(reqs[0]?.type).toBe('none');
+    });
+  });
+
+  describe('init', () => {
+    it('initializes successfully when vaultPath exists', async () => {
+      const connector = new ObsidianConnector(makeConfig(tempDir));
+      await expect(connector.init()).resolves.toBeUndefined();
+    });
+
+    it('throws when vaultPath is not configured', async () => {
+      const connector = new ObsidianConnector(makeConfig(undefined));
+      await expect(connector.init()).rejects.toThrow(/vault path/i);
+    });
+
+    it('throws when vaultPath does not exist', async () => {
+      const connector = new ObsidianConnector(makeConfig('/nonexistent/path/vault'));
+      await expect(connector.init()).rejects.toThrow(/does not exist/i);
+    });
+  });
+
+  describe('authenticate', () => {
+    it('returns true when vaultPath exists', async () => {
+      const connector = new ObsidianConnector(makeConfig(tempDir));
+      expect(await connector.authenticate()).toBe(true);
+    });
+
+    it('returns false when no vaultPath configured', async () => {
+      const connector = new ObsidianConnector(makeConfig(undefined));
+      expect(await connector.authenticate()).toBe(false);
+    });
+  });
+
+  describe('poll', () => {
+    it('returns empty array when no md files exist', async () => {
+      const connector = new ObsidianConnector(makeConfig(tempDir));
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toEqual([]);
+    });
+
+    it('returns md files modified after since', async () => {
+      const since = new Date('2024-01-01T00:00:00.000Z');
+      const oldFile = join(tempDir, 'old-note.md');
+      const newFile = join(tempDir, 'new-note.md');
+
+      createMdFile(oldFile, '# Old Note', new Date('2023-12-31T23:59:59.000Z'));
+      createMdFile(newFile, '# New Note\n\nContent here', new Date('2024-01-01T00:00:01.000Z'));
+
+      const connector = new ObsidianConnector(makeConfig(tempDir));
+      await connector.init();
+      const items = await connector.poll(since);
+
+      expect(items).toHaveLength(1);
+      expect(items[0]?.sourceId).toBe('new-note.md');
+    });
+
+    it('sets sourceId to relative path from vault root', async () => {
+      const notesDir = join(tempDir, 'notes');
+      mkdirSync(notesDir);
+      const filePath = join(notesDir, 'my-note.md');
+      createMdFile(filePath, '# Note', new Date('2024-06-01T00:00:00.000Z'));
+
+      const connector = new ObsidianConnector(makeConfig(tempDir));
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+
+      const noteItem = items.find((i) => i.sourceId.includes('my-note.md'));
+      expect(noteItem?.sourceId).toBe('notes/my-note.md');
+    });
+
+    it('sets source to "obsidian"', async () => {
+      createMdFile(join(tempDir, 'test.md'), '# Test', new Date('2024-01-01T00:00:01.000Z'));
+      const connector = new ObsidianConnector(makeConfig(tempDir));
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.source).toBe('obsidian');
+    });
+
+    it('sets type to "note"', async () => {
+      createMdFile(join(tempDir, 'test.md'), '# Test', new Date('2024-01-01T00:00:01.000Z'));
+      const connector = new ObsidianConnector(makeConfig(tempDir));
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.type).toBe('note');
+    });
+
+    it('sets content to full markdown content', async () => {
+      const content = '# My Note\n\nThis is the body text.';
+      createMdFile(join(tempDir, 'test.md'), content, new Date('2024-01-01T00:00:01.000Z'));
+      const connector = new ObsidianConnector(makeConfig(tempDir));
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.content).toBe(content);
+    });
+
+    it('sets channel to parent directory name for nested files', async () => {
+      const subDir = join(tempDir, 'projects');
+      mkdirSync(subDir);
+      createMdFile(join(subDir, 'plan.md'), '# Plan', new Date('2024-06-01T00:00:00.000Z'));
+
+      const connector = new ObsidianConnector(makeConfig(tempDir));
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+
+      const item = items.find((i) => i.sourceId.includes('plan.md'));
+      expect(item?.channel).toBe('projects');
+    });
+
+    it('sets channel to "vault" for root-level files', async () => {
+      createMdFile(join(tempDir, 'root.md'), '# Root', new Date('2024-06-01T00:00:00.000Z'));
+
+      const connector = new ObsidianConnector(makeConfig(tempDir));
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+
+      const item = items.find((i) => i.sourceId === 'root.md');
+      expect(item?.channel).toBe('vault');
+    });
+
+    it('skips hidden directories', async () => {
+      const hiddenDir = join(tempDir, '.obsidian');
+      mkdirSync(hiddenDir);
+      createMdFile(
+        join(hiddenDir, 'config.md'),
+        'hidden content',
+        new Date('2024-06-01T00:00:00.000Z')
+      );
+
+      const connector = new ObsidianConnector(makeConfig(tempDir));
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items.some((i) => i.sourceId.includes('.obsidian'))).toBe(false);
+    });
+
+    it('handles nested subdirectories recursively', async () => {
+      const deepDir = join(tempDir, 'a', 'b', 'c');
+      mkdirSync(deepDir, { recursive: true });
+      createMdFile(join(deepDir, 'deep.md'), '# Deep', new Date('2024-06-01T00:00:00.000Z'));
+
+      const connector = new ObsidianConnector(makeConfig(tempDir));
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items.some((i) => i.sourceId.includes('deep.md'))).toBe(true);
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('returns healthy after successful poll', async () => {
+      const connector = new ObsidianConnector(makeConfig(tempDir));
+      await connector.init();
+      await connector.poll(new Date(0));
+      const health = await connector.healthCheck();
+      expect(health.healthy).toBe(true);
+    });
+
+    it('tracks lastPollTime after poll', async () => {
+      const connector = new ObsidianConnector(makeConfig(tempDir));
+      await connector.init();
+      const before = new Date();
+      await connector.poll(new Date(0));
+      const health = await connector.healthCheck();
+      expect(health.lastPollTime).not.toBeNull();
+      expect(health.lastPollTime!.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    });
+  });
+
+  describe('dispose', () => {
+    it('disposes without error', async () => {
+      const connector = new ObsidianConnector(makeConfig(tempDir));
+      await connector.init();
+      await expect(connector.dispose()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/standalone/tests/connectors/sheets.test.ts
+++ b/packages/standalone/tests/connectors/sheets.test.ts
@@ -1,0 +1,351 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SheetsConnector } from '../../src/connectors/sheets/index.js';
+import type { ConnectorConfig } from '../../src/connectors/framework/types.js';
+
+// Mock child_process
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+import { execSync } from 'child_process';
+const mockExecSync = vi.mocked(execSync);
+
+function makeConfig(overrides: Partial<ConnectorConfig> = {}): ConnectorConfig {
+  return {
+    enabled: true,
+    pollIntervalMinutes: 10,
+    channels: {
+      tasks: {
+        role: 'truth',
+        name: 'tasks',
+        spreadsheetId: 'sheet-abc123',
+        sheetRange: 'A1:D100',
+      },
+    },
+    auth: {
+      type: 'cli',
+      cli: 'gws',
+      cliAuthCommand: 'gws auth login',
+    },
+    ...overrides,
+  };
+}
+
+function makeSheetValues(rows: string[][]): string {
+  return JSON.stringify({ values: rows });
+}
+
+describe('SheetsConnector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecSync.mockReturnValue('' as unknown as ReturnType<typeof execSync>);
+  });
+
+  describe('name and type', () => {
+    it('has name "sheets"', () => {
+      const connector = new SheetsConnector(makeConfig());
+      expect(connector.name).toBe('sheets');
+    });
+
+    it('has type "api"', () => {
+      const connector = new SheetsConnector(makeConfig());
+      expect(connector.type).toBe('api');
+    });
+  });
+
+  describe('getAuthRequirements', () => {
+    it('returns cli auth requirement for gws', () => {
+      const connector = new SheetsConnector(makeConfig());
+      const reqs = connector.getAuthRequirements();
+      expect(reqs).toHaveLength(1);
+      expect(reqs[0]?.type).toBe('cli');
+      expect(reqs[0]?.cli).toBe('gws');
+      expect(reqs[0]?.cliAuthCommand).toBe('gws auth login');
+    });
+  });
+
+  describe('init', () => {
+    it('initializes when gws CLI is available', async () => {
+      mockExecSync.mockReturnValue('gws version 1.0.0' as unknown as ReturnType<typeof execSync>);
+      const connector = new SheetsConnector(makeConfig());
+      await expect(connector.init()).resolves.toBeUndefined();
+    });
+
+    it('throws when gws CLI is not found', async () => {
+      mockExecSync.mockImplementation(() => {
+        throw new Error('command not found: gws');
+      });
+      const connector = new SheetsConnector(makeConfig());
+      await expect(connector.init()).rejects.toThrow(/gws/i);
+    });
+  });
+
+  describe('authenticate', () => {
+    it('returns true when gws auth status succeeds', async () => {
+      mockExecSync.mockReturnValue('' as unknown as ReturnType<typeof execSync>);
+      const connector = new SheetsConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(true);
+    });
+
+    it('returns false when gws auth status throws', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>) // init --version
+        .mockImplementationOnce(() => {
+          throw new Error('not authenticated');
+        });
+      const connector = new SheetsConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(false);
+    });
+  });
+
+  describe('poll', () => {
+    it('returns empty array when sheet has no data rows', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>) // init
+        .mockReturnValueOnce(
+          makeSheetValues([['Name', 'Status', 'Owner']]) as unknown as ReturnType<typeof execSync>
+        ); // only header row
+      const connector = new SheetsConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toEqual([]);
+    });
+
+    it('returns empty array when sheet has no values at all', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(JSON.stringify({}) as unknown as ReturnType<typeof execSync>);
+      const connector = new SheetsConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toEqual([]);
+    });
+
+    it('emits spreadsheet_row items for all rows on first poll', async () => {
+      const rows = [
+        ['Task', 'Status', 'Owner'],
+        ['Fix bug', 'In Progress', 'Alice'],
+        ['Write docs', 'Todo', 'Bob'],
+      ];
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(makeSheetValues(rows) as unknown as ReturnType<typeof execSync>);
+      const connector = new SheetsConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(2);
+      expect(items[0]?.type).toBe('spreadsheet_row');
+      expect(items[1]?.type).toBe('spreadsheet_row');
+    });
+
+    it('sets source to "sheets"', async () => {
+      const rows = [
+        ['Task', 'Status'],
+        ['Fix bug', 'Done'],
+      ];
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(makeSheetValues(rows) as unknown as ReturnType<typeof execSync>);
+      const connector = new SheetsConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.source).toBe('sheets');
+    });
+
+    it('sets sourceId as "spreadsheetId:rowKey"', async () => {
+      const rows = [
+        ['Task', 'Status'],
+        ['TASK-001', 'Done'],
+      ];
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(makeSheetValues(rows) as unknown as ReturnType<typeof execSync>);
+      const connector = new SheetsConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.sourceId).toBe('sheet-abc123:TASK-001');
+    });
+
+    it('formats content as "Col1: val1 | Col2: val2 | ..."', async () => {
+      const rows = [
+        ['Task', 'Status', 'Owner'],
+        ['Fix bug', 'In Progress', 'Alice'],
+      ];
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(makeSheetValues(rows) as unknown as ReturnType<typeof execSync>);
+      const connector = new SheetsConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.content).toBe('Task: Fix bug | Status: In Progress | Owner: Alice');
+    });
+
+    it('sets author to "spreadsheet"', async () => {
+      const rows = [['Task'], ['Fix bug']];
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(makeSheetValues(rows) as unknown as ReturnType<typeof execSync>);
+      const connector = new SheetsConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.author).toBe('spreadsheet');
+    });
+
+    it('sets channel from config name', async () => {
+      const rows = [['Task'], ['Fix bug']];
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(makeSheetValues(rows) as unknown as ReturnType<typeof execSync>);
+      const connector = new SheetsConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.channel).toBe('tasks');
+    });
+
+    it('emits only changed rows on subsequent polls', async () => {
+      const initialRows = [
+        ['Task', 'Status'],
+        ['TASK-001', 'Todo'],
+        ['TASK-002', 'Done'],
+      ];
+      const updatedRows = [
+        ['Task', 'Status'],
+        ['TASK-001', 'In Progress'], // changed
+        ['TASK-002', 'Done'], // unchanged
+      ];
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>) // init
+        .mockReturnValueOnce(makeSheetValues(initialRows) as unknown as ReturnType<typeof execSync>) // first poll
+        .mockReturnValueOnce(
+          makeSheetValues(updatedRows) as unknown as ReturnType<typeof execSync>
+        ); // second poll
+      const connector = new SheetsConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0)); // first poll — captures snapshot
+      const items = await connector.poll(new Date(0)); // second poll
+      expect(items).toHaveLength(1);
+      expect(items[0]?.sourceId).toBe('sheet-abc123:TASK-001');
+      expect(items[0]?.content).toBe('Task: TASK-001 | Status: In Progress');
+    });
+
+    it('emits new rows added between polls', async () => {
+      const initialRows = [
+        ['Task', 'Status'],
+        ['TASK-001', 'Todo'],
+      ];
+      const updatedRows = [
+        ['Task', 'Status'],
+        ['TASK-001', 'Todo'],
+        ['TASK-002', 'New'],
+      ];
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(makeSheetValues(initialRows) as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(
+          makeSheetValues(updatedRows) as unknown as ReturnType<typeof execSync>
+        );
+      const connector = new SheetsConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(1);
+      expect(items[0]?.sourceId).toBe('sheet-abc123:TASK-002');
+    });
+
+    it('skips channels without spreadsheetId', async () => {
+      const config = makeConfig({
+        channels: {
+          'no-sheet': { role: 'truth', name: 'no-sheet' },
+        },
+      });
+      mockExecSync.mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>);
+      const connector = new SheetsConnector(config);
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toEqual([]);
+      // Should not call gws sheets
+      expect(mockExecSync).toHaveBeenCalledTimes(1); // only init
+    });
+
+    it('skips channels with role "ignore"', async () => {
+      const config = makeConfig({
+        channels: {
+          ignored: {
+            role: 'ignore',
+            name: 'ignored',
+            spreadsheetId: 'sheet-xyz',
+            sheetRange: 'A1:Z100',
+          },
+        },
+      });
+      mockExecSync.mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>);
+      const connector = new SheetsConnector(config);
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toEqual([]);
+      expect(mockExecSync).toHaveBeenCalledTimes(1); // only init
+    });
+
+    it('skips rows with all columns empty', async () => {
+      const rows = [
+        ['Task', 'Status'],
+        ['', ''],
+      ];
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(makeSheetValues(rows) as unknown as ReturnType<typeof execSync>);
+      const connector = new SheetsConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toEqual([]);
+    });
+
+    it('handles "Using keyring backend:" prefix before JSON', async () => {
+      const rows = [['Task'], ['Fix bug']];
+      const prefixed = 'Using keyring backend: SecretService\n' + makeSheetValues(rows);
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(prefixed as unknown as ReturnType<typeof execSync>);
+      const connector = new SheetsConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(1);
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('reflects lastPollTime and lastPollCount after poll', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(makeSheetValues([['Task']]) as unknown as ReturnType<typeof execSync>);
+      const connector = new SheetsConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      const health = await connector.healthCheck();
+      expect(health.lastPollTime).not.toBeNull();
+      expect(health.lastPollCount).toBe(0);
+    });
+  });
+
+  describe('dispose', () => {
+    it('clears the snapshot so next poll emits all rows again', async () => {
+      const rows = [
+        ['Task', 'Status'],
+        ['TASK-001', 'Todo'],
+      ];
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(makeSheetValues(rows) as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(makeSheetValues(rows) as unknown as ReturnType<typeof execSync>);
+      const connector = new SheetsConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0)); // captures snapshot
+      await connector.dispose();
+      const items = await connector.poll(new Date(0)); // snapshot cleared → all rows new
+      expect(items).toHaveLength(1);
+    });
+  });
+});

--- a/packages/standalone/tests/connectors/slack.test.ts
+++ b/packages/standalone/tests/connectors/slack.test.ts
@@ -1,0 +1,291 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SlackConnector } from '../../src/connectors/slack/index.js';
+import type { ConnectorConfig } from '../../src/connectors/framework/types.js';
+
+// Mock @slack/web-api
+vi.mock('@slack/web-api', () => {
+  return {
+    WebClient: vi.fn().mockImplementation(() => mockWebClient),
+  };
+});
+
+const mockWebClient = {
+  auth: {
+    test: vi.fn().mockResolvedValue({ ok: true, user_id: 'U123' }),
+  },
+  conversations: {
+    history: vi.fn(),
+  },
+  users: {
+    info: vi.fn(),
+  },
+};
+
+function makeConfig(overrides: Partial<ConnectorConfig> = {}): ConnectorConfig {
+  return {
+    enabled: true,
+    pollIntervalMinutes: 5,
+    channels: {
+      C001: { role: 'hub', name: 'general' },
+      C002: { role: 'spoke', name: 'dev' },
+      C003: { role: 'ignore', name: 'noise' },
+    },
+    auth: {
+      type: 'token',
+      tokenName: 'SLACK_BOT_TOKEN',
+      token: 'xoxb-test-token',
+    },
+    ...overrides,
+  };
+}
+
+describe('SlackConnector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWebClient.conversations.history.mockResolvedValue({ messages: [] });
+    mockWebClient.users.info.mockResolvedValue({
+      user: { real_name: 'Alice', name: 'alice' },
+    });
+  });
+
+  describe('name and type', () => {
+    it('has name "slack"', () => {
+      const connector = new SlackConnector(makeConfig());
+      expect(connector.name).toBe('slack');
+    });
+
+    it('has type "api"', () => {
+      const connector = new SlackConnector(makeConfig());
+      expect(connector.type).toBe('api');
+    });
+  });
+
+  describe('getAuthRequirements', () => {
+    it('returns token auth requirement with SLACK_BOT_TOKEN', () => {
+      const connector = new SlackConnector(makeConfig());
+      const reqs = connector.getAuthRequirements();
+      expect(reqs).toHaveLength(1);
+      expect(reqs[0]?.type).toBe('token');
+      expect(reqs[0]?.tokenName).toBe('SLACK_BOT_TOKEN');
+    });
+  });
+
+  describe('init', () => {
+    it('initializes successfully with a token', async () => {
+      const connector = new SlackConnector(makeConfig());
+      await expect(connector.init()).resolves.toBeUndefined();
+    });
+
+    it('throws when token is missing', async () => {
+      const connector = new SlackConnector(
+        makeConfig({ auth: { type: 'token', tokenName: 'SLACK_BOT_TOKEN' } })
+      );
+      // Ensure env var is not set
+      const originalEnv = process.env['SLACK_BOT_TOKEN'];
+      delete process.env['SLACK_BOT_TOKEN'];
+      await expect(connector.init()).rejects.toThrow(/token/i);
+      if (originalEnv !== undefined) process.env['SLACK_BOT_TOKEN'] = originalEnv;
+    });
+  });
+
+  describe('authenticate', () => {
+    it('returns true when auth.test succeeds', async () => {
+      const connector = new SlackConnector(makeConfig());
+      await connector.init();
+      const result = await connector.authenticate();
+      expect(result).toBe(true);
+    });
+
+    it('returns false when not initialized', async () => {
+      const connector = new SlackConnector(makeConfig());
+      const result = await connector.authenticate();
+      expect(result).toBe(false);
+    });
+
+    it('returns false when auth.test throws', async () => {
+      mockWebClient.auth.test.mockRejectedValueOnce(new Error('invalid_auth'));
+      const connector = new SlackConnector(makeConfig());
+      await connector.init();
+      const result = await connector.authenticate();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('poll', () => {
+    it('returns empty array when no messages', async () => {
+      const connector = new SlackConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toEqual([]);
+    });
+
+    it('skips channels with role "ignore"', async () => {
+      const connector = new SlackConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+
+      // conversations.history should be called for C001 and C002, not C003
+      const calls = mockWebClient.conversations.history.mock.calls.map(
+        (c: unknown[]) => (c[0] as { channel: string }).channel
+      );
+      expect(calls).toContain('C001');
+      expect(calls).toContain('C002');
+      expect(calls).not.toContain('C003');
+    });
+
+    it('skips bot messages', async () => {
+      mockWebClient.conversations.history.mockResolvedValueOnce({
+        messages: [
+          { ts: '1700000001.000', user: 'U123', text: 'hello', bot_id: 'B001' },
+          { ts: '1700000002.000', user: 'U456', text: 'world' },
+        ],
+      });
+      const connector = new SlackConnector(
+        makeConfig({ channels: { C001: { role: 'hub', name: 'general' } } })
+      );
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(1);
+      expect(items[0]?.content).toBe('world');
+    });
+
+    it('resolves user IDs to names', async () => {
+      mockWebClient.conversations.history.mockResolvedValueOnce({
+        messages: [{ ts: '1700000001.000', user: 'U999', text: 'hi there' }],
+      });
+      mockWebClient.users.info.mockResolvedValueOnce({
+        user: { real_name: 'Bob Smith', name: 'bob' },
+      });
+      const connector = new SlackConnector(
+        makeConfig({ channels: { C001: { role: 'hub', name: 'general' } } })
+      );
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.author).toBe('Bob Smith');
+    });
+
+    it('caches user info to avoid repeated API calls', async () => {
+      mockWebClient.conversations.history.mockResolvedValueOnce({
+        messages: [
+          { ts: '1700000001.000', user: 'U999', text: 'msg1' },
+          { ts: '1700000002.000', user: 'U999', text: 'msg2' },
+        ],
+      });
+      mockWebClient.users.info.mockResolvedValue({
+        user: { real_name: 'Bob Smith', name: 'bob' },
+      });
+      const connector = new SlackConnector(
+        makeConfig({ channels: { C001: { role: 'hub', name: 'general' } } })
+      );
+      await connector.init();
+      await connector.poll(new Date(0));
+      // Should only call users.info once despite two messages from same user
+      expect(mockWebClient.users.info).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses channelId as fallback for sourceId', async () => {
+      mockWebClient.conversations.history.mockResolvedValueOnce({
+        messages: [{ ts: '1700000001.000', user: 'U123', text: 'test' }],
+      });
+      const connector = new SlackConnector(
+        makeConfig({ channels: { C001: { role: 'hub', name: 'general' } } })
+      );
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.sourceId).toBe('C001:1700000001.000');
+    });
+
+    it('sets source to "slack"', async () => {
+      mockWebClient.conversations.history.mockResolvedValueOnce({
+        messages: [{ ts: '1700000001.000', user: 'U123', text: 'test' }],
+      });
+      const connector = new SlackConnector(
+        makeConfig({ channels: { C001: { role: 'hub', name: 'general' } } })
+      );
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.source).toBe('slack');
+    });
+
+    it('sets type to "message"', async () => {
+      mockWebClient.conversations.history.mockResolvedValueOnce({
+        messages: [{ ts: '1700000001.000', user: 'U123', text: 'test' }],
+      });
+      const connector = new SlackConnector(
+        makeConfig({ channels: { C001: { role: 'hub', name: 'general' } } })
+      );
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.type).toBe('message');
+    });
+
+    it('sorts results by timestamp ascending', async () => {
+      mockWebClient.conversations.history
+        .mockResolvedValueOnce({
+          messages: [
+            { ts: '1700000003.000', user: 'U123', text: 'third' },
+            { ts: '1700000001.000', user: 'U123', text: 'first' },
+          ],
+        })
+        .mockResolvedValueOnce({
+          messages: [{ ts: '1700000002.000', user: 'U123', text: 'second' }],
+        });
+      const connector = new SlackConnector(
+        makeConfig({
+          channels: {
+            C001: { role: 'hub', name: 'general' },
+            C002: { role: 'spoke', name: 'dev' },
+          },
+        })
+      );
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.content).toBe('first');
+      expect(items[1]?.content).toBe('second');
+      expect(items[2]?.content).toBe('third');
+    });
+
+    it('uses oldest param based on since timestamp', async () => {
+      const since = new Date('2024-01-01T00:00:00.000Z');
+      const connector = new SlackConnector(
+        makeConfig({ channels: { C001: { role: 'hub', name: 'general' } } })
+      );
+      await connector.init();
+      await connector.poll(since);
+
+      const call = mockWebClient.conversations.history.mock.calls[0] as Array<{ oldest: string }>;
+      const oldest = parseFloat(call[0]?.oldest ?? '0');
+      expect(oldest).toBeCloseTo(since.getTime() / 1000, 0);
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('returns healthy after successful poll', async () => {
+      mockWebClient.conversations.history.mockResolvedValue({ messages: [] });
+      const connector = new SlackConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      const health = await connector.healthCheck();
+      expect(health.healthy).toBe(true);
+      expect(health.lastPollTime).not.toBeNull();
+    });
+
+    it('is unhealthy before init', async () => {
+      const connector = new SlackConnector(makeConfig());
+      const health = await connector.healthCheck();
+      expect(health.healthy).toBe(false);
+    });
+  });
+
+  describe('dispose', () => {
+    it('clears client and user cache', async () => {
+      const connector = new SlackConnector(makeConfig());
+      await connector.init();
+      await connector.dispose();
+      // After dispose, authenticate should return false (client is null)
+      const result = await connector.authenticate();
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/packages/standalone/tests/connectors/telegram.test.ts
+++ b/packages/standalone/tests/connectors/telegram.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TelegramConnector } from '../../src/connectors/telegram/index.js';
+import type { ConnectorConfig } from '../../src/connectors/framework/types.js';
+
+function makeConfig(overrides: Partial<ConnectorConfig> = {}): ConnectorConfig {
+  return {
+    enabled: true,
+    pollIntervalMinutes: 5,
+    channels: {
+      '-1001234567890': { role: 'hub', name: 'project-chat' },
+      '-1009999999999': { role: 'ignore', name: 'noise' },
+    },
+    auth: {
+      type: 'token',
+      tokenName: 'TELEGRAM_BOT_TOKEN',
+      token: 'test-telegram-token',
+    },
+    ...overrides,
+  };
+}
+
+function makeUpdate(overrides: Record<string, unknown> = {}) {
+  return {
+    update_id: 100001,
+    message: {
+      message_id: 42,
+      from: { id: 111, first_name: 'Alice', username: 'alice' },
+      date: 1700000001,
+      text: 'Hello from Telegram',
+      chat: { id: -1001234567890, type: 'supergroup', title: 'Project Chat' },
+    },
+    ...overrides,
+  };
+}
+
+function makeGetUpdatesResponse(updates: unknown[]) {
+  return {
+    ok: true,
+    json: vi.fn().mockResolvedValue({ ok: true, result: updates }),
+  };
+}
+
+describe('TelegramConnector', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('name and type', () => {
+    it('has name "telegram"', () => {
+      const connector = new TelegramConnector(makeConfig());
+      expect(connector.name).toBe('telegram');
+    });
+
+    it('has type "api"', () => {
+      const connector = new TelegramConnector(makeConfig());
+      expect(connector.type).toBe('api');
+    });
+  });
+
+  describe('getAuthRequirements', () => {
+    it('returns token auth requirement with TELEGRAM_BOT_TOKEN', () => {
+      const connector = new TelegramConnector(makeConfig());
+      const reqs = connector.getAuthRequirements();
+      expect(reqs).toHaveLength(1);
+      expect(reqs[0]?.type).toBe('token');
+      expect(reqs[0]?.tokenName).toBe('TELEGRAM_BOT_TOKEN');
+    });
+  });
+
+  describe('init', () => {
+    it('initializes successfully with a token', async () => {
+      const connector = new TelegramConnector(makeConfig());
+      await expect(connector.init()).resolves.toBeUndefined();
+    });
+
+    it('throws when token is missing', async () => {
+      const connector = new TelegramConnector(
+        makeConfig({ auth: { type: 'token', tokenName: 'TELEGRAM_BOT_TOKEN' } })
+      );
+      const originalEnv = process.env['TELEGRAM_BOT_TOKEN'];
+      delete process.env['TELEGRAM_BOT_TOKEN'];
+      await expect(connector.init()).rejects.toThrow(/token/i);
+      if (originalEnv !== undefined) process.env['TELEGRAM_BOT_TOKEN'] = originalEnv;
+    });
+  });
+
+  describe('authenticate', () => {
+    it('returns true when getMe responds with ok=true', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: vi.fn().mockResolvedValue({ ok: true, result: { id: 1 } }),
+        })
+      );
+      const connector = new TelegramConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(true);
+    });
+
+    it('returns false when fetch returns ok=false', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+      const connector = new TelegramConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(false);
+    });
+
+    it('returns false when not initialized', async () => {
+      const connector = new TelegramConnector(makeConfig());
+      expect(await connector.authenticate()).toBe(false);
+    });
+
+    it('returns false when fetch throws', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+      const connector = new TelegramConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(false);
+    });
+  });
+
+  describe('poll', () => {
+    it('returns empty array when no updates', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeGetUpdatesResponse([])));
+      const connector = new TelegramConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toEqual([]);
+    });
+
+    it('filters messages by date > since', async () => {
+      const since = new Date('2024-01-01T00:00:00.000Z'); // epoch 1704067200
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          makeGetUpdatesResponse([
+            makeUpdate({
+              update_id: 1,
+              message: { ...makeUpdate().message, message_id: 1, date: 1704067199 },
+            }),
+            makeUpdate({
+              update_id: 2,
+              message: { ...makeUpdate().message, message_id: 2, date: 1704067201 },
+            }),
+          ])
+        )
+      );
+      const connector = new TelegramConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(since);
+      expect(items).toHaveLength(1);
+      expect(items[0]?.timestamp.getTime()).toBe(1704067201 * 1000);
+    });
+
+    it('sets sourceId as "chatId:messageId"', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeGetUpdatesResponse([makeUpdate()])));
+      const connector = new TelegramConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.sourceId).toBe('-1001234567890:42');
+    });
+
+    it('sets source to "telegram"', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeGetUpdatesResponse([makeUpdate()])));
+      const connector = new TelegramConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.source).toBe('telegram');
+    });
+
+    it('sets author from first_name', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeGetUpdatesResponse([makeUpdate()])));
+      const connector = new TelegramConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.author).toBe('Alice');
+    });
+
+    it('sets type to "message"', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeGetUpdatesResponse([makeUpdate()])));
+      const connector = new TelegramConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.type).toBe('message');
+    });
+
+    it('skips updates without message', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi
+          .fn()
+          .mockResolvedValue(
+            makeGetUpdatesResponse([{ update_id: 200, edited_message: { text: 'edited' } }])
+          )
+      );
+      const connector = new TelegramConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(0);
+    });
+
+    it('skips messages without text', async () => {
+      const update = makeUpdate();
+      // Remove text from the message
+      const msgWithoutText = { ...update.message };
+      delete (msgWithoutText as Record<string, unknown>)['text'];
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(makeGetUpdatesResponse([{ ...update, message: msgWithoutText }]))
+      );
+      const connector = new TelegramConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(0);
+    });
+
+    it('advances offset after poll', async () => {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValue(makeGetUpdatesResponse([makeUpdate({ update_id: 999 })]));
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new TelegramConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      // Second poll should use offset=1000
+      await connector.poll(new Date(0));
+      const secondCallUrl = String(mockFetch.mock.calls[1]?.[0]);
+      expect(secondCallUrl).toContain('offset=1000');
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('returns healthy after successful poll', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeGetUpdatesResponse([])));
+      const connector = new TelegramConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      const health = await connector.healthCheck();
+      expect(health.healthy).toBe(true);
+    });
+
+    it('tracks lastPollTime after poll', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeGetUpdatesResponse([])));
+      const connector = new TelegramConnector(makeConfig());
+      await connector.init();
+      const before = new Date();
+      await connector.poll(new Date(0));
+      const health = await connector.healthCheck();
+      expect(health.lastPollTime).not.toBeNull();
+      expect(health.lastPollTime!.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    });
+  });
+
+  describe('dispose', () => {
+    it('clears token so authenticate returns false', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: vi.fn().mockResolvedValue({ ok: true }),
+        })
+      );
+      const connector = new TelegramConnector(makeConfig());
+      await connector.init();
+      await connector.dispose();
+      expect(await connector.authenticate()).toBe(false);
+    });
+  });
+});

--- a/packages/standalone/tests/connectors/trello.test.ts
+++ b/packages/standalone/tests/connectors/trello.test.ts
@@ -1,0 +1,377 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock fs to prevent state file I/O from interfering with tests
+vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn().mockReturnValue('{}'),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+import { TrelloConnector } from '../../src/connectors/trello/index.js';
+import type { ConnectorConfig } from '../../src/connectors/framework/types.js';
+
+function makeConfig(overrides: Partial<ConnectorConfig> = {}): ConnectorConfig {
+  return {
+    enabled: true,
+    pollIntervalMinutes: 5,
+    channels: {
+      board1: {
+        role: 'truth',
+        name: 'project-board',
+        boardId: 'board-abc123',
+      },
+    },
+    auth: {
+      type: 'token',
+      tokenName: 'TRELLO_TOKEN',
+      token: 'myApiKey:myToken',
+    },
+    ...overrides,
+  };
+}
+
+function makeTrelloList(
+  id: string,
+  name: string,
+  cards: Array<{ id: string; name: string; dateLastActivity?: string }>
+) {
+  return {
+    id,
+    name,
+    cards: cards.map((c) => ({
+      id: c.id,
+      name: c.name,
+      idMembers: [],
+      dateLastActivity: c.dateLastActivity ?? '2024-01-01T00:00:00.000Z',
+    })),
+  };
+}
+
+describe('TrelloConnector', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('name and type', () => {
+    it('has name "trello"', () => {
+      const connector = new TrelloConnector(makeConfig());
+      expect(connector.name).toBe('trello');
+    });
+
+    it('has type "api"', () => {
+      const connector = new TrelloConnector(makeConfig());
+      expect(connector.type).toBe('api');
+    });
+  });
+
+  describe('getAuthRequirements', () => {
+    it('returns token auth requirement with TRELLO_TOKEN', () => {
+      const connector = new TrelloConnector(makeConfig());
+      const reqs = connector.getAuthRequirements();
+      expect(reqs).toHaveLength(1);
+      expect(reqs[0]?.type).toBe('token');
+      expect(reqs[0]?.tokenName).toBe('TRELLO_TOKEN');
+    });
+  });
+
+  describe('init', () => {
+    it('initializes with a valid apiKey:token', async () => {
+      const connector = new TrelloConnector(makeConfig());
+      await expect(connector.init()).resolves.toBeUndefined();
+    });
+
+    it('throws when token is missing', async () => {
+      const connector = new TrelloConnector(
+        makeConfig({ auth: { type: 'token', tokenName: 'TRELLO_TOKEN' } })
+      );
+      const orig = process.env['TRELLO_TOKEN'];
+      delete process.env['TRELLO_TOKEN'];
+      await expect(connector.init()).rejects.toThrow(/token/i);
+      if (orig !== undefined) process.env['TRELLO_TOKEN'] = orig;
+    });
+
+    it('throws when token format is invalid (no colon)', async () => {
+      const connector = new TrelloConnector(
+        makeConfig({ auth: { type: 'token', token: 'invalidtoken' } })
+      );
+      await expect(connector.init()).rejects.toThrow(/format/i);
+    });
+  });
+
+  describe('authenticate', () => {
+    it('returns true when /members/me responds with 200', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(true);
+    });
+
+    it('returns false when /members/me responds with non-200', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(false);
+    });
+
+    it('returns false when not initialized', async () => {
+      const connector = new TrelloConnector(makeConfig());
+      expect(await connector.authenticate()).toBe(false);
+    });
+
+    it('returns false when fetch throws', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      expect(await connector.authenticate()).toBe(false);
+    });
+  });
+
+  describe('poll', () => {
+    it('throws when not initialized', async () => {
+      const connector = new TrelloConnector(makeConfig());
+      await expect(connector.poll(new Date(0))).rejects.toThrow(/not initialized/i);
+    });
+
+    it('returns empty array when board has no lists', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue([]) })
+      );
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toEqual([]);
+    });
+
+    it('emits kanban_card items for all cards on first poll', async () => {
+      const lists = [
+        makeTrelloList('list1', 'Todo', [{ id: 'card1', name: 'Task A' }]),
+        makeTrelloList('list2', 'Done', [{ id: 'card2', name: 'Task B' }]),
+      ];
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(lists) })
+      );
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(2);
+      expect(items[0]?.type).toBe('kanban_card');
+      expect(items[1]?.type).toBe('kanban_card');
+    });
+
+    it('sets source to "trello"', async () => {
+      const lists = [makeTrelloList('list1', 'Todo', [{ id: 'card1', name: 'Task A' }])];
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(lists) })
+      );
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.source).toBe('trello');
+    });
+
+    it('sets sourceId as "boardId:cardId:timestamp"', async () => {
+      const lists = [makeTrelloList('list1', 'Todo', [{ id: 'card-xyz', name: 'Task A' }])];
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(lists) })
+      );
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.sourceId).toMatch(/^board-abc123:card-xyz:\d+$/);
+    });
+
+    it('formats content as "cardName | listName" for new cards', async () => {
+      const lists = [makeTrelloList('list1', 'Backlog', [{ id: 'card1', name: 'Build feature' }])];
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(lists) })
+      );
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.content).toBe('Build feature | Backlog');
+    });
+
+    it('formats content with "(from: prevList)" for moved cards', async () => {
+      const listsFirst = [makeTrelloList('list1', 'Todo', [{ id: 'card1', name: 'Task A' }])];
+      const listsSecond = [
+        makeTrelloList('list2', 'In Progress', [{ id: 'card1', name: 'Task A' }]),
+      ];
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue(listsFirst) })
+        .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue(listsSecond) });
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0)); // first poll
+      const items = await connector.poll(new Date(0)); // second poll
+      expect(items).toHaveLength(1);
+      expect(items[0]?.content).toBe('Task A | In Progress (from: Todo)');
+    });
+
+    it('does not emit cards that have not moved between polls', async () => {
+      const lists = [makeTrelloList('list1', 'Todo', [{ id: 'card1', name: 'Task A' }])];
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue(lists) })
+        .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue(lists) });
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(0);
+    });
+
+    it('sets author to "trello"', async () => {
+      const lists = [makeTrelloList('list1', 'Todo', [{ id: 'card1', name: 'Task A' }])];
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(lists) })
+      );
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.author).toBe('trello');
+    });
+
+    it('sets channel from config name', async () => {
+      const lists = [makeTrelloList('list1', 'Todo', [{ id: 'card1', name: 'Task A' }])];
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(lists) })
+      );
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.channel).toBe('project-board');
+    });
+
+    it('sets timestamp from dateLastActivity', async () => {
+      const activityTime = '2024-06-15T12:00:00.000Z';
+      const lists = [
+        makeTrelloList('list1', 'Todo', [
+          { id: 'card1', name: 'Task A', dateLastActivity: activityTime },
+        ]),
+      ];
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(lists) })
+      );
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items[0]?.timestamp.toISOString()).toBe(activityTime);
+    });
+
+    it('skips channels without boardId', async () => {
+      const config = makeConfig({
+        channels: { 'no-board': { role: 'truth', name: 'no-board' } },
+      });
+      const mockFetch = vi.fn();
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new TrelloConnector(config);
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toEqual([]);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('skips channels with role "ignore"', async () => {
+      const config = makeConfig({
+        channels: {
+          board1: { role: 'ignore', name: 'ignored', boardId: 'board-abc123' },
+        },
+      });
+      const mockFetch = vi.fn();
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new TrelloConnector(config);
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toEqual([]);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('uses apiKey and token from config auth token', async () => {
+      const lists = [makeTrelloList('list1', 'Todo', [{ id: 'card1', name: 'Task A' }])];
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue(lists),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      const calledUrl = String(mockFetch.mock.calls[0]?.[0]);
+      expect(calledUrl).toContain('key=myApiKey');
+      expect(calledUrl).toContain('token=myToken');
+    });
+
+    it('handles HTTP error from board endpoint gracefully', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 403 }));
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toEqual([]);
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('reflects lastPollTime and lastPollCount after poll', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue([]) })
+      );
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      const health = await connector.healthCheck();
+      expect(health.lastPollTime).not.toBeNull();
+      expect(health.lastPollCount).toBe(0);
+    });
+
+    it('returns healthy:true after successful poll', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue([]) })
+      );
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      const health = await connector.healthCheck();
+      expect(health.healthy).toBe(true);
+    });
+  });
+
+  describe('dispose', () => {
+    it('clears token so authenticate returns false', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      await connector.dispose();
+      expect(await connector.authenticate()).toBe(false);
+    });
+
+    it('clears card states so next poll emits all cards again', async () => {
+      const lists = [makeTrelloList('list1', 'Todo', [{ id: 'card1', name: 'Task A' }])];
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(lists) });
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0)); // first poll — card state captured
+      await connector.dispose();
+      // Re-init since token was cleared
+      await connector.init();
+      const items = await connector.poll(new Date(0)); // card state cleared → all cards new again
+      expect(items).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Connector Framework** — plugin-based architecture with IConnector interface, ConnectorRegistry, PollingScheduler (batch mode), RawStore (per-connector SQLite), gws-utils shared CLI wrapper
- **13 Connectors** — Slack, Telegram, Discord, Chatwork, Gmail, Calendar, Drive, Sheets, Trello, Notion, Obsidian, Kagemusha, iMessage
- **Truth-first 3-pass extraction** — Pass 0: structured data → ProjectTruth (no LLM). Pass 1: hub activity + truth context → LLM extraction. Pass 2: spoke → project linking
- **Source role classification** — truth/hub/deliverable/spoke/reference per channel
- **CLI** — `mama connector add/remove/list/status`, config at `~/.mama/connectors.json`
- **DB migration 025** — extend kind CHECK for task/schedule memory types
- **Code simplification** — gws-utils extracted, extractAndSave deduplicates loops, dead code removed (-449 lines)

## Test plan

- [x] 2,366 tests pass (`pnpm test`)
- [x] Typecheck clean (`pnpm typecheck`)
- [x] E2E verified: Kagemusha (129 items), Gmail (32), Calendar (50), Sheets (62 rows) → 49 memories extracted across 12 projects
- [x] Hub/spoke classification working: spoke extraction references hub context
- [x] No personal info in diff (scanned with automated check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connector Framework with 13 integrations (Slack, Discord, Gmail, Drive, Sheets, Trello, Notion, Telegram, Chatwork, Calendar, Obsidian, iMessage, Kagemusha)
  * CLI: mama connector (add/remove/list/status) with per-user config (~/.mama/connectors.json)
  * Batch polling scheduler with per-connector raw evidence storage and unified 3‑pass truth-first extraction pipeline

* **Enhancements**
  * Memory kinds extended to include task and schedule

* **Documentation**
  * Docs and design spec added; package version updated to 0.17.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->