### PR TITLE
fix(entities): approve actually merges canonical entity nodes (#79)

### DIFF
--- a/packages/mama-core/package.json
+++ b/packages/mama-core/package.json
@@ -26,7 +26,8 @@
     "./time-formatter": "./dist/time-formatter.js",
     "./outcome-tracker": "./dist/outcome-tracker.js",
     "./query-intent": "./dist/query-intent.js",
-    "./test-utils": "./dist/test-utils.js"
+    "./test-utils": "./dist/test-utils.js",
+    "./entities/store": "./dist/entities/store.js"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/mama-core/src/entities/recall-bridge.ts
+++ b/packages/mama-core/src/entities/recall-bridge.ts
@@ -1,6 +1,7 @@
 import { getAdapter, initDB } from '../db-manager.js';
 import type { MemoryRecord, MemoryScopeRef } from '../memory/types.js';
 import { projectEntityToRecallSummary } from './projection.js';
+import { EntityMergeError, resolveCanonicalEntityId } from './store.js';
 import type { EntityAlias, EntityNode, EntityTimelineEvent } from './types.js';
 
 function mapNode(row: Record<string, unknown>): EntityNode {
@@ -61,22 +62,59 @@ export async function queryCanonicalEntities(
   await initDB();
   const adapter = getAdapter();
   const escapedQuery = escapeLikeQuery(query);
-  const rows = adapter
+
+  // Match aliases and labels regardless of whether the owning node is merged,
+  // then chain-walk each match to its canonical terminal. Without this,
+  // searching by the old name of a merged entity returns nothing because the
+  // filter `n.status='active' AND n.merged_into IS NULL` would drop the
+  // source row. Matches Policy A2 in
+  // docs/superpowers/specs/2026-04-13-canonical-entity-merge-design.md.
+  const matchedRows = adapter
     .prepare(
       `
-        SELECT DISTINCT n.*
+        SELECT DISTINCT n.id AS matched_id
         FROM entity_nodes n
         LEFT JOIN entity_aliases a ON a.entity_id = n.id
         WHERE (
           lower(n.preferred_label) LIKE '%' || lower(?) || '%' ESCAPE '\\'
           OR lower(COALESCE(a.label, '')) LIKE '%' || lower(?) || '%' ESCAPE '\\'
         )
-          AND n.status = 'active'
-          AND n.merged_into IS NULL
-        ORDER BY n.updated_at DESC
       `
     )
-    .all(escapedQuery, escapedQuery) as Array<Record<string, unknown>>;
+    .all(escapedQuery, escapedQuery) as Array<{ matched_id: string }>;
+
+  const canonicalIdSet = new Set<string>();
+  for (const match of matchedRows) {
+    try {
+      canonicalIdSet.add(resolveCanonicalEntityId(adapter, match.matched_id));
+    } catch (err) {
+      // Cycle or missing node — skip this match rather than poison the whole
+      // recall. Merge integrity errors are surfaced elsewhere (the review
+      // handler 409 path) where the user can actually act on them.
+      if (!(err instanceof EntityMergeError)) {
+        throw err;
+      }
+    }
+  }
+
+  if (canonicalIdSet.size === 0) {
+    return [];
+  }
+
+  const canonicalIds = Array.from(canonicalIdSet);
+  const placeholders = canonicalIds.map(() => '?').join(', ');
+  const rows = adapter
+    .prepare(
+      `
+        SELECT *
+        FROM entity_nodes
+        WHERE id IN (${placeholders})
+          AND status = 'active'
+          AND merged_into IS NULL
+        ORDER BY updated_at DESC
+      `
+    )
+    .all(...canonicalIds) as Array<Record<string, unknown>>;
 
   const scopedRows =
     scopes.length === 0

--- a/packages/mama-core/src/entities/store.ts
+++ b/packages/mama-core/src/entities/store.ts
@@ -526,7 +526,7 @@ export function mergeEntityNodes(input: MergeEntityNodesInput): MergeEntityNodes
   }
 
   const source = adapter.prepare('SELECT * FROM entity_nodes WHERE id = ?').get(source_id) as
-    | Record<string, unknown>
+    | EntityNode
     | undefined;
   if (!source) {
     throw new EntityMergeError(
@@ -536,7 +536,7 @@ export function mergeEntityNodes(input: MergeEntityNodesInput): MergeEntityNodes
   }
 
   const target = adapter.prepare('SELECT * FROM entity_nodes WHERE id = ?').get(target_id) as
-    | Record<string, unknown>
+    | EntityNode
     | undefined;
   if (!target) {
     throw new EntityMergeError(
@@ -545,19 +545,13 @@ export function mergeEntityNodes(input: MergeEntityNodesInput): MergeEntityNodes
     );
   }
 
-  if (
-    source.status === 'merged' ||
-    (typeof source.merged_into === 'string' && source.merged_into.length > 0)
-  ) {
+  if (source.status === 'merged' || source.merged_into) {
     throw new EntityMergeError(
       'entity.merge_source_already_merged',
       `Source entity ${source_id} is already merged`
     );
   }
-  if (
-    target.status === 'merged' ||
-    (typeof target.merged_into === 'string' && target.merged_into.length > 0)
-  ) {
+  if (target.status === 'merged' || target.merged_into) {
     throw new EntityMergeError(
       'entity.merge_target_already_merged',
       `Target entity ${target_id} is already merged`
@@ -569,13 +563,13 @@ export function mergeEntityNodes(input: MergeEntityNodesInput): MergeEntityNodes
   if (source.kind !== target.kind) {
     throw new EntityMergeError(
       'entity.merge_kind_mismatch',
-      `Cannot merge ${String(source.kind)} into ${String(target.kind)}`
+      `Cannot merge ${source.kind} into ${target.kind}`
     );
   }
   if (source.scope_kind !== target.scope_kind || source.scope_id !== target.scope_id) {
     throw new EntityMergeError(
       'entity.merge_scope_mismatch',
-      `Cannot merge across scopes: ${String(source.scope_kind)}/${String(source.scope_id)} vs ${String(target.scope_kind)}/${String(target.scope_id)}`
+      `Cannot merge across scopes: ${source.scope_kind}/${source.scope_id ?? 'null'} vs ${target.scope_kind}/${target.scope_id ?? 'null'}`
     );
   }
 

--- a/packages/mama-core/src/entities/store.ts
+++ b/packages/mama-core/src/entities/store.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { getAdapter, initDB } from '../db-manager.js';
 import {
   ENTITY_KINDS,
@@ -7,6 +8,26 @@ import {
   type EntityNode,
   type EntityObservation,
 } from './types.js';
+
+export interface EntityStoreAdapter {
+  prepare(sql: string): {
+    run(...params: unknown[]): { changes: number; lastInsertRowid: number | bigint };
+    get(...params: unknown[]): unknown;
+    all(...params: unknown[]): unknown[];
+  };
+}
+
+export class EntityMergeError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string
+  ) {
+    super(message);
+    this.name = 'EntityMergeError';
+  }
+}
+
+const MAX_MERGE_CHAIN_DEPTH = 8;
 
 type CreateEntityNodeInput = Omit<EntityNode, 'created_at' | 'updated_at'>;
 type AttachEntityAliasInput = Omit<EntityAlias, 'created_at'>;
@@ -417,4 +438,201 @@ export async function upsertEntityObservations(
     observations.push(await upsertEntityObservation(input));
   }
   return observations;
+}
+
+/**
+ * Walks the `entity_nodes.merged_into` chain from the given id and returns the
+ * terminal (unmerged) entity id. Detects cycles and caps depth. Read-only.
+ *
+ * Matches the chain-walking design decided in
+ * `docs/superpowers/specs/2026-04-13-canonical-entity-merge-design.md` (Policy A2).
+ */
+export function resolveCanonicalEntityId(adapter: EntityStoreAdapter, id: string): string {
+  const seen = new Set<string>();
+  let current = id;
+  for (let depth = 0; depth < MAX_MERGE_CHAIN_DEPTH; depth++) {
+    if (seen.has(current)) {
+      throw new EntityMergeError(
+        'entity.merge_chain_cycle',
+        `Cycle detected in merged_into chain starting at ${id}`
+      );
+    }
+    seen.add(current);
+    const row = adapter
+      .prepare('SELECT merged_into FROM entity_nodes WHERE id = ?')
+      .get(current) as { merged_into: string | null } | undefined;
+    if (!row) {
+      throw new EntityMergeError(
+        'entity.node_not_found',
+        `Entity node ${current} not found while resolving canonical id for ${id}`
+      );
+    }
+    if (!row.merged_into) {
+      return current;
+    }
+    current = row.merged_into;
+  }
+  throw new EntityMergeError(
+    'entity.merge_chain_too_deep',
+    `merged_into chain exceeds depth ${MAX_MERGE_CHAIN_DEPTH} starting at ${id}`
+  );
+}
+
+export interface MergeEntityNodesInput {
+  adapter: EntityStoreAdapter;
+  source_id: string;
+  target_id: string;
+  actor_type: 'system' | 'user' | 'agent';
+  actor_id: string;
+  reason: string;
+  candidate_id: string | null;
+  evidence_json: string;
+}
+
+export interface MergeEntityNodesResult {
+  merge_action_id: string;
+  timeline_event_id: string;
+  merged_at: number;
+}
+
+/**
+ * Marks `source_id` as merged into `target_id`, emits a timeline event, and
+ * inserts the entity_merge_actions audit row with both entity IDs populated.
+ *
+ * Intentionally NOT wrapped in its own transaction — the caller is expected
+ * to wrap the call in `adapter.transaction(...)` so the candidate status
+ * update and this merge land atomically (Policy B1, hard transaction).
+ *
+ * Validates: source != target, both exist, both active/unmerged, same kind,
+ * same scope. Throws `EntityMergeError` with a stable `code` on any violation.
+ */
+export function mergeEntityNodes(input: MergeEntityNodesInput): MergeEntityNodesResult {
+  const {
+    adapter,
+    source_id,
+    target_id,
+    actor_type,
+    actor_id,
+    reason,
+    candidate_id,
+    evidence_json,
+  } = input;
+
+  if (!source_id || !target_id) {
+    throw new EntityMergeError('entity.merge_invalid_args', 'source_id and target_id are required');
+  }
+  if (source_id === target_id) {
+    throw new EntityMergeError('entity.merge_self', 'Cannot merge an entity into itself');
+  }
+
+  const source = adapter.prepare('SELECT * FROM entity_nodes WHERE id = ?').get(source_id) as
+    | Record<string, unknown>
+    | undefined;
+  if (!source) {
+    throw new EntityMergeError(
+      'entity.merge_source_not_found',
+      `Source entity ${source_id} not found`
+    );
+  }
+
+  const target = adapter.prepare('SELECT * FROM entity_nodes WHERE id = ?').get(target_id) as
+    | Record<string, unknown>
+    | undefined;
+  if (!target) {
+    throw new EntityMergeError(
+      'entity.merge_target_not_found',
+      `Target entity ${target_id} not found`
+    );
+  }
+
+  if (
+    source.status === 'merged' ||
+    (typeof source.merged_into === 'string' && source.merged_into.length > 0)
+  ) {
+    throw new EntityMergeError(
+      'entity.merge_source_already_merged',
+      `Source entity ${source_id} is already merged`
+    );
+  }
+  if (
+    target.status === 'merged' ||
+    (typeof target.merged_into === 'string' && target.merged_into.length > 0)
+  ) {
+    throw new EntityMergeError(
+      'entity.merge_target_already_merged',
+      `Target entity ${target_id} is already merged`
+    );
+  }
+  if (source.status === 'archived' || target.status === 'archived') {
+    throw new EntityMergeError('entity.merge_archived', 'Cannot merge archived entities');
+  }
+  if (source.kind !== target.kind) {
+    throw new EntityMergeError(
+      'entity.merge_kind_mismatch',
+      `Cannot merge ${String(source.kind)} into ${String(target.kind)}`
+    );
+  }
+  if (source.scope_kind !== target.scope_kind || source.scope_id !== target.scope_id) {
+    throw new EntityMergeError(
+      'entity.merge_scope_mismatch',
+      `Cannot merge across scopes: ${String(source.scope_kind)}/${String(source.scope_id)} vs ${String(target.scope_kind)}/${String(target.scope_id)}`
+    );
+  }
+
+  const mergedAt = now();
+  const mergeActionId = `mact_${randomUUID()}`;
+  const timelineEventId = `et_${randomUUID()}`;
+
+  adapter
+    .prepare(
+      `UPDATE entity_nodes SET merged_into = ?, status = 'merged', updated_at = ? WHERE id = ?`
+    )
+    .run(target_id, mergedAt, source_id);
+
+  adapter
+    .prepare(
+      `
+        INSERT INTO entity_timeline_events (
+          id, entity_id, event_type, observed_at, source_ref, summary, details, created_at
+        )
+        VALUES (?, ?, 'merged', ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      timelineEventId,
+      source_id,
+      mergedAt,
+      candidate_id,
+      `Merged into ${target_id}`,
+      JSON.stringify({ target_entity_id: target_id, reason, actor_id, actor_type }),
+      mergedAt
+    );
+
+  adapter
+    .prepare(
+      `
+        INSERT INTO entity_merge_actions (
+          id, action_type, source_entity_id, target_entity_id, candidate_id,
+          actor_type, actor_id, reason, evidence_json, created_at
+        )
+        VALUES (?, 'merge', ?, ?, ?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      mergeActionId,
+      source_id,
+      target_id,
+      candidate_id,
+      actor_type,
+      actor_id,
+      reason,
+      evidence_json,
+      mergedAt
+    );
+
+  return {
+    merge_action_id: mergeActionId,
+    timeline_event_id: timelineEventId,
+    merged_at: mergedAt,
+  };
 }

--- a/packages/mama-core/tests/entities/recall-bridge.test.ts
+++ b/packages/mama-core/tests/entities/recall-bridge.test.ts
@@ -126,4 +126,57 @@ describe('Story E1.8: Canonical entity recall bridge', () => {
 
     expect(rows.map((row) => row.id)).not.toContain('entity_project_alpha_merged');
   });
+
+  it('follows the merged_into chain when searching by a merged source label', async () => {
+    // Regression for Codex finding #1 on PR #82: after merging source→target,
+    // searching by the source's old label must still return the canonical
+    // target via chain walking. Without chain walk, the alias of the merged
+    // source is orphaned in recall because the n.status='active' AND
+    // n.merged_into IS NULL filter drops the source row.
+    const adapter = getAdapter();
+    adapter
+      .prepare(
+        `INSERT INTO entity_nodes (id, kind, preferred_label, status, scope_kind, scope_id, merged_into, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        'entity_legacy_source',
+        'project',
+        'Project Legacy Name',
+        'merged',
+        'project',
+        'scope-alpha',
+        'entity_project_alpha',
+        1710000000000,
+        1710000001000
+      );
+    adapter
+      .prepare(
+        `INSERT INTO entity_aliases (id, entity_id, label, normalized_label, lang, script, label_type, source_type, source_ref, confidence, status, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        'alias_legacy_unique',
+        'entity_legacy_source',
+        'Alpha Prime Codename',
+        'alpha prime codename',
+        'en',
+        'Latn',
+        'alt',
+        'slack',
+        'slack:C123',
+        0.9,
+        'active',
+        1710000002000
+      );
+
+    const rows = await queryCanonicalEntities(
+      'Alpha Prime Codename',
+      [{ kind: 'project', id: 'scope-alpha' }],
+      { limit: 10 }
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe('entity_project_alpha');
+  });
 });

--- a/packages/standalone/src/api/entity-review-handler.ts
+++ b/packages/standalone/src/api/entity-review-handler.ts
@@ -1,6 +1,11 @@
 import { randomUUID } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { URL } from 'node:url';
+import {
+  EntityMergeError,
+  mergeEntityNodes,
+  resolveCanonicalEntityId,
+} from '@jungjaehoon/mama-core/entities/store';
 
 function candidateStaleEnvelope(context: Record<string, unknown>): {
   error: { code: string; message: string; hint: string; doc_url: string };
@@ -484,8 +489,6 @@ export async function handleReviewEntityCandidate(
     return;
   }
 
-  const mergeActionId = `mact_${randomUUID()}`;
-  const createdAt = Date.now();
   const evidenceJson = JSON.stringify({
     candidate_id: id,
     left_ref: candidate.left_ref,
@@ -494,7 +497,68 @@ export async function handleReviewEntityCandidate(
     rule_trace: parseRuleTrace(candidate.rule_trace),
   });
 
-  const persistDecision = () => {
+  // Best-effort resolve each candidate ref to an owning entity_node id.
+  // Supported: ref is a direct entity_nodes.id, or an entity_aliases.id that
+  // points at one. Observation-only refs (cluster candidates with no backing
+  // entity) intentionally return null — the approve path then falls back to
+  // audit-only behavior for backward compat, matching the v1 scope in
+  // docs/superpowers/specs/2026-04-13-canonical-entity-merge-design.md.
+  const resolveRefToEntityId = (refId: string): string | null => {
+    const alias = adapter
+      .prepare(`SELECT entity_id FROM entity_aliases WHERE id = ?`)
+      .get(refId) as { entity_id: string } | undefined;
+    const initialEntityId = alias?.entity_id ?? refId;
+
+    const node = adapter
+      .prepare(`SELECT id FROM entity_nodes WHERE id = ?`)
+      .get(initialEntityId) as { id: string } | undefined;
+    if (!node) {
+      return null;
+    }
+    try {
+      return resolveCanonicalEntityId(adapter, node.id);
+    } catch {
+      return null;
+    }
+  };
+
+  const leftEntityId = resolveRefToEntityId(candidate.left_ref);
+  const rightEntityId = resolveRefToEntityId(candidate.right_ref);
+  const canRealMerge =
+    action === 'approve' &&
+    leftEntityId !== null &&
+    rightEntityId !== null &&
+    leftEntityId !== rightEntityId;
+
+  let mergeActionId = `mact_${randomUUID()}`;
+  let createdAt = Date.now();
+
+  const runRealMerge = () => {
+    const result = mergeEntityNodes({
+      adapter,
+      source_id: leftEntityId as string,
+      target_id: rightEntityId as string,
+      actor_type: 'user',
+      actor_id: actorId,
+      reason,
+      candidate_id: id,
+      evidence_json: evidenceJson,
+    });
+    mergeActionId = result.merge_action_id;
+    createdAt = result.merged_at;
+
+    adapter
+      .prepare(
+        `
+          UPDATE entity_resolution_candidates
+          SET status = ?, updated_at = ?
+          WHERE id = ?
+        `
+      )
+      .run(candidateStatus, createdAt, id);
+  };
+
+  const runAuditOnly = () => {
     adapter
       .prepare(
         `
@@ -508,8 +572,8 @@ export async function handleReviewEntityCandidate(
       .run(
         mergeActionId,
         actionType,
-        null,
-        null,
+        leftEntityId,
+        rightEntityId,
         id,
         'user',
         actorId,
@@ -529,13 +593,36 @@ export async function handleReviewEntityCandidate(
       .run(candidateStatus, createdAt, id);
   };
 
-  if (typeof adapter.transaction === 'function') {
-    const txResult = adapter.transaction(persistDecision as never) as unknown;
-    if (typeof txResult === 'function') {
-      txResult();
+  const persistDecision = canRealMerge ? runRealMerge : runAuditOnly;
+
+  try {
+    if (typeof adapter.transaction === 'function') {
+      const txResult = adapter.transaction(persistDecision as never) as unknown;
+      if (typeof txResult === 'function') {
+        txResult();
+      }
+    } else {
+      persistDecision();
     }
-  } else {
-    persistDecision();
+  } catch (err) {
+    if (err instanceof EntityMergeError) {
+      json(res, 409, {
+        error: {
+          code: err.code,
+          message: err.message,
+          hint: 'Inspect entity_nodes state for the candidate refs before retrying.',
+          doc_url: 'docs/operations/entity-substrate-runbook.md#merge-failed',
+        },
+        context: {
+          candidate_id: id,
+          attempted_action: action,
+          left_entity_id: leftEntityId,
+          right_entity_id: rightEntityId,
+        },
+      });
+      return;
+    }
+    throw err;
   }
 
   json(res, 200, {
@@ -544,5 +631,6 @@ export async function handleReviewEntityCandidate(
     action: actionType,
     actor_id: actorId,
     created_at: new Date(createdAt).toISOString(),
+    merge_applied: canRealMerge,
   });
 }

--- a/packages/standalone/src/api/entity-review-handler.ts
+++ b/packages/standalone/src/api/entity-review-handler.ts
@@ -503,6 +503,10 @@ export async function handleReviewEntityCandidate(
   // entity) intentionally return null — the approve path then falls back to
   // audit-only behavior for backward compat, matching the v1 scope in
   // docs/superpowers/specs/2026-04-13-canonical-entity-merge-design.md.
+  //
+  // Merge-chain integrity errors (cycle, depth cap) are NOT swallowed — they
+  // propagate to the outer try/catch so the handler returns 409 with a stable
+  // code instead of silently downgrading to an audit-only write.
   const resolveRefToEntityId = (refId: string): string | null => {
     const alias = adapter
       .prepare(`SELECT entity_id FROM entity_aliases WHERE id = ?`)
@@ -517,13 +521,37 @@ export async function handleReviewEntityCandidate(
     }
     try {
       return resolveCanonicalEntityId(adapter, node.id);
-    } catch {
-      return null;
+    } catch (err) {
+      if (err instanceof EntityMergeError && err.code === 'entity.node_not_found') {
+        return null;
+      }
+      throw err;
     }
   };
 
-  const leftEntityId = resolveRefToEntityId(candidate.left_ref);
-  const rightEntityId = resolveRefToEntityId(candidate.right_ref);
+  let leftEntityId: string | null;
+  let rightEntityId: string | null;
+  try {
+    leftEntityId = resolveRefToEntityId(candidate.left_ref);
+    rightEntityId = resolveRefToEntityId(candidate.right_ref);
+  } catch (err) {
+    if (err instanceof EntityMergeError) {
+      json(res, 409, {
+        error: {
+          code: err.code,
+          message: err.message,
+          hint: 'Inspect entity_nodes state for the candidate refs before retrying.',
+          doc_url: 'docs/operations/entity-substrate-runbook.md#merge-failed',
+        },
+        context: {
+          candidate_id: id,
+          attempted_action: action,
+        },
+      });
+      return;
+    }
+    throw err;
+  }
   const canRealMerge =
     action === 'approve' &&
     leftEntityId !== null &&

--- a/packages/standalone/tests/api/entity-review-handler.test.ts
+++ b/packages/standalone/tests/api/entity-review-handler.test.ts
@@ -717,6 +717,122 @@ describe('Story E1.8: Entity review API', () => {
       expect(action.action_type).toBe('merge');
     });
 
+    it('propagates merge chain cycle errors as 409 instead of silent audit-only fallback', async () => {
+      // Regression for Codex finding #2 on PR #82: resolveRefToEntityId used
+      // to swallow ALL EntityMergeError types, letting a cyclic merged_into
+      // chain return 200 with merge_applied=false. The fix narrows the catch
+      // to entity.node_not_found so cycles/depth-cap errors propagate to the
+      // outer 409 envelope.
+      // Create A first without merge, then B pointing to A, then update A to
+      // point back at B. This forms the cycle without violating the
+      // entity_nodes.merged_into foreign key.
+      await createEntityNode({
+        id: 'entity_cycle_a',
+        kind: 'project',
+        preferred_label: 'Cycle A',
+        status: 'active',
+        scope_kind: 'channel',
+        scope_id: 'C_cycle',
+        merged_into: null,
+      });
+      await createEntityNode({
+        id: 'entity_cycle_b',
+        kind: 'project',
+        preferred_label: 'Cycle B',
+        status: 'active',
+        scope_kind: 'channel',
+        scope_id: 'C_cycle',
+        merged_into: 'entity_cycle_a',
+      });
+      getAdapter()
+        .prepare(
+          `UPDATE entity_nodes SET merged_into = 'entity_cycle_b' WHERE id = 'entity_cycle_a'`
+        )
+        .run();
+      await createEntityNode({
+        id: 'entity_cycle_target',
+        kind: 'project',
+        preferred_label: 'Cycle Target',
+        status: 'active',
+        scope_kind: 'channel',
+        scope_id: 'C_cycle',
+        merged_into: null,
+      });
+      await attachEntityAlias({
+        id: 'alias_cycle_a',
+        entity_id: 'entity_cycle_a',
+        label: 'Cycle A',
+        normalized_label: 'cycle a',
+        lang: 'en',
+        script: 'Latn',
+        label_type: 'pref',
+        source_type: 'synthetic',
+        source_ref: 'synthetic:test',
+        confidence: 0.9,
+        status: 'active',
+      });
+      await attachEntityAlias({
+        id: 'alias_cycle_target',
+        entity_id: 'entity_cycle_target',
+        label: 'Cycle Target',
+        normalized_label: 'cycle target',
+        lang: 'en',
+        script: 'Latn',
+        label_type: 'pref',
+        source_type: 'synthetic',
+        source_ref: 'synthetic:test',
+        confidence: 0.9,
+        status: 'active',
+      });
+      getAdapter()
+        .prepare(
+          `
+            INSERT INTO entity_resolution_candidates (
+              id, candidate_kind, left_ref, right_ref, status, score_total,
+              score_structural, score_string, score_context, score_graph, score_embedding,
+              rule_trace, extractor_version, embedding_model_version, created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `
+        )
+        .run(
+          'candidate_cycle_broken',
+          'entity_to_entity',
+          'alias_cycle_a',
+          'alias_cycle_target',
+          'pending',
+          0.9,
+          0.9,
+          0.8,
+          0.5,
+          0,
+          0,
+          JSON.stringify(['broken_chain']),
+          'history-extractor@v1',
+          'multilingual-e5-large',
+          Date.now(),
+          Date.now()
+        );
+
+      const req = createMockRequest({
+        method: 'POST',
+        url: '/api/entities/candidates/candidate_cycle_broken/approve',
+        body: { reason: 'attempt to approve cyclic chain' },
+      });
+      const res = createMockResponse();
+      await handleReviewEntityCandidate(req, res.res, getAdapter(), 'approve');
+
+      expect(res.getStatus()).toBe(409);
+      const body = res.readJson() as { error: { code: string } };
+      expect(body.error.code).toBe('entity.merge_chain_cycle');
+
+      // Candidate stays pending — no silent approve-then-audit-only.
+      const candidateRow = getAdapter()
+        .prepare('SELECT status FROM entity_resolution_candidates WHERE id = ?')
+        .get('candidate_cycle_broken') as { status: string };
+      expect(candidateRow.status).toBe('pending');
+    });
+
     it('returns 409 entity.merge_scope_mismatch when entities cross scopes', async () => {
       await createEntityNode({
         id: 'entity_scope_a',

--- a/packages/standalone/tests/api/entity-review-handler.test.ts
+++ b/packages/standalone/tests/api/entity-review-handler.test.ts
@@ -546,4 +546,275 @@ describe('Story E1.8: Entity review API', () => {
       expect(body.error.message).toContain('Request body too large');
     });
   });
+
+  describe('Issue #79: approve actually merges canonical entities', () => {
+    async function seedEntityPair(scopeId: string): Promise<{
+      sourceEntityId: string;
+      targetEntityId: string;
+      candidateId: string;
+    }> {
+      const sourceEntityId = 'entity_source_79';
+      const targetEntityId = 'entity_target_79';
+      await createEntityNode({
+        id: sourceEntityId,
+        kind: 'project',
+        preferred_label: 'Project 79 Source',
+        status: 'active',
+        scope_kind: 'channel',
+        scope_id: scopeId,
+        merged_into: null,
+      });
+      await createEntityNode({
+        id: targetEntityId,
+        kind: 'project',
+        preferred_label: 'Project 79 Target',
+        status: 'active',
+        scope_kind: 'channel',
+        scope_id: scopeId,
+        merged_into: null,
+      });
+      await attachEntityAlias({
+        id: 'alias_source_79',
+        entity_id: sourceEntityId,
+        label: 'Project 79 Source',
+        normalized_label: 'project 79 source',
+        lang: 'en',
+        script: 'Latn',
+        label_type: 'pref',
+        source_type: 'synthetic',
+        source_ref: 'synthetic:test',
+        confidence: 0.9,
+        status: 'active',
+      });
+      await attachEntityAlias({
+        id: 'alias_target_79',
+        entity_id: targetEntityId,
+        label: 'Project 79 Target',
+        normalized_label: 'project 79 target',
+        lang: 'en',
+        script: 'Latn',
+        label_type: 'pref',
+        source_type: 'synthetic',
+        source_ref: 'synthetic:test',
+        confidence: 0.9,
+        status: 'active',
+      });
+
+      const candidateId = 'candidate_issue79';
+      getAdapter()
+        .prepare(
+          `
+            INSERT INTO entity_resolution_candidates (
+              id, candidate_kind, left_ref, right_ref, status, score_total,
+              score_structural, score_string, score_context, score_graph, score_embedding,
+              rule_trace, extractor_version, embedding_model_version, created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `
+        )
+        .run(
+          candidateId,
+          'entity_to_entity',
+          'alias_source_79',
+          'alias_target_79',
+          'pending',
+          0.92,
+          0.9,
+          0.85,
+          0.7,
+          0,
+          0,
+          JSON.stringify(['structural_match']),
+          'history-extractor@v1',
+          'multilingual-e5-large',
+          Date.now(),
+          Date.now()
+        );
+
+      return { sourceEntityId, targetEntityId, candidateId };
+    }
+
+    it('populates source/target entity IDs and sets merged_into on approve', async () => {
+      const { sourceEntityId, targetEntityId, candidateId } = await seedEntityPair('C_issue79');
+
+      const req = createMockRequest({
+        method: 'POST',
+        url: `/api/entities/candidates/${candidateId}/approve`,
+        body: { reason: 'same project' },
+      });
+      const res = createMockResponse();
+      await handleReviewEntityCandidate(req, res.res, getAdapter(), 'approve');
+
+      expect(res.getStatus()).toBe(200);
+      const body = res.readJson() as { merge_applied: boolean; merge_action_id: string };
+      expect(body.merge_applied).toBe(true);
+
+      // Merge action row has both entity IDs populated (was null before the fix).
+      const action = getAdapter()
+        .prepare(
+          'SELECT source_entity_id, target_entity_id, action_type FROM entity_merge_actions WHERE id = ?'
+        )
+        .get(body.merge_action_id) as {
+        source_entity_id: string | null;
+        target_entity_id: string | null;
+        action_type: string;
+      };
+      expect(action.source_entity_id).toBe(sourceEntityId);
+      expect(action.target_entity_id).toBe(targetEntityId);
+      expect(action.action_type).toBe('merge');
+
+      // Source entity is now tombstoned into target.
+      const source = getAdapter()
+        .prepare('SELECT merged_into, status FROM entity_nodes WHERE id = ?')
+        .get(sourceEntityId) as { merged_into: string | null; status: string };
+      expect(source.merged_into).toBe(targetEntityId);
+      expect(source.status).toBe('merged');
+
+      // Target entity is untouched.
+      const target = getAdapter()
+        .prepare('SELECT merged_into, status FROM entity_nodes WHERE id = ?')
+        .get(targetEntityId) as { merged_into: string | null; status: string };
+      expect(target.merged_into).toBeNull();
+      expect(target.status).toBe('active');
+
+      // Timeline event recorded the merge on the source entity.
+      const timeline = getAdapter()
+        .prepare(
+          'SELECT event_type, entity_id FROM entity_timeline_events WHERE entity_id = ? AND event_type = ?'
+        )
+        .get(sourceEntityId, 'merged') as { event_type: string; entity_id: string };
+      expect(timeline.event_type).toBe('merged');
+    });
+
+    it('falls back to audit-only when refs do not resolve to entity nodes', async () => {
+      // Original cluster-observation path — no backing entities. Must not regress.
+      await seedCandidate({
+        candidateId: 'candidate_cluster_only',
+        leftId: 'obs_cluster_left',
+        rightId: 'obs_cluster_right',
+        leftLabel: 'Cluster Left',
+        rightLabel: 'Cluster Right',
+        scoreTotal: 0.81,
+        scopeId: 'C_cluster',
+      });
+
+      const req = createMockRequest({
+        method: 'POST',
+        url: '/api/entities/candidates/candidate_cluster_only/approve',
+        body: { reason: 'approve observation cluster' },
+      });
+      const res = createMockResponse();
+      await handleReviewEntityCandidate(req, res.res, getAdapter(), 'approve');
+
+      expect(res.getStatus()).toBe(200);
+      const body = res.readJson() as { merge_applied: boolean };
+      expect(body.merge_applied).toBe(false);
+
+      // Audit row exists but no entity was mutated (no entity nodes to mutate).
+      const action = getAdapter()
+        .prepare('SELECT action_type FROM entity_merge_actions WHERE candidate_id = ?')
+        .get('candidate_cluster_only') as { action_type: string };
+      expect(action.action_type).toBe('merge');
+    });
+
+    it('returns 409 entity.merge_scope_mismatch when entities cross scopes', async () => {
+      await createEntityNode({
+        id: 'entity_scope_a',
+        kind: 'project',
+        preferred_label: 'Scope A',
+        status: 'active',
+        scope_kind: 'channel',
+        scope_id: 'C_scope_a',
+        merged_into: null,
+      });
+      await createEntityNode({
+        id: 'entity_scope_b',
+        kind: 'project',
+        preferred_label: 'Scope B',
+        status: 'active',
+        scope_kind: 'channel',
+        scope_id: 'C_scope_b',
+        merged_into: null,
+      });
+      await attachEntityAlias({
+        id: 'alias_scope_a',
+        entity_id: 'entity_scope_a',
+        label: 'Scope A',
+        normalized_label: 'scope a',
+        lang: 'en',
+        script: 'Latn',
+        label_type: 'pref',
+        source_type: 'synthetic',
+        source_ref: 'synthetic:test',
+        confidence: 0.9,
+        status: 'active',
+      });
+      await attachEntityAlias({
+        id: 'alias_scope_b',
+        entity_id: 'entity_scope_b',
+        label: 'Scope B',
+        normalized_label: 'scope b',
+        lang: 'en',
+        script: 'Latn',
+        label_type: 'pref',
+        source_type: 'synthetic',
+        source_ref: 'synthetic:test',
+        confidence: 0.9,
+        status: 'active',
+      });
+      getAdapter()
+        .prepare(
+          `
+            INSERT INTO entity_resolution_candidates (
+              id, candidate_kind, left_ref, right_ref, status, score_total,
+              score_structural, score_string, score_context, score_graph, score_embedding,
+              rule_trace, extractor_version, embedding_model_version, created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `
+        )
+        .run(
+          'candidate_cross_scope',
+          'entity_to_entity',
+          'alias_scope_a',
+          'alias_scope_b',
+          'pending',
+          0.85,
+          0.9,
+          0.8,
+          0.5,
+          0,
+          0,
+          JSON.stringify(['cross_scope']),
+          'history-extractor@v1',
+          'multilingual-e5-large',
+          Date.now(),
+          Date.now()
+        );
+
+      const req = createMockRequest({
+        method: 'POST',
+        url: '/api/entities/candidates/candidate_cross_scope/approve',
+        body: { reason: 'attempt cross-scope merge' },
+      });
+      const res = createMockResponse();
+      await handleReviewEntityCandidate(req, res.res, getAdapter(), 'approve');
+
+      expect(res.getStatus()).toBe(409);
+      const body = res.readJson() as { error: { code: string } };
+      expect(body.error.code).toBe('entity.merge_scope_mismatch');
+
+      // Candidate was NOT updated; entities were NOT mutated.
+      const candidateRow = getAdapter()
+        .prepare('SELECT status FROM entity_resolution_candidates WHERE id = ?')
+        .get('candidate_cross_scope') as { status: string };
+      expect(candidateRow.status).toBe('pending');
+
+      const scopeA = getAdapter()
+        .prepare('SELECT status, merged_into FROM entity_nodes WHERE id = ?')
+        .get('entity_scope_a') as { status: string; merged_into: string | null };
+      expect(scopeA.status).toBe('active');
+      expect(scopeA.merged_into).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Fixes the shipped-code bug surfaced by Codex during the /autoplan review of the entity operations viewer: \`approve\` was a no-op for actual canonical entity merging.
- Adds \`mergeEntityNodes()\` + \`resolveCanonicalEntityId()\` helpers in \`mama-core/src/entities/store.ts\` per the policy design in the drawer-first PR #81.
- Updates the review handler to call the real merge when both candidate refs resolve to entity nodes, with a safe audit-only fallback for cluster-observation candidates.

## Before / after
**Before:** \`POST /api/entities/candidates/:id/approve\` inserted \`entity_merge_actions\` with \`source_entity_id\`/\`target_entity_id\` both \`null\` and flipped candidate status. Never mutated \`entity_nodes\`. The \`merged_into\` chain was read everywhere but written nowhere.

**After:**
- Both entity IDs are populated on the merge action row.
- \`source.merged_into = target\`, \`source.status = 'merged'\`.
- \`entity_timeline_events\` gets a \`merged\` row for the source.
- Response includes \`merge_applied: boolean\` so callers can distinguish a real merge from the audit-only fallback.

## Policies (from #81's design doc)
- **A2 — read-time chain walking.** \`resolveCanonicalEntityId()\` walks \`merged_into\` with cycle detection + depth cap 8. Preserves un-merge as a future option.
- **B1 — hard transaction.** Candidate stays \`pending\` on any failure. \`EntityMergeError\` surfaces as 409 with stable codes.

## Error codes added
- \`entity.merge_self\`
- \`entity.merge_source_not_found\` / \`entity.merge_target_not_found\`
- \`entity.merge_source_already_merged\` / \`entity.merge_target_already_merged\`
- \`entity.merge_archived\`
- \`entity.merge_kind_mismatch\` / \`entity.merge_scope_mismatch\`
- \`entity.merge_chain_cycle\` / \`entity.merge_chain_too_deep\`

## Tests
- [x] 12 / 12 entity-review-handler tests pass (9 existing + 3 new)
- [x] 160 / 160 mama-core tests pass
- [x] Typecheck clean on mama-core and standalone
- [x] New cases: real merge path populates IDs + tombstones source + emits timeline event; cluster-observation fallback stays audit-only; cross-scope attempt returns 409 without mutating entities

## Package export
Adds \`@jungjaehoon/mama-core/entities/store\` to the exports map so standalone can import the new helpers without rootDir violations.

Closes #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added entity merge functionality to consolidate duplicate or related entities.
  * Implemented canonical entity resolution to automatically direct queries to merged entity targets.

* **Bug Fixes**
  * Improved entity queries to correctly handle merged entities by resolving them to their canonical sources.

* **Tests**
  * Added comprehensive test coverage for entity merging and merge conflict scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->