### PR TITLE
release: mama-os 0.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ MAMA outperforms SuperMemory while running **entirely locally** with open-source
 
 | Package                                          | Version | Description                                              |
 | ------------------------------------------------ | ------- | -------------------------------------------------------- |
-| [@jungjaehoon/mama-os](packages/standalone/)     | 0.18.2  | Always-on runtime — connectors, knowledge agents, viewer |
+| [@jungjaehoon/mama-os](packages/standalone/)     | 0.19.0  | Always-on runtime — connectors, knowledge agents, viewer |
 | [@jungjaehoon/mama-server](packages/mcp-server/) | 1.12.1  | MCP server for Claude Desktop/Code                       |
 | [@jungjaehoon/mama-core](packages/mama-core/)    | 1.4.2   | Core library (memory engine, embeddings, DB)             |
 | [mama plugin](packages/claude-code-plugin/)      | 1.9.0   | Claude Code plugin (marketplace)                         |

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -258,7 +258,7 @@ Each package has independent versioning:
 - **mama-core:** 1.4.2 (stable API)
 - **mama-server:** 1.12.1 (follows MAMA version)
 - **claude-code-plugin:** 1.9.0 (follows MAMA version)
-- **mama-os:** 0.18.2 (standalone agent)
+- **mama-os:** 0.19.0 (standalone agent)
 
 ## Distribution Strategy
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -10,7 +10,7 @@ MAMA is a pnpm workspace-based monorepo with four packages:
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.18.2  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.19.0  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.12.1  |
 | MAMA Core          | `packages/mama-core/`          | Internal           | `@jungjaehoon/mama-core`   | 1.4.2   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.9.0   |
@@ -60,7 +60,7 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.18.2          |
+| `packages/standalone/package.json`                       | `version` | 0.19.0          |
 | `packages/mcp-server/package.json`                       | `version` | 1.12.1          |
 | `packages/mama-core/package.json`                        | `version` | 1.4.2           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.9.0           |

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.18.2",
+  "version": "0.19.0",
   "description": "MAMA OS - Local AI Runtime. Your scattered knowledge, organized by AI agents that never sleep.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- bump \ to 0.19.0
- align README and release-facing docs with the published standalone version
- keep server/core/plugin versions unchanged for this release

## Verification
- pnpm test
- pnpm build
- commit hook typecheck + package tests passed locally