### PR TITLE
docs: provenance drawer v1 + canonical merge design

### DIFF
--- a/docs/superpowers/specs/2026-04-13-canonical-entity-merge-design.md
+++ b/docs/superpowers/specs/2026-04-13-canonical-entity-merge-design.md
@@ -1,0 +1,278 @@
+# Canonical Entity Merge — Design Pass
+
+## Status
+
+**Design only.** This document resolves the two policy questions that block
+issue #79 (`entity-review-handler.ts:521` approve is a no-op, and
+`mergeEntities()` is unimplemented end-to-end in `mama-core`). Implementation
+lands in a separate PR after review.
+
+## Why now
+
+Surfaced during the `/autoplan` review of the entity operations viewer
+(2026-04-13). Codex eng caught that `approve` only writes an
+`entity_merge_actions` row and flips candidate status — it never mutates the
+canonical graph. Deeper review showed `merged_into` is read in
+`projection.ts:16` and `recall-bridge.ts:75`, but **zero write sites** set
+it anywhere in the repo. The schema anticipates merges; the write path is
+missing.
+
+Any meaningful Review UI work, and any future Integrity / lineage work,
+depends on this being real. It also blocks the provenance drawer v1 in a
+subtle way: the drawer's "Entity merged (tombstoned)" state requires the
+`merged_into` chain to actually be populated.
+
+## Scope
+
+This document decides:
+
+1. **Policy A — Observation/alias repointing.** When entity B is merged into
+   entity A, do we re-point `entity_observations.entity_node_id` and
+   `entity_aliases.entity_node_id` to A, or do we leave them pointing at B
+   and rely on `merged_into` chain walking at read time?
+2. **Policy B — Rollback / transaction semantics.** If the merge write
+   fails partway through, does the candidate revert to `pending`, or does
+   it enter an error state the user must manually resolve?
+
+It does **not** decide:
+
+- Winner selection (target vs source). That's a separate preference per
+  candidate — out of scope here, picked by the caller.
+- Split, alias edit, label edit — those are different mutations with
+  different semantics.
+- Structured-rule storage (do_not_merge_pair, canonical_label_preference).
+  Explicitly deferred until there's demand.
+
+## Policy A — Repointing vs chain walking
+
+### Option A1 — Write-time repointing
+
+On merge, update every `entity_observations.entity_node_id = B` and every
+`entity_aliases.entity_node_id = B` to point at `A`. Set
+`B.merged_into = A`, `B.status = 'merged'`. Future reads against A see all
+observations directly.
+
+**Pros:**
+
+- Read path is simple. Recall, projection, and the provenance drawer can
+  join on `entity_node_id` without walking a chain.
+- Impact queries ("which decisions cite entity A?") return the right
+  answer even if someone forgot to chain-walk.
+- N+1 risk on read drops, which matters for the drawer's "Memory impact"
+  section that counts citing decisions.
+
+**Cons:**
+
+- Merge is an O(observations + aliases + timeline_events) write.
+  Potentially expensive for long-lived entities.
+- History is harder to inspect post-merge. "Which observations originally
+  cited B?" requires reading `entity_merge_actions.evidence_json` instead
+  of a direct query.
+- If we ever want to **un-merge**, repointing is a one-way door. Chain
+  walking is reversible by clearing `merged_into`.
+
+### Option A2 — Read-time chain walking (current design intent)
+
+On merge, set `B.merged_into = A`, `B.status = 'merged'`, and nothing else.
+Observations and aliases keep pointing at B. Read paths walk the
+`merged_into` chain (as `projection.ts` and `recall-bridge.ts` already do).
+
+**Pros:**
+
+- Merge is O(1) writes — one entity row update plus the merge action row.
+- Un-merge is a single column reset. History of which observations cited
+  which raw entity is preserved naturally.
+- Matches the existing read-side code; no new joins needed in the drawer.
+
+**Cons:**
+
+- Every read path that queries observations or aliases by `entity_node_id`
+  must join or filter through `merged_into`. If any consumer forgets, the
+  answer is silently wrong.
+- Impact queries require a recursive CTE or a two-step lookup. SQLite's
+  recursive CTE is fine but uglier than a direct join.
+- The provenance drawer's "Memory impact" count has to chase chains,
+  which increases N+1 risk on wide entities.
+
+### Recommendation: A2 with a helper view
+
+Pick **A2 (read-time chain walking)** for v1, and introduce a SQL view or
+a single helper function in `mama-core/src/entities/store.ts` that every
+consumer uses:
+
+```ts
+function resolveCanonicalEntityId(adapter, id): string {
+  // walks merged_into with cycle detection, returns terminal id
+}
+```
+
+All reads route through this helper. Consumers that need it in SQL get a
+view:
+
+```sql
+CREATE VIEW IF NOT EXISTS canonical_entity_observations AS
+  SELECT o.*, coalesce_merged_chain(n.id) AS canonical_entity_id
+  FROM entity_observations o
+  JOIN entity_nodes n ON n.id = o.entity_node_id;
+```
+
+(SQLite doesn't have a real `coalesce_merged_chain` function — the view
+would use a recursive CTE. The point is there is ONE join pattern, not
+many.)
+
+Why A2:
+
+- Matches the code that already exists (`projection.ts`, `recall-bridge.ts`
+  already walk the chain).
+- Un-merge is cheap and possible. This matters because the review
+  experience is "we made a mistake, undo the merge" and any v1 that makes
+  un-merge hard will be hated.
+- The N+1 risk is real but bounded. The drawer's "Memory impact" section
+  can cap the recursive CTE depth at 4 (anyone making merge chains deeper
+  than 4 has bigger problems) and the existing query planner handles the
+  rest.
+
+Migration: add a single helper function in `store.ts`, update the
+existing `recall-bridge.ts` and `projection.ts` call sites to use it, add
+SQL tests that verify chain walking returns the terminal node.
+
+## Policy B — Rollback / transaction semantics
+
+### Option B1 — Hard transaction, candidate stays pending on failure
+
+Wrap the full merge in a single SQLite transaction:
+
+1. INSERT `entity_merge_actions` row with source/target IDs populated
+2. UPDATE `B.merged_into = A`, `B.status = 'merged'`
+3. INSERT `entity_timeline_events` row
+4. UPDATE `entity_resolution_candidates.status = 'resolved'`
+
+If any step fails, the entire transaction rolls back. The candidate stays
+`pending`. The user retries from the Review UI.
+
+**Pros:**
+
+- Atomic. No half-merged state ever exists.
+- User can retry cleanly.
+- Matches the existing `persistDecision` wrapper at
+  `entity-review-handler.ts:532` (already uses `adapter.transaction`).
+
+**Cons:**
+
+- Transactions holding multiple table writes can be slow on `better-sqlite3`
+  under heavy concurrent reads. Not a current concern (single-user local
+  DB), could matter later.
+- Hides the error from any downstream consumer that was watching the
+  merge_actions table.
+
+### Option B2 — Per-step with error state
+
+Each step is its own write. If step 2 fails after step 1 succeeded, the
+candidate enters a new `error_merge_partial` status. The user manually
+resolves via a repair action.
+
+**Pros:**
+
+- Surfaces partial failures explicitly.
+- Merge action row acts as an audit trail even on failure.
+
+**Cons:**
+
+- Introduces a new candidate status and a new repair UI — neither of which
+  exists in v1.
+- The schema requires migration to add the status.
+- Debuggability is worse, not better: "why is this candidate in
+  `error_merge_partial`" without a good repair surface is just confusion.
+
+### Recommendation: B1 (hard transaction)
+
+Pick **B1**. It's what the existing handler is already structured for
+(`adapter.transaction` is already in use at line 532), and the "partial
+failure with repair UI" world doesn't exist yet in v1. If we ever need
+partial-failure visibility, the merge action row still gets inserted
+atomically with the rest, so post-hoc forensics are possible via the
+append-only `entity_merge_actions` table.
+
+One addition: on transaction rollback, emit a structured log line
+(`[entity.merge] transaction rollback: <reason>`) and return an error
+envelope `{ code: "entity.merge_failed", ... }` so the UI can distinguish
+"your click did nothing" from "server error unrelated to your click".
+
+## What the implementation PR looks like
+
+Once these two policies are accepted, the implementation PR is small:
+
+1. **New function** `mergeEntityNodes(adapter, sourceId, targetId, actor, reason)`
+   in `packages/mama-core/src/entities/store.ts` or new
+   `packages/mama-core/src/entities/merge.ts`. Validates refs exist,
+   same kind, same scope. Wraps the 4 writes above in
+   `adapter.transaction`. Returns the merge action id.
+2. **New helper** `resolveCanonicalEntityId(adapter, id)` in `store.ts`.
+   Used by projection and recall bridges.
+3. **Handler update** at `entity-review-handler.ts:407`. Before calling
+   `persistDecision`, resolve candidate refs to owning entity IDs. Pass
+   those to `mergeEntityNodes`. Populate the merge action row's
+   source/target IDs from the resolved values (fixes the null bug at
+   line 497 in the same change).
+4. **Migration** none required. `merged_into` column already exists.
+5. **Tests** in `packages/standalone/tests/api/entity-review-handler.test.ts`:
+   - approve populates source/target entity IDs
+   - after approve, source entity has `merged_into = target`
+   - after approve, recall returns one entity, not two
+   - approve on already-merged source is idempotent or returns a
+     409 `entity.already_merged`
+   - transaction failure at any step leaves no mutation behind
+6. **Regression test** in `packages/mama-core/tests/entities/projection.test.ts`:
+   chain walking with depth > 1 still resolves correctly.
+
+Total surface area: one new function, one new helper, two edits to the
+handler, two test files. No schema migration. No new API routes.
+
+## Risks
+
+- **Bulk merges.** If someone approves 100 candidates in a row, each
+  transaction is its own round trip. Not a v1 problem but worth noting
+  for future batch UX.
+- **Concurrent approve.** Two tabs approving the same candidate: second
+  one hits `entity_resolution_candidates.status != 'pending'` and gets
+  the existing stale envelope. Safe.
+- **Merge cycles.** Policy A2 relies on `merged_into` chain walking, which
+  already has cycle detection at `projection.ts:17`. The new
+  `resolveCanonicalEntityId` helper must reuse that logic, not reinvent it.
+- **Scope mismatch.** If the caller passes entities with different scopes,
+  merge must reject with `entity.merge_scope_mismatch`. Cross-scope merges
+  are a product decision outside v1.
+
+## Open questions for implementation PR
+
+1. Where exactly does the handler resolve `candidate.left_ref` and
+   `candidate.right_ref` to entity IDs today? The refs are observation
+   refs, so resolution goes through `entity_observations.entity_node_id`.
+   The PR must either share this logic with `resolveRef` at
+   `entity-review-handler.ts:201` or refactor it out.
+2. Should the timeline event include the merge evidence snapshot
+   (`rule_trace`, score breakdown), or just the merge action id? Default:
+   just the id — the action row holds the evidence.
+3. For scope: do we reject cross-scope merges outright, or allow "widen
+   to global" as a side effect? Default: reject in v1. Revisit when
+   there's a real case.
+
+These do not block the design decision. They are PR-time decisions the
+implementer records in the PR description.
+
+## References
+
+- Issue #79 — tracking issue for the bug and this design
+- `packages/standalone/src/api/entity-review-handler.ts:407,497,521,532` —
+  current handler
+- `packages/mama-core/src/entities/projection.ts:16` — existing chain walker
+- `packages/mama-core/src/entities/recall-bridge.ts:75` — existing
+  merged-filter join
+- `packages/mama-core/db/migrations/026-create-canonical-entity-tables.sql`
+  — where `merged_into` column lives
+- `/autoplan` review section in
+  `docs/superpowers/specs/2026-04-13-entity-operations-viewer-design.md`
+  — context for why this surfaced now
+- Provenance drawer v1 spec
+  (`2026-04-13-provenance-drawer-v1-design.md`) — dependency on
+  chain-walking being consistent

--- a/docs/superpowers/specs/2026-04-13-provenance-drawer-v1-design.md
+++ b/docs/superpowers/specs/2026-04-13-provenance-drawer-v1-design.md
@@ -1,0 +1,360 @@
+# Provenance Drawer v1 — Design
+
+## Status
+
+**Active v1 spec.** This document supersedes
+`2026-04-13-entity-operations-viewer-design.md` as the concrete plan for the
+first shipped iteration of entity-aware operator tooling. The older document
+is retained as a long-term roadmap; its full `/autoplan` review is the direct
+source of this spec's shape.
+
+## Why this exists
+
+The `/autoplan` review (CEO + Design + Eng + DX, dual voices) unanimously
+recommended killing the 4 new top-level tabs (Lineage / Entities / Review /
+Integrity) and shipping a contextual drawer first. The reasoning, in one
+line: **data-model objects are not navigation objects.** The user's real
+question is "why is this memory here?" — not "show me the ingest pipeline
+as a standing workspace."
+
+This drawer is the minimum surface that answers that question.
+
+## Problem statement
+
+When a user sees a surprising or wrong item in Memory (or reads a raw row in
+Feed), they currently cannot answer:
+
+- which raw connector row produced this?
+- how did it become an entity observation?
+- which entity did it resolve to?
+- was there human review, or did it auto-merge?
+- what other memory items share the same entity?
+
+The backing data exists (`entity_observations`, `entity_resolution_candidates`,
+`entity_nodes`, `entity_merge_actions`, `entity_timeline_events`,
+`decisions`), but there is no read path that crosses all of them from a
+single row.
+
+## Goals
+
+1. From any Memory item or Feed raw row, the user reaches the originating
+   raw evidence in ≤ 3 clicks.
+2. The drawer is read-only. No mutation actions in v1.
+3. No new top-level tabs. No changes to the sidebar or mobile bottom bar.
+4. Reuse existing Viewer shell patterns (filter bar, loading overlay,
+   split-pane) — do not invent a new component system.
+5. One HTTP round-trip per drawer open. No N+1 fan-out in the frontend.
+6. Every surface has loading, empty, error, and "legacy pre-substrate"
+   states explicitly specified.
+7. Agent-accessible: every piece of information visible in the drawer is
+   also readable via a documented REST endpoint.
+
+## Non-goals (explicit)
+
+- No entity merge, split, alias edit, or label edit (blocked by issue #79
+  anyway — `mergeEntities()` is unimplemented in `mama-core`).
+- No Review queue, Integrity queue, Lineage run console, or Entity list tab.
+- No continuous orphan score. No `entity_change_events` table. No
+  `entity_affected_outputs` table. No `ingest_runs` table. None of these
+  are introduced by this spec.
+- No structured-rule DSL. No `do_not_merge_pair`. No
+  `canonical_label_preference`. No human-knowledge store.
+- No desktop/mobile responsive rewrite. Drawer must work within existing
+  Viewer shell constraints.
+- No v1 telemetry on usage. That arrives in v1.1 before any tab promotion
+  decision.
+
+## Entry points
+
+The drawer is reachable from exactly two places in v1:
+
+1. **Memory tab — decision row.** Add a small "Trace" icon button at the
+   end of each decision row in the Memory tab list. Clicking opens the
+   drawer with `?memoryId=…`. Keyboard: `t` on the focused row.
+2. **Feed tab — raw row.** Add a "Trace" icon button at the end of each
+   raw row in `connector-feed.ts`. Clicking opens the drawer with
+   `?rawId=…&connector=…`. Keyboard: `t` on the focused row.
+
+Nothing else gets a "Trace" button in v1. No dashboard widgets, no wiki,
+no agents tab. If this drawer earns its keep, we add more entry points
+in v1.1.
+
+## Drawer structure
+
+The drawer is a right-side panel overlaying the current tab. It does not
+replace the tab. Closing the drawer returns to the previous scroll
+position. Escape closes. Outside click closes. `?` opens a keyboard-help
+popover.
+
+### Sections (top to bottom)
+
+```
+┌────────────────────────────────────────────────┐
+│ Trace                             [×] close     │
+├────────────────────────────────────────────────┤
+│ Source                                          │
+│   connector · channel · author · timestamp     │
+│   "Open raw row"  "Open channel"                │
+├────────────────────────────────────────────────┤
+│ Observation                                     │
+│   surface form → normalized form                │
+│   kind hint · extractor version                 │
+│   (empty state: "no observation extracted")     │
+├────────────────────────────────────────────────┤
+│ Entity                                          │
+│   preferred label · kind · scope                │
+│   resolved via: [auto-merge / human review /    │
+│                  direct create]                 │
+│   score breakdown (read-only, collapsed)        │
+│   "Show other memories that cite this entity"   │
+├────────────────────────────────────────────────┤
+│ Memory impact                                   │
+│   N other decisions cite this entity            │
+│   (list, capped at 10, "view all" link         │
+│    only if count > 10)                         │
+└────────────────────────────────────────────────┘
+```
+
+The drawer opens in two modes depending on entry point:
+
+- **Memory mode** (from a decision row): sections render top→bottom.
+  Focus lands on the "Source" section so the user immediately sees
+  where it came from.
+- **Raw mode** (from a Feed row): sections render top→bottom. Focus
+  lands on the "Observation" section because the user already knows
+  the source; they are asking "was this extracted?"
+
+Sections collapse gracefully when data is missing. There is no "no data"
+blank screen — every case has text.
+
+## Data model (nothing new)
+
+This spec introduces **zero new tables and zero schema migrations.** It
+reads from tables that already exist:
+
+- `decisions` (memory items) — resolved by `memoryId`
+- `entity_observations` — resolved by `(connector, raw_record_id)` and by
+  `entity_node_id`
+- `entity_nodes` (+ `merged_into` chain walking via existing
+  `projection.ts:16`) — resolved by observation
+- `entity_resolution_candidates` + `entity_merge_actions` — resolved by
+  `entity_node_id` for the "resolved via" line
+- raw connector DBs at `~/.mama/connectors/<name>/raw.db` — resolved by
+  `(connector, raw_record_id)` through `raw-store.ts`
+
+The **one plumbing gap this spec does introduce:** observations must carry
+a back-reference to the originating raw row. Today, `history-extractor.ts:42`
+builds observation drafts with raw refs, but the end-to-end path from a
+decision back to its raw row is not wired. This is addressed by (a)
+persisting the raw ref on observation insert, and (b) persisting a
+`entity_observation_id` link on decision rows that originated from entity
+extraction. Both are additive columns on existing tables. Migration file:
+`packages/mama-core/db/migrations/029-provenance-drawer-backlinks.sql`
+(TBD).
+
+## API surface (agent-accessible)
+
+One endpoint is added. No MCP tool changes in v1.
+
+### `GET /api/provenance/:kind/:id`
+
+`kind` is `memory` or `raw`. Returns the full drawer payload in one
+response. Shape:
+
+```jsonc
+{
+  "source": {
+    "connector": "slack",
+    "channel": "proj-x",
+    "author": "jh",
+    "timestamp": "2026-04-11T02:14:00Z",
+    "raw_record_id": "slack_T_...",
+    "raw_snippet": "..."
+  },
+  "observation": {
+    "id": "obs_...",
+    "surface_form": "Proj X launch",
+    "normalized_form": "proj x launch",
+    "kind_hint": "project",
+    "extractor_version": "v0.3",
+    "status": "extracted"
+  },
+  "entity": {
+    "id": "ent_...",
+    "preferred_label": "Project X",
+    "kind": "project",
+    "scope": { "kind": "project", "id": "proj-x" },
+    "resolved_via": "auto_merge",
+    "merge_action_id": null,
+    "score_breakdown": { "structural": 0.8, "string": 0.7, ... }
+  },
+  "memory_impact": {
+    "decision_count": 14,
+    "recent_decisions": [ /* up to 10 */ ]
+  },
+  "legacy": false
+}
+```
+
+**`legacy: true`** is the explicit signal for pre-substrate decisions —
+the response still returns the memory item with `observation: null,
+entity: null, memory_impact: null` and a `legacy_reason` string. The
+frontend renders the "Pre-substrate memory — no lineage available"
+empty state and offers a link to `docs/operations/entity-substrate-runbook.md`.
+
+Error envelope follows the existing
+`{ code, message, hint, doc_url }` contract (see
+`entity-review-handler.ts:6`).
+
+Auth is gated via the same `isAuthenticated()` middleware used by
+`/api/entities/*` (`graph-api.ts:1224`). No new auth code.
+
+## State matrix
+
+| State                      | Source                                                  | Observation                         | Entity                                                               | Memory impact     |
+| -------------------------- | ------------------------------------------------------- | ----------------------------------- | -------------------------------------------------------------------- | ----------------- |
+| Loading                    | skeleton rows                                           | skeleton rows                       | skeleton rows                                                        | skeleton rows     |
+| Happy path                 | full row                                                | full row                            | full row + badge                                                     | count + 10 rows   |
+| Legacy (pre-substrate)     | full row                                                | "no lineage available"              | hidden                                                               | hidden            |
+| Extraction dropped row     | full row                                                | "row was not extracted: `<reason>`" | hidden                                                               | hidden            |
+| Entity not yet resolved    | full row                                                | full row                            | "pending resolution"                                                 | hidden            |
+| Entity merged (tombstoned) | full row                                                | full row                            | follows `merged_into` chain, shows target, "(merged from ...)" badge | count from target |
+| Raw DB missing             | "raw source unavailable: `<connector>` raw DB not open" | hidden                              | hidden                                                               | hidden            |
+| 404                        | empty page + "item not found" + back button             |                                     |                                                                      |                   |
+| Auth required              | hand off to `auth-middleware` redirect                  |                                     |                                                                      |                   |
+
+## Responsive
+
+- **Desktop (≥ 1024 px):** drawer is a 480-px right rail overlaying the
+  current tab content. Backdrop dims tab content.
+- **Tablet (768 – 1024 px):** drawer is a 60 %-width right rail. Same
+  behavior.
+- **Mobile (< 768 px):** drawer is a full-screen modal with a persistent
+  top back button. Bottom tab bar hides while drawer is open. Swipe-down
+  gesture closes.
+
+No three-pane layouts. No collapsible inspectors. The drawer is one
+scrollable column everywhere.
+
+## Accessibility
+
+- Focus moves into the drawer on open. First focusable element is the
+  close button.
+- Focus returns to the "Trace" button that triggered the drawer on close.
+- `role="dialog"`, `aria-modal="true"`, `aria-labelledby` pointing at
+  the "Trace" header.
+- Escape closes. Tab cycles within the drawer (focus trap).
+- Score breakdown renders as a definition list `<dl>` with spoken labels:
+  "structural similarity: 0.8 out of 1.0". No color-only severity.
+- Keyboard shortcut: `t` on a focused Memory or Feed row opens the drawer.
+  `?` in the drawer opens the keyboard-help popover.
+- Touch targets on mobile ≥ 44 px for close, "Open raw row", "Open channel",
+  "Show other memories that cite this entity".
+
+WCAG 2.2 AA is an acceptance criterion.
+
+## Error contract
+
+Every error response body must carry
+`{ code, message, hint, doc_url, context }`. Codes introduced in v1:
+
+- `provenance.memory_not_found` — memory item does not exist
+- `provenance.raw_not_found` — raw row not found in any open connector raw DB
+- `provenance.connector_db_unavailable` — connector raw DB is not open
+- `provenance.legacy_lineage_missing` — item exists but predates the substrate
+- `provenance.observation_extraction_failed` — upstream extractor dropped the row
+
+`doc_url` points at `docs/operations/entity-substrate-runbook.md#<anchor>`.
+
+## Implementation ordering
+
+1. **Schema migration** `029-provenance-drawer-backlinks.sql` — add
+   `entity_observations.source_raw_connector`,
+   `entity_observations.source_raw_record_id`, and
+   `decisions.entity_observation_id` nullable columns. Backfill is
+   explicitly not attempted — existing rows stay null and render as
+   `legacy: true`.
+2. **Write-path plumbing** — `history-extractor.ts` persists raw ref on
+   observation insert; whichever pipeline turns observations into
+   decisions persists the observation link.
+3. **Read handler** — new file
+   `packages/standalone/src/api/provenance-handler.ts` implementing
+   `GET /api/provenance/:kind/:id`. Single-query join where possible;
+   at most 3 round trips to the DB (decision / observation+entity /
+   impact count).
+4. **API client** — add `ApiClient.getProvenance(kind, id)` in
+   `packages/standalone/public/viewer/src/utils/api.ts`.
+5. **Viewer module** — new file
+   `packages/standalone/public/viewer/src/modules/provenance-drawer.ts`.
+   Consumes the shell's existing overlay component (reuse whatever
+   `settings.ts` or `memory.ts` use for modal chrome).
+6. **Integration** — two call sites: Memory tab decision row + Feed tab
+   raw row.
+7. **Tests** — happy path, legacy, raw-db-missing, 404 for both modes.
+   A11y smoke test: drawer opens, focus trap works, escape closes,
+   focus returns.
+
+No step in this list requires touching `entity-review.ts`,
+`entity-audit.ts`, `graph.ts`, `/api/entities/candidates`, or the
+canonical merge routine that doesn't exist yet (#79).
+
+## Acceptance criteria
+
+This spec is satisfied when the Viewer can answer, **within 15 seconds
+of a cold session open**:
+
+1. From a Memory decision: which raw row produced this? (≤ 3 clicks)
+2. From a Feed raw row: was this extracted, and if so into which entity?
+   (≤ 2 clicks)
+3. From either: which other memories cite the same entity? (1 additional
+   click)
+4. For pre-substrate decisions: the user sees an explicit "no lineage
+   available" state with a link to the runbook — never a broken page or
+   fake link.
+5. For an AI agent: the same information is reachable via a single
+   documented `GET` request with a stable response shape.
+
+## What earns a v1.1 promotion
+
+The drawer is a test, not an end state. Telemetry (added in v1.1) should
+measure:
+
+- drawer opens per session
+- most-common entry point (Memory vs Feed)
+- which section users scroll to / dwell on
+- how often the "other memories" link is clicked
+- how often legacy states are hit
+
+If the drawer is opened frequently and users consistently drill into a
+specific section, that section becomes a candidate for a dedicated
+surface (tab or sub-view under a single `Operations` parent). If the
+drawer is opened rarely, the 4-tab plan from the long-term roadmap is
+falsified and we close it.
+
+## Open questions for implementer
+
+1. Where exactly does the entity-extraction pipeline write `decisions`
+   rows today? The back-link column needs to be populated at that write
+   site, and it may live in `history-extractor.ts`, `memory/api.ts`,
+   or somewhere between. This spec assumes the integrator finds it.
+2. Can `recall-bridge.ts`'s existing `merged_into`-aware join be reused
+   in the provenance read path, or does the drawer need its own join?
+3. Should the "Show other memories" list be filtered by current scope
+   (project/channel) or global? Default: global, with a filter chip.
+
+These do not block the spec; they are decisions the first implementation
+PR must make and record in its PR description.
+
+## References
+
+- `/autoplan` review findings at the bottom of
+  `docs/superpowers/specs/2026-04-13-entity-operations-viewer-design.md`
+- Existing error envelope pattern: `entity-review-handler.ts:6`
+- Existing `merged_into` chain walking: `projection.ts:16`,
+  `recall-bridge.ts:75`
+- Existing raw storage: `raw-store.ts:24`,
+  `connector-feed-handler.ts:91`
+- Existing auth gate: `graph-api.ts:1224`
+- Blocker surfaced during review (tracked separately, does not block
+  this spec): issue #79 — canonical entity merging is unimplemented in
+  `mama-core`.


### PR DESCRIPTION
## Summary
- Adds **Provenance Drawer v1** design spec — the concrete v1 that replaces the 4-new-tabs plan that /autoplan rejected. Read-only, one new endpoint, no new tables, no mutation.
- Adds **Canonical Entity Merge** design pass — resolves the two policy questions blocking issue #79 (read-time chain walking + hard transaction).

## Why
PR #80 captured the /autoplan review that rejected the 4-tab entity operations viewer plan. This PR turns the accepted "drawer-first" reframe into an implementable spec, and unblocks the separately-tracked merge bug by deciding the two policies its implementation PR needs.

## Files
- \`docs/superpowers/specs/2026-04-13-provenance-drawer-v1-design.md\` (new, 360 lines)
- \`docs/superpowers/specs/2026-04-13-canonical-entity-merge-design.md\` (new, 278 lines)

## Policy decisions recorded
**Drawer v1:**
- Entry points: Memory row + Feed row only. Two "Trace" buttons. No new tabs.
- One endpoint: \`GET /api/provenance/:kind/:id\`. Single payload, auth via existing middleware.
- Additive schema only: back-link columns on \`entity_observations\` and \`decisions\`. No backfill; pre-substrate rows render \`legacy: true\`.
- Explicit 9-row state matrix including legacy, merged tombstone, extraction-dropped, raw-db-missing.
- A11y is an acceptance criterion (WCAG 2.2 AA, focus trap, keyboard shortcut).

**Canonical merge (resolves #79 design questions):**
- Policy A → **read-time chain walking** (A2). Preserves un-merge, matches existing \`projection.ts\`/\`recall-bridge.ts\`. Helper: \`resolveCanonicalEntityId\`.
- Policy B → **hard transaction** (B1). Candidate stays pending on failure, error envelope \`entity.merge_failed\`.
- Implementation scope: one new \`mergeEntityNodes()\` + one helper + two handler edits. No migration. No new routes.

## Test plan
- [x] Docs-only change
- [x] Local commit hook passed
- [ ] Reviewer: confirm drawer entry points (Memory + Feed only) and merge policy (A2 + B1) before any code PR lands

Closes the docs side of #79's design pass. Implementation PR will follow as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design specifications for the Provenance Drawer feature, allowing users to trace data lineage from Memory and Feed tabs via "Trace" buttons and keyboard shortcuts with full responsive and accessibility support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->