### PR TITLE
feat(mama-core): case-first substrate (Phase 1+2+3) + mcp-server case_timeline_range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ docs/test/
 docs/.codex_write_test.txt
 docs/*.docx
 .sisyphus/
+docs/superpowers/
 
 .gemini/
 gha-creds-*.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.19.1] / mama-core [1.5.0] / mcp-server [1.13.0] - 2026-04-20
+
 ### Added
 
+- **Case-first memory substrate** — Added the case-first schema, write paths, timeline range reader, freshness sweeper, merge/split flows, corrections, composition overrides, and MCP case timeline tool for bounded case narrative access
 - **Canonical entity substrate foundation** — Added first-class entity types, errors, normalization,
   persistence, candidate generation, resolution rules, recall bridge wiring, and audit metrics for
   multilingual canonical identity handling across MAMA core
@@ -20,6 +23,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **Learned ranker + suggest integration** — `mama.suggest()` now exposes learned-ranker metadata, respects `rerankWithLearned`, preserves memory source types for fallback rows, and keeps graph expansion counts aligned with the returned result set
+- **Standalone Claude auth detection** — standalone install/init/setup/run/status flows now prefer `claude auth status` for Claude Code login detection, while preserving the legacy `~/.claude/.credentials.json` fallback for older environments
 - **Slack-to-entity ingest path** — Connector ingestion now preserves raw provenance into
   `entity_observations` so connector evidence can be traced from raw rows through observations and
   downstream entity workflows
@@ -31,6 +36,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **Review follow-up hardening** — Membership unpin now clears manual-pin metadata, freshness writes refresh `freshness_checked_at` without mutating stable scores, drifted-case listings exclude terminal rows, and exact-merge lineage adoption no longer floats async work inside sync transactions
+- **Standalone auth UX** — postinstall and setup no longer falsely warn about missing Claude Code auth when `claude auth status` is valid, and release/setup docs now describe the actual login path (`claude auth login`)
 - **Entity review follow-up hardening** — Review handlers now prefer stable actor UUID identity,
   validate byte-sized request bodies, resolve alias-backed evidence correctly, and fail loudly on
   malformed persisted audit metrics

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This is the provider-sanctioned execution method. No API keys to manage, no toke
 
 ```bash
 # Already have Claude Code?
-claude --version   # If this works, you're ready
+claude auth status # If this shows loggedIn=true, you're ready
 mama start         # MAMA uses your existing authentication
 ```
 
@@ -133,9 +133,9 @@ MAMA outperforms SuperMemory while running **entirely locally** with open-source
 
 | Package                                          | Version | Description                                              |
 | ------------------------------------------------ | ------- | -------------------------------------------------------- |
-| [@jungjaehoon/mama-os](packages/standalone/)     | 0.19.0  | Always-on runtime — connectors, knowledge agents, viewer |
-| [@jungjaehoon/mama-server](packages/mcp-server/) | 1.12.1  | MCP server for Claude Desktop/Code                       |
-| [@jungjaehoon/mama-core](packages/mama-core/)    | 1.4.2   | Core library (memory engine, embeddings, DB)             |
+| [@jungjaehoon/mama-os](packages/standalone/)     | 0.19.1  | Always-on runtime — connectors, knowledge agents, viewer |
+| [@jungjaehoon/mama-server](packages/mcp-server/) | 1.13.0  | MCP server for Claude Desktop/Code                       |
+| [@jungjaehoon/mama-core](packages/mama-core/)    | 1.5.0   | Core library (memory engine, embeddings, DB)             |
 | [mama plugin](packages/claude-code-plugin/)      | 1.9.0   | Claude Code plugin (marketplace)                         |
 | [memorybench](packages/memorybench/)             | 1.0.0   | Memory retrieval benchmarking framework                  |
 
@@ -154,6 +154,7 @@ MAMA outperforms SuperMemory while running **entirely locally** with open-source
 ### MAMA OS (full runtime)
 
 ```bash
+claude auth login   # or: codex login
 npx @jungjaehoon/mama-os init
 mama start   # starts daemon at localhost:3847
 ```
@@ -162,7 +163,7 @@ Web viewer at `http://localhost:3847/viewer`. The current Viewer ships `Dashboar
 `Feed`, `Wiki`, `Agents`, `Logs`, and `Settings`; chat opens from the floating shell instead of a
 dedicated tab. Connects to Discord, Slack, Telegram.
 
-> **Requires:** [Claude Code CLI](https://claude.ai/claude-code) or [Codex CLI](https://www.npmjs.com/package/@openai/codex) installed and authenticated. Node.js >= 22.
+> **Requires:** [Claude Code CLI](https://claude.ai/claude-code) or [Codex CLI](https://www.npmjs.com/package/@openai/codex) installed and authenticated. Node.js >= 22.13.0.
 
 ### MCP Server (Claude Desktop)
 
@@ -218,6 +219,8 @@ pnpm test     # 2800+ tests across all packages
 ```
 
 See [CLAUDE.md](CLAUDE.md) for development guidelines.
+
+_Last updated: 2026-04-20_
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,3 @@ _Last updated: 2026-04-20_
 ## License
 
 MIT
-
----
-
-_Last updated: 2026-04-12_

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -255,10 +255,10 @@ pnpm clean
 
 Each package has independent versioning:
 
-- **mama-core:** 1.4.2 (stable API)
-- **mama-server:** 1.12.1 (follows MAMA version)
+- **mama-core:** 1.5.0 (stable API)
+- **mama-server:** 1.13.0 (follows MAMA version)
 - **claude-code-plugin:** 1.9.0 (follows MAMA version)
-- **mama-os:** 0.19.0 (standalone agent)
+- **mama-os:** 0.19.1 (standalone agent)
 
 ## Distribution Strategy
 

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -17,8 +17,10 @@ Run this checklist in order for every release candidate.
 2. Align release-facing docs
    - Update [README](../../README.md)
    - Update [CHANGELOG](../../CHANGELOG.md)
+   - Update operator/install docs when auth detection, setup flow, or CLI UX changed
    - Update roadmap/design docs for the affected release train
    - Remove or archive stale docs for deleted surfaces
+   - Keep local-only planning artifacts out of release commits (`docs/superpowers/`, `.sisyphus/`)
 
 3. Verify versions
    - Check package versions in workspace `package.json` files
@@ -32,6 +34,7 @@ Run this checklist in order for every release candidate.
 5. Prepare release commit
    - Commit doc alignment, generated files, and code together when they describe the same release slice
    - Keep generated artifacts in sync with the committed source
+   - Verify generated standalone artifacts such as `packages/standalone/src/agent/gateway-tools.md`
 
 6. Publish
    - Bump versions intentionally
@@ -61,6 +64,7 @@ A release is not ready until these are true:
 - CHANGELOG contains an unreleased/release entry for the exact changes being shipped
 - Roadmap docs distinguish shipped foundation work from next-branch architecture
 - Deleted surfaces are no longer described as active features
+- Local-only superpower planning/review docs are ignored unless intentionally promoted into public docs
 
 ---
 

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -98,4 +98,4 @@ pnpm -r exec npm version <patch|minor|major>
 
 ---
 
-**Last Updated:** 2026-04-12
+**Last Updated:** 2026-04-20

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -10,9 +10,9 @@ MAMA is a pnpm workspace-based monorepo with four packages:
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.19.0  |
-| MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.12.1  |
-| MAMA Core          | `packages/mama-core/`          | Internal           | `@jungjaehoon/mama-core`   | 1.4.2   |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.19.1  |
+| MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.13.0  |
+| MAMA Core          | `packages/mama-core/`          | Internal           | `@jungjaehoon/mama-core`   | 1.5.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.9.0   |
 
 ---
@@ -60,9 +60,9 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.19.0          |
-| `packages/mcp-server/package.json`                       | `version` | 1.12.1          |
-| `packages/mama-core/package.json`                        | `version` | 1.4.2           |
+| `packages/standalone/package.json`                       | `version` | 0.19.1          |
+| `packages/mcp-server/package.json`                       | `version` | 1.13.0          |
+| `packages/mama-core/package.json`                        | `version` | 1.5.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.9.0           |
 | `packages/claude-code-plugin/.claude-plugin/plugin.json` | `version` | 1.8.3           |
 

--- a/docs/guides/standalone-setup.md
+++ b/docs/guides/standalone-setup.md
@@ -54,7 +54,7 @@ ls ~/.mama/.codex/auth.json ~/.codex/auth.json
 
 # Check Claude CLI (alternative backend)
 claude --version
-ls ~/.claude/.credentials.json
+claude auth status
 ```
 
 **If Codex CLI is not installed:**
@@ -128,7 +128,8 @@ mama init
 `mama init` auto-selects the default backend:
 
 - Uses `codex-mcp` if `~/.mama/.codex/auth.json` or `~/.codex/auth.json` exists
-- Falls back to `claude` if `~/.claude/.credentials.json` exists
+- Falls back to `claude` if `claude auth status` reports a logged-in session
+- Legacy fallback: older Claude Code installs may still be detected via `~/.claude/.credentials.json`
 - Fails with guidance if neither backend is authenticated
 
 You can override this per user/environment:
@@ -171,7 +172,7 @@ mama setup
 
 **What the setup wizard does:**
 
-1. **Verifies Claude Code authentication** - Checks OAuth token validity
+1. **Checks Claude Code login** - Uses `claude auth status` (with legacy credentials fallback)
 2. **Starts setup server** - Launches web interface on port 3848
 3. **Opens browser** - Guides you through 10-phase onboarding
 4. **Configures integrations** - Helps set up Discord/Slack/Telegram bots
@@ -660,27 +661,27 @@ source ~/.bashrc  # or source ~/.zshrc
 
 ### Claude Code authentication failed
 
-**Cause:** Not logged in to Claude Code CLI
+**Cause:** Claude Code CLI is not installed or not logged in
 
 **Fix:**
 
 ```bash
-# Login to Claude Code
-claude login
+# Verify Claude Code login state
+claude auth status
 
-# Verify credentials exist
-ls ~/.claude/.credentials.json
+# Login to Claude Code
+claude auth login
 ```
 
 ### OAuth token expired
 
-**Cause:** Claude Code session expired
+**Cause:** Legacy OAuth credentials expired or Claude Code session needs refresh
 
 **Fix:**
 
 ```bash
 # Re-login to Claude Code
-claude login
+claude auth login
 
 # Restart MAMA
 mama restart

--- a/docs/guides/standalone-setup.md
+++ b/docs/guides/standalone-setup.md
@@ -805,4 +805,4 @@ sudo systemctl status mama
 ---
 
 **Author**: SpineLift Team
-**Last Updated**: 2026-02-07
+**Last Updated**: 2026-04-20

--- a/docs/guides/standalone-troubleshooting.md
+++ b/docs/guides/standalone-troubleshooting.md
@@ -547,7 +547,7 @@ mama status
 # Output includes:
 # - Running state (실행 중 / 정지됨)
 # - PID and uptime
-# - OAuth token validity
+# - Claude Code login state
 # - Database path
 # - Model configuration
 # - Log level
@@ -644,8 +644,8 @@ rm ~/.mama/logs/*.log
 # 4. Remove PID file
 rm ~/.mama/mama.pid
 
-# 5. Verify API key is set
-echo $ANTHROPIC_API_KEY
+# 5. Verify Claude Code login
+claude auth status
 
 # 6. Start fresh
 mama start --foreground

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -4,7 +4,9 @@ This document details the Model Context Protocol (MCP) tools provided by the MAM
 
 ## Overview
 
-MAMA (Memory-Augmented MCP Assistant) provides **11 tools** for decision tracking, scoped memory, semantic search, conversation ingestion, and session continuity.
+MAMA (Memory-Augmented MCP Assistant) provides **13 tools** for decision tracking, scoped memory, semantic search, conversation ingestion, contracts lookup, bounded case timelines, and session continuity.
+
+The current MCP server ships both the consolidated memory tools (`save`, `search`, `update`, `load_checkpoint`) and compatibility / operational helpers such as `search_decisions_and_contracts` and `case_timeline_range`.
 
 **Design Principle (v1.3.3):** LLM can infer decision relationships from time-ordered search results. All tools support `scopes` for project/channel isolation and `event_date` for temporal tracking. Decisions connect through explicit edge types. Fewer tools = more LLM flexibility.
 
@@ -67,6 +69,26 @@ All tools return a standard MCP response structure.
 ---
 
 ## Tool Catalog
+
+### Current MCP Tool Surface
+
+The current `@jungjaehoon/mama-server` package exposes these 13 tools:
+
+| Tool                             | Purpose                                               |
+| -------------------------------- | ----------------------------------------------------- |
+| `save_decision`                  | Save a decision with optional scopes and `event_date` |
+| `recall_decision`                | Recall history for a topic or scoped memory           |
+| `suggest_decision`               | Semantic search for related decisions                 |
+| `list_decisions`                 | List recent decisions/checkpoints                     |
+| `update_outcome`                 | Update a decision outcome                             |
+| `search_narrative`               | Narrative search with link expansion                  |
+| `ingest_conversation`            | Ingest message history into memory                    |
+| `save_checkpoint`                | Save a session checkpoint                             |
+| `load_checkpoint`                | Resume the latest checkpoint                          |
+| `generate_quality_report`        | Emit quality/coverage metrics                         |
+| `get_restart_metrics`            | Read restart health metrics                           |
+| `search_decisions_and_contracts` | Joint decision + contract lookup                      |
+| `case_timeline_range`            | Read bounded case-first timeline windows              |
 
 ### 1. `save`
 
@@ -262,6 +284,49 @@ No parameters required.
   }
 }
 ```
+
+---
+
+### 5. `search_decisions_and_contracts`
+
+Search prior decisions together with related contract metadata used by hook/tooling flows.
+
+#### Input Schema
+
+| Field           | Type   | Required | Description                              |
+| --------------- | ------ | -------- | ---------------------------------------- |
+| `query`         | string | No       | Semantic search query                    |
+| `decisionLimit` | number | No       | Max decision hits to return              |
+| `contractLimit` | number | No       | Max contract hits to return              |
+| `filePath`      | string | No       | Narrow contract search to a file path    |
+| `toolName`      | string | No       | Narrow contract search to a tool context |
+
+#### Response Notes
+
+- Returns matched decisions plus related contract/tool metadata
+- Used by pre-tool and post-tool safety / routing flows
+- Best treated as an operator / integration surface rather than a human-facing memory tool
+
+---
+
+### 6. `case_timeline_range`
+
+Read a bounded timeline window for a case-first workflow.
+
+#### Input Schema
+
+| Field     | Type   | Required | Description                                             |
+| --------- | ------ | -------- | ------------------------------------------------------- |
+| `case_id` | string | Yes      | Requested case id (may resolve through canonical chain) |
+| `from`    | string | No       | Inclusive lower timestamp/date bound                    |
+| `to`      | string | No       | Inclusive upper timestamp/date bound                    |
+| `limit`   | number | No       | Maximum timeline items to return                        |
+
+#### Response Notes
+
+- Resolves canonical case chain before reading timeline rows
+- Returns bounded timeline items from case-first state, linked decisions, and connector events
+- Intended for reviewable case-first navigation rather than generic semantic search
 
 ---
 
@@ -968,5 +1033,5 @@ If upgrading from v1.1 (11 tools) to v1.2+ (4 tools):
 
 ---
 
-**Last Updated:** 2026-02-22
-**Version:** 0.10.0
+**Last Updated:** 2026-04-20
+**Version:** 1.13.0

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -188,7 +188,7 @@ mama init --skip-auth-check  # Skip API validation
 - Creates `mama-workspace/` directory
 - Generates default `config.yaml`
 - Initializes SQLite database
-- Validates Claude API key (unless skipped)
+- Validates available backend login state (`claude auth status` / Codex auth) unless skipped
 
 ---
 
@@ -217,6 +217,7 @@ mama setup --no-browser   # Don't open browser
 
 **What it does:**
 
+- Checks Claude Code login state with `claude auth status` (or legacy fallback)
 - Launches 9-phase onboarding wizard
 - Configures gateway integrations (Discord, Slack, Telegram)
 - Sets up personality and preferences

--- a/packages/claude-code-plugin/tests/tools/list-recall-tools.test.js
+++ b/packages/claude-code-plugin/tests/tools/list-recall-tools.test.js
@@ -17,6 +17,7 @@ import { initDB, getAdapter, closeDB } from '@jungjaehoon/mama-core/db-manager';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
+import crypto from 'crypto';
 
 // Test database path (isolated from production)
 const TEST_DB_PATH = path.join(
@@ -32,6 +33,18 @@ const mockContext = {
     error: () => {},
   },
 };
+
+function insertSeedDecision(adapter, { id, topic, decision, reasoning, createdAt }) {
+  adapter
+    .prepare(
+      `
+        INSERT INTO decisions (
+          id, topic, decision, reasoning, confidence, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(id, topic, decision, reasoning, 0.5, createdAt, createdAt);
+}
 
 describe('Story M4.1: list_decisions and recall_decision Tools (ported from mcp-server)', () => {
   beforeAll(async () => {
@@ -320,17 +333,19 @@ describe('Story M4.1: list_decisions and recall_decision Tools (ported from mcp-
 
   describe('AC #6: Query performance < 100ms (p95)', () => {
     it('should complete list_decisions in < 100ms (p95)', async () => {
-      // Create 100 decisions for realistic test
+      // Seed directly so the measurement reflects list_decisions latency,
+      // not save-time auto-search/embedding work.
+      const adapter = getAdapter();
+      const now = Date.now();
+
       for (let i = 0; i < 100; i++) {
-        await saveDecisionTool.handler(
-          {
-            topic: `perf_topic_${i}`,
-            decision: `Performance test decision ${i}`,
-            reasoning: `Testing latency with decision ${i}`,
-            confidence: 0.5,
-          },
-          mockContext
-        );
+        insertSeedDecision(adapter, {
+          id: `decision_perf_topic_${i}_${crypto.randomUUID().slice(0, 8)}`,
+          topic: `perf_topic_${i}`,
+          decision: `Performance test decision ${i}`,
+          reasoning: `Testing latency with decision ${i}`,
+          createdAt: now + i,
+        });
       }
 
       // Measure latency across 20 calls (p95 = 19th result)

--- a/packages/mama-core/db/migrations/030-case-first-memory-substrate.sql
+++ b/packages/mama-core/db/migrations/030-case-first-memory-substrate.sql
@@ -1,0 +1,901 @@
+-- Migration 030: Case-First Memory Substrate (Phase 1 + 2 + 3)
+-- Consolidated from pre-ship migrations 030..049.
+-- Covers: entity substrate (decision_entity_sources, entity_lineage,
+-- entity_policy), event_datetime column + backfill + created_at fill,
+-- entity observation source-locator refactor, case_truth +
+-- case_memberships + case_corrections + case_proposal_queue,
+-- wiki page search index, entity_timeline_events.role,
+-- connector_event_index, learned ranker + search feedback,
+-- case_links + tombstones, case promotion/freshness columns,
+-- case membership explanation columns.
+-- Spec: docs/superpowers/specs/2026-04-17-mama-work-case-first-memory-system-design.md
+
+-- ================================================================
+-- Entity substrate — decision_entity_sources
+-- ================================================================
+CREATE TABLE IF NOT EXISTS decision_entity_sources (
+  decision_id TEXT NOT NULL,
+  entity_observation_id TEXT NOT NULL,
+  relation_type TEXT NOT NULL DEFAULT 'support',
+  created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+  FOREIGN KEY (decision_id) REFERENCES decisions(id) ON DELETE CASCADE,
+  FOREIGN KEY (entity_observation_id) REFERENCES entity_observations(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_decision_entity_sources_unique
+  ON decision_entity_sources(decision_id, entity_observation_id, relation_type);
+
+CREATE INDEX IF NOT EXISTS idx_decision_entity_sources_decision
+  ON decision_entity_sources(decision_id);
+
+CREATE INDEX IF NOT EXISTS idx_decision_entity_sources_observation
+  ON decision_entity_sources(entity_observation_id);
+
+
+-- ================================================================
+-- Entity substrate — lineage tables
+-- ================================================================
+CREATE TABLE IF NOT EXISTS entity_ingest_runs (
+  id TEXT PRIMARY KEY,
+  connector TEXT NOT NULL,
+  run_kind TEXT NOT NULL CHECK (run_kind IN ('live', 'replay', 'backfill')),
+  status TEXT NOT NULL CHECK (status IN ('running', 'complete', 'failed')),
+  scope_key TEXT NOT NULL,
+  source_window_start INTEGER,
+  source_window_end INTEGER,
+  raw_count INTEGER NOT NULL DEFAULT 0,
+  observation_count INTEGER NOT NULL DEFAULT 0,
+  candidate_count INTEGER NOT NULL DEFAULT 0,
+  reviewable_count INTEGER NOT NULL DEFAULT 0,
+  audit_run_id TEXT,
+  audit_classification TEXT CHECK (audit_classification IN ('improved', 'stable', 'regressed', 'inconclusive')),
+  error_reason TEXT,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+  completed_at INTEGER,
+  FOREIGN KEY (audit_run_id) REFERENCES entity_audit_runs(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_ingest_runs_connector_created_at
+  ON entity_ingest_runs(connector, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_entity_ingest_runs_status_created_at
+  ON entity_ingest_runs(status, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS entity_lineage_links (
+  id TEXT PRIMARY KEY,
+  canonical_entity_id TEXT NOT NULL,
+  entity_observation_id TEXT NOT NULL,
+  source_entity_id TEXT,
+  contribution_kind TEXT NOT NULL CHECK (
+    contribution_kind IN ('seed', 'merge_adopt', 'manual_attach', 'rollback_restore')
+  ),
+  run_id TEXT,
+  candidate_id TEXT,
+  review_action_id TEXT,
+  status TEXT NOT NULL CHECK (status IN ('active', 'superseded', 'rolled_back')),
+  capture_mode TEXT NOT NULL CHECK (capture_mode IN ('direct', 'backfilled')),
+  confidence REAL NOT NULL DEFAULT 1,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000),
+  superseded_at INTEGER,
+  FOREIGN KEY (canonical_entity_id) REFERENCES entity_nodes(id) ON DELETE CASCADE,
+  FOREIGN KEY (entity_observation_id) REFERENCES entity_observations(id) ON DELETE CASCADE,
+  FOREIGN KEY (source_entity_id) REFERENCES entity_nodes(id) ON DELETE SET NULL,
+  FOREIGN KEY (run_id) REFERENCES entity_ingest_runs(id) ON DELETE SET NULL,
+  FOREIGN KEY (candidate_id) REFERENCES entity_resolution_candidates(id) ON DELETE SET NULL,
+  FOREIGN KEY (review_action_id) REFERENCES entity_merge_actions(id) ON DELETE SET NULL,
+  CHECK (confidence >= 0 AND confidence <= 1)
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_lineage_links_entity_status_created_at
+  ON entity_lineage_links(canonical_entity_id, status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_entity_lineage_links_observation
+  ON entity_lineage_links(entity_observation_id);
+CREATE INDEX IF NOT EXISTS idx_entity_lineage_links_run
+  ON entity_lineage_links(run_id);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_entity_lineage_active_pair
+  ON entity_lineage_links(canonical_entity_id, entity_observation_id)
+  WHERE status = 'active';
+
+
+-- ================================================================
+-- Entity substrate — policy tables
+-- ================================================================
+CREATE TABLE IF NOT EXISTS entity_policy (
+  policy_key TEXT PRIMARY KEY,
+  policy_kind TEXT NOT NULL,
+  value_json TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS entity_role_bindings (
+  actor_id TEXT PRIMARY KEY,
+  role TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS entity_policy_proposals (
+  proposal_id TEXT PRIMARY KEY,
+  policy_key TEXT NOT NULL,
+  policy_kind TEXT NOT NULL,
+  proposed_value_json TEXT NOT NULL,
+  proposer_actor TEXT NOT NULL,
+  approver_actor TEXT,
+  reason TEXT NOT NULL,
+  status TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  approved_at INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_policy_kind
+  ON entity_policy(policy_kind, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_entity_policy_proposals_status_created
+  ON entity_policy_proposals(status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_entity_policy_proposals_policy_key
+  ON entity_policy_proposals(policy_key, created_at DESC);
+
+-- ================================================================
+-- Temporal — add event_datetime column
+-- ================================================================
+-- Migration 033: Add event_datetime column to decisions table
+-- Stores source event timestamp in milliseconds when known.
+ALTER TABLE decisions ADD COLUMN event_datetime INTEGER;
+
+CREATE INDEX IF NOT EXISTS idx_decisions_event_datetime ON decisions(event_datetime);
+
+
+-- ================================================================
+-- Temporal — backfill from linked observations
+-- ================================================================
+-- Migration 034: Backfill event_datetime for existing decisions
+-- Priority:
+-- 1) Latest linked observation timestamp when provenance exists
+-- 2) event_date at 00:00:00 UTC when only date is known
+
+UPDATE decisions
+SET event_datetime = (
+  SELECT MAX(COALESCE(o.timestamp_observed, o.created_at))
+  FROM decision_entity_sources des
+  JOIN entity_observations o ON o.id = des.entity_observation_id
+  WHERE des.decision_id = decisions.id
+)
+WHERE event_datetime IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM decision_entity_sources des
+    JOIN entity_observations o ON o.id = des.entity_observation_id
+    WHERE des.decision_id = decisions.id
+  );
+
+UPDATE decisions
+SET event_datetime = CAST(strftime('%s', event_date || 'T00:00:00Z') AS INTEGER) * 1000
+WHERE event_datetime IS NULL
+  AND event_date IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_decisions_event_datetime_backfill ON decisions(event_datetime);
+
+
+-- ================================================================
+-- Temporal — final fill from created_at
+-- ================================================================
+-- Migration 035: Fill any remaining event_datetime gaps from created_at
+-- This is the final fallback for decisions that have neither provenance-linked
+-- observation timestamps nor an explicit event_date.
+
+UPDATE decisions
+SET event_datetime = created_at
+WHERE event_datetime IS NULL;
+
+
+-- ================================================================
+-- Source locator — add column + seed from raw_db_ref
+-- ================================================================
+ALTER TABLE entity_observations ADD COLUMN source_locator TEXT;
+
+UPDATE entity_observations
+SET source_locator = source_raw_db_ref
+WHERE source_locator IS NULL;
+
+
+-- ================================================================
+-- Source locator — switch identity + triggers
+-- ================================================================
+UPDATE entity_observations
+SET source_locator = COALESCE(source_locator, source_raw_db_ref, '')
+WHERE source_locator IS NULL OR source_locator = '';
+
+DROP INDEX IF EXISTS idx_entity_observations_source_record;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_entity_observations_source_record
+  ON entity_observations(
+    source_connector,
+    source_locator,
+    source_raw_record_id,
+    observation_type
+  );
+
+CREATE INDEX IF NOT EXISTS idx_entity_observations_source_locator_record
+  ON entity_observations(source_connector, source_locator, source_raw_record_id);
+
+CREATE TRIGGER IF NOT EXISTS trg_entity_observations_backfill_source_locator_insert
+AFTER INSERT ON entity_observations
+WHEN (NEW.source_locator IS NULL OR NEW.source_locator = '')
+  AND COALESCE(NEW.source_raw_db_ref, '') <> ''
+BEGIN
+  UPDATE entity_observations
+  SET source_locator = NEW.source_raw_db_ref
+  WHERE id = NEW.id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_entity_observations_backfill_source_locator_update
+AFTER UPDATE ON entity_observations
+WHEN (NEW.source_locator IS NULL OR NEW.source_locator = '')
+  AND COALESCE(NEW.source_raw_db_ref, '') <> ''
+BEGIN
+  UPDATE entity_observations
+  SET source_locator = NEW.source_raw_db_ref
+  WHERE id = NEW.id;
+END;
+
+
+-- ================================================================
+-- Source locator — drop legacy raw_db_ref
+-- ================================================================
+UPDATE entity_observations
+SET source_locator = COALESCE(source_locator, source_raw_db_ref, '')
+WHERE source_locator IS NULL OR source_locator = '';
+
+DROP TRIGGER IF EXISTS trg_entity_observations_backfill_source_locator_insert;
+DROP TRIGGER IF EXISTS trg_entity_observations_backfill_source_locator_update;
+
+ALTER TABLE entity_observations DROP COLUMN source_raw_db_ref;
+
+
+-- ================================================================
+-- Phase 1 — case_truth
+-- ================================================================
+-- Migration 039: Create case_truth table
+-- Phase 1 of MAMA Case-First Memory System
+-- Spec: docs/superpowers/specs/2026-04-17-mama-work-case-first-memory-system-design.md §5.2
+
+CREATE TABLE IF NOT EXISTS case_truth (
+  case_id TEXT PRIMARY KEY,                                                 -- UUID, also persisted in wiki frontmatter
+  current_wiki_path TEXT,                                                   -- nullable (merged cases retain no current page)
+  title TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active','blocked','resolved','stale','archived','merged','split')),
+  status_reason TEXT,
+  primary_actors TEXT,                                                      -- JSON: [{entity_id, role}]
+  blockers TEXT,                                                            -- JSON: [{text, source_decision_id?, source_event_id?}]
+  last_activity_at TEXT,                                                    -- ISO 8601 — fast-writer field
+  canonical_case_id TEXT REFERENCES case_truth(case_id),                    -- merge survivor pointer
+  split_from_case_id TEXT REFERENCES case_truth(case_id),                   -- split parent reference
+  wiki_path_history TEXT,                                                   -- JSON: [{path, valid_from, valid_to}]
+  scope_refs TEXT,                                                          -- JSON: [{kind, id}]
+  confidence TEXT,                                                          -- high | medium | low
+  compiled_at TEXT,                                                         -- wiki-compiler last write
+  state_updated_at TEXT,                                                    -- memory-agent last write (status / last_activity)
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_case_truth_current_path
+  ON case_truth(current_wiki_path COLLATE NOCASE)
+  WHERE current_wiki_path IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_case_truth_status ON case_truth(status);
+CREATE INDEX IF NOT EXISTS idx_case_truth_canonical ON case_truth(canonical_case_id);
+CREATE INDEX IF NOT EXISTS idx_case_truth_last_activity ON case_truth(last_activity_at DESC);
+
+
+-- ================================================================
+-- Phase 1 — case_memberships
+-- ================================================================
+-- Migration 040: Create case_memberships table
+-- Phase 1 of MAMA Case-First Memory System
+-- Spec: docs/superpowers/specs/2026-04-17-mama-work-case-first-memory-system-design.md §5.3
+--
+-- Locked tombstone encoding (§0d Option B): (status='stale', user_locked=1).
+-- CHECK enum stays at 5 values; no 'stale_locked'.
+
+CREATE TABLE IF NOT EXISTS case_memberships (
+  case_id TEXT NOT NULL REFERENCES case_truth(case_id),
+  source_type TEXT NOT NULL CHECK(source_type IN ('decision','event','observation','artifact')),
+  source_id TEXT NOT NULL,
+  role TEXT,                                                                -- soft-typed: primary | supporting | contradicting | ...
+  confidence REAL CHECK(confidence IS NULL OR (confidence >= 0 AND confidence <= 1)),
+  reason TEXT,
+  status TEXT NOT NULL CHECK(status IN ('active','candidate','removed','excluded','stale')),
+  added_by TEXT NOT NULL CHECK(added_by IN ('wiki-compiler','memory-agent','user-correction')),
+  added_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  user_locked INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (case_id, source_type, source_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_case_memberships_source
+  ON case_memberships(source_type, source_id, status);
+CREATE INDEX IF NOT EXISTS idx_case_memberships_case_status
+  ON case_memberships(case_id, status);
+
+
+-- ================================================================
+-- Phase 1 — case_corrections
+-- ================================================================
+-- Migration 041: Create case_corrections table
+-- Phase 1 of MAMA Case-First Memory System
+-- Spec: docs/superpowers/specs/2026-04-17-mama-work-case-first-memory-system-design.md §5.4
+--
+-- Option C (Phase 0 §0f): target_ref_json TEXT (readable canonical JSON) +
+-- target_ref_hash BLOB (32-byte SHA-256 over canonical JSON).
+-- Partial UNIQUE index on (case_id, target_ref_hash) WHERE active lock ensures
+-- one active lock per (case, target).
+--
+-- Phase 1 SCAFFOLD ONLY: the table ships empty. Write flows
+-- (apply/revert/supersede helpers, HITL UX, recompile lock-respect) are
+-- Phase 2 per spec §14 L811 amendment.
+
+CREATE TABLE IF NOT EXISTS case_corrections (
+  correction_id TEXT PRIMARY KEY,                                           -- UUID
+  case_id TEXT NOT NULL REFERENCES case_truth(case_id),
+  target_kind TEXT NOT NULL CHECK(target_kind IN ('case_field','membership','wiki_section')),
+  target_ref_json TEXT NOT NULL,                                            -- canonical JSON (human-readable)
+  target_ref_hash BLOB NOT NULL CHECK(length(target_ref_hash) = 32),        -- SHA-256 32 bytes
+  field_name TEXT,                                                          -- redundant convenience for target_kind='case_field'
+  old_value_json TEXT,                                                      -- snapshot at correction time
+  new_value_json TEXT NOT NULL,                                             -- user's intended value
+  reason TEXT NOT NULL,
+  is_lock_active INTEGER NOT NULL DEFAULT 1,
+  superseded_by TEXT REFERENCES case_corrections(correction_id),
+  reverted_at TEXT,
+  applied_by TEXT NOT NULL,
+  applied_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_case_corrections_case_active
+  ON case_corrections(case_id, is_lock_active, reverted_at);
+
+-- Partial UNIQUE: at most one active lock per (case_id, target_ref_hash).
+-- Reverted or superseded rows do not block new active locks on the same target.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_case_corrections_active_target
+  ON case_corrections(case_id, target_ref_hash)
+  WHERE is_lock_active = 1 AND reverted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_case_corrections_target_kind
+  ON case_corrections(case_id, target_kind);
+
+
+-- ================================================================
+-- Phase 1 — case_proposal_queue
+-- ================================================================
+-- Migration 042: Create case_proposal_queue table
+-- Phase 1 of MAMA Case-First Memory System
+-- Spec: docs/superpowers/specs/2026-04-17-mama-work-case-first-memory-system-design.md §5.7
+--
+-- Acceptance-layer queue for LLM proposals rejected by the deterministic
+-- acceptance layer (§4.2). Phase 1 SCAFFOLD + quarantine writes only; HITL
+-- resolution UX is Phase 2.
+--
+-- payload_fingerprint is a SHA-256 (32 bytes) over a STABLE per-kind canonical
+-- JSON subset — NOT over the full proposed_payload (full LLM output varies
+-- across runs and would defeat dedup). Per-kind subsets live in the
+-- acceptance-layer implementation; see spec §5.7 write rules.
+
+CREATE TABLE IF NOT EXISTS case_proposal_queue (
+  proposal_id TEXT PRIMARY KEY,                                             -- UUID
+  project TEXT NOT NULL,
+  proposal_kind TEXT NOT NULL CHECK(proposal_kind IN (
+    'ambiguous_slug',
+    'duplicate_frontmatter',
+    'missing_frontmatter',
+    'unknown_case_id',
+    'stale_case_id',
+    'merged_target',
+    'archived_target',
+    'lock_conflict',
+    'corrupt_frontmatter',
+    'quarantined_accepted_case'
+  )),
+  proposed_payload TEXT NOT NULL,                                           -- JSON: full LLM proposal
+  payload_fingerprint BLOB NOT NULL CHECK(length(payload_fingerprint) = 32),
+  conflicting_case_id TEXT,
+  detected_at TEXT NOT NULL,
+  resolved_at TEXT,
+  resolution TEXT CHECK(resolution IS NULL OR resolution IN ('accepted','rejected','modified','merged')),
+  resolution_note TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_case_proposal_queue_unresolved
+  ON case_proposal_queue(project, resolved_at);
+CREATE INDEX IF NOT EXISTS idx_case_proposal_queue_kind
+  ON case_proposal_queue(proposal_kind, resolved_at);
+
+-- Composite UNIQUE for idempotent re-detection. COALESCE allows dedup even
+-- when conflicting_case_id is NULL (e.g. corrupt_frontmatter).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_case_proposal_queue_dedup
+  ON case_proposal_queue(
+    project,
+    proposal_kind,
+    COALESCE(conflicting_case_id, ''),
+    payload_fingerprint
+  )
+  WHERE resolved_at IS NULL;
+
+
+-- ================================================================
+-- Phase 1 — wiki_page_search_index
+-- ================================================================
+-- Migration 043: Wiki page search index for mama_search integration
+-- Phase 1 of MAMA Case-First Memory System
+-- Spec: docs/superpowers/specs/2026-04-17-mama-work-case-first-memory-system-design.md §7.1
+--
+-- Tables: wiki_page_index (metadata), wiki_page_embeddings (vectors),
+-- wiki_pages_fts (FTS5 inverted index). FTS5 is REGULAR (not contentless,
+-- not external-content) with `page_id UNINDEXED` for app-side hit mapping.
+-- Sync triggers use standard INSERT / DELETE+INSERT / DELETE.
+--
+-- App-layer writes to wiki_page_index MUST NOT use INSERT OR REPLACE
+-- (that toggles rowids and leaves FTS pointing at deleted rows). Use
+-- INSERT ... ON CONFLICT(page_id) DO UPDATE SET ... so the UPDATE trigger
+-- fires and the FTS stays consistent.
+
+CREATE TABLE IF NOT EXISTS wiki_page_index (
+  page_id TEXT PRIMARY KEY,
+  source_type TEXT NOT NULL DEFAULT 'wiki_page' CHECK(source_type = 'wiki_page'),
+  source_locator TEXT NOT NULL,
+  case_id TEXT REFERENCES case_truth(case_id),
+  title TEXT NOT NULL,
+  -- Spec §5.6 enum (original 4 + 'case' added in Phase 1). DB-level CHECK
+  -- prevents malformed page_type from entering the search index and later
+  -- silently breaking the mama_search roll-up that keys on 'case'.
+  page_type TEXT NOT NULL CHECK(page_type IN ('entity','lesson','synthesis','process','case')),
+  content TEXT NOT NULL,
+  confidence TEXT,
+  compiled_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(source_type, source_locator)
+);
+
+CREATE TABLE IF NOT EXISTS wiki_page_embeddings (
+  page_id TEXT PRIMARY KEY REFERENCES wiki_page_index(page_id) ON DELETE CASCADE,
+  embedding BLOB NOT NULL
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS wiki_pages_fts USING fts5(
+  page_id UNINDEXED,
+  title,
+  content,
+  source_locator
+);
+
+-- INSERT trigger: sync new row into FTS.
+CREATE TRIGGER IF NOT EXISTS trg_wiki_page_index_ai
+AFTER INSERT ON wiki_page_index
+BEGIN
+  INSERT INTO wiki_pages_fts(page_id, title, content, source_locator)
+  VALUES (NEW.page_id, NEW.title, NEW.content, NEW.source_locator);
+END;
+
+-- UPDATE trigger: delete-then-insert keeps FTS tokens in sync on edits.
+-- Only fires when indexed/stored FTS-adjacent columns change; page_id stays
+-- unchanged via the UPSERT contract noted above.
+CREATE TRIGGER IF NOT EXISTS trg_wiki_page_index_au
+AFTER UPDATE OF title, content, source_locator ON wiki_page_index
+BEGIN
+  DELETE FROM wiki_pages_fts WHERE page_id = OLD.page_id;
+  INSERT INTO wiki_pages_fts(page_id, title, content, source_locator)
+  VALUES (NEW.page_id, NEW.title, NEW.content, NEW.source_locator);
+END;
+
+-- DELETE trigger: remove all FTS rows for the page.
+CREATE TRIGGER IF NOT EXISTS trg_wiki_page_index_ad
+AFTER DELETE ON wiki_page_index
+BEGIN
+  DELETE FROM wiki_pages_fts WHERE page_id = OLD.page_id;
+END;
+
+
+-- ================================================================
+-- Phase 2 — entity_timeline_events.role
+-- ================================================================
+-- Migration 044: Add entity_timeline_events.role
+--
+-- Phase 2 Task 1 (spec §14 item 11, §4 L105-111): add a nullable `role`
+-- column to `entity_timeline_events` so memory-agent role inference
+-- (Phase 2 Task 3) can attach a role to each timeline event without
+-- constraining downstream consumers. Role is soft-typed per spec §5.1
+-- (requester | implementer | reviewer | observer | affected | NULL)
+-- — the CHECK enum is intentionally NOT applied so future spec changes
+-- don't require another migration.
+
+ALTER TABLE entity_timeline_events ADD COLUMN role TEXT;
+
+
+-- ================================================================
+-- Phase 3 — connector_event_index
+-- ================================================================
+-- Migration 045: Create connector_event_index and replay-safe connector cursors
+-- Phase 3 of MAMA Case-First Memory System
+-- Spec: docs/superpowers/specs/2026-04-17-mama-work-case-first-memory-system-design.md Amendment 9
+
+CREATE TABLE IF NOT EXISTS connector_event_index (
+  event_index_id TEXT PRIMARY KEY,
+  source_connector TEXT NOT NULL,
+  source_type TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  source_locator TEXT,
+  channel TEXT,
+  author TEXT,
+  title TEXT,
+  content TEXT NOT NULL,
+  event_datetime INTEGER,
+  event_date TEXT,
+  source_timestamp_ms INTEGER NOT NULL,
+  metadata_json TEXT,
+  artifact_locator TEXT,
+  artifact_title TEXT,
+  content_hash BLOB NOT NULL CHECK(length(content_hash) = 32),
+  indexed_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  expires_at TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_connector_event_index_source_identity
+  ON connector_event_index(source_connector, source_id);
+
+CREATE INDEX IF NOT EXISTS idx_connector_event_index_cursor_order
+  ON connector_event_index(source_connector, source_timestamp_ms, source_id);
+
+CREATE INDEX IF NOT EXISTS idx_connector_event_index_event_datetime
+  ON connector_event_index(event_datetime, event_index_id);
+
+CREATE INDEX IF NOT EXISTS idx_connector_event_index_event_date
+  ON connector_event_index(event_date, event_datetime, event_index_id);
+
+CREATE INDEX IF NOT EXISTS idx_connector_event_index_artifact_locator
+  ON connector_event_index(artifact_locator)
+  WHERE artifact_locator IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_connector_event_index_expires_at
+  ON connector_event_index(expires_at)
+  WHERE expires_at IS NOT NULL;
+
+CREATE VIRTUAL TABLE IF NOT EXISTS connector_event_index_fts USING fts5(
+  event_index_id UNINDEXED,
+  title,
+  content,
+  author,
+  channel,
+  tokenize = 'unicode61 remove_diacritics 2'
+);
+
+CREATE TRIGGER IF NOT EXISTS trg_connector_event_index_ai
+AFTER INSERT ON connector_event_index
+BEGIN
+  INSERT INTO connector_event_index_fts(event_index_id, title, content, author, channel)
+  VALUES (NEW.event_index_id, NEW.title, NEW.content, NEW.author, NEW.channel);
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_connector_event_index_au
+AFTER UPDATE OF title, content, author, channel ON connector_event_index
+BEGIN
+  DELETE FROM connector_event_index_fts WHERE event_index_id = OLD.event_index_id;
+  INSERT INTO connector_event_index_fts(event_index_id, title, content, author, channel)
+  VALUES (NEW.event_index_id, NEW.title, NEW.content, NEW.author, NEW.channel);
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_connector_event_index_ad
+AFTER DELETE ON connector_event_index
+BEGIN
+  DELETE FROM connector_event_index_fts WHERE event_index_id = OLD.event_index_id;
+END;
+
+CREATE TABLE IF NOT EXISTS connector_event_index_cursors (
+  connector_name TEXT PRIMARY KEY,
+  last_seen_timestamp_ms INTEGER NOT NULL DEFAULT 0,
+  last_seen_source_id TEXT NOT NULL DEFAULT '',
+  last_sweep_at TEXT,
+  last_success_at TEXT,
+  last_error TEXT,
+  last_error_at TEXT,
+  indexed_count INTEGER NOT NULL DEFAULT 0
+);
+
+
+-- ================================================================
+-- Phase 3 — search_feedback + ranker
+-- ================================================================
+-- Migration 046: Create search_feedback and ranker_model_versions
+-- Phase 3 of MAMA Case-First Memory System
+-- Spec: docs/superpowers/specs/2026-04-17-mama-work-case-first-memory-system-design.md Amendment 10
+
+CREATE TABLE IF NOT EXISTS search_feedback (
+  feedback_id TEXT PRIMARY KEY,
+  query TEXT NOT NULL,
+  query_hash BLOB NOT NULL CHECK(length(query_hash) = 32),
+  question_type TEXT NOT NULL CHECK(question_type IN (
+    'status',
+    'timeline',
+    'artifact',
+    'correction',
+    'decision_reason',
+    'how_to',
+    'unknown'
+  )),
+  result_source_type TEXT NOT NULL CHECK(result_source_type IN (
+    'decision',
+    'checkpoint',
+    'wiki_page',
+    'case',
+    'connector_event'
+  )),
+  result_source_id TEXT NOT NULL,
+  case_id TEXT REFERENCES case_truth(case_id),
+  feedback_kind TEXT NOT NULL CHECK(feedback_kind IN ('shown','click','accept','reject','hide')),
+  rank_position INTEGER NOT NULL CHECK(rank_position >= 0),
+  score_before REAL,
+  score_after REAL,
+  session_id TEXT,
+  actor TEXT NOT NULL,
+  metadata_json TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_search_feedback_query_hash_created
+  ON search_feedback(query_hash, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_search_feedback_result_created
+  ON search_feedback(result_source_type, result_source_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_search_feedback_case_created
+  ON search_feedback(case_id, created_at DESC)
+  WHERE case_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_search_feedback_kind_created
+  ON search_feedback(feedback_kind, created_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_search_feedback_shown_dedupe
+  ON search_feedback(session_id, query_hash, result_source_type, result_source_id)
+  WHERE feedback_kind = 'shown' AND session_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS ranker_model_versions (
+  model_id TEXT PRIMARY KEY,
+  model_version TEXT NOT NULL,
+  feature_set_version TEXT NOT NULL,
+  coefficients_json TEXT NOT NULL,
+  metrics_json TEXT NOT NULL,
+  training_window_json TEXT NOT NULL,
+  baseline_metrics_json TEXT NOT NULL,
+  quality_gate_status TEXT NOT NULL CHECK(quality_gate_status IN ('passed','failed','not_run')),
+  trained_at TEXT NOT NULL,
+  trained_by TEXT,
+  active INTEGER NOT NULL DEFAULT 0 CHECK(active IN (0,1))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ranker_model_versions_single_active
+  ON ranker_model_versions(active)
+  WHERE active = 1;
+
+CREATE INDEX IF NOT EXISTS idx_ranker_model_versions_trained_at
+  ON ranker_model_versions(trained_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ranker_model_versions_feature_set
+  ON ranker_model_versions(feature_set_version);
+
+CREATE TABLE IF NOT EXISTS search_ranker_settings (
+  key TEXT PRIMARY KEY,
+  value_json TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+INSERT OR IGNORE INTO search_ranker_settings (key, value_json, updated_at)
+VALUES ('search_feedback_retention_days', '180', strftime('%Y-%m-%dT%H:%M:%fZ','now'));
+
+
+-- ================================================================
+-- Phase 3 — case_links + tombstones
+-- ================================================================
+-- Migration 047: Create case_links and revoked wiki tombstones
+-- Phase 3 of MAMA Case-First Memory System
+-- Spec: docs/superpowers/specs/2026-04-17-mama-work-case-first-memory-system-design.md Amendment 11
+
+CREATE TABLE IF NOT EXISTS case_links (
+  link_id TEXT PRIMARY KEY,
+  case_id_from TEXT NOT NULL REFERENCES case_truth(case_id),
+  case_id_to TEXT NOT NULL REFERENCES case_truth(case_id),
+  link_type TEXT NOT NULL CHECK(link_type IN (
+    'related',
+    'supersedes-case',
+    'subcase-of',
+    'blocked-by',
+    'duplicate-of'
+  )),
+  created_at TEXT NOT NULL,
+  created_by TEXT NOT NULL,
+  confidence REAL CHECK(confidence IS NULL OR (confidence >= 0 AND confidence <= 1)),
+  reason_json TEXT,
+  source_kind TEXT NOT NULL DEFAULT 'manual' CHECK(source_kind IN (
+    'manual',
+    'wiki_compiler',
+    'hitl_correction',
+    'system_backfill'
+  )),
+  source_ref TEXT,
+  source_ref_fingerprint BLOB CHECK(
+    source_ref_fingerprint IS NULL OR length(source_ref_fingerprint) = 32
+  ),
+  revoked_at TEXT,
+  revoked_by TEXT,
+  revoke_reason TEXT,
+  CHECK(case_id_from <> case_id_to)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_case_links_active_unique
+  ON case_links(case_id_from, case_id_to, link_type)
+  WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_case_links_from_active
+  ON case_links(case_id_from, created_at DESC, link_id)
+  WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_case_links_to_active
+  ON case_links(case_id_to, created_at DESC, link_id)
+  WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_case_links_type_active
+  ON case_links(link_type, created_at DESC, link_id)
+  WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_case_links_source_ref_fingerprint
+  ON case_links(source_ref_fingerprint)
+  WHERE source_ref_fingerprint IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS case_links_revoked_wiki_tombstones (
+  tombstone_id TEXT PRIMARY KEY,
+  case_id_from TEXT NOT NULL,
+  case_id_to TEXT NOT NULL,
+  link_type TEXT NOT NULL,
+  source_ref_fingerprint BLOB NOT NULL CHECK(length(source_ref_fingerprint) = 32),
+  source_ref TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  created_by TEXT NOT NULL,
+  revoke_reason TEXT NOT NULL,
+  unsuppressed_at TEXT,
+  unsuppressed_by TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_case_links_wiki_tombstone_active_unique
+  ON case_links_revoked_wiki_tombstones(
+    case_id_from,
+    case_id_to,
+    link_type,
+    source_ref_fingerprint
+  )
+  WHERE unsuppressed_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_case_links_wiki_tombstone_source
+  ON case_links_revoked_wiki_tombstones(case_id_from, unsuppressed_at);
+
+INSERT OR IGNORE INTO case_links (
+  link_id,
+  case_id_from,
+  case_id_to,
+  link_type,
+  created_at,
+  created_by,
+  confidence,
+  reason_json,
+  source_kind,
+  source_ref,
+  source_ref_fingerprint,
+  revoked_at,
+  revoked_by,
+  revoke_reason
+)
+SELECT
+  'backfill:canonical:' || case_id,
+  case_id,
+  canonical_case_id,
+  'duplicate-of',
+  updated_at,
+  'system',
+  NULL,
+  '{"authority":"case_truth.canonical_case_id"}',
+  'system_backfill',
+  'case_truth.canonical_case_id',
+  NULL,
+  NULL,
+  NULL,
+  NULL
+FROM case_truth
+WHERE canonical_case_id IS NOT NULL
+  AND canonical_case_id <> case_id;
+
+INSERT OR IGNORE INTO case_links (
+  link_id,
+  case_id_from,
+  case_id_to,
+  link_type,
+  created_at,
+  created_by,
+  confidence,
+  reason_json,
+  source_kind,
+  source_ref,
+  source_ref_fingerprint,
+  revoked_at,
+  revoked_by,
+  revoke_reason
+)
+SELECT
+  'backfill:split:' || case_id,
+  case_id,
+  split_from_case_id,
+  'subcase-of',
+  updated_at,
+  'system',
+  NULL,
+  '{"authority":"case_truth.split_from_case_id"}',
+  'system_backfill',
+  'case_truth.split_from_case_id',
+  NULL,
+  NULL,
+  NULL,
+  NULL
+FROM case_truth
+WHERE split_from_case_id IS NOT NULL
+  AND split_from_case_id <> case_id;
+
+
+-- ================================================================
+-- Phase 3 — case_truth promotion + freshness
+-- ================================================================
+-- Migration 048: Add case promotion and freshness columns
+-- Phase 3 of MAMA Case-First Memory System
+-- Spec: docs/superpowers/specs/2026-04-17-mama-work-case-first-memory-system-design.md Amendments 12 + 13
+
+ALTER TABLE case_truth ADD COLUMN canonical_decision_id TEXT;
+ALTER TABLE case_truth ADD COLUMN canonical_event_id TEXT;
+ALTER TABLE case_truth ADD COLUMN promoted_at TEXT;
+ALTER TABLE case_truth ADD COLUMN promoted_by TEXT;
+ALTER TABLE case_truth ADD COLUMN promotion_reason TEXT;
+
+ALTER TABLE case_truth ADD COLUMN freshness_score REAL CHECK(
+  freshness_score IS NULL OR (freshness_score >= 0 AND freshness_score <= 1)
+);
+ALTER TABLE case_truth ADD COLUMN freshness_state TEXT CHECK(
+  freshness_state IS NULL OR freshness_state IN ('fresh','stale','drifted','unknown')
+);
+ALTER TABLE case_truth ADD COLUMN freshness_score_is_drifted INTEGER NOT NULL DEFAULT 0 CHECK(
+  freshness_score_is_drifted IN (0,1)
+);
+ALTER TABLE case_truth ADD COLUMN freshness_drift_threshold REAL CHECK(
+  freshness_drift_threshold IS NULL OR (
+    freshness_drift_threshold >= 0 AND freshness_drift_threshold <= 1
+  )
+);
+ALTER TABLE case_truth ADD COLUMN freshness_checked_at TEXT;
+ALTER TABLE case_truth ADD COLUMN freshness_reason_json TEXT;
+
+
+-- ================================================================
+-- Phase 3 — case_memberships explanation columns
+-- ================================================================
+-- Migration 049: Add case membership explanation columns
+-- Phase 3 of MAMA Case-First Memory System
+-- Spec: docs/superpowers/specs/2026-04-17-mama-work-case-first-memory-system-design.md Amendment 14
+
+ALTER TABLE case_memberships ADD COLUMN assignment_strategy TEXT;
+ALTER TABLE case_memberships ADD COLUMN score_breakdown_json TEXT;
+ALTER TABLE case_memberships ADD COLUMN source_locator TEXT;
+ALTER TABLE case_memberships ADD COLUMN explanation_updated_at TEXT;
+
+
+-- ================================================================
+-- Final schema_version marker
+-- ================================================================
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES (30, 'Case-First Memory Substrate consolidated (Phase 1+2+3)');

--- a/packages/mama-core/db/migrations/031-wiki-page-index-provenance-columns.sql
+++ b/packages/mama-core/db/migrations/031-wiki-page-index-provenance-columns.sql
@@ -1,0 +1,2 @@
+ALTER TABLE wiki_page_index ADD COLUMN source_ids TEXT;
+ALTER TABLE wiki_page_index ADD COLUMN entity_refs TEXT;

--- a/packages/mama-core/package.json
+++ b/packages/mama-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-core",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "MAMA Core - Shared modules for Memory-Augmented MCP Assistant",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mama-core/package.json
+++ b/packages/mama-core/package.json
@@ -27,7 +27,25 @@
     "./outcome-tracker": "./dist/outcome-tracker.js",
     "./query-intent": "./dist/query-intent.js",
     "./test-utils": "./dist/test-utils.js",
-    "./entities/store": "./dist/entities/store.js"
+    "./entities/store": "./dist/entities/store.js",
+    "./entities/candidate-generator": "./dist/entities/candidate-generator.js",
+    "./canonicalize": "./dist/canonicalize.js",
+    "./cases/types": "./dist/cases/types.js",
+    "./cases/store": "./dist/cases/store.js",
+    "./cases/role-inference": "./dist/cases/role-inference.js",
+    "./cases/target-ref": "./dist/cases/target-ref.js",
+    "./cases/corrections": "./dist/cases/corrections.js",
+    "./cases/sqlite-transaction": "./dist/cases/sqlite-transaction.js",
+    "./cases/live-state": "./dist/cases/live-state.js",
+    "./cases/tombstone-sweeper": "./dist/cases/tombstone-sweeper.js",
+    "./cases/merge-split": "./dist/cases/merge-split.js",
+    "./cases/membership-matcher": "./dist/cases/membership-matcher.js",
+    "./cases/search-rollup": "./dist/cases/search-rollup.js",
+    "./cases/timeline-range": "./dist/cases/timeline-range.js",
+    "./cases/wiki-page-index": "./dist/cases/wiki-page-index.js",
+    "./connectors": "./dist/connectors/event-index.js",
+    "./connectors/event-index": "./dist/connectors/event-index.js",
+    "./connectors/types": "./dist/connectors/types.js"
   },
   "scripts": {
     "build": "tsc",
@@ -72,7 +90,6 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.18.1",
-    "typescript": "^5.4.0",
     "vitest": "^1.0.0"
   },
   "files": [

--- a/packages/mama-core/package.json
+++ b/packages/mama-core/package.json
@@ -90,6 +90,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.18.1",
+    "typescript": "^5.4.0",
     "vitest": "^1.0.0"
   },
   "files": [

--- a/packages/mama-core/package.json
+++ b/packages/mama-core/package.json
@@ -90,7 +90,6 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.18.1",
-    "typescript": "^5.4.0",
     "vitest": "^1.0.0"
   },
   "files": [

--- a/packages/mama-core/src/canonicalize.ts
+++ b/packages/mama-core/src/canonicalize.ts
@@ -101,17 +101,26 @@ export function canonicalizeJSON(value: unknown): string {
 /**
  * Produce the 32-byte SHA-256 digest of the canonical JSON form of `value`.
  *
- * Accepts either a raw value (canonicalizes first) or a pre-canonicalized
- * JSON string. When passed a string, the helper treats it as already-canonical
- * JSON and hashes the bytes directly — callers that already called
- * `canonicalizeJSON` should prefer that path to avoid double-canonicalization.
- *
  * Invariant: `targetRefHash(obj)` === `targetRefHash(canonicalizeJSON(obj))`.
  */
-export function targetRefHash(valueOrCanonicalJson: unknown): Buffer {
-  const json =
-    typeof valueOrCanonicalJson === 'string'
-      ? valueOrCanonicalJson
-      : canonicalizeJSON(valueOrCanonicalJson);
+export function targetRefHash(value: unknown): Buffer {
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      const canonicalJson = canonicalizeJSON(parsed);
+      if (canonicalJson === value) {
+        return targetRefHashCanonicalJSON(value);
+      }
+    } catch {
+      // Raw strings are canonicalized below.
+    }
+  }
+
+  const json = canonicalizeJSON(value);
+  return targetRefHashCanonicalJSON(json);
+}
+
+export function targetRefHashCanonicalJSON(canonicalJson: string): Buffer {
+  const json = canonicalJson;
   return createHash('sha256').update(json, 'utf8').digest();
 }

--- a/packages/mama-core/src/canonicalize.ts
+++ b/packages/mama-core/src/canonicalize.ts
@@ -1,0 +1,117 @@
+/**
+ * Canonical JSON serializer + SHA-256 hash for `case_corrections.target_ref`.
+ *
+ * Phase 1 of MAMA Case-First Memory System (spec §5.4 Option C).
+ *
+ * Behavior:
+ * - recursively sort object keys in lexicographic UTF-8 order
+ * - preserve array order (semantic)
+ * - reject undefined values with typed error code `canonicalize.undefined_value`
+ * - reject function values with typed error code `canonicalize.function_value`
+ * - reject non-finite numbers (NaN, +/- Infinity) with `canonicalize.non_finite_number`
+ * - serialize normalized value via JSON.stringify (after normalization)
+ * - hash canonical JSON string with SHA-256 over UTF-8 bytes → 32-byte Buffer
+ *
+ * No top-level await. No ESM-only runtime dependency. Safe for CJS consumers
+ * (mcp-server, claude-code-plugin) via package export `./canonicalize`.
+ *
+ * @module canonicalize
+ */
+
+import { createHash } from 'node:crypto';
+
+export type CanonicalizeErrorCode =
+  | 'canonicalize.undefined_value'
+  | 'canonicalize.function_value'
+  | 'canonicalize.non_finite_number';
+
+export class CanonicalizeError extends Error {
+  public readonly code: CanonicalizeErrorCode;
+  constructor(code: CanonicalizeErrorCode, message: string) {
+    super(message);
+    this.name = 'CanonicalizeError';
+    this.code = code;
+  }
+}
+
+function normalize(value: unknown, path = '$'): unknown {
+  if (value === null) return null;
+
+  const type = typeof value;
+
+  if (type === 'undefined') {
+    throw new CanonicalizeError(
+      'canonicalize.undefined_value',
+      `undefined is not serializable (at ${path})`
+    );
+  }
+
+  if (type === 'function') {
+    throw new CanonicalizeError(
+      'canonicalize.function_value',
+      `functions are not serializable (at ${path})`
+    );
+  }
+
+  if (type === 'number') {
+    const n = value as number;
+    if (!Number.isFinite(n)) {
+      throw new CanonicalizeError(
+        'canonicalize.non_finite_number',
+        `non-finite number ${String(n)} is not serializable (at ${path})`
+      );
+    }
+    return n;
+  }
+
+  if (type === 'bigint') {
+    return (value as bigint).toString();
+  }
+
+  if (type === 'string' || type === 'boolean') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item, idx) => normalize(item, `${path}[${idx}]`));
+  }
+
+  if (type === 'object') {
+    const obj = value as Record<string, unknown>;
+    const sortedKeys = Object.keys(obj).sort();
+    const out: Record<string, unknown> = {};
+    for (const key of sortedKeys) {
+      out[key] = normalize(obj[key], `${path}.${key}`);
+    }
+    return out;
+  }
+
+  return value;
+}
+
+/**
+ * Produce a canonical JSON string for `value`.
+ *
+ * Two calls with semantically equivalent input produce byte-identical output.
+ */
+export function canonicalizeJSON(value: unknown): string {
+  return JSON.stringify(normalize(value));
+}
+
+/**
+ * Produce the 32-byte SHA-256 digest of the canonical JSON form of `value`.
+ *
+ * Accepts either a raw value (canonicalizes first) or a pre-canonicalized
+ * JSON string. When passed a string, the helper treats it as already-canonical
+ * JSON and hashes the bytes directly — callers that already called
+ * `canonicalizeJSON` should prefer that path to avoid double-canonicalization.
+ *
+ * Invariant: `targetRefHash(obj)` === `targetRefHash(canonicalizeJSON(obj))`.
+ */
+export function targetRefHash(valueOrCanonicalJson: unknown): Buffer {
+  const json =
+    typeof valueOrCanonicalJson === 'string'
+      ? valueOrCanonicalJson
+      : canonicalizeJSON(valueOrCanonicalJson);
+  return createHash('sha256').update(json, 'utf8').digest();
+}

--- a/packages/mama-core/src/cases/case-links.ts
+++ b/packages/mama-core/src/cases/case-links.ts
@@ -1099,6 +1099,14 @@ export function listActiveCaseLinks(
     resolution.terminal_case_id,
     resolution.chain
   );
+  if (chain.length === 0) {
+    return {
+      terminal_case_id: resolution.terminal_case_id,
+      resolved_via_case_id: resolution.resolved_via_case_id,
+      chain,
+      links: [],
+    };
+  }
 
   const rows = linkAdapter
     .prepare(

--- a/packages/mama-core/src/cases/case-links.ts
+++ b/packages/mama-core/src/cases/case-links.ts
@@ -1,0 +1,1213 @@
+import { createHash, createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
+
+import { canonicalizeJSON } from '../canonicalize.js';
+import type { DatabaseAdapter } from '../db-manager.js';
+import { runImmediateTransaction, type ImmediateTransactionAdapter } from './sqlite-transaction.js';
+import { resolveCanonicalCaseChain } from './store.js';
+import type { CanonicalCaseResolution } from './types.js';
+
+export type CaseLinkType =
+  | 'related'
+  | 'supersedes-case'
+  | 'subcase-of'
+  | 'blocked-by'
+  | 'duplicate-of';
+
+export type CaseLinkSourceKind = 'manual' | 'wiki_compiler' | 'hitl_correction' | 'system_backfill';
+
+export interface CaseLinkRecord {
+  link_id: string;
+  case_id_from: string;
+  case_id_to: string;
+  link_type: CaseLinkType;
+  created_at: string;
+  created_by: string;
+  confidence: number | null;
+  reason_json: string | null;
+  source_kind: CaseLinkSourceKind;
+  source_ref: string | null;
+  source_ref_fingerprint: Buffer | null;
+  source_ref_fingerprint_hex: string | null;
+  revoked_at: string | null;
+  revoked_by: string | null;
+  revoke_reason: string | null;
+}
+
+export interface CaseLinkCreateInput {
+  link_id?: string;
+  case_id_from: string;
+  case_id_to: string;
+  link_type: CaseLinkType;
+  created_by: string;
+  confidence?: number | null;
+  reason_json?: string | Record<string, unknown> | null;
+  source_kind?: CaseLinkSourceKind;
+  source_ref?: string | null;
+  source_ref_fingerprint?: Buffer | Uint8Array | null;
+  unsuppress_wiki_tombstone?: boolean;
+  expected_current_value_json?: string | null;
+  reconfirm_token?: string | null;
+  session_id?: string | null;
+  now?: string;
+}
+
+export interface CaseLinkRevokeInput {
+  link_id: string;
+  revoked_by: string;
+  revoke_reason: string;
+  expected_current_value_json?: string | null;
+  reconfirm_token?: string | null;
+  session_id?: string | null;
+  now?: string;
+}
+
+export interface CaseLinkRequiresReconfirmResult {
+  kind: 'requires_reconfirm';
+  code: 'case.correction_requires_reconfirm';
+  case_id: string;
+  target_kind: 'case_link';
+  target_ref_json: string;
+  current_value_json: string;
+  old_value_json: string | null;
+  proposed_new_value_json: string;
+  reconfirm_token: string;
+  reconfirm_token_expires_at: string;
+  message: string;
+}
+
+export type CaseLinkCreateResult =
+  | { kind: 'created'; link_id: string; source_ref_fingerprint_hex: string }
+  | CaseLinkRequiresReconfirmResult
+  | {
+      kind: 'rejected';
+      code:
+        | 'case.precompile_gap'
+        | 'case.terminal_status'
+        | 'case.self_link'
+        | 'case.wiki_tombstone_conflict'
+        | 'case.correction_active_conflict'
+        | 'case.reconfirm_token_replayed';
+      message: string;
+      case_id?: string;
+    };
+
+export type CaseLinkRevokeResult =
+  | { kind: 'revoked'; link_id: string }
+  | CaseLinkRequiresReconfirmResult
+  | {
+      kind: 'rejected';
+      code:
+        | 'case.case_link_not_found'
+        | 'case.wiki_tombstone_fingerprint_missing'
+        | 'case.reconfirm_token_replayed';
+      message: string;
+      link_id?: string;
+    };
+
+export interface ListActiveCaseLinksResult {
+  terminal_case_id: string;
+  resolved_via_case_id: string | null;
+  chain: string[];
+  links: CaseLinkRecord[];
+}
+
+export interface BackfillStructuralLinksResult {
+  duplicate_of_inserted: number;
+  subcase_of_inserted: number;
+}
+
+type CaseLinkAdapter = Pick<DatabaseAdapter, 'prepare' | 'transaction'> &
+  Partial<Pick<ImmediateTransactionAdapter, 'exec'>>;
+
+interface CaseGateRow {
+  case_id: string;
+  status: string;
+  canonical_case_id: string | null;
+  split_from_case_id: string | null;
+  title: string;
+  current_wiki_path: string | null;
+  updated_at: string;
+}
+
+interface ReconfirmTokenPayload {
+  v: 1;
+  kid: string;
+  nonce: string;
+  case_id: string;
+  target_kind: 'case_link';
+  target_ref_hash_hex: string;
+  current_value_hash_hex: string;
+  proposed_value_hash_hex: string;
+  confirmed_by: string;
+  session_id: string | null;
+  expires_at: string;
+}
+
+interface ReconfirmTokenEnvelope {
+  kid: string;
+  payload: ReconfirmTokenPayload;
+  signature_hex: string;
+}
+
+interface CurrentSecret {
+  kid: string;
+  secret: Buffer;
+}
+
+const TERMINAL_CASE_STATUSES = new Set(['merged', 'archived', 'split']);
+const RECONFIRM_TOKEN_TTL_MS = 10 * 60_000;
+
+function normalizeNow(value?: string): string {
+  return value ?? new Date().toISOString();
+}
+
+function timestampMs(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+function createdAtMs(value: string): number {
+  return timestampMs(value);
+}
+
+function randomLinkId(): string {
+  return `link_${randomUUID().replace(/-/g, '')}`;
+}
+
+function randomTombstoneId(): string {
+  return `tomb_${randomUUID().replace(/-/g, '')}`;
+}
+
+function deterministicLinkId(nonce: string): string {
+  return `link_${sha256Hex(`case-link-reconfirm:v1:${nonce}`).slice(0, 32)}`;
+}
+
+function sha256Hex(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function hmacHex(secret: Buffer, value: string): string {
+  return createHmac('sha256', secret).update(value, 'utf8').digest('hex');
+}
+
+function decodeSecret(raw: string): Buffer | null {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  if (/^[0-9a-f]+$/i.test(trimmed) && trimmed.length % 2 === 0) {
+    const hex = Buffer.from(trimmed, 'hex');
+    if (hex.length >= 32) {
+      return hex;
+    }
+  }
+
+  const base64 = Buffer.from(trimmed, 'base64');
+  if (base64.length >= 32) {
+    return base64;
+  }
+
+  const utf8 = Buffer.from(trimmed, 'utf8');
+  if (utf8.length >= 32) {
+    return utf8;
+  }
+
+  return null;
+}
+
+function secretKid(secret: Buffer): string {
+  return createHash('sha256').update(secret).digest('hex').slice(0, 16);
+}
+
+function currentSecret(): CurrentSecret {
+  const raw = process.env.MAMA_RECONFIRM_TOKEN_SECRET;
+  const secret = raw ? decodeSecret(raw) : null;
+  if (!secret) {
+    throw new Error('MAMA_RECONFIRM_TOKEN_SECRET must be a 32+ byte base64 or hex secret.');
+  }
+
+  return { kid: secretKid(secret), secret };
+}
+
+function verificationSecrets(): Map<string, Buffer> {
+  const secrets = new Map<string, Buffer>();
+  const current = currentSecret();
+  secrets.set(current.kid, current.secret);
+
+  for (const raw of (process.env.MAMA_RECONFIRM_TOKEN_OLD_SECRETS ?? '').split(',')) {
+    const secret = decodeSecret(raw);
+    if (secret) {
+      secrets.set(secretKid(secret), secret);
+    }
+  }
+
+  return secrets;
+}
+
+function encodeReconfirmToken(payload: ReconfirmTokenPayload, secret: Buffer): string {
+  const payloadJson = canonicalizeJSON(payload);
+  const envelope: ReconfirmTokenEnvelope = {
+    kid: payload.kid,
+    payload,
+    signature_hex: hmacHex(secret, payloadJson),
+  };
+
+  return Buffer.from(canonicalizeJSON(envelope), 'utf8').toString('base64url');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readReconfirmEnvelope(token: string): ReconfirmTokenEnvelope | null {
+  try {
+    const parsed = JSON.parse(Buffer.from(token, 'base64url').toString('utf8')) as unknown;
+    if (!isRecord(parsed) || !isRecord(parsed.payload)) {
+      return null;
+    }
+
+    const payload = parsed.payload;
+    if (
+      parsed.kid !== payload.kid ||
+      payload.v !== 1 ||
+      typeof parsed.kid !== 'string' ||
+      typeof parsed.signature_hex !== 'string' ||
+      typeof payload.kid !== 'string' ||
+      typeof payload.nonce !== 'string' ||
+      typeof payload.case_id !== 'string' ||
+      payload.target_kind !== 'case_link' ||
+      typeof payload.target_ref_hash_hex !== 'string' ||
+      typeof payload.current_value_hash_hex !== 'string' ||
+      typeof payload.proposed_value_hash_hex !== 'string' ||
+      typeof payload.confirmed_by !== 'string' ||
+      !(payload.session_id === null || typeof payload.session_id === 'string') ||
+      typeof payload.expires_at !== 'string'
+    ) {
+      return null;
+    }
+
+    return {
+      kid: parsed.kid,
+      payload: payload as unknown as ReconfirmTokenPayload,
+      signature_hex: parsed.signature_hex,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function verifyReconfirmToken(input: {
+  token: string;
+  case_id: string;
+  target_ref_hash_hex: string;
+  proposed_value_hash_hex: string;
+  confirmed_by: string;
+  session_id: string | null;
+  now: string;
+}): ReconfirmTokenPayload | null {
+  const envelope = readReconfirmEnvelope(input.token);
+  if (!envelope) {
+    return null;
+  }
+
+  const secret = verificationSecrets().get(envelope.kid);
+  if (!secret) {
+    return null;
+  }
+
+  const expected = Buffer.from(hmacHex(secret, canonicalizeJSON(envelope.payload)), 'hex');
+  const actual = Buffer.from(envelope.signature_hex, 'hex');
+  if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
+    return null;
+  }
+
+  const expiresAtMs = Date.parse(envelope.payload.expires_at);
+  if (!Number.isFinite(expiresAtMs) || expiresAtMs <= timestampMs(input.now)) {
+    return null;
+  }
+
+  if (
+    envelope.payload.case_id !== input.case_id ||
+    envelope.payload.target_ref_hash_hex !== input.target_ref_hash_hex ||
+    envelope.payload.proposed_value_hash_hex !== input.proposed_value_hash_hex ||
+    envelope.payload.confirmed_by !== input.confirmed_by ||
+    envelope.payload.session_id !== input.session_id
+  ) {
+    return null;
+  }
+
+  return envelope.payload;
+}
+
+function buildRequiresReconfirm(input: {
+  case_id: string;
+  target_ref_json: string;
+  target_ref_hash_hex: string;
+  current_value_json: string;
+  old_value_json: string | null;
+  proposed_new_value_json: string;
+  confirmed_by: string;
+  session_id: string | null;
+  now: string;
+}): CaseLinkRequiresReconfirmResult {
+  const secret = currentSecret();
+  const expiresAt = new Date(timestampMs(input.now) + RECONFIRM_TOKEN_TTL_MS).toISOString();
+  const payload: ReconfirmTokenPayload = {
+    v: 1,
+    kid: secret.kid,
+    nonce: randomUUID(),
+    case_id: input.case_id,
+    target_kind: 'case_link',
+    target_ref_hash_hex: input.target_ref_hash_hex,
+    current_value_hash_hex: sha256Hex(input.current_value_json),
+    proposed_value_hash_hex: sha256Hex(input.proposed_new_value_json),
+    confirmed_by: input.confirmed_by,
+    session_id: input.session_id,
+    expires_at: expiresAt,
+  };
+
+  return {
+    kind: 'requires_reconfirm',
+    code: 'case.correction_requires_reconfirm',
+    case_id: input.case_id,
+    target_kind: 'case_link',
+    target_ref_json: input.target_ref_json,
+    current_value_json: input.current_value_json,
+    old_value_json: input.old_value_json,
+    proposed_new_value_json: input.proposed_new_value_json,
+    reconfirm_token: encodeReconfirmToken(payload, secret.secret),
+    reconfirm_token_expires_at: expiresAt,
+    message: 'The target changed since the viewed snapshot. Reconfirm against the current value.',
+  };
+}
+
+function parseJsonValue(value: string): unknown {
+  return JSON.parse(value) as unknown;
+}
+
+function canonicalExpectedJson(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  return canonicalizeJSON(parseJsonValue(value));
+}
+
+function toBuffer(value: unknown): Buffer | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (Buffer.isBuffer(value)) {
+    return value;
+  }
+  if (value instanceof Uint8Array) {
+    return Buffer.from(value);
+  }
+  throw new Error('Expected SQLite BLOB value to be a Buffer.');
+}
+
+function nullableString(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return String(value);
+}
+
+function nullableNumber(value: unknown): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function mapCaseLinkRow(row: Record<string, unknown>): CaseLinkRecord {
+  const fingerprint = toBuffer(row.source_ref_fingerprint);
+  return {
+    link_id: String(row.link_id),
+    case_id_from: String(row.case_id_from),
+    case_id_to: String(row.case_id_to),
+    link_type: String(row.link_type) as CaseLinkType,
+    created_at: String(row.created_at),
+    created_by: String(row.created_by),
+    confidence: nullableNumber(row.confidence),
+    reason_json: nullableString(row.reason_json),
+    source_kind: String(row.source_kind) as CaseLinkSourceKind,
+    source_ref: nullableString(row.source_ref),
+    source_ref_fingerprint: fingerprint,
+    source_ref_fingerprint_hex: fingerprint ? fingerprint.toString('hex') : null,
+    revoked_at: nullableString(row.revoked_at),
+    revoked_by: nullableString(row.revoked_by),
+    revoke_reason: nullableString(row.revoke_reason),
+  };
+}
+
+function placeholders(values: readonly unknown[]): string {
+  if (values.length === 0) {
+    throw new Error('Cannot build SQL IN clause for an empty value list.');
+  }
+  return values.map(() => '?').join(', ');
+}
+
+function loadCase(adapter: CaseLinkAdapter, caseId: string): CaseGateRow | null {
+  const row = adapter
+    .prepare(
+      `
+        SELECT case_id, status, canonical_case_id, split_from_case_id, title,
+               current_wiki_path, updated_at
+        FROM case_truth
+        WHERE case_id = ?
+      `
+    )
+    .get(caseId) as CaseGateRow | undefined;
+
+  return row ?? null;
+}
+
+function caseSnapshot(row: CaseGateRow): Record<string, unknown> {
+  return {
+    case_id: row.case_id,
+    status: row.status,
+    canonical_case_id: row.canonical_case_id,
+    split_from_case_id: row.split_from_case_id,
+    title: row.title,
+    current_wiki_path: row.current_wiki_path,
+    updated_at: row.updated_at,
+  };
+}
+
+function reasonJson(value: CaseLinkCreateInput['reason_json']): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  return canonicalizeJSON(value);
+}
+
+function caseLinkTargetRefJson(input: {
+  case_id_from: string;
+  case_id_to: string;
+  link_type: CaseLinkType;
+}): string {
+  return canonicalizeJSON({
+    kind: 'case_link',
+    case_id_from: input.case_id_from,
+    case_id_to: input.case_id_to,
+    link_type: input.link_type,
+  });
+}
+
+function activeLinkForTriple(
+  adapter: CaseLinkAdapter,
+  input: { case_id_from: string; case_id_to: string; link_type: CaseLinkType }
+): CaseLinkRecord | null {
+  const row = adapter
+    .prepare(
+      `
+        SELECT *
+        FROM case_links
+        WHERE case_id_from = ?
+          AND case_id_to = ?
+          AND link_type = ?
+          AND revoked_at IS NULL
+        LIMIT 1
+      `
+    )
+    .get(input.case_id_from, input.case_id_to, input.link_type) as
+    | Record<string, unknown>
+    | undefined;
+
+  return row ? mapCaseLinkRow(row) : null;
+}
+
+function linkExistsById(adapter: CaseLinkAdapter, linkId: string): boolean {
+  const row = adapter.prepare('SELECT link_id FROM case_links WHERE link_id = ?').get(linkId) as
+    | { link_id: string }
+    | undefined;
+  return Boolean(row);
+}
+
+function activeTombstoneRow(
+  adapter: CaseLinkAdapter,
+  input: { source_case_id: string; target_case_id: string; link_type: CaseLinkType },
+  fingerprint = sha256TombstoneFingerprint(input)
+): { tombstone_id: string } | null {
+  const row = adapter
+    .prepare(
+      `
+        SELECT tombstone_id
+        FROM case_links_revoked_wiki_tombstones
+        WHERE case_id_from = ?
+          AND case_id_to = ?
+          AND link_type = ?
+          AND source_ref_fingerprint = ?
+          AND unsuppressed_at IS NULL
+        LIMIT 1
+      `
+    )
+    .get(input.source_case_id, input.target_case_id, input.link_type, fingerprint) as
+    | { tombstone_id: string }
+    | undefined;
+
+  return row ?? null;
+}
+
+function unsuppressWikiTombstoneInTransaction(
+  adapter: CaseLinkAdapter,
+  input: {
+    source_case_id: string;
+    target_case_id: string;
+    link_type: CaseLinkType;
+    unsuppressed_by: string;
+    now: string;
+  }
+): number {
+  const fingerprint = sha256TombstoneFingerprint(input);
+  const result = adapter
+    .prepare(
+      `
+        UPDATE case_links_revoked_wiki_tombstones
+        SET unsuppressed_at = ?, unsuppressed_by = ?
+        WHERE case_id_from = ?
+          AND case_id_to = ?
+          AND link_type = ?
+          AND source_ref_fingerprint = ?
+          AND unsuppressed_at IS NULL
+      `
+    )
+    .run(
+      input.now,
+      input.unsuppressed_by,
+      input.source_case_id,
+      input.target_case_id,
+      input.link_type,
+      fingerprint
+    );
+
+  return result.changes;
+}
+
+function currentCreateValueJson(
+  adapter: CaseLinkAdapter,
+  input: CaseLinkCreateInput,
+  sourceCase: CaseGateRow,
+  targetCase: CaseGateRow
+): string {
+  return canonicalizeJSON({
+    source_case: caseSnapshot(sourceCase),
+    target_case: caseSnapshot(targetCase),
+    target_ref: {
+      kind: 'case_link',
+      case_id_from: input.case_id_from,
+      case_id_to: input.case_id_to,
+      link_type: input.link_type,
+    },
+    active_link: activeLinkForTriple(adapter, input),
+    wiki_tombstone_active: isWikiTombstoneActive(adapter, {
+      source_case_id: input.case_id_from,
+      target_case_id: input.case_id_to,
+      link_type: input.link_type,
+    }),
+  });
+}
+
+function proposedCreateValueJson(input: CaseLinkCreateInput): string {
+  return canonicalizeJSON({
+    case_id_from: input.case_id_from,
+    case_id_to: input.case_id_to,
+    link_type: input.link_type,
+    confidence: input.confidence ?? null,
+    reason_json: reasonJson(input.reason_json),
+    source_kind: input.source_kind ?? 'manual',
+    source_ref: input.source_ref ?? null,
+  });
+}
+
+function currentRevokeValueJson(row: CaseLinkRecord): string {
+  return canonicalizeJSON({
+    link_id: row.link_id,
+    case_id_from: row.case_id_from,
+    case_id_to: row.case_id_to,
+    link_type: row.link_type,
+    revoked_at: row.revoked_at,
+    revoked_by: row.revoked_by,
+    revoke_reason: row.revoke_reason,
+    source_kind: row.source_kind,
+    source_ref_fingerprint_hex: row.source_ref_fingerprint_hex,
+  });
+}
+
+function insertMemoryEvent(input: {
+  adapter: CaseLinkAdapter;
+  event_type: 'case.link_created' | 'case.link_revoked';
+  actor: string;
+  case_id: string;
+  link_id: string;
+  reason: unknown;
+  now: string;
+}): void {
+  input.adapter
+    .prepare(
+      `
+        INSERT INTO memory_events (
+          event_id, event_type, actor, source_turn_id, memory_id, topic,
+          scope_refs, evidence_refs, reason, created_at
+        )
+        VALUES (?, ?, ?, NULL, NULL, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      `me_${randomUUID()}`,
+      input.event_type,
+      input.actor,
+      `case:${input.case_id}`,
+      canonicalizeJSON([{ type: 'case', id: input.case_id }]),
+      canonicalizeJSON([input.link_id]),
+      canonicalizeJSON(input.reason),
+      createdAtMs(input.now)
+    );
+}
+
+function expandCaseChainForAssembly(
+  adapter: CaseLinkAdapter,
+  terminalCaseId: string,
+  resolvedChain: string[]
+): string[] {
+  const rows = adapter
+    .prepare(
+      `
+        WITH RECURSIVE merged_chain(case_id, depth) AS (
+          SELECT case_id, 0
+            FROM case_truth
+           WHERE case_id = ?
+
+          UNION
+
+          SELECT ct.case_id, merged_chain.depth + 1
+            FROM case_truth ct
+            JOIN merged_chain ON ct.canonical_case_id = merged_chain.case_id
+           WHERE merged_chain.depth < 64
+        )
+        SELECT case_id
+          FROM merged_chain
+         ORDER BY depth ASC, case_id ASC
+      `
+    )
+    .all(terminalCaseId) as Array<{ case_id: string }>;
+
+  const chain: string[] = [];
+  for (const caseId of [...resolvedChain, ...rows.map((row) => row.case_id)]) {
+    if (!chain.includes(caseId)) {
+      chain.push(caseId);
+    }
+  }
+  return chain;
+}
+
+export function sha256TombstoneFingerprint(input: {
+  source_case_id: string;
+  target_case_id: string;
+  link_type: CaseLinkType;
+}): Buffer {
+  return createHash('sha256')
+    .update(
+      canonicalizeJSON({
+        source_case_id: input.source_case_id,
+        target_case_id: input.target_case_id,
+        link_type: input.link_type,
+      }),
+      'utf8'
+    )
+    .digest();
+}
+
+export function createCaseLink(
+  adapter: DatabaseAdapter,
+  input: CaseLinkCreateInput
+): CaseLinkCreateResult {
+  const linkAdapter = adapter as unknown as CaseLinkAdapter;
+
+  return runImmediateTransaction(linkAdapter, () => {
+    const now = normalizeNow(input.now);
+    const sourceKind = input.source_kind ?? 'manual';
+
+    if (input.case_id_from === input.case_id_to) {
+      return {
+        kind: 'rejected',
+        code: 'case.self_link',
+        message: 'Case links cannot point to the same case.',
+        case_id: input.case_id_from,
+      };
+    }
+
+    const sourceCase = loadCase(linkAdapter, input.case_id_from);
+    if (!sourceCase) {
+      return {
+        kind: 'rejected',
+        code: 'case.precompile_gap',
+        message: `Source case ${input.case_id_from} does not exist.`,
+        case_id: input.case_id_from,
+      };
+    }
+
+    const targetCase = loadCase(linkAdapter, input.case_id_to);
+    if (!targetCase) {
+      return {
+        kind: 'rejected',
+        code: 'case.precompile_gap',
+        message: `Target case ${input.case_id_to} does not exist.`,
+        case_id: input.case_id_to,
+      };
+    }
+
+    for (const row of [sourceCase, targetCase]) {
+      if (TERMINAL_CASE_STATUSES.has(row.status)) {
+        return {
+          kind: 'rejected',
+          code: 'case.terminal_status',
+          message: `Case links cannot target terminal case status ${row.status}.`,
+          case_id: row.case_id,
+        };
+      }
+    }
+
+    const targetRefJson = caseLinkTargetRefJson(input);
+    const targetRefHashHex = sha256Hex(targetRefJson);
+    const currentValueJson = currentCreateValueJson(linkAdapter, input, sourceCase, targetCase);
+    const canonicalExpectedCurrent = canonicalExpectedJson(input.expected_current_value_json);
+    const proposedNewValueJson = proposedCreateValueJson(input);
+    let linkId = input.link_id ?? randomLinkId();
+
+    if (canonicalExpectedCurrent !== null && canonicalExpectedCurrent !== currentValueJson) {
+      const token = input.reconfirm_token ?? null;
+      if (!token) {
+        return buildRequiresReconfirm({
+          case_id: input.case_id_from,
+          target_ref_json: targetRefJson,
+          target_ref_hash_hex: targetRefHashHex,
+          current_value_json: currentValueJson,
+          old_value_json: input.expected_current_value_json ?? null,
+          proposed_new_value_json: proposedNewValueJson,
+          confirmed_by: input.created_by,
+          session_id: input.session_id ?? null,
+          now,
+        });
+      }
+
+      const payload = verifyReconfirmToken({
+        token,
+        case_id: input.case_id_from,
+        target_ref_hash_hex: targetRefHashHex,
+        proposed_value_hash_hex: sha256Hex(proposedNewValueJson),
+        confirmed_by: input.created_by,
+        session_id: input.session_id ?? null,
+        now,
+      });
+
+      if (!payload || payload.current_value_hash_hex !== sha256Hex(currentValueJson)) {
+        return buildRequiresReconfirm({
+          case_id: input.case_id_from,
+          target_ref_json: targetRefJson,
+          target_ref_hash_hex: targetRefHashHex,
+          current_value_json: currentValueJson,
+          old_value_json: input.expected_current_value_json ?? null,
+          proposed_new_value_json: proposedNewValueJson,
+          confirmed_by: input.created_by,
+          session_id: input.session_id ?? null,
+          now,
+        });
+      }
+
+      linkId = deterministicLinkId(payload.nonce);
+      if (linkExistsById(linkAdapter, linkId)) {
+        return {
+          kind: 'rejected',
+          code: 'case.reconfirm_token_replayed',
+          message: 'Reconfirm token has already been consumed.',
+          case_id: input.case_id_from,
+        };
+      }
+    }
+
+    const fingerprint =
+      toBuffer(input.source_ref_fingerprint) ??
+      sha256TombstoneFingerprint({
+        source_case_id: input.case_id_from,
+        target_case_id: input.case_id_to,
+        link_type: input.link_type,
+      });
+
+    if (sourceKind === 'manual') {
+      const tombstone = activeTombstoneRow(
+        linkAdapter,
+        {
+          source_case_id: input.case_id_from,
+          target_case_id: input.case_id_to,
+          link_type: input.link_type,
+        },
+        fingerprint
+      );
+
+      if (tombstone && input.unsuppress_wiki_tombstone !== true) {
+        return {
+          kind: 'rejected',
+          code: 'case.wiki_tombstone_conflict',
+          message: 'A revoked wiki-emitted link tombstone exists for this relationship.',
+          case_id: input.case_id_from,
+        };
+      }
+
+      if (tombstone) {
+        unsuppressWikiTombstoneInTransaction(linkAdapter, {
+          source_case_id: input.case_id_from,
+          target_case_id: input.case_id_to,
+          link_type: input.link_type,
+          unsuppressed_by: input.created_by,
+          now,
+        });
+      }
+    }
+
+    if (activeLinkForTriple(linkAdapter, input)) {
+      return {
+        kind: 'rejected',
+        code: 'case.correction_active_conflict',
+        message: 'An active case link already exists for this relationship.',
+        case_id: input.case_id_from,
+      };
+    }
+
+    linkAdapter
+      .prepare(
+        `
+          INSERT INTO case_links (
+            link_id, case_id_from, case_id_to, link_type, created_at, created_by,
+            confidence, reason_json, source_kind, source_ref, source_ref_fingerprint,
+            revoked_at, revoked_by, revoke_reason
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL)
+        `
+      )
+      .run(
+        linkId,
+        input.case_id_from,
+        input.case_id_to,
+        input.link_type,
+        now,
+        input.created_by,
+        input.confidence ?? null,
+        reasonJson(input.reason_json),
+        sourceKind,
+        input.source_ref ?? null,
+        fingerprint
+      );
+
+    insertMemoryEvent({
+      adapter: linkAdapter,
+      event_type: 'case.link_created',
+      actor: input.created_by,
+      case_id: input.case_id_from,
+      link_id: linkId,
+      reason: {
+        case_id_from: input.case_id_from,
+        case_id_to: input.case_id_to,
+        link_type: input.link_type,
+        source_kind: sourceKind,
+      },
+      now,
+    });
+
+    return {
+      kind: 'created',
+      link_id: linkId,
+      source_ref_fingerprint_hex: fingerprint.toString('hex'),
+    };
+  });
+}
+
+export function revokeCaseLink(
+  adapter: DatabaseAdapter,
+  input: CaseLinkRevokeInput
+): CaseLinkRevokeResult {
+  const linkAdapter = adapter as unknown as CaseLinkAdapter;
+
+  return runImmediateTransaction(linkAdapter, () => {
+    const now = normalizeNow(input.now);
+    const raw = linkAdapter
+      .prepare('SELECT * FROM case_links WHERE link_id = ?')
+      .get(input.link_id) as Record<string, unknown> | undefined;
+
+    if (!raw) {
+      return {
+        kind: 'rejected',
+        code: 'case.case_link_not_found',
+        message: `Case link ${input.link_id} was not found.`,
+        link_id: input.link_id,
+      };
+    }
+
+    const row = mapCaseLinkRow(raw);
+    if (row.revoked_at !== null) {
+      return {
+        kind: 'rejected',
+        code: 'case.case_link_not_found',
+        message: `Case link ${input.link_id} is already revoked.`,
+        link_id: input.link_id,
+      };
+    }
+
+    if (row.source_kind === 'wiki_compiler' && !row.source_ref_fingerprint) {
+      return {
+        kind: 'rejected',
+        code: 'case.wiki_tombstone_fingerprint_missing',
+        message: 'Cannot revoke a wiki compiler link without its stored source_ref_fingerprint.',
+        link_id: input.link_id,
+      };
+    }
+
+    const targetRefJson = caseLinkTargetRefJson(row);
+    const targetRefHashHex = sha256Hex(targetRefJson);
+    const currentValueJson = currentRevokeValueJson(row);
+    const canonicalExpectedCurrent = canonicalExpectedJson(input.expected_current_value_json);
+    const proposedNewValueJson = canonicalizeJSON({
+      link_id: input.link_id,
+      revoked_at: now,
+      revoked_by: input.revoked_by,
+      revoke_reason: input.revoke_reason,
+    });
+
+    if (canonicalExpectedCurrent !== null && canonicalExpectedCurrent !== currentValueJson) {
+      const token = input.reconfirm_token ?? null;
+      if (!token) {
+        return buildRequiresReconfirm({
+          case_id: row.case_id_from,
+          target_ref_json: targetRefJson,
+          target_ref_hash_hex: targetRefHashHex,
+          current_value_json: currentValueJson,
+          old_value_json: input.expected_current_value_json ?? null,
+          proposed_new_value_json: proposedNewValueJson,
+          confirmed_by: input.revoked_by,
+          session_id: input.session_id ?? null,
+          now,
+        });
+      }
+
+      const payload = verifyReconfirmToken({
+        token,
+        case_id: row.case_id_from,
+        target_ref_hash_hex: targetRefHashHex,
+        proposed_value_hash_hex: sha256Hex(proposedNewValueJson),
+        confirmed_by: input.revoked_by,
+        session_id: input.session_id ?? null,
+        now,
+      });
+
+      if (!payload || payload.current_value_hash_hex !== sha256Hex(currentValueJson)) {
+        return buildRequiresReconfirm({
+          case_id: row.case_id_from,
+          target_ref_json: targetRefJson,
+          target_ref_hash_hex: targetRefHashHex,
+          current_value_json: currentValueJson,
+          old_value_json: input.expected_current_value_json ?? null,
+          proposed_new_value_json: proposedNewValueJson,
+          confirmed_by: input.revoked_by,
+          session_id: input.session_id ?? null,
+          now,
+        });
+      }
+    }
+
+    linkAdapter
+      .prepare(
+        `
+          UPDATE case_links
+          SET revoked_at = ?, revoked_by = ?, revoke_reason = ?
+          WHERE link_id = ?
+            AND revoked_at IS NULL
+        `
+      )
+      .run(now, input.revoked_by, input.revoke_reason, input.link_id);
+
+    if (row.source_kind === 'wiki_compiler' && row.source_ref_fingerprint) {
+      linkAdapter
+        .prepare(
+          `
+            INSERT OR IGNORE INTO case_links_revoked_wiki_tombstones (
+              tombstone_id, case_id_from, case_id_to, link_type, source_ref_fingerprint,
+              source_ref, created_at, created_by, revoke_reason, unsuppressed_at,
+              unsuppressed_by
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)
+          `
+        )
+        .run(
+          randomTombstoneId(),
+          row.case_id_from,
+          row.case_id_to,
+          row.link_type,
+          row.source_ref_fingerprint,
+          row.source_ref ?? `case_link:${row.link_id}`,
+          now,
+          input.revoked_by,
+          input.revoke_reason
+        );
+    }
+
+    insertMemoryEvent({
+      adapter: linkAdapter,
+      event_type: 'case.link_revoked',
+      actor: input.revoked_by,
+      case_id: row.case_id_from,
+      link_id: input.link_id,
+      reason: {
+        case_id_from: row.case_id_from,
+        case_id_to: row.case_id_to,
+        link_type: row.link_type,
+        revoke_reason: input.revoke_reason,
+        tombstone_written: row.source_kind === 'wiki_compiler',
+      },
+      now,
+    });
+
+    return { kind: 'revoked', link_id: input.link_id };
+  });
+}
+
+export function listActiveCaseLinks(
+  adapter: DatabaseAdapter,
+  caseId: string
+): ListActiveCaseLinksResult {
+  const linkAdapter = adapter as unknown as CaseLinkAdapter;
+  const resolution: CanonicalCaseResolution = resolveCanonicalCaseChain(linkAdapter, caseId);
+  const chain = expandCaseChainForAssembly(
+    linkAdapter,
+    resolution.terminal_case_id,
+    resolution.chain
+  );
+
+  const rows = linkAdapter
+    .prepare(
+      `
+        SELECT *
+        FROM case_links
+        WHERE revoked_at IS NULL
+          AND (
+            case_id_from IN (${placeholders(chain)})
+            OR case_id_to IN (${placeholders(chain)})
+          )
+        ORDER BY created_at DESC, link_id ASC
+      `
+    )
+    .all(...chain, ...chain) as Array<Record<string, unknown>>;
+
+  return {
+    terminal_case_id: resolution.terminal_case_id,
+    resolved_via_case_id: resolution.resolved_via_case_id,
+    chain,
+    links: rows.map(mapCaseLinkRow),
+  };
+}
+
+export function isWikiTombstoneActive(
+  adapter: DatabaseAdapter | CaseLinkAdapter,
+  input: { source_case_id: string; target_case_id: string; link_type: CaseLinkType }
+): boolean {
+  return Boolean(activeTombstoneRow(adapter as unknown as CaseLinkAdapter, input));
+}
+
+export function unsuppressWikiTombstone(
+  adapter: DatabaseAdapter,
+  input: {
+    source_case_id: string;
+    target_case_id: string;
+    link_type: CaseLinkType;
+    unsuppressed_by: string;
+    now?: string;
+  }
+): { kind: 'unsuppressed'; unsuppressed_count: number } {
+  const linkAdapter = adapter as unknown as CaseLinkAdapter;
+
+  return runImmediateTransaction(linkAdapter, () => ({
+    kind: 'unsuppressed',
+    unsuppressed_count: unsuppressWikiTombstoneInTransaction(linkAdapter, {
+      source_case_id: input.source_case_id,
+      target_case_id: input.target_case_id,
+      link_type: input.link_type,
+      unsuppressed_by: input.unsuppressed_by,
+      now: normalizeNow(input.now),
+    }),
+  }));
+}
+
+export function backfillStructuralLinks(adapter: DatabaseAdapter): BackfillStructuralLinksResult {
+  const linkAdapter = adapter as unknown as CaseLinkAdapter;
+
+  return runImmediateTransaction(linkAdapter, () => {
+    const duplicateResult = linkAdapter
+      .prepare(
+        `
+          INSERT OR IGNORE INTO case_links (
+            link_id, case_id_from, case_id_to, link_type, created_at, created_by,
+            confidence, reason_json, source_kind, source_ref, source_ref_fingerprint,
+            revoked_at, revoked_by, revoke_reason
+          )
+          SELECT
+            'backfill:canonical:' || case_id,
+            case_id,
+            canonical_case_id,
+            'duplicate-of',
+            updated_at,
+            'system',
+            NULL,
+            '{"authority":"case_truth.canonical_case_id"}',
+            'system_backfill',
+            'case_truth.canonical_case_id',
+            NULL,
+            NULL,
+            NULL,
+            NULL
+          FROM case_truth
+          WHERE canonical_case_id IS NOT NULL
+            AND canonical_case_id <> case_id
+        `
+      )
+      .run();
+
+    const splitResult = linkAdapter
+      .prepare(
+        `
+          INSERT OR IGNORE INTO case_links (
+            link_id, case_id_from, case_id_to, link_type, created_at, created_by,
+            confidence, reason_json, source_kind, source_ref, source_ref_fingerprint,
+            revoked_at, revoked_by, revoke_reason
+          )
+          SELECT
+            'backfill:split:' || case_id,
+            case_id,
+            split_from_case_id,
+            'subcase-of',
+            updated_at,
+            'system',
+            NULL,
+            '{"authority":"case_truth.split_from_case_id"}',
+            'system_backfill',
+            'case_truth.split_from_case_id',
+            NULL,
+            NULL,
+            NULL,
+            NULL
+          FROM case_truth
+          WHERE split_from_case_id IS NOT NULL
+            AND split_from_case_id <> case_id
+        `
+      )
+      .run();
+
+    return {
+      duplicate_of_inserted: duplicateResult.changes,
+      subcase_of_inserted: splitResult.changes,
+    };
+  });
+}

--- a/packages/mama-core/src/cases/case-links.ts
+++ b/packages/mama-core/src/cases/case-links.ts
@@ -562,9 +562,9 @@ function unsuppressWikiTombstoneInTransaction(
     link_type: CaseLinkType;
     unsuppressed_by: string;
     now: string;
-  }
+  },
+  fingerprint = sha256TombstoneFingerprint(input)
 ): number {
-  const fingerprint = sha256TombstoneFingerprint(input);
   const result = adapter
     .prepare(
       `
@@ -840,6 +840,15 @@ export function createCaseLink(
       });
 
     if (sourceKind === 'manual') {
+      if (activeLinkForTriple(linkAdapter, input)) {
+        return {
+          kind: 'rejected',
+          code: 'case.correction_active_conflict',
+          message: 'An active case link already exists for this relationship.',
+          case_id: input.case_id_from,
+        };
+      }
+
       const tombstone = activeTombstoneRow(
         linkAdapter,
         {
@@ -860,13 +869,17 @@ export function createCaseLink(
       }
 
       if (tombstone) {
-        unsuppressWikiTombstoneInTransaction(linkAdapter, {
-          source_case_id: input.case_id_from,
-          target_case_id: input.case_id_to,
-          link_type: input.link_type,
-          unsuppressed_by: input.created_by,
-          now,
-        });
+        unsuppressWikiTombstoneInTransaction(
+          linkAdapter,
+          {
+            source_case_id: input.case_id_from,
+            target_case_id: input.case_id_to,
+            link_type: input.link_type,
+            unsuppressed_by: input.created_by,
+            now,
+          },
+          fingerprint
+        );
       }
     }
 

--- a/packages/mama-core/src/cases/case-links.ts
+++ b/packages/mama-core/src/cases/case-links.ts
@@ -3,7 +3,7 @@ import { createHash, createHmac, randomUUID, timingSafeEqual } from 'node:crypto
 import { canonicalizeJSON } from '../canonicalize.js';
 import type { DatabaseAdapter } from '../db-manager.js';
 import { runImmediateTransaction, type ImmediateTransactionAdapter } from './sqlite-transaction.js';
-import { resolveCanonicalCaseChain } from './store.js';
+import { expandCaseChainForAssembly, resolveCanonicalCaseChain } from './store.js';
 import type { CanonicalCaseResolution } from './types.js';
 
 export type CaseLinkType =
@@ -668,42 +668,6 @@ function insertMemoryEvent(input: {
       canonicalizeJSON(input.reason),
       createdAtMs(input.now)
     );
-}
-
-function expandCaseChainForAssembly(
-  adapter: CaseLinkAdapter,
-  terminalCaseId: string,
-  resolvedChain: string[]
-): string[] {
-  const rows = adapter
-    .prepare(
-      `
-        WITH RECURSIVE merged_chain(case_id, depth) AS (
-          SELECT case_id, 0
-            FROM case_truth
-           WHERE case_id = ?
-
-          UNION
-
-          SELECT ct.case_id, merged_chain.depth + 1
-            FROM case_truth ct
-            JOIN merged_chain ON ct.canonical_case_id = merged_chain.case_id
-           WHERE merged_chain.depth < 64
-        )
-        SELECT case_id
-          FROM merged_chain
-         ORDER BY depth ASC, case_id ASC
-      `
-    )
-    .all(terminalCaseId) as Array<{ case_id: string }>;
-
-  const chain: string[] = [];
-  for (const caseId of [...resolvedChain, ...rows.map((row) => row.case_id)]) {
-    if (!chain.includes(caseId)) {
-      chain.push(caseId);
-    }
-  }
-  return chain;
 }
 
 export function sha256TombstoneFingerprint(input: {

--- a/packages/mama-core/src/cases/composition-overrides.ts
+++ b/packages/mama-core/src/cases/composition-overrides.ts
@@ -609,6 +609,17 @@ function casCheck(input: {
   });
 
   if (!payload || payload.current_value_hash_hex !== sha256Hex(input.current_value_json)) {
+    if (payload) {
+      const replayEventId = deterministicEventId(payload.nonce);
+      if (memoryEventExists(input.adapter, replayEventId)) {
+        return {
+          kind: 'rejected',
+          code: 'case.reconfirm_token_replayed',
+          message: 'Reconfirm token has already been consumed.',
+          case_id: input.case_id,
+        };
+      }
+    }
     return buildRequiresReconfirm({
       case_id: input.case_id,
       target_ref_json: input.target_ref_json,

--- a/packages/mama-core/src/cases/composition-overrides.ts
+++ b/packages/mama-core/src/cases/composition-overrides.ts
@@ -1,0 +1,1088 @@
+import { createHash, createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
+
+import { canonicalizeJSON } from '../canonicalize.js';
+import type { DatabaseAdapter } from '../db-manager.js';
+import { runImmediateTransaction, type ImmediateTransactionAdapter } from './sqlite-transaction.js';
+import { resolveCanonicalCaseChain } from './store.js';
+import type { CanonicalCaseResolution, CaseMembershipSourceType } from './types.js';
+
+export interface CaseCompositionCasInput {
+  expected_current_value_json?: string | null;
+  reconfirm_token?: string | null;
+  session_id?: string | null;
+}
+
+export interface PinCaseMembershipInput extends CaseCompositionCasInput {
+  case_id: string;
+  source_type: CaseMembershipSourceType;
+  source_id: string;
+  pinned_by: string;
+  reason: string;
+  now?: string;
+}
+
+export interface UnpinCaseMembershipInput extends CaseCompositionCasInput {
+  case_id: string;
+  source_type: CaseMembershipSourceType;
+  source_id: string;
+  unpinned_by: string;
+  reason?: string | null;
+  now?: string;
+}
+
+export interface PromoteCaseSourceInput extends CaseCompositionCasInput {
+  case_id: string;
+  source_type: 'decision' | 'event' | 'observation' | 'artifact';
+  source_id: string;
+  promoted_by: string;
+  reason: string;
+  now?: string;
+}
+
+export interface CaseCompositionRequiresReconfirmResult {
+  kind: 'requires_reconfirm';
+  code: 'case.correction_requires_reconfirm';
+  case_id: string;
+  target_kind: 'membership';
+  target_ref_json: string;
+  current_value_json: string;
+  old_value_json: string | null;
+  proposed_new_value_json: string;
+  reconfirm_token: string;
+  reconfirm_token_expires_at: string;
+  message: string;
+}
+
+export type CaseCompositionRejectedCode =
+  | 'case.precompile_gap'
+  | 'case.terminal_status'
+  | 'case.membership_not_found'
+  | 'case.membership_stale'
+  | 'case.promote_invalid_source_type'
+  | 'case.promote_source_not_active'
+  | 'case.reconfirm_token_replayed';
+
+export type PinCaseMembershipResult =
+  | {
+      kind: 'pinned';
+      case_id: string;
+      terminal_case_id: string;
+      resolved_via_case_id: string | null;
+      chain: string[];
+      membership_case_id: string;
+    }
+  | CaseCompositionRequiresReconfirmResult
+  | { kind: 'rejected'; code: CaseCompositionRejectedCode; message: string; case_id?: string };
+
+export type UnpinCaseMembershipResult =
+  | {
+      kind: 'unpinned';
+      case_id: string;
+      terminal_case_id: string;
+      resolved_via_case_id: string | null;
+      chain: string[];
+      membership_case_id: string;
+    }
+  | CaseCompositionRequiresReconfirmResult
+  | { kind: 'rejected'; code: CaseCompositionRejectedCode; message: string; case_id?: string };
+
+export type PromoteCaseSourceResult =
+  | {
+      kind: 'promoted';
+      case_id: string;
+      terminal_case_id: string;
+      resolved_via_case_id: string | null;
+      chain: string[];
+      membership_case_id: string;
+      canonical_decision_id: string | null;
+      canonical_event_id: string | null;
+    }
+  | CaseCompositionRequiresReconfirmResult
+  | { kind: 'rejected'; code: CaseCompositionRejectedCode; message: string; case_id?: string };
+
+type CompositionAdapter = Pick<DatabaseAdapter, 'prepare' | 'transaction'> &
+  Partial<Pick<ImmediateTransactionAdapter, 'exec'>>;
+
+interface CaseGateRow {
+  case_id: string;
+  status: string;
+  canonical_decision_id: string | null;
+  canonical_event_id: string | null;
+}
+
+interface MembershipRow {
+  case_id: string;
+  source_type: CaseMembershipSourceType;
+  source_id: string;
+  status: string;
+  role: string | null;
+  confidence: number | null;
+  reason: string | null;
+  user_locked: number;
+  assignment_strategy: string | null;
+  assigned_at: string | null;
+  updated_at: string;
+}
+
+interface ReconfirmTokenPayload {
+  v: 1;
+  kid: string;
+  nonce: string;
+  case_id: string;
+  target_kind: 'membership';
+  target_ref_hash_hex: string;
+  current_value_hash_hex: string;
+  proposed_value_hash_hex: string;
+  confirmed_by: string;
+  session_id: string | null;
+  expires_at: string;
+}
+
+interface ReconfirmTokenEnvelope {
+  kid: string;
+  payload: ReconfirmTokenPayload;
+  signature_hex: string;
+}
+
+interface CurrentSecret {
+  kid: string;
+  secret: Buffer;
+}
+
+const TERMINAL_CASE_STATUSES = new Set(['merged', 'archived', 'split']);
+const RECONFIRM_TOKEN_TTL_MS = 10 * 60_000;
+
+function normalizeNow(value?: string): string {
+  return value ?? new Date().toISOString();
+}
+
+function timestampMs(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+function createdAtMs(value: string): number {
+  return timestampMs(value);
+}
+
+function sha256Hex(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function hmacHex(secret: Buffer, value: string): string {
+  return createHmac('sha256', secret).update(value, 'utf8').digest('hex');
+}
+
+function deterministicEventId(nonce: string): string {
+  return `me_${sha256Hex(`case-composition-reconfirm:v1:${nonce}`).slice(0, 32)}`;
+}
+
+function decodeSecret(raw: string): Buffer | null {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  if (/^[0-9a-f]+$/i.test(trimmed) && trimmed.length % 2 === 0) {
+    const hex = Buffer.from(trimmed, 'hex');
+    if (hex.length >= 32) {
+      return hex;
+    }
+  }
+
+  const base64 = Buffer.from(trimmed, 'base64');
+  if (base64.length >= 32) {
+    return base64;
+  }
+
+  const utf8 = Buffer.from(trimmed, 'utf8');
+  if (utf8.length >= 32) {
+    return utf8;
+  }
+
+  return null;
+}
+
+function secretKid(secret: Buffer): string {
+  return createHash('sha256').update(secret).digest('hex').slice(0, 16);
+}
+
+function currentSecret(): CurrentSecret {
+  const raw = process.env.MAMA_RECONFIRM_TOKEN_SECRET;
+  const secret = raw ? decodeSecret(raw) : null;
+  if (!secret) {
+    throw new Error('MAMA_RECONFIRM_TOKEN_SECRET must be a 32+ byte base64 or hex secret.');
+  }
+
+  return { kid: secretKid(secret), secret };
+}
+
+function verificationSecrets(): Map<string, Buffer> {
+  const secrets = new Map<string, Buffer>();
+  const current = currentSecret();
+  secrets.set(current.kid, current.secret);
+
+  for (const raw of (process.env.MAMA_RECONFIRM_TOKEN_OLD_SECRETS ?? '').split(',')) {
+    const secret = decodeSecret(raw);
+    if (secret) {
+      secrets.set(secretKid(secret), secret);
+    }
+  }
+
+  return secrets;
+}
+
+function encodeReconfirmToken(payload: ReconfirmTokenPayload, secret: Buffer): string {
+  const payloadJson = canonicalizeJSON(payload);
+  const envelope: ReconfirmTokenEnvelope = {
+    kid: payload.kid,
+    payload,
+    signature_hex: hmacHex(secret, payloadJson),
+  };
+
+  return Buffer.from(canonicalizeJSON(envelope), 'utf8').toString('base64url');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readReconfirmEnvelope(token: string): ReconfirmTokenEnvelope | null {
+  try {
+    const parsed = JSON.parse(Buffer.from(token, 'base64url').toString('utf8')) as unknown;
+    if (!isRecord(parsed) || !isRecord(parsed.payload)) {
+      return null;
+    }
+
+    const payload = parsed.payload;
+    if (
+      parsed.kid !== payload.kid ||
+      payload.v !== 1 ||
+      typeof parsed.kid !== 'string' ||
+      typeof parsed.signature_hex !== 'string' ||
+      typeof payload.kid !== 'string' ||
+      typeof payload.nonce !== 'string' ||
+      typeof payload.case_id !== 'string' ||
+      payload.target_kind !== 'membership' ||
+      typeof payload.target_ref_hash_hex !== 'string' ||
+      typeof payload.current_value_hash_hex !== 'string' ||
+      typeof payload.proposed_value_hash_hex !== 'string' ||
+      typeof payload.confirmed_by !== 'string' ||
+      !(payload.session_id === null || typeof payload.session_id === 'string') ||
+      typeof payload.expires_at !== 'string'
+    ) {
+      return null;
+    }
+
+    return {
+      kid: parsed.kid,
+      payload: payload as unknown as ReconfirmTokenPayload,
+      signature_hex: parsed.signature_hex,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function verifyReconfirmToken(input: {
+  token: string;
+  case_id: string;
+  target_ref_hash_hex: string;
+  proposed_value_hash_hex: string;
+  confirmed_by: string;
+  session_id: string | null;
+  now: string;
+}): ReconfirmTokenPayload | null {
+  const envelope = readReconfirmEnvelope(input.token);
+  if (!envelope) {
+    return null;
+  }
+
+  const secret = verificationSecrets().get(envelope.kid);
+  if (!secret) {
+    return null;
+  }
+
+  const expected = Buffer.from(hmacHex(secret, canonicalizeJSON(envelope.payload)), 'hex');
+  const actual = Buffer.from(envelope.signature_hex, 'hex');
+  if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
+    return null;
+  }
+
+  const expiresAtMs = Date.parse(envelope.payload.expires_at);
+  if (!Number.isFinite(expiresAtMs) || expiresAtMs <= timestampMs(input.now)) {
+    return null;
+  }
+
+  if (
+    envelope.payload.case_id !== input.case_id ||
+    envelope.payload.target_ref_hash_hex !== input.target_ref_hash_hex ||
+    envelope.payload.proposed_value_hash_hex !== input.proposed_value_hash_hex ||
+    envelope.payload.confirmed_by !== input.confirmed_by ||
+    envelope.payload.session_id !== input.session_id
+  ) {
+    return null;
+  }
+
+  return envelope.payload;
+}
+
+function buildRequiresReconfirm(input: {
+  case_id: string;
+  target_ref_json: string;
+  target_ref_hash_hex: string;
+  current_value_json: string;
+  old_value_json: string | null;
+  proposed_new_value_json: string;
+  confirmed_by: string;
+  session_id: string | null;
+  now: string;
+}): CaseCompositionRequiresReconfirmResult {
+  const secret = currentSecret();
+  const expiresAt = new Date(timestampMs(input.now) + RECONFIRM_TOKEN_TTL_MS).toISOString();
+  const payload: ReconfirmTokenPayload = {
+    v: 1,
+    kid: secret.kid,
+    nonce: randomUUID(),
+    case_id: input.case_id,
+    target_kind: 'membership',
+    target_ref_hash_hex: input.target_ref_hash_hex,
+    current_value_hash_hex: sha256Hex(input.current_value_json),
+    proposed_value_hash_hex: sha256Hex(input.proposed_new_value_json),
+    confirmed_by: input.confirmed_by,
+    session_id: input.session_id,
+    expires_at: expiresAt,
+  };
+
+  return {
+    kind: 'requires_reconfirm',
+    code: 'case.correction_requires_reconfirm',
+    case_id: input.case_id,
+    target_kind: 'membership',
+    target_ref_json: input.target_ref_json,
+    current_value_json: input.current_value_json,
+    old_value_json: input.old_value_json,
+    proposed_new_value_json: input.proposed_new_value_json,
+    reconfirm_token: encodeReconfirmToken(payload, secret.secret),
+    reconfirm_token_expires_at: expiresAt,
+    message: 'The target changed since the viewed snapshot. Reconfirm against the current value.',
+  };
+}
+
+function parseJsonValue(value: string): unknown {
+  return JSON.parse(value) as unknown;
+}
+
+function canonicalExpectedJson(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  return canonicalizeJSON(parseJsonValue(value));
+}
+
+function placeholders(values: readonly unknown[]): string {
+  if (values.length === 0) {
+    throw new Error('Cannot build SQL IN clause for an empty value list.');
+  }
+  return values.map(() => '?').join(', ');
+}
+
+function resolveChain(adapter: CompositionAdapter, caseId: string): CanonicalCaseResolution | null {
+  try {
+    return resolveCanonicalCaseChain(adapter, caseId);
+  } catch (error) {
+    if (error instanceof Error && /not found/i.test(error.message)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function expandCaseChainForAssembly(
+  adapter: CompositionAdapter,
+  terminalCaseId: string,
+  resolvedChain: string[]
+): string[] {
+  const rows = adapter
+    .prepare(
+      `
+        WITH RECURSIVE merged_chain(case_id, depth) AS (
+          SELECT case_id, 0
+            FROM case_truth
+           WHERE case_id = ?
+
+          UNION
+
+          SELECT ct.case_id, merged_chain.depth + 1
+            FROM case_truth ct
+            JOIN merged_chain ON ct.canonical_case_id = merged_chain.case_id
+           WHERE merged_chain.depth < 64
+        )
+        SELECT case_id
+          FROM merged_chain
+         ORDER BY depth ASC, case_id ASC
+      `
+    )
+    .all(terminalCaseId) as Array<{ case_id: string }>;
+
+  const chain: string[] = [];
+  for (const caseId of [...resolvedChain, ...rows.map((row) => row.case_id)]) {
+    if (!chain.includes(caseId)) {
+      chain.push(caseId);
+    }
+  }
+  return chain;
+}
+
+function loadCaseGate(adapter: CompositionAdapter, caseId: string): CaseGateRow | null {
+  const row = adapter
+    .prepare(
+      `
+        SELECT case_id, status, canonical_decision_id, canonical_event_id
+        FROM case_truth
+        WHERE case_id = ?
+      `
+    )
+    .get(caseId) as CaseGateRow | undefined;
+
+  return row ?? null;
+}
+
+function findMembership(
+  adapter: CompositionAdapter,
+  chain: string[],
+  sourceType: CaseMembershipSourceType,
+  sourceId: string
+): MembershipRow | null {
+  const row = adapter
+    .prepare(
+      `
+        SELECT case_id, source_type, source_id, status, role, confidence, reason,
+               user_locked, assignment_strategy, added_at AS assigned_at, updated_at
+        FROM case_memberships
+        WHERE case_id IN (${placeholders(chain)})
+          AND source_type = ?
+          AND source_id = ?
+        ORDER BY
+          CASE status
+            WHEN 'active' THEN 0
+            WHEN 'candidate' THEN 1
+            WHEN 'excluded' THEN 2
+            WHEN 'removed' THEN 3
+            ELSE 4
+          END ASC,
+          user_locked DESC,
+          updated_at DESC,
+          case_id ASC
+        LIMIT 1
+      `
+    )
+    .get(...chain, sourceType, sourceId) as MembershipRow | undefined;
+
+  return row ?? null;
+}
+
+function membershipTargetRefJson(input: { source_type: string; source_id: string }): string {
+  return canonicalizeJSON({
+    kind: 'membership',
+    source_type: input.source_type,
+    source_id: input.source_id,
+  });
+}
+
+function membershipSnapshot(row: MembershipRow): Record<string, unknown> {
+  return {
+    case_id: row.case_id,
+    source_type: row.source_type,
+    source_id: row.source_id,
+    status: row.status,
+    role: row.role,
+    confidence: row.confidence,
+    reason: row.reason,
+    user_locked: Number(row.user_locked) === 1 ? 1 : 0,
+    assignment_strategy: row.assignment_strategy,
+    assigned_at: row.assigned_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function appendReason(existing: string | null, reason: string): string {
+  if (!existing || existing.trim().length === 0) {
+    return reason;
+  }
+  return `${existing}\nmanual-pin: ${reason}`;
+}
+
+function insertMemoryEvent(input: {
+  adapter: CompositionAdapter;
+  event_type: 'case.membership_pinned' | 'case.membership_unpinned' | 'case.source_promoted';
+  event_id?: string;
+  actor: string;
+  case_id: string;
+  evidence_refs: unknown[];
+  reason: unknown;
+  now: string;
+}): void {
+  input.adapter
+    .prepare(
+      `
+        INSERT INTO memory_events (
+          event_id, event_type, actor, source_turn_id, memory_id, topic,
+          scope_refs, evidence_refs, reason, created_at
+        )
+        VALUES (?, ?, ?, NULL, NULL, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      input.event_id ?? `me_${randomUUID()}`,
+      input.event_type,
+      input.actor,
+      `case:${input.case_id}`,
+      canonicalizeJSON([{ type: 'case', id: input.case_id }]),
+      canonicalizeJSON(input.evidence_refs),
+      canonicalizeJSON(input.reason),
+      createdAtMs(input.now)
+    );
+}
+
+function memoryEventExists(adapter: CompositionAdapter, eventId: string): boolean {
+  const row = adapter
+    .prepare('SELECT event_id FROM memory_events WHERE event_id = ?')
+    .get(eventId) as { event_id: string } | undefined;
+  return Boolean(row);
+}
+
+function casCheck(input: {
+  adapter: CompositionAdapter;
+  case_id: string;
+  target_ref_json: string;
+  current_value_json: string;
+  expected_current_value_json?: string | null;
+  proposed_new_value_json: string;
+  actor: string;
+  session_id?: string | null;
+  reconfirm_token?: string | null;
+  now: string;
+}):
+  | { kind: 'ok'; event_id?: string }
+  | CaseCompositionRequiresReconfirmResult
+  | { kind: 'rejected'; code: 'case.reconfirm_token_replayed'; message: string; case_id: string } {
+  const canonicalExpectedCurrent = canonicalExpectedJson(input.expected_current_value_json);
+  if (canonicalExpectedCurrent === null || canonicalExpectedCurrent === input.current_value_json) {
+    return { kind: 'ok' };
+  }
+
+  const targetRefHashHex = sha256Hex(input.target_ref_json);
+  const token = input.reconfirm_token ?? null;
+  if (!token) {
+    return buildRequiresReconfirm({
+      case_id: input.case_id,
+      target_ref_json: input.target_ref_json,
+      target_ref_hash_hex: targetRefHashHex,
+      current_value_json: input.current_value_json,
+      old_value_json: input.expected_current_value_json ?? null,
+      proposed_new_value_json: input.proposed_new_value_json,
+      confirmed_by: input.actor,
+      session_id: input.session_id ?? null,
+      now: input.now,
+    });
+  }
+
+  const payload = verifyReconfirmToken({
+    token,
+    case_id: input.case_id,
+    target_ref_hash_hex: targetRefHashHex,
+    proposed_value_hash_hex: sha256Hex(input.proposed_new_value_json),
+    confirmed_by: input.actor,
+    session_id: input.session_id ?? null,
+    now: input.now,
+  });
+
+  if (!payload || payload.current_value_hash_hex !== sha256Hex(input.current_value_json)) {
+    return buildRequiresReconfirm({
+      case_id: input.case_id,
+      target_ref_json: input.target_ref_json,
+      target_ref_hash_hex: targetRefHashHex,
+      current_value_json: input.current_value_json,
+      old_value_json: input.expected_current_value_json ?? null,
+      proposed_new_value_json: input.proposed_new_value_json,
+      confirmed_by: input.actor,
+      session_id: input.session_id ?? null,
+      now: input.now,
+    });
+  }
+
+  const eventId = deterministicEventId(payload.nonce);
+  if (memoryEventExists(input.adapter, eventId)) {
+    return {
+      kind: 'rejected',
+      code: 'case.reconfirm_token_replayed',
+      message: 'Reconfirm token has already been consumed.',
+      case_id: input.case_id,
+    };
+  }
+
+  return { kind: 'ok', event_id: eventId };
+}
+
+export function pinCaseMembership(
+  adapter: DatabaseAdapter,
+  input: PinCaseMembershipInput
+): PinCaseMembershipResult {
+  const compositionAdapter = adapter as unknown as CompositionAdapter;
+
+  return runImmediateTransaction(compositionAdapter, () => {
+    const now = normalizeNow(input.now);
+    const resolution = resolveChain(compositionAdapter, input.case_id);
+    if (!resolution) {
+      return {
+        kind: 'rejected',
+        code: 'case.precompile_gap',
+        message: `Case ${input.case_id} does not exist.`,
+        case_id: input.case_id,
+      };
+    }
+
+    const terminalCase = loadCaseGate(compositionAdapter, resolution.terminal_case_id);
+    if (!terminalCase) {
+      return {
+        kind: 'rejected',
+        code: 'case.precompile_gap',
+        message: `Case ${resolution.terminal_case_id} does not exist.`,
+        case_id: resolution.terminal_case_id,
+      };
+    }
+
+    if (TERMINAL_CASE_STATUSES.has(terminalCase.status)) {
+      return {
+        kind: 'rejected',
+        code: 'case.terminal_status',
+        message: `Cannot pin membership on terminal case status ${terminalCase.status}.`,
+        case_id: terminalCase.case_id,
+      };
+    }
+
+    const chain = expandCaseChainForAssembly(
+      compositionAdapter,
+      resolution.terminal_case_id,
+      resolution.chain
+    );
+    const membership = findMembership(
+      compositionAdapter,
+      chain,
+      input.source_type,
+      input.source_id
+    );
+
+    if (!membership) {
+      return {
+        kind: 'rejected',
+        code: 'case.membership_not_found',
+        message: 'Membership row was not found in the canonical case chain.',
+        case_id: resolution.terminal_case_id,
+      };
+    }
+
+    if (membership.status === 'stale') {
+      return {
+        kind: 'rejected',
+        code: 'case.membership_stale',
+        message: 'Stale memberships cannot be pinned.',
+        case_id: membership.case_id,
+      };
+    }
+
+    const targetRefJson = membershipTargetRefJson(input);
+    const newReason = appendReason(membership.reason, input.reason);
+    const currentValueJson = canonicalizeJSON(membershipSnapshot(membership));
+    const proposedNewValueJson = canonicalizeJSON({
+      ...membershipSnapshot(membership),
+      user_locked: 1,
+      assignment_strategy: 'manual-pin',
+      reason: newReason,
+    });
+    const cas = casCheck({
+      adapter: compositionAdapter,
+      case_id: resolution.terminal_case_id,
+      target_ref_json: targetRefJson,
+      current_value_json: currentValueJson,
+      expected_current_value_json: input.expected_current_value_json,
+      proposed_new_value_json: proposedNewValueJson,
+      actor: input.pinned_by,
+      session_id: input.session_id,
+      reconfirm_token: input.reconfirm_token,
+      now,
+    });
+    if (cas.kind !== 'ok') {
+      return cas;
+    }
+
+    compositionAdapter
+      .prepare(
+        `
+          UPDATE case_memberships
+          SET user_locked = 1,
+              assignment_strategy = 'manual-pin',
+              reason = ?,
+              updated_at = ?,
+              explanation_updated_at = ?
+          WHERE case_id = ?
+            AND source_type = ?
+            AND source_id = ?
+            AND status <> 'stale'
+        `
+      )
+      .run(newReason, now, now, membership.case_id, membership.source_type, membership.source_id);
+
+    insertMemoryEvent({
+      adapter: compositionAdapter,
+      event_type: 'case.membership_pinned',
+      event_id: cas.event_id,
+      actor: input.pinned_by,
+      case_id: resolution.terminal_case_id,
+      evidence_refs: [membership.source_id],
+      reason: {
+        source_type: membership.source_type,
+        source_id: membership.source_id,
+        membership_case_id: membership.case_id,
+        reason: input.reason,
+      },
+      now,
+    });
+
+    return {
+      kind: 'pinned',
+      case_id: input.case_id,
+      terminal_case_id: resolution.terminal_case_id,
+      resolved_via_case_id: resolution.resolved_via_case_id,
+      chain,
+      membership_case_id: membership.case_id,
+    };
+  });
+}
+
+export function unpinCaseMembership(
+  adapter: DatabaseAdapter,
+  input: UnpinCaseMembershipInput
+): UnpinCaseMembershipResult {
+  const compositionAdapter = adapter as unknown as CompositionAdapter;
+
+  return runImmediateTransaction(compositionAdapter, () => {
+    const now = normalizeNow(input.now);
+    const resolution = resolveChain(compositionAdapter, input.case_id);
+    if (!resolution) {
+      return {
+        kind: 'rejected',
+        code: 'case.precompile_gap',
+        message: `Case ${input.case_id} does not exist.`,
+        case_id: input.case_id,
+      };
+    }
+
+    const terminalCase = loadCaseGate(compositionAdapter, resolution.terminal_case_id);
+    if (!terminalCase) {
+      return {
+        kind: 'rejected',
+        code: 'case.precompile_gap',
+        message: `Case ${resolution.terminal_case_id} does not exist.`,
+        case_id: resolution.terminal_case_id,
+      };
+    }
+
+    if (TERMINAL_CASE_STATUSES.has(terminalCase.status)) {
+      return {
+        kind: 'rejected',
+        code: 'case.terminal_status',
+        message: `Cannot unpin membership on terminal case status ${terminalCase.status}.`,
+        case_id: terminalCase.case_id,
+      };
+    }
+
+    const chain = expandCaseChainForAssembly(
+      compositionAdapter,
+      resolution.terminal_case_id,
+      resolution.chain
+    );
+    const membership = findMembership(
+      compositionAdapter,
+      chain,
+      input.source_type,
+      input.source_id
+    );
+
+    if (!membership) {
+      return {
+        kind: 'rejected',
+        code: 'case.membership_not_found',
+        message: 'Membership row was not found in the canonical case chain.',
+        case_id: resolution.terminal_case_id,
+      };
+    }
+
+    if (membership.status === 'stale') {
+      return {
+        kind: 'rejected',
+        code: 'case.membership_stale',
+        message: 'Stale memberships cannot be unpinned.',
+        case_id: membership.case_id,
+      };
+    }
+
+    const targetRefJson = membershipTargetRefJson(input);
+    const currentValueJson = canonicalizeJSON(membershipSnapshot(membership));
+    const proposedNewValueJson = canonicalizeJSON({
+      ...membershipSnapshot(membership),
+      user_locked: 0,
+    });
+    const cas = casCheck({
+      adapter: compositionAdapter,
+      case_id: resolution.terminal_case_id,
+      target_ref_json: targetRefJson,
+      current_value_json: currentValueJson,
+      expected_current_value_json: input.expected_current_value_json,
+      proposed_new_value_json: proposedNewValueJson,
+      actor: input.unpinned_by,
+      session_id: input.session_id,
+      reconfirm_token: input.reconfirm_token,
+      now,
+    });
+    if (cas.kind !== 'ok') {
+      return cas;
+    }
+
+    compositionAdapter
+      .prepare(
+        `
+          UPDATE case_memberships
+          SET user_locked = 0,
+              updated_at = ?
+          WHERE case_id = ?
+            AND source_type = ?
+            AND source_id = ?
+            AND status <> 'stale'
+        `
+      )
+      .run(now, membership.case_id, membership.source_type, membership.source_id);
+
+    insertMemoryEvent({
+      adapter: compositionAdapter,
+      event_type: 'case.membership_unpinned',
+      event_id: cas.event_id,
+      actor: input.unpinned_by,
+      case_id: resolution.terminal_case_id,
+      evidence_refs: [membership.source_id],
+      reason: {
+        source_type: membership.source_type,
+        source_id: membership.source_id,
+        membership_case_id: membership.case_id,
+        reason: input.reason ?? null,
+      },
+      now,
+    });
+
+    return {
+      kind: 'unpinned',
+      case_id: input.case_id,
+      terminal_case_id: resolution.terminal_case_id,
+      resolved_via_case_id: resolution.resolved_via_case_id,
+      chain,
+      membership_case_id: membership.case_id,
+    };
+  });
+}
+
+export function promoteCaseSource(
+  adapter: DatabaseAdapter,
+  input: PromoteCaseSourceInput
+): PromoteCaseSourceResult {
+  const compositionAdapter = adapter as unknown as CompositionAdapter;
+
+  return runImmediateTransaction(compositionAdapter, () => {
+    const now = normalizeNow(input.now);
+
+    if (input.source_type !== 'decision' && input.source_type !== 'event') {
+      return {
+        kind: 'rejected',
+        code: 'case.promote_invalid_source_type',
+        message: 'Only decision and event memberships can be promoted.',
+        case_id: input.case_id,
+      };
+    }
+
+    const resolution = resolveChain(compositionAdapter, input.case_id);
+    if (!resolution) {
+      return {
+        kind: 'rejected',
+        code: 'case.precompile_gap',
+        message: `Case ${input.case_id} does not exist.`,
+        case_id: input.case_id,
+      };
+    }
+
+    const terminalCase = loadCaseGate(compositionAdapter, resolution.terminal_case_id);
+    if (!terminalCase) {
+      return {
+        kind: 'rejected',
+        code: 'case.precompile_gap',
+        message: `Case ${resolution.terminal_case_id} does not exist.`,
+        case_id: resolution.terminal_case_id,
+      };
+    }
+
+    if (TERMINAL_CASE_STATUSES.has(terminalCase.status)) {
+      return {
+        kind: 'rejected',
+        code: 'case.terminal_status',
+        message: `Cannot promote source on terminal case status ${terminalCase.status}.`,
+        case_id: terminalCase.case_id,
+      };
+    }
+
+    const chain = expandCaseChainForAssembly(
+      compositionAdapter,
+      resolution.terminal_case_id,
+      resolution.chain
+    );
+    const membership = findMembership(
+      compositionAdapter,
+      chain,
+      input.source_type,
+      input.source_id
+    );
+
+    if (!membership || membership.status !== 'active') {
+      return {
+        kind: 'rejected',
+        code: 'case.promote_source_not_active',
+        message: 'Promoted source must be an active membership in the canonical case chain.',
+        case_id: resolution.terminal_case_id,
+      };
+    }
+
+    const targetRefJson = membershipTargetRefJson(input);
+    const currentValueJson = canonicalizeJSON({
+      promotion: {
+        canonical_decision_id: terminalCase.canonical_decision_id,
+        canonical_event_id: terminalCase.canonical_event_id,
+      },
+      membership: membershipSnapshot(membership),
+    });
+    const proposedCanonicalDecisionId =
+      input.source_type === 'decision' ? input.source_id : terminalCase.canonical_decision_id;
+    const proposedCanonicalEventId =
+      input.source_type === 'event' ? input.source_id : terminalCase.canonical_event_id;
+    const proposedNewValueJson = canonicalizeJSON({
+      promotion: {
+        canonical_decision_id: proposedCanonicalDecisionId,
+        canonical_event_id: proposedCanonicalEventId,
+        promoted_at: now,
+        promoted_by: input.promoted_by,
+        promotion_reason: input.reason,
+      },
+      membership: {
+        ...membershipSnapshot(membership),
+        user_locked: 1,
+      },
+    });
+    const cas = casCheck({
+      adapter: compositionAdapter,
+      case_id: resolution.terminal_case_id,
+      target_ref_json: targetRefJson,
+      current_value_json: currentValueJson,
+      expected_current_value_json: input.expected_current_value_json,
+      proposed_new_value_json: proposedNewValueJson,
+      actor: input.promoted_by,
+      session_id: input.session_id,
+      reconfirm_token: input.reconfirm_token,
+      now,
+    });
+    if (cas.kind !== 'ok') {
+      return cas;
+    }
+
+    if (input.source_type === 'decision') {
+      compositionAdapter
+        .prepare(
+          `
+            UPDATE case_truth
+            SET canonical_decision_id = ?,
+                promoted_at = ?,
+                promoted_by = ?,
+                promotion_reason = ?,
+                updated_at = ?
+            WHERE case_id = ?
+          `
+        )
+        .run(
+          input.source_id,
+          now,
+          input.promoted_by,
+          input.reason,
+          now,
+          resolution.terminal_case_id
+        );
+    } else {
+      compositionAdapter
+        .prepare(
+          `
+            UPDATE case_truth
+            SET canonical_event_id = ?,
+                promoted_at = ?,
+                promoted_by = ?,
+                promotion_reason = ?,
+                updated_at = ?
+            WHERE case_id = ?
+          `
+        )
+        .run(
+          input.source_id,
+          now,
+          input.promoted_by,
+          input.reason,
+          now,
+          resolution.terminal_case_id
+        );
+    }
+
+    compositionAdapter
+      .prepare(
+        `
+          UPDATE case_memberships
+          SET user_locked = 1,
+              updated_at = ?
+          WHERE case_id = ?
+            AND source_type = ?
+            AND source_id = ?
+            AND status = 'active'
+        `
+      )
+      .run(now, membership.case_id, membership.source_type, membership.source_id);
+
+    insertMemoryEvent({
+      adapter: compositionAdapter,
+      event_type: 'case.source_promoted',
+      event_id: cas.event_id,
+      actor: input.promoted_by,
+      case_id: resolution.terminal_case_id,
+      evidence_refs: [membership.source_id],
+      reason: {
+        source_type: membership.source_type,
+        source_id: membership.source_id,
+        membership_case_id: membership.case_id,
+        reason: input.reason,
+      },
+      now,
+    });
+
+    return {
+      kind: 'promoted',
+      case_id: input.case_id,
+      terminal_case_id: resolution.terminal_case_id,
+      resolved_via_case_id: resolution.resolved_via_case_id,
+      chain,
+      membership_case_id: membership.case_id,
+      canonical_decision_id: proposedCanonicalDecisionId,
+      canonical_event_id: proposedCanonicalEventId,
+    };
+  });
+}

--- a/packages/mama-core/src/cases/composition-overrides.ts
+++ b/packages/mama-core/src/cases/composition-overrides.ts
@@ -3,7 +3,7 @@ import { createHash, createHmac, randomUUID, timingSafeEqual } from 'node:crypto
 import { canonicalizeJSON } from '../canonicalize.js';
 import type { DatabaseAdapter } from '../db-manager.js';
 import { runImmediateTransaction, type ImmediateTransactionAdapter } from './sqlite-transaction.js';
-import { resolveCanonicalCaseChain } from './store.js';
+import { expandCaseChainForAssembly, resolveCanonicalCaseChain } from './store.js';
 import type { CanonicalCaseResolution, CaseMembershipSourceType } from './types.js';
 
 export interface CaseCompositionCasInput {
@@ -396,42 +396,6 @@ function resolveChain(adapter: CompositionAdapter, caseId: string): CanonicalCas
     }
     throw error;
   }
-}
-
-function expandCaseChainForAssembly(
-  adapter: CompositionAdapter,
-  terminalCaseId: string,
-  resolvedChain: string[]
-): string[] {
-  const rows = adapter
-    .prepare(
-      `
-        WITH RECURSIVE merged_chain(case_id, depth) AS (
-          SELECT case_id, 0
-            FROM case_truth
-           WHERE case_id = ?
-
-          UNION
-
-          SELECT ct.case_id, merged_chain.depth + 1
-            FROM case_truth ct
-            JOIN merged_chain ON ct.canonical_case_id = merged_chain.case_id
-           WHERE merged_chain.depth < 64
-        )
-        SELECT case_id
-          FROM merged_chain
-         ORDER BY depth ASC, case_id ASC
-      `
-    )
-    .all(terminalCaseId) as Array<{ case_id: string }>;
-
-  const chain: string[] = [];
-  for (const caseId of [...resolvedChain, ...rows.map((row) => row.case_id)]) {
-    if (!chain.includes(caseId)) {
-      chain.push(caseId);
-    }
-  }
-  return chain;
 }
 
 function loadCaseGate(adapter: CompositionAdapter, caseId: string): CaseGateRow | null {

--- a/packages/mama-core/src/cases/composition-overrides.ts
+++ b/packages/mama-core/src/cases/composition-overrides.ts
@@ -975,7 +975,6 @@ export function promoteCaseSource(
       promotion: {
         canonical_decision_id: proposedCanonicalDecisionId,
         canonical_event_id: proposedCanonicalEventId,
-        promoted_at: now,
         promoted_by: input.promoted_by,
         promotion_reason: input.reason,
       },

--- a/packages/mama-core/src/cases/composition-overrides.ts
+++ b/packages/mama-core/src/cases/composition-overrides.ts
@@ -510,7 +510,17 @@ function appendReason(existing: string | null, reason: string): string {
   if (!existing || existing.trim().length === 0) {
     return reason;
   }
-  return `${existing}\nmanual-pin: ${reason}`;
+  const lines = existing.split('\n');
+  const lastLine = lines.at(-1)?.trim() ?? '';
+  const nextLine = `manual-pin: ${reason}`;
+  if (lastLine === nextLine) {
+    return existing;
+  }
+  if (lastLine.startsWith('manual-pin:')) {
+    lines[lines.length - 1] = nextLine;
+    return lines.join('\n');
+  }
+  return `${existing}\n${nextLine}`;
 }
 
 function insertMemoryEvent(input: {

--- a/packages/mama-core/src/cases/composition-overrides.ts
+++ b/packages/mama-core/src/cases/composition-overrides.ts
@@ -818,6 +818,7 @@ export function unpinCaseMembership(
     const proposedNewValueJson = canonicalizeJSON({
       ...membershipSnapshot(membership),
       user_locked: 0,
+      assignment_strategy: null,
     });
     const cas = casCheck({
       adapter: compositionAdapter,
@@ -840,6 +841,7 @@ export function unpinCaseMembership(
         `
           UPDATE case_memberships
           SET user_locked = 0,
+              assignment_strategy = NULL,
               updated_at = ?
           WHERE case_id = ?
             AND source_type = ?

--- a/packages/mama-core/src/cases/corrections.ts
+++ b/packages/mama-core/src/cases/corrections.ts
@@ -12,6 +12,7 @@ export type CaseCorrectionErrorCode =
   | 'case.correction_active_conflict'
   | 'case.correction_not_found'
   | 'case.correction_reverted'
+  | 'case.correction_inactive'
   | 'case.correction_already_superseded'
   | 'case.supersede_target_mismatch'
   | 'case.reconfirm_token_invalid'
@@ -57,6 +58,7 @@ export interface RevertCorrectionInput {
 
 export type CorrectionRevertResult =
   | { kind: 'reverted'; correction_id: string; case_id: string }
+  | { kind: 'precompile_gap'; code: 'case.precompile_gap'; case_id: string }
   | { kind: 'rejected'; code: CaseCorrectionErrorCode; message: string; correction_id?: string };
 
 export interface SupersedeCorrectionInput {
@@ -181,6 +183,7 @@ interface CorrectionStatusRow {
   old_value_json: string | null;
   is_lock_active: number;
   reverted_at: string | null;
+  superseded_by?: string | null;
 }
 
 interface CurrentSecret {
@@ -229,6 +232,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function parseJsonValue(value: string): unknown {
   return JSON.parse(value) as unknown;
+}
+
+function canonicalJsonOrNull(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  return canonicalizeJSON(parseJsonValue(value));
 }
 
 function nullableString(value: unknown): string | null {
@@ -974,9 +984,10 @@ export function applyCorrection(
     const canonical = canonicalTargetRef(input.target_ref);
     const targetRefHashHex = canonical.hash.toString('hex');
     const currentValueJson = readCurrentValueJson(correctionAdapter, input);
+    const expectedOldValueJson = canonicalJsonOrNull(input.old_value_json);
     let correctionId = randomCorrectionId();
 
-    if (typeof input.old_value_json === 'string' && input.old_value_json !== currentValueJson) {
+    if (expectedOldValueJson !== null && expectedOldValueJson !== currentValueJson) {
       const token = input.reconfirm_token ?? null;
       if (!token) {
         return buildRequiresReconfirm({
@@ -985,7 +996,7 @@ export function applyCorrection(
           target_ref_json: canonical.json,
           target_ref_hash_hex: targetRefHashHex,
           current_value_json: currentValueJson,
-          old_value_json: input.old_value_json,
+          old_value_json: expectedOldValueJson,
           proposed_new_value_json: input.new_value_json,
           confirmed_by: input.confirmed_by,
           session_id: input.session_id ?? null,
@@ -1011,7 +1022,7 @@ export function applyCorrection(
           target_ref_json: canonical.json,
           target_ref_hash_hex: targetRefHashHex,
           current_value_json: currentValueJson,
-          old_value_json: input.old_value_json,
+          old_value_json: expectedOldValueJson,
           proposed_new_value_json: input.new_value_json,
           confirmed_by: input.confirmed_by,
           session_id: input.session_id ?? null,
@@ -1036,7 +1047,7 @@ export function applyCorrection(
           target_ref_json: canonical.json,
           target_ref_hash_hex: targetRefHashHex,
           current_value_json: currentValueJson,
-          old_value_json: input.old_value_json,
+          old_value_json: expectedOldValueJson,
           proposed_new_value_json: input.new_value_json,
           confirmed_by: input.confirmed_by,
           session_id: input.session_id ?? null,
@@ -1117,6 +1128,7 @@ export function revertCorrection(
         `
           SELECT correction_id, case_id, target_kind, target_ref_json, field_name,
                  old_value_json, is_lock_active, reverted_at
+                 , superseded_by
           FROM case_corrections
           WHERE correction_id = ?
         `
@@ -1132,12 +1144,48 @@ export function revertCorrection(
       };
     }
 
-    if (row.reverted_at !== null || Number(row.is_lock_active) === 0) {
+    if (row.reverted_at !== null) {
       return {
         kind: 'rejected',
         code: 'case.correction_reverted',
         message: 'Correction has already been reverted.',
         correction_id: input.correction_id,
+      };
+    }
+    if (Number(row.is_lock_active) === 0 && row.superseded_by) {
+      return {
+        kind: 'rejected',
+        code: 'case.correction_already_superseded',
+        message: 'Correction has already been superseded.',
+        correction_id: input.correction_id,
+      };
+    }
+    if (Number(row.is_lock_active) === 0) {
+      return {
+        kind: 'rejected',
+        code: 'case.correction_inactive',
+        message: 'Correction is inactive.',
+        correction_id: input.correction_id,
+      };
+    }
+
+    const caseRow = correctionAdapter
+      .prepare('SELECT status, canonical_case_id FROM case_truth WHERE case_id = ?')
+      .get(row.case_id) as CaseGateRow | undefined;
+
+    if (!caseRow) {
+      return {
+        kind: 'precompile_gap',
+        code: 'case.precompile_gap',
+        case_id: row.case_id,
+      };
+    }
+    if (TERMINAL_CASE_STATUSES.has(caseRow.status)) {
+      return {
+        kind: 'rejected',
+        code: 'case.terminal_status',
+        message: 'Case is in a terminal status.',
+        case_id: row.case_id,
       };
     }
 
@@ -1258,10 +1306,18 @@ export function supersedeCorrection(
     }
 
     if (Number(old.is_lock_active) === 0) {
+      if (old.superseded_by !== null) {
+        return {
+          kind: 'rejected',
+          code: 'case.correction_already_superseded',
+          message: 'Correction has already been superseded.',
+          correction_id: input.old_correction_id,
+        };
+      }
       return {
         kind: 'rejected',
-        code: 'case.correction_reverted',
-        message: 'Cannot supersede an inactive correction.',
+        code: 'case.correction_inactive',
+        message: 'Correction is inactive.',
         correction_id: input.old_correction_id,
       };
     }

--- a/packages/mama-core/src/cases/corrections.ts
+++ b/packages/mama-core/src/cases/corrections.ts
@@ -1,0 +1,1439 @@
+import { createHash, createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
+
+import { canonicalizeJSON } from '../canonicalize.js';
+import type { DatabaseAdapter } from '../db-manager.js';
+import { runImmediateTransaction, type ImmediateTransactionAdapter } from './sqlite-transaction.js';
+import { canonicalTargetRef, type CaseTargetRef } from './target-ref.js';
+import type { CaseCorrectionRequiresReconfirmResult } from './types.js';
+
+export type CaseCorrectionErrorCode =
+  | 'case.precompile_gap'
+  | 'case.correction_requires_reconfirm'
+  | 'case.correction_active_conflict'
+  | 'case.correction_not_found'
+  | 'case.correction_reverted'
+  | 'case.correction_already_superseded'
+  | 'case.supersede_target_mismatch'
+  | 'case.reconfirm_token_invalid'
+  | 'case.reconfirm_token_replayed'
+  | 'case.terminal_status'
+  | 'case.lock_held';
+
+export interface ApplyCorrectionInput {
+  case_id: string;
+  target_kind: 'case_field' | 'membership' | 'wiki_section';
+  target_ref: CaseTargetRef;
+  field_name?: 'status' | 'status_reason' | 'primary_actors' | 'blockers' | 'confidence';
+  old_value_json?: string | null;
+  reconfirm_token?: string | null;
+  session_id?: string | null;
+  new_value_json: string;
+  reason: string;
+  confirmed: true;
+  confirmed_by: string;
+  confirmation_summary: string;
+  now?: string;
+}
+
+export type CorrectionApplyResult =
+  | {
+      kind: 'applied';
+      correction_id: string;
+      case_id: string;
+      target_ref_json: string;
+      canonical_hash_hex: string;
+    }
+  | CaseCorrectionRequiresReconfirmResult
+  | { kind: 'precompile_gap'; code: 'case.precompile_gap'; case_id: string }
+  | { kind: 'rejected'; code: CaseCorrectionErrorCode; message: string; case_id: string };
+
+export interface RevertCorrectionInput {
+  correction_id: string;
+  confirmed: true;
+  confirmed_by: string;
+  confirmation_summary: string;
+  now?: string;
+}
+
+export type CorrectionRevertResult =
+  | { kind: 'reverted'; correction_id: string; case_id: string }
+  | { kind: 'rejected'; code: CaseCorrectionErrorCode; message: string; correction_id?: string };
+
+export interface SupersedeCorrectionInput {
+  old_correction_id: string;
+  new_value_json: string;
+  reason: string;
+  confirmed: true;
+  confirmed_by: string;
+  confirmation_summary: string;
+  /**
+   * The current value the user saw in the drawer when they chose to
+   * supersede. When provided and it disagrees with the live value, the
+   * helper returns `case.correction_requires_reconfirm`. Omit to skip
+   * CAS — in that case the caller trusts the active correction as the
+   * sole source of truth.
+   */
+  expected_current_value_json?: string | null;
+  reconfirm_token?: string | null;
+  session_id?: string | null;
+  now?: string;
+}
+
+export type CorrectionSupersedeResult =
+  | {
+      kind: 'superseded';
+      old_correction_id: string;
+      new_correction_id: string;
+      case_id: string;
+      target_ref_json: string;
+      canonical_hash_hex: string;
+    }
+  | CaseCorrectionRequiresReconfirmResult
+  | { kind: 'precompile_gap'; code: 'case.precompile_gap'; case_id: string }
+  | {
+      kind: 'rejected';
+      code: CaseCorrectionErrorCode;
+      message: string;
+      correction_id?: string;
+      case_id?: string;
+    };
+
+export interface ReconfirmTokenPayload {
+  v: 1;
+  kid: string;
+  nonce: string;
+  case_id: string;
+  target_kind: ApplyCorrectionInput['target_kind'];
+  target_ref_hash_hex: string;
+  current_value_hash_hex: string;
+  proposed_value_hash_hex: string;
+  confirmed_by: string;
+  session_id: string | null;
+  expires_at: string;
+}
+
+export interface ReconfirmTokenEnvelope {
+  kid: string;
+  payload: ReconfirmTokenPayload;
+  signature_hex: string;
+}
+
+export interface InsertCaseCorrectionLockInput {
+  correction_id?: string;
+  case_id: string;
+  target_kind: ApplyCorrectionInput['target_kind'];
+  target_ref: CaseTargetRef;
+  field_name?: ApplyCorrectionInput['field_name'] | null;
+  old_value_json: string | null;
+  new_value_json: string;
+  reason: string;
+  applied_by: string;
+  applied_at: string;
+  is_lock_active?: 0 | 1;
+  superseded_by?: string | null;
+}
+
+export interface InsertCaseCorrectionLockResult {
+  correction_id: string;
+  case_id: string;
+  target_kind: ApplyCorrectionInput['target_kind'];
+  target_ref_json: string;
+  target_ref_hash: Uint8Array;
+  canonical_hash_hex: string;
+  applied_at: string;
+  is_lock_active: 0 | 1;
+}
+
+type CorrectionAdapter = Pick<DatabaseAdapter, 'prepare' | 'transaction'> &
+  Partial<Pick<ImmediateTransactionAdapter, 'exec'>>;
+
+type CorrectionFieldName = NonNullable<ApplyCorrectionInput['field_name']>;
+
+interface CaseGateRow {
+  case_id: string;
+  status: string;
+  canonical_case_id: string | null;
+}
+
+interface CaseTruthValueRow {
+  status: string;
+  status_reason: string | null;
+  primary_actors: string | null;
+  blockers: string | null;
+  confidence: string | null;
+}
+
+interface MembershipValueRow {
+  status: string;
+  role: string | null;
+  confidence: number | null;
+  reason: string | null;
+  user_locked: number;
+  added_by?: string;
+}
+
+interface CorrectionStatusRow {
+  correction_id: string;
+  case_id: string;
+  is_lock_active: number;
+  reverted_at: string | null;
+}
+
+interface CurrentSecret {
+  kid: string;
+  secret: Buffer;
+}
+
+const RECONFIRM_TOKEN_TTL_MS = 10 * 60_000;
+const TERMINAL_CASE_STATUSES = new Set(['merged', 'archived', 'split']);
+const CORRECTION_FIELD_NAMES = new Set<string>([
+  'status',
+  'status_reason',
+  'primary_actors',
+  'blockers',
+  'confidence',
+]);
+
+function normalizeNow(value?: string): string {
+  return value ?? new Date().toISOString();
+}
+
+function timestampMs(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+function sha256Hex(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function hmacHex(secret: Buffer, value: string): string {
+  return createHmac('sha256', secret).update(value, 'utf8').digest('hex');
+}
+
+function deterministicCorrectionId(nonce: string): string {
+  return `corr_${sha256Hex(`case-reconfirm:v1:${nonce}`).slice(0, 32)}`;
+}
+
+function randomCorrectionId(): string {
+  return `corr_${randomUUID().replace(/-/g, '')}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseJsonValue(value: string): unknown {
+  return JSON.parse(value) as unknown;
+}
+
+function nullableString(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return String(value);
+}
+
+function nullableNumber(value: unknown): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const n = Number(value);
+  if (!Number.isFinite(n)) {
+    throw new Error('Membership confidence must be a finite number.');
+  }
+  return n;
+}
+
+function canonicalStoredJson(value: string | null): string {
+  if (value === null || value.trim().length === 0) {
+    return canonicalizeJSON(null);
+  }
+  return canonicalizeJSON(parseJsonValue(value));
+}
+
+function decodeSecret(raw: string): Buffer | null {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  if (/^[0-9a-f]+$/i.test(trimmed) && trimmed.length % 2 === 0) {
+    const hex = Buffer.from(trimmed, 'hex');
+    if (hex.length >= 32) {
+      return hex;
+    }
+  }
+
+  const base64 = Buffer.from(trimmed, 'base64');
+  if (base64.length >= 32) {
+    return base64;
+  }
+
+  const utf8 = Buffer.from(trimmed, 'utf8');
+  if (utf8.length >= 32) {
+    return utf8;
+  }
+
+  return null;
+}
+
+function secretKid(secret: Buffer): string {
+  return createHash('sha256').update(secret).digest('hex').slice(0, 16);
+}
+
+function currentSecret(): CurrentSecret {
+  const raw = process.env.MAMA_RECONFIRM_TOKEN_SECRET;
+  const secret = raw ? decodeSecret(raw) : null;
+  if (!secret) {
+    throw new Error('MAMA_RECONFIRM_TOKEN_SECRET must be a 32+ byte base64 or hex secret.');
+  }
+
+  return {
+    kid: secretKid(secret),
+    secret,
+  };
+}
+
+function verificationSecrets(): Map<string, Buffer> {
+  const secrets = new Map<string, Buffer>();
+  const current = currentSecret();
+  secrets.set(current.kid, current.secret);
+
+  for (const raw of (process.env.MAMA_RECONFIRM_TOKEN_OLD_SECRETS ?? '').split(',')) {
+    const secret = decodeSecret(raw);
+    if (secret) {
+      secrets.set(secretKid(secret), secret);
+    }
+  }
+
+  return secrets;
+}
+
+function encodeReconfirmToken(payload: ReconfirmTokenPayload, secret: Buffer): string {
+  const payloadJson = canonicalizeJSON(payload);
+  const signatureHex = hmacHex(secret, payloadJson);
+  const envelope: ReconfirmTokenEnvelope = {
+    kid: payload.kid,
+    payload,
+    signature_hex: signatureHex,
+  };
+
+  return Buffer.from(canonicalizeJSON(envelope), 'utf8').toString('base64url');
+}
+
+function readReconfirmEnvelope(token: string): ReconfirmTokenEnvelope | null {
+  try {
+    const parsed = JSON.parse(Buffer.from(token, 'base64url').toString('utf8')) as unknown;
+    if (!isRecord(parsed) || !isRecord(parsed.payload)) {
+      return null;
+    }
+
+    const payload = parsed.payload;
+    if (
+      parsed.kid !== payload.kid ||
+      payload.v !== 1 ||
+      typeof parsed.kid !== 'string' ||
+      typeof parsed.signature_hex !== 'string' ||
+      typeof payload.kid !== 'string' ||
+      typeof payload.nonce !== 'string' ||
+      typeof payload.case_id !== 'string' ||
+      typeof payload.target_kind !== 'string' ||
+      typeof payload.target_ref_hash_hex !== 'string' ||
+      typeof payload.current_value_hash_hex !== 'string' ||
+      typeof payload.proposed_value_hash_hex !== 'string' ||
+      typeof payload.confirmed_by !== 'string' ||
+      !(payload.session_id === null || typeof payload.session_id === 'string') ||
+      typeof payload.expires_at !== 'string'
+    ) {
+      return null;
+    }
+
+    if (
+      payload.target_kind !== 'case_field' &&
+      payload.target_kind !== 'membership' &&
+      payload.target_kind !== 'wiki_section'
+    ) {
+      return null;
+    }
+
+    return {
+      kid: parsed.kid,
+      payload: payload as unknown as ReconfirmTokenPayload,
+      signature_hex: parsed.signature_hex,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function verifyReconfirmToken(input: {
+  token: string;
+  case_id: string;
+  target_kind: ApplyCorrectionInput['target_kind'];
+  target_ref_hash_hex: string;
+  proposed_value_hash_hex: string;
+  confirmed_by: string;
+  session_id: string | null;
+  now: string;
+}): ReconfirmTokenPayload | null {
+  const envelope = readReconfirmEnvelope(input.token);
+  if (!envelope) {
+    return null;
+  }
+
+  const secret = verificationSecrets().get(envelope.kid);
+  if (!secret) {
+    return null;
+  }
+
+  const expected = Buffer.from(hmacHex(secret, canonicalizeJSON(envelope.payload)), 'hex');
+  const actual = Buffer.from(envelope.signature_hex, 'hex');
+  if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
+    return null;
+  }
+
+  const expiresAtMs = Date.parse(envelope.payload.expires_at);
+  if (!Number.isFinite(expiresAtMs) || expiresAtMs <= timestampMs(input.now)) {
+    return null;
+  }
+
+  if (
+    envelope.payload.case_id !== input.case_id ||
+    envelope.payload.target_kind !== input.target_kind ||
+    envelope.payload.target_ref_hash_hex !== input.target_ref_hash_hex ||
+    envelope.payload.proposed_value_hash_hex !== input.proposed_value_hash_hex ||
+    envelope.payload.confirmed_by !== input.confirmed_by ||
+    envelope.payload.session_id !== input.session_id
+  ) {
+    return null;
+  }
+
+  return envelope.payload;
+}
+
+function buildRequiresReconfirm(input: {
+  case_id: string;
+  target_kind: ApplyCorrectionInput['target_kind'];
+  target_ref_json: string;
+  target_ref_hash_hex: string;
+  current_value_json: string;
+  old_value_json: string | null;
+  proposed_new_value_json: string;
+  confirmed_by: string;
+  session_id: string | null;
+  now: string;
+}): Extract<CorrectionApplyResult, { kind: 'requires_reconfirm' }> {
+  const secret = currentSecret();
+  const expiresAt = new Date(timestampMs(input.now) + RECONFIRM_TOKEN_TTL_MS).toISOString();
+  const payload: ReconfirmTokenPayload = {
+    v: 1,
+    kid: secret.kid,
+    nonce: randomUUID(),
+    case_id: input.case_id,
+    target_kind: input.target_kind,
+    target_ref_hash_hex: input.target_ref_hash_hex,
+    current_value_hash_hex: sha256Hex(input.current_value_json),
+    proposed_value_hash_hex: sha256Hex(input.proposed_new_value_json),
+    confirmed_by: input.confirmed_by,
+    session_id: input.session_id,
+    expires_at: expiresAt,
+  };
+
+  return {
+    kind: 'requires_reconfirm',
+    code: 'case.correction_requires_reconfirm',
+    case_id: input.case_id,
+    target_kind: input.target_kind,
+    target_ref_json: input.target_ref_json,
+    current_value_json: input.current_value_json,
+    old_value_json: input.old_value_json,
+    proposed_new_value_json: input.proposed_new_value_json,
+    reconfirm_token: encodeReconfirmToken(payload, secret.secret),
+    reconfirm_token_expires_at: expiresAt,
+    message: 'The target changed since the viewed snapshot. Reconfirm against the current value.',
+  };
+}
+
+function requireMatchingTargetKind(input: ApplyCorrectionInput): void {
+  if (input.target_ref.kind !== input.target_kind) {
+    throw new Error(
+      `Correction target_kind ${input.target_kind} does not match target_ref kind ${input.target_ref.kind}.`
+    );
+  }
+}
+
+function correctionFieldName(input: ApplyCorrectionInput): CorrectionFieldName {
+  const fieldFromRef = input.target_ref.kind === 'case_field' ? input.target_ref.field : null;
+  const field = input.field_name ?? fieldFromRef;
+  if (!field || !CORRECTION_FIELD_NAMES.has(field)) {
+    throw new Error(`Unsupported case correction field: ${String(field)}`);
+  }
+
+  if (input.field_name && fieldFromRef && input.field_name !== fieldFromRef) {
+    throw new Error('field_name must match target_ref.field.');
+  }
+
+  return field as CorrectionFieldName;
+}
+
+function membershipTarget(
+  input: ApplyCorrectionInput
+): Extract<CaseTargetRef, { kind: 'membership' }> {
+  if (input.target_ref.kind !== 'membership') {
+    throw new Error('Membership correction requires membership target_ref.');
+  }
+  return input.target_ref;
+}
+
+function readCaseFieldCurrentValueJson(
+  adapter: CorrectionAdapter,
+  caseId: string,
+  field: CorrectionFieldName
+): string {
+  const row = adapter
+    .prepare(
+      `
+        SELECT status, status_reason, primary_actors, blockers, confidence
+        FROM case_truth
+        WHERE case_id = ?
+      `
+    )
+    .get(caseId) as CaseTruthValueRow | undefined;
+
+  if (!row) {
+    throw new Error(`case_truth row disappeared while applying correction: ${caseId}`);
+  }
+
+  if (field === 'primary_actors' || field === 'blockers') {
+    return canonicalStoredJson(row[field]);
+  }
+
+  return canonicalizeJSON(row[field]);
+}
+
+function readMembershipCurrentValueJson(
+  adapter: CorrectionAdapter,
+  caseId: string,
+  sourceType: string,
+  sourceId: string
+): string {
+  const row = adapter
+    .prepare(
+      `
+        SELECT status, role, confidence, reason, user_locked
+        FROM case_memberships
+        WHERE case_id = ?
+          AND source_type = ?
+          AND source_id = ?
+      `
+    )
+    .get(caseId, sourceType, sourceId) as MembershipValueRow | undefined;
+
+  if (!row) {
+    return canonicalizeJSON(null);
+  }
+
+  return canonicalizeJSON({
+    status: row.status,
+    role: row.role,
+    confidence: row.confidence,
+    reason: row.reason,
+    user_locked: Number(row.user_locked) === 1 ? 1 : 0,
+  });
+}
+
+function readCurrentValueJson(adapter: CorrectionAdapter, input: ApplyCorrectionInput): string {
+  if (input.target_kind === 'case_field') {
+    return readCaseFieldCurrentValueJson(adapter, input.case_id, correctionFieldName(input));
+  }
+
+  if (input.target_kind === 'membership') {
+    const target = membershipTarget(input);
+    return readMembershipCurrentValueJson(
+      adapter,
+      input.case_id,
+      target.source_type,
+      target.source_id
+    );
+  }
+
+  return canonicalizeJSON(null);
+}
+
+function storageValueForCaseField(field: CorrectionFieldName, newValueJson: string): string | null {
+  const value = parseJsonValue(newValueJson);
+  if (value === null) {
+    return null;
+  }
+
+  if (field === 'primary_actors' || field === 'blockers') {
+    return canonicalizeJSON(value);
+  }
+
+  if (typeof value !== 'string') {
+    throw new Error(`Case field ${field} correction value must be a JSON string or null.`);
+  }
+
+  return value;
+}
+
+function applyCaseFieldMutation(input: {
+  adapter: CorrectionAdapter;
+  case_id: string;
+  field: CorrectionFieldName;
+  new_value_json: string;
+  now: string;
+}): void {
+  const storageValue = storageValueForCaseField(input.field, input.new_value_json);
+  const result = input.adapter
+    .prepare(
+      `
+        UPDATE case_truth
+           SET ${input.field} = ?,
+               updated_at = ?
+         WHERE case_id = ?
+           AND status NOT IN ('merged','archived','split')
+      `
+    )
+    .run(storageValue, input.now, input.case_id);
+
+  if (result.changes !== 1) {
+    throw new Error(`Failed to apply case field correction for case_id=${input.case_id}.`);
+  }
+
+  const actual = readCaseFieldCurrentValueJson(input.adapter, input.case_id, input.field);
+  const expected = canonicalizeJSON(parseJsonValue(input.new_value_json));
+  if (actual !== expected) {
+    throw new Error(`Case field correction verification failed for ${input.field}.`);
+  }
+}
+
+function membershipStatus(value: unknown): 'active' | 'excluded' | 'removed' {
+  if (value === 'active' || value === 'excluded' || value === 'removed') {
+    return value;
+  }
+  throw new Error('Membership correction status must be active, excluded, or removed.');
+}
+
+function verifyMembershipMutation(input: {
+  adapter: CorrectionAdapter;
+  case_id: string;
+  source_type: string;
+  source_id: string;
+  expected: Record<string, unknown>;
+}): void {
+  const row = input.adapter
+    .prepare(
+      `
+        SELECT status, role, confidence, reason, user_locked, added_by
+        FROM case_memberships
+        WHERE case_id = ?
+          AND source_type = ?
+          AND source_id = ?
+      `
+    )
+    .get(input.case_id, input.source_type, input.source_id) as MembershipValueRow | undefined;
+
+  if (!row) {
+    throw new Error('Membership correction verification failed: row missing.');
+  }
+
+  const expectedStatus = String(input.expected.status);
+  if (
+    row.status !== expectedStatus ||
+    Number(row.user_locked) !== 1 ||
+    row.added_by !== 'user-correction'
+  ) {
+    throw new Error('Membership correction verification failed.');
+  }
+
+  if (expectedStatus === 'active') {
+    const expectedRole = nullableString(input.expected.role);
+    const expectedConfidence = nullableNumber(input.expected.confidence);
+    const expectedReason = nullableString(input.expected.reason);
+
+    if (
+      row.role !== expectedRole ||
+      row.confidence !== expectedConfidence ||
+      row.reason !== expectedReason
+    ) {
+      throw new Error('Active membership correction verification failed.');
+    }
+  }
+}
+
+function applyMembershipMutation(input: {
+  adapter: CorrectionAdapter;
+  case_id: string;
+  target: Extract<CaseTargetRef, { kind: 'membership' }>;
+  new_value_json: string;
+  reason: string;
+  now: string;
+}): void {
+  const value = parseJsonValue(input.new_value_json);
+  if (!isRecord(value)) {
+    throw new Error('Membership correction value must be a JSON object.');
+  }
+
+  const status = membershipStatus(value.status);
+  if (status === 'removed') {
+    input.adapter
+      .prepare(
+        `
+          UPDATE case_memberships
+             SET status = 'removed',
+                 user_locked = 1,
+                 added_by = 'user-correction',
+                 updated_at = ?
+           WHERE case_id = ?
+             AND source_type = ?
+             AND source_id = ?
+        `
+      )
+      .run(input.now, input.case_id, input.target.source_type, input.target.source_id);
+  } else if (status === 'excluded') {
+    const confidence = nullableNumber(value.confidence);
+    const reason = nullableString(value.reason) ?? input.reason;
+    input.adapter
+      .prepare(
+        `
+          INSERT INTO case_memberships (
+            case_id, source_type, source_id, role, confidence, reason, status,
+            added_by, added_at, user_locked, updated_at
+          )
+          VALUES (?, ?, ?, NULL, ?, ?, 'excluded', 'user-correction', ?, 1, ?)
+          ON CONFLICT(case_id, source_type, source_id) DO UPDATE SET
+            role = excluded.role,
+            confidence = excluded.confidence,
+            reason = excluded.reason,
+            status = excluded.status,
+            added_by = 'user-correction',
+            user_locked = 1,
+            updated_at = excluded.updated_at
+        `
+      )
+      .run(
+        input.case_id,
+        input.target.source_type,
+        input.target.source_id,
+        confidence,
+        reason,
+        input.now,
+        input.now
+      );
+  } else {
+    const role = nullableString(value.role);
+    const confidence = nullableNumber(value.confidence);
+    const reason = nullableString(value.reason);
+    input.adapter
+      .prepare(
+        `
+          INSERT INTO case_memberships (
+            case_id, source_type, source_id, role, confidence, reason, status,
+            added_by, added_at, user_locked, updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, 'active', 'user-correction', ?, 1, ?)
+          ON CONFLICT(case_id, source_type, source_id) DO UPDATE SET
+            role = excluded.role,
+            confidence = excluded.confidence,
+            reason = excluded.reason,
+            status = excluded.status,
+            added_by = 'user-correction',
+            user_locked = 1,
+            updated_at = excluded.updated_at
+        `
+      )
+      .run(
+        input.case_id,
+        input.target.source_type,
+        input.target.source_id,
+        role,
+        confidence,
+        reason,
+        input.now,
+        input.now
+      );
+  }
+
+  verifyMembershipMutation({
+    adapter: input.adapter,
+    case_id: input.case_id,
+    source_type: input.target.source_type,
+    source_id: input.target.source_id,
+    expected: value,
+  });
+}
+
+function applyTargetMutation(input: {
+  adapter: CorrectionAdapter;
+  correction: ApplyCorrectionInput;
+  now: string;
+}): void {
+  if (input.correction.target_kind === 'case_field') {
+    applyCaseFieldMutation({
+      adapter: input.adapter,
+      case_id: input.correction.case_id,
+      field: correctionFieldName(input.correction),
+      new_value_json: input.correction.new_value_json,
+      now: input.now,
+    });
+    return;
+  }
+
+  if (input.correction.target_kind === 'membership') {
+    applyMembershipMutation({
+      adapter: input.adapter,
+      case_id: input.correction.case_id,
+      target: membershipTarget(input.correction),
+      new_value_json: input.correction.new_value_json,
+      reason: input.correction.reason,
+      now: input.now,
+    });
+  }
+}
+
+function insertCorrectionMemoryEvent(input: {
+  adapter: CorrectionAdapter;
+  event_type: 'case.correction_applied' | 'case.correction_reverted' | 'case.correction_superseded';
+  correction_id: string;
+  case_id: string;
+  actor: string;
+  source_turn_id?: string | null;
+  confirmation_summary: string;
+  now: string;
+  extra_refs?: string[];
+}): void {
+  const evidenceRefs = [input.correction_id, ...(input.extra_refs ?? [])];
+  input.adapter
+    .prepare(
+      `
+        INSERT INTO memory_events (
+          event_id, event_type, actor, source_turn_id, memory_id, topic,
+          scope_refs, evidence_refs, reason, created_at
+        )
+        VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      `evt_${randomUUID().replace(/-/g, '')}`,
+      input.event_type,
+      input.actor,
+      input.source_turn_id ?? null,
+      `case:${input.case_id}`,
+      canonicalizeJSON([{ type: 'case', id: input.case_id }]),
+      canonicalizeJSON(evidenceRefs),
+      canonicalizeJSON({
+        correction_id: input.correction_id,
+        confirmation_summary: input.confirmation_summary,
+        ...(input.extra_refs ? { predecessor_correction_ids: input.extra_refs } : {}),
+      }),
+      timestampMs(input.now)
+    );
+}
+
+function activeCorrectionForTarget(
+  adapter: CorrectionAdapter,
+  caseId: string,
+  targetRefHash: Buffer
+): { correction_id: string } | null {
+  const row = adapter
+    .prepare(
+      `
+        SELECT correction_id
+        FROM case_corrections
+        WHERE case_id = ?
+          AND target_ref_hash = ?
+          AND is_lock_active = 1
+          AND reverted_at IS NULL
+        LIMIT 1
+      `
+    )
+    .get(caseId, targetRefHash) as { correction_id: string } | undefined;
+
+  return row ?? null;
+}
+
+function correctionExists(adapter: CorrectionAdapter, correctionId: string): boolean {
+  const row = adapter
+    .prepare('SELECT correction_id FROM case_corrections WHERE correction_id = ?')
+    .get(correctionId) as { correction_id: string } | undefined;
+  return row !== undefined;
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  return (
+    error instanceof Error && /UNIQUE constraint|SQLITE_CONSTRAINT_UNIQUE/i.test(error.message)
+  );
+}
+
+export function insertCaseCorrectionLock(
+  adapter: DatabaseAdapter,
+  input: InsertCaseCorrectionLockInput
+): InsertCaseCorrectionLockResult {
+  const correctionAdapter = adapter as unknown as CorrectionAdapter;
+  const canonical = canonicalTargetRef(input.target_ref);
+  const correctionId = input.correction_id ?? randomCorrectionId();
+  const isLockActive = input.is_lock_active ?? 1;
+
+  correctionAdapter
+    .prepare(
+      `
+        INSERT INTO case_corrections (
+          correction_id, case_id, target_kind, target_ref_json, target_ref_hash,
+          field_name, old_value_json, new_value_json, reason,
+          applied_by, applied_at, is_lock_active, reverted_at, superseded_by
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?);
+      `
+    )
+    .run(
+      correctionId,
+      input.case_id,
+      input.target_kind,
+      canonical.json,
+      canonical.hash,
+      input.field_name ?? null,
+      input.old_value_json,
+      input.new_value_json,
+      input.reason,
+      input.applied_by,
+      input.applied_at,
+      isLockActive,
+      input.superseded_by ?? null
+    );
+
+  return {
+    correction_id: correctionId,
+    case_id: input.case_id,
+    target_kind: input.target_kind,
+    target_ref_json: canonical.json,
+    target_ref_hash: canonical.hash,
+    canonical_hash_hex: canonical.hash.toString('hex'),
+    applied_at: input.applied_at,
+    is_lock_active: isLockActive,
+  };
+}
+
+export function applyCorrection(
+  adapter: DatabaseAdapter,
+  input: ApplyCorrectionInput
+): CorrectionApplyResult {
+  const correctionAdapter = adapter as unknown as CorrectionAdapter;
+
+  return runImmediateTransaction(correctionAdapter, () => {
+    requireMatchingTargetKind(input);
+    const now = normalizeNow(input.now);
+    const caseRow = correctionAdapter
+      .prepare(
+        `
+          SELECT case_id, status, canonical_case_id
+          FROM case_truth
+          WHERE case_id = ?;
+        `
+      )
+      .get(input.case_id) as CaseGateRow | undefined;
+
+    if (!caseRow) {
+      return { kind: 'precompile_gap', code: 'case.precompile_gap', case_id: input.case_id };
+    }
+
+    if (TERMINAL_CASE_STATUSES.has(caseRow.status)) {
+      return {
+        kind: 'rejected',
+        code: 'case.terminal_status',
+        message: `Active corrections cannot target terminal case status ${caseRow.status}.`,
+        case_id: input.case_id,
+      };
+    }
+
+    const canonical = canonicalTargetRef(input.target_ref);
+    const targetRefHashHex = canonical.hash.toString('hex');
+    const currentValueJson = readCurrentValueJson(correctionAdapter, input);
+    let correctionId = randomCorrectionId();
+
+    if (typeof input.old_value_json === 'string' && input.old_value_json !== currentValueJson) {
+      const token = input.reconfirm_token ?? null;
+      if (!token) {
+        return buildRequiresReconfirm({
+          case_id: input.case_id,
+          target_kind: input.target_kind,
+          target_ref_json: canonical.json,
+          target_ref_hash_hex: targetRefHashHex,
+          current_value_json: currentValueJson,
+          old_value_json: input.old_value_json,
+          proposed_new_value_json: input.new_value_json,
+          confirmed_by: input.confirmed_by,
+          session_id: input.session_id ?? null,
+          now,
+        });
+      }
+
+      const payload = verifyReconfirmToken({
+        token,
+        case_id: input.case_id,
+        target_kind: input.target_kind,
+        target_ref_hash_hex: targetRefHashHex,
+        proposed_value_hash_hex: sha256Hex(input.new_value_json),
+        confirmed_by: input.confirmed_by,
+        session_id: input.session_id ?? null,
+        now,
+      });
+
+      if (!payload) {
+        return buildRequiresReconfirm({
+          case_id: input.case_id,
+          target_kind: input.target_kind,
+          target_ref_json: canonical.json,
+          target_ref_hash_hex: targetRefHashHex,
+          current_value_json: currentValueJson,
+          old_value_json: input.old_value_json,
+          proposed_new_value_json: input.new_value_json,
+          confirmed_by: input.confirmed_by,
+          session_id: input.session_id ?? null,
+          now,
+        });
+      }
+
+      correctionId = deterministicCorrectionId(payload.nonce);
+      if (correctionExists(correctionAdapter, correctionId)) {
+        return {
+          kind: 'rejected',
+          code: 'case.reconfirm_token_replayed',
+          message: 'Reconfirm token has already been consumed.',
+          case_id: input.case_id,
+        };
+      }
+
+      if (payload.current_value_hash_hex !== sha256Hex(currentValueJson)) {
+        return buildRequiresReconfirm({
+          case_id: input.case_id,
+          target_kind: input.target_kind,
+          target_ref_json: canonical.json,
+          target_ref_hash_hex: targetRefHashHex,
+          current_value_json: currentValueJson,
+          old_value_json: input.old_value_json,
+          proposed_new_value_json: input.new_value_json,
+          confirmed_by: input.confirmed_by,
+          session_id: input.session_id ?? null,
+          now,
+        });
+      }
+    }
+
+    if (activeCorrectionForTarget(correctionAdapter, input.case_id, canonical.hash)) {
+      return {
+        kind: 'rejected',
+        code: 'case.correction_active_conflict',
+        message: 'An active correction already locks this target.',
+        case_id: input.case_id,
+      };
+    }
+
+    let inserted: InsertCaseCorrectionLockResult;
+    try {
+      inserted = insertCaseCorrectionLock(adapter, {
+        correction_id: correctionId,
+        case_id: input.case_id,
+        target_kind: input.target_kind,
+        target_ref: input.target_ref,
+        field_name: input.target_kind === 'case_field' ? correctionFieldName(input) : null,
+        old_value_json: currentValueJson,
+        new_value_json: input.new_value_json,
+        reason: input.reason,
+        applied_by: input.confirmed_by,
+        applied_at: now,
+        is_lock_active: 1,
+        superseded_by: null,
+      });
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        return {
+          kind: 'rejected',
+          code: 'case.correction_active_conflict',
+          message: 'An active correction already locks this target.',
+          case_id: input.case_id,
+        };
+      }
+      throw error;
+    }
+
+    applyTargetMutation({ adapter: correctionAdapter, correction: input, now });
+    insertCorrectionMemoryEvent({
+      adapter: correctionAdapter,
+      event_type: 'case.correction_applied',
+      correction_id: inserted.correction_id,
+      case_id: input.case_id,
+      actor: input.confirmed_by,
+      source_turn_id: input.session_id ?? null,
+      confirmation_summary: input.confirmation_summary,
+      now,
+    });
+
+    return {
+      kind: 'applied',
+      correction_id: inserted.correction_id,
+      case_id: input.case_id,
+      target_ref_json: inserted.target_ref_json,
+      canonical_hash_hex: inserted.canonical_hash_hex,
+    };
+  });
+}
+
+export function revertCorrection(
+  adapter: DatabaseAdapter,
+  input: RevertCorrectionInput
+): CorrectionRevertResult {
+  const correctionAdapter = adapter as unknown as CorrectionAdapter;
+
+  return runImmediateTransaction(correctionAdapter, () => {
+    const now = normalizeNow(input.now);
+    const row = correctionAdapter
+      .prepare(
+        `
+          SELECT correction_id, case_id, is_lock_active, reverted_at
+          FROM case_corrections
+          WHERE correction_id = ?
+        `
+      )
+      .get(input.correction_id) as CorrectionStatusRow | undefined;
+
+    if (!row) {
+      return {
+        kind: 'rejected',
+        code: 'case.correction_not_found',
+        message: 'Correction not found.',
+        correction_id: input.correction_id,
+      };
+    }
+
+    if (row.reverted_at !== null || Number(row.is_lock_active) === 0) {
+      return {
+        kind: 'rejected',
+        code: 'case.correction_reverted',
+        message: 'Correction has already been reverted.',
+        correction_id: input.correction_id,
+      };
+    }
+
+    correctionAdapter
+      .prepare(
+        `
+          UPDATE case_corrections
+             SET reverted_at = ?,
+                 is_lock_active = 0
+           WHERE correction_id = ?
+        `
+      )
+      .run(now, input.correction_id);
+
+    insertCorrectionMemoryEvent({
+      adapter: correctionAdapter,
+      event_type: 'case.correction_reverted',
+      correction_id: input.correction_id,
+      case_id: row.case_id,
+      actor: input.confirmed_by,
+      confirmation_summary: input.confirmation_summary,
+      now,
+    });
+
+    return { kind: 'reverted', correction_id: input.correction_id, case_id: row.case_id };
+  });
+}
+
+/**
+ * supersedeCorrection — Phase 2b. Unblocked by spec amendment-8 (2026-04-18)
+ * which added `superseded_by` to the mutable-column set in §5.4.
+ *
+ * Semantics: user changes their mind on an active correction. Inside a single
+ * transaction:
+ *   1. Read OLD row; reject if not found / reverted / already superseded / inactive.
+ *   2. INSERT new correction row referencing the same (case_id, target_kind,
+ *      target_ref_hash) with new_value_json and is_lock_active=1.
+ *   3. UPDATE OLD row: superseded_by = new.correction_id, is_lock_active = 0.
+ *   4. Emit case.correction_superseded memory_event.
+ *
+ * Per spec §5.4 invariant (amendment-8), the three mutable columns are
+ * is_lock_active + reverted_at + superseded_by. superseded_by is written
+ * ONLY inside this transition.
+ */
+export function supersedeCorrection(
+  adapter: DatabaseAdapter,
+  input: SupersedeCorrectionInput
+): CorrectionSupersedeResult {
+  const correctionAdapter = adapter as unknown as CorrectionAdapter;
+
+  return runImmediateTransaction(correctionAdapter, () => {
+    const now = normalizeNow(input.now);
+    const old = correctionAdapter
+      .prepare(
+        `
+          SELECT correction_id, case_id, target_kind, target_ref_json, target_ref_hash,
+                 field_name, is_lock_active, reverted_at, superseded_by
+          FROM case_corrections
+          WHERE correction_id = ?
+        `
+      )
+      .get(input.old_correction_id) as
+      | {
+          correction_id: string;
+          case_id: string;
+          target_kind: 'case_field' | 'membership' | 'wiki_section';
+          target_ref_json: string;
+          target_ref_hash: Uint8Array;
+          field_name: string | null;
+          is_lock_active: number;
+          reverted_at: string | null;
+          superseded_by: string | null;
+        }
+      | undefined;
+
+    if (!old) {
+      return {
+        kind: 'rejected',
+        code: 'case.correction_not_found',
+        message: 'Old correction not found.',
+        correction_id: input.old_correction_id,
+      };
+    }
+
+    if (old.reverted_at !== null) {
+      return {
+        kind: 'rejected',
+        code: 'case.correction_reverted',
+        message: 'Cannot supersede a reverted correction.',
+        correction_id: input.old_correction_id,
+      };
+    }
+
+    if (old.superseded_by !== null) {
+      return {
+        kind: 'rejected',
+        code: 'case.correction_already_superseded',
+        message: 'Correction has already been superseded.',
+        correction_id: input.old_correction_id,
+      };
+    }
+
+    if (Number(old.is_lock_active) === 0) {
+      return {
+        kind: 'rejected',
+        code: 'case.correction_reverted',
+        message: 'Cannot supersede an inactive correction.',
+        correction_id: input.old_correction_id,
+      };
+    }
+
+    // Terminal-case gate — mirror applyCorrection. Supersede must not
+    // rotate locks or mutate live state on merged/archived/split cases.
+    // Without this guard, case_field supersede throws from
+    // applyCaseFieldMutation (transaction rolls back but handler leaks
+    // 500) and membership supersede silently writes to a dead case.
+    const caseRow = correctionAdapter
+      .prepare('SELECT status, canonical_case_id FROM case_truth WHERE case_id = ?')
+      .get(old.case_id) as CaseGateRow | undefined;
+
+    if (!caseRow) {
+      return {
+        kind: 'precompile_gap',
+        code: 'case.precompile_gap',
+        case_id: old.case_id,
+      };
+    }
+
+    if (TERMINAL_CASE_STATUSES.has(caseRow.status)) {
+      return {
+        kind: 'rejected',
+        code: 'case.terminal_status',
+        message: `Supersede rejected: case is in terminal status ${caseRow.status}.`,
+        case_id: old.case_id,
+      };
+    }
+
+    let newCorrectionId = randomCorrectionId();
+
+    // Reconstruct the ApplyCorrection-shaped input from OLD's canonical
+    // target_ref_json so we can reuse readCurrentValueJson + applyTargetMutation.
+    // The JSON round-trips through canonicalizeJSON on insert so it is safe to
+    // parse here without re-validating shape.
+    const syntheticTargetRef = parseJsonValue(old.target_ref_json) as CaseTargetRef;
+    const syntheticInput: ApplyCorrectionInput = {
+      case_id: old.case_id,
+      target_kind: old.target_kind,
+      target_ref: syntheticTargetRef,
+      field_name: (old.field_name as ApplyCorrectionInput['field_name']) ?? undefined,
+      new_value_json: input.new_value_json,
+      reason: input.reason,
+      confirmed: true,
+      confirmed_by: input.confirmed_by,
+      confirmation_summary: input.confirmation_summary,
+    };
+
+    // Snapshot the current live value BEFORE mutating so the NEW row's
+    // old_value_json reflects the state the user actually superseded
+    // (not NULL, which would erase the audit trail).
+    const currentValueJson = readCurrentValueJson(correctionAdapter, syntheticInput);
+    const targetRefHashHex = Buffer.from(old.target_ref_hash).toString('hex');
+
+    // CAS / reconfirm dance — mirrors applyCorrection. Now that supersede
+    // actually writes live state (P1-1 fix), a stale-view supersede could
+    // silently overwrite a value the user never saw. Opt-in via
+    // expected_current_value_json (undefined/null = skip CAS).
+    //
+    // Canonicalize the caller's expected value before comparison so
+    // key-ordering or whitespace differences do not cause false 409s.
+    // Invalid JSON (including empty string "") throws at the handler
+    // boundary — the caller sees a validation_error rather than a bogus
+    // silent 409.
+    let canonicalExpectedCurrent: string | null = null;
+    if (typeof input.expected_current_value_json === 'string') {
+      canonicalExpectedCurrent = canonicalizeJSON(
+        parseJsonValue(input.expected_current_value_json)
+      );
+    }
+
+    if (canonicalExpectedCurrent !== null && canonicalExpectedCurrent !== currentValueJson) {
+      const token = input.reconfirm_token ?? null;
+      if (!token) {
+        return buildRequiresReconfirm({
+          case_id: old.case_id,
+          target_kind: old.target_kind,
+          target_ref_json: old.target_ref_json,
+          target_ref_hash_hex: targetRefHashHex,
+          current_value_json: currentValueJson,
+          old_value_json: input.expected_current_value_json ?? null,
+          proposed_new_value_json: input.new_value_json,
+          confirmed_by: input.confirmed_by,
+          session_id: input.session_id ?? null,
+          now,
+        });
+      }
+
+      const payload = verifyReconfirmToken({
+        token,
+        case_id: old.case_id,
+        target_kind: old.target_kind,
+        target_ref_hash_hex: targetRefHashHex,
+        proposed_value_hash_hex: sha256Hex(input.new_value_json),
+        confirmed_by: input.confirmed_by,
+        session_id: input.session_id ?? null,
+        now,
+      });
+
+      if (!payload) {
+        return buildRequiresReconfirm({
+          case_id: old.case_id,
+          target_kind: old.target_kind,
+          target_ref_json: old.target_ref_json,
+          target_ref_hash_hex: targetRefHashHex,
+          current_value_json: currentValueJson,
+          old_value_json: input.expected_current_value_json ?? null,
+          proposed_new_value_json: input.new_value_json,
+          confirmed_by: input.confirmed_by,
+          session_id: input.session_id ?? null,
+          now,
+        });
+      }
+
+      newCorrectionId = deterministicCorrectionId(payload.nonce);
+      if (correctionExists(correctionAdapter, newCorrectionId)) {
+        return {
+          kind: 'rejected',
+          code: 'case.reconfirm_token_replayed',
+          message: 'Reconfirm token has already been consumed.',
+          case_id: old.case_id,
+        };
+      }
+
+      if (payload.current_value_hash_hex !== sha256Hex(currentValueJson)) {
+        return buildRequiresReconfirm({
+          case_id: old.case_id,
+          target_kind: old.target_kind,
+          target_ref_json: old.target_ref_json,
+          target_ref_hash_hex: targetRefHashHex,
+          current_value_json: currentValueJson,
+          old_value_json: input.expected_current_value_json ?? null,
+          proposed_new_value_json: input.new_value_json,
+          confirmed_by: input.confirmed_by,
+          session_id: input.session_id ?? null,
+          now,
+        });
+      }
+    }
+
+    // Drop OLD lock FIRST so the partial-unique (case_id, target_ref_hash)
+    // slot is free before INSERTing the NEW active row.
+    correctionAdapter
+      .prepare(
+        `
+          UPDATE case_corrections
+             SET is_lock_active = 0
+           WHERE correction_id = ?
+        `
+      )
+      .run(input.old_correction_id);
+
+    correctionAdapter
+      .prepare(
+        `
+          INSERT INTO case_corrections (
+            correction_id, case_id, target_kind, target_ref_json, target_ref_hash,
+            field_name, old_value_json, new_value_json, reason,
+            applied_by, applied_at, is_lock_active, reverted_at, superseded_by
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, NULL, NULL)
+        `
+      )
+      .run(
+        newCorrectionId,
+        old.case_id,
+        old.target_kind,
+        old.target_ref_json,
+        old.target_ref_hash,
+        old.field_name,
+        currentValueJson,
+        input.new_value_json,
+        input.reason,
+        input.confirmed_by,
+        now
+      );
+
+    // Populate linkage last — sole mutation of superseded_by, permitted by
+    // spec §5.4 amendment-8 (2026-04-18).
+    correctionAdapter
+      .prepare(
+        `
+          UPDATE case_corrections
+             SET superseded_by = ?
+           WHERE correction_id = ?
+        `
+      )
+      .run(newCorrectionId, input.old_correction_id);
+
+    // Write the revised value to the live target (case_truth / case_memberships)
+    // so the correction drawer and the case board stay consistent. wiki_section
+    // targets are overlay-only and intentionally no-op here.
+    applyTargetMutation({ adapter: correctionAdapter, correction: syntheticInput, now });
+
+    insertCorrectionMemoryEvent({
+      adapter: correctionAdapter,
+      event_type: 'case.correction_superseded',
+      correction_id: newCorrectionId,
+      case_id: old.case_id,
+      actor: input.confirmed_by,
+      confirmation_summary: input.confirmation_summary,
+      now,
+      extra_refs: [old.correction_id],
+    });
+
+    return {
+      kind: 'superseded',
+      old_correction_id: input.old_correction_id,
+      new_correction_id: newCorrectionId,
+      case_id: old.case_id,
+      target_ref_json: old.target_ref_json,
+      canonical_hash_hex: Buffer.from(old.target_ref_hash).toString('hex'),
+    };
+  });
+}

--- a/packages/mama-core/src/cases/corrections.ts
+++ b/packages/mama-core/src/cases/corrections.ts
@@ -267,30 +267,51 @@ function canonicalStoredJson(value: string | null): string {
   return canonicalizeJSON(parseJsonValue(value));
 }
 
+function decodeSecretWithEncoding(
+  value: string,
+  encoding: 'hex' | 'base64' | 'utf8'
+): Buffer | null {
+  if (value.length === 0) {
+    return null;
+  }
+
+  if (encoding === 'hex') {
+    if (!/^[0-9a-f]+$/i.test(value) || value.length % 2 !== 0) {
+      return null;
+    }
+    const hex = Buffer.from(value, 'hex');
+    return hex.length >= 32 ? hex : null;
+  }
+
+  const decoded = Buffer.from(value, encoding);
+  return decoded.length >= 32 ? decoded : null;
+}
+
 function decodeSecret(raw: string): Buffer | null {
   const trimmed = raw.trim();
   if (trimmed.length === 0) {
     return null;
   }
 
-  if (/^[0-9a-f]+$/i.test(trimmed) && trimmed.length % 2 === 0) {
-    const hex = Buffer.from(trimmed, 'hex');
-    if (hex.length >= 32) {
-      return hex;
-    }
+  const explicitEncoding = trimmed.match(/^(hex|base64|utf8):(.*)$/is);
+  if (explicitEncoding) {
+    return decodeSecretWithEncoding(
+      explicitEncoding[2]?.trim() ?? '',
+      explicitEncoding[1].toLowerCase() as 'hex' | 'base64' | 'utf8'
+    );
   }
 
-  const base64 = Buffer.from(trimmed, 'base64');
-  if (base64.length >= 32) {
+  const hex = decodeSecretWithEncoding(trimmed, 'hex');
+  if (hex) {
+    return hex;
+  }
+
+  const base64 = decodeSecretWithEncoding(trimmed, 'base64');
+  if (base64) {
     return base64;
   }
 
-  const utf8 = Buffer.from(trimmed, 'utf8');
-  if (utf8.length >= 32) {
-    return utf8;
-  }
-
-  return null;
+  return decodeSecretWithEncoding(trimmed, 'utf8');
 }
 
 function secretKid(secret: Buffer): string {
@@ -301,7 +322,9 @@ function currentSecret(): CurrentSecret {
   const raw = process.env.MAMA_RECONFIRM_TOKEN_SECRET;
   const secret = raw ? decodeSecret(raw) : null;
   if (!secret) {
-    throw new Error('MAMA_RECONFIRM_TOKEN_SECRET must be a 32+ byte base64 or hex secret.');
+    throw new Error(
+      'MAMA_RECONFIRM_TOKEN_SECRET must be a 32+ byte secret (optionally prefixed with hex:, base64:, or utf8:).'
+    );
   }
 
   return {
@@ -1208,7 +1231,7 @@ export function revertCorrection(
         new_value_json:
           row.target_kind === 'membership'
             ? revertMembershipValueJson(row.old_value_json)
-            : row.old_value_json ?? canonicalizeJSON(null),
+            : (row.old_value_json ?? canonicalizeJSON(null)),
         reason: 'Revert correction',
         confirmed: true,
         confirmed_by: input.confirmed_by,
@@ -1474,30 +1497,19 @@ export function supersedeCorrection(
       )
       .run(input.old_correction_id);
 
-    correctionAdapter
-      .prepare(
-        `
-          INSERT INTO case_corrections (
-            correction_id, case_id, target_kind, target_ref_json, target_ref_hash,
-            field_name, old_value_json, new_value_json, reason,
-            applied_by, applied_at, is_lock_active, reverted_at, superseded_by
-          )
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, NULL, NULL)
-        `
-      )
-      .run(
-        newCorrectionId,
-        old.case_id,
-        old.target_kind,
-        old.target_ref_json,
-        old.target_ref_hash,
-        old.field_name,
-        currentValueJson,
-        input.new_value_json,
-        input.reason,
-        input.confirmed_by,
-        now
-      );
+    insertCaseCorrectionLock(adapter, {
+      correction_id: newCorrectionId,
+      case_id: old.case_id,
+      target_kind: old.target_kind,
+      target_ref: syntheticTargetRef,
+      field_name: (old.field_name as ApplyCorrectionInput['field_name']) ?? undefined,
+      old_value_json: currentValueJson,
+      new_value_json: input.new_value_json,
+      reason: input.reason,
+      applied_by: input.confirmed_by,
+      applied_at: now,
+      is_lock_active: 1,
+    });
 
     // Populate linkage last — sole mutation of superseded_by, permitted by
     // spec §5.4 amendment-8 (2026-04-18).

--- a/packages/mama-core/src/cases/corrections.ts
+++ b/packages/mama-core/src/cases/corrections.ts
@@ -827,6 +827,14 @@ function applyTargetMutation(input: {
   }
 }
 
+function revertMembershipValueJson(value: string | null): string {
+  const canonicalValue = canonicalJsonOrNull(value);
+  if (canonicalValue === null || canonicalValue === canonicalizeJSON(null)) {
+    return canonicalizeJSON({ status: 'removed' });
+  }
+  return canonicalValue;
+}
+
 function insertCorrectionMemoryEvent(input: {
   adapter: CorrectionAdapter;
   event_type: 'case.correction_applied' | 'case.correction_reverted' | 'case.correction_superseded';
@@ -1197,7 +1205,10 @@ export function revertCorrection(
         target_ref: parseJsonValue(row.target_ref_json) as CaseTargetRef,
         field_name: row.field_name ?? undefined,
         old_value_json: null,
-        new_value_json: row.old_value_json ?? canonicalizeJSON(null),
+        new_value_json:
+          row.target_kind === 'membership'
+            ? revertMembershipValueJson(row.old_value_json)
+            : row.old_value_json ?? canonicalizeJSON(null),
         reason: 'Revert correction',
         confirmed: true,
         confirmed_by: input.confirmed_by,

--- a/packages/mama-core/src/cases/corrections.ts
+++ b/packages/mama-core/src/cases/corrections.ts
@@ -1317,14 +1317,6 @@ export function supersedeCorrection(
     }
 
     if (Number(old.is_lock_active) === 0) {
-      if (old.superseded_by !== null) {
-        return {
-          kind: 'rejected',
-          code: 'case.correction_already_superseded',
-          message: 'Correction has already been superseded.',
-          correction_id: input.old_correction_id,
-        };
-      }
       return {
         kind: 'rejected',
         code: 'case.correction_inactive',

--- a/packages/mama-core/src/cases/corrections.ts
+++ b/packages/mama-core/src/cases/corrections.ts
@@ -175,6 +175,10 @@ interface MembershipValueRow {
 interface CorrectionStatusRow {
   correction_id: string;
   case_id: string;
+  target_kind: ApplyCorrectionInput['target_kind'];
+  target_ref_json: string;
+  field_name: ApplyCorrectionInput['field_name'] | null;
+  old_value_json: string | null;
   is_lock_active: number;
   reverted_at: string | null;
 }
@@ -510,6 +514,17 @@ function readCaseFieldCurrentValueJson(
     return canonicalStoredJson(row[field]);
   }
 
+  if (field === 'confidence') {
+    if (row.confidence === null || row.confidence === undefined) {
+      return canonicalizeJSON(null);
+    }
+    const confidence = Number(row.confidence);
+    if (!Number.isFinite(confidence)) {
+      throw new Error(`case_truth confidence is not a finite number for case_id=${caseId}`);
+    }
+    return canonicalizeJSON(confidence);
+  }
+
   return canonicalizeJSON(row[field]);
 }
 
@@ -570,6 +585,14 @@ function storageValueForCaseField(field: CorrectionFieldName, newValueJson: stri
 
   if (field === 'primary_actors' || field === 'blockers') {
     return canonicalizeJSON(value);
+  }
+
+  if (field === 'confidence') {
+    const confidence = Number(value);
+    if (!Number.isFinite(confidence)) {
+      throw new Error('Case field confidence correction value must be a finite number or null.');
+    }
+    return String(confidence);
   }
 
   if (typeof value !== 'string') {
@@ -1092,7 +1115,8 @@ export function revertCorrection(
     const row = correctionAdapter
       .prepare(
         `
-          SELECT correction_id, case_id, is_lock_active, reverted_at
+          SELECT correction_id, case_id, target_kind, target_ref_json, field_name,
+                 old_value_json, is_lock_active, reverted_at
           FROM case_corrections
           WHERE correction_id = ?
         `
@@ -1116,6 +1140,23 @@ export function revertCorrection(
         correction_id: input.correction_id,
       };
     }
+
+    applyTargetMutation({
+      adapter: correctionAdapter,
+      correction: {
+        case_id: row.case_id,
+        target_kind: row.target_kind,
+        target_ref: parseJsonValue(row.target_ref_json) as CaseTargetRef,
+        field_name: row.field_name ?? undefined,
+        old_value_json: null,
+        new_value_json: row.old_value_json ?? canonicalizeJSON(null),
+        reason: 'Revert correction',
+        confirmed: true,
+        confirmed_by: input.confirmed_by,
+        confirmation_summary: input.confirmation_summary,
+      },
+      now,
+    });
 
     correctionAdapter
       .prepare(

--- a/packages/mama-core/src/cases/freshness.ts
+++ b/packages/mama-core/src/cases/freshness.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { canonicalizeJSON } from '../canonicalize.js';
 import type { DatabaseAdapter } from '../db-manager.js';
 import { runImmediateTransaction, type ImmediateTransactionAdapter } from './sqlite-transaction.js';
-import { resolveCanonicalCaseChain } from './store.js';
+import { expandCaseChainForAssembly, resolveCanonicalCaseChain } from './store.js';
 import type { CanonicalCaseResolution } from './types.js';
 
 export type CaseFreshnessState = 'fresh' | 'stale' | 'drifted' | 'unknown';
@@ -114,42 +114,6 @@ function resolveChain(adapter: FreshnessAdapter, caseId: string): CanonicalCaseR
     }
     throw error;
   }
-}
-
-function expandCaseChainForAssembly(
-  adapter: FreshnessAdapter,
-  terminalCaseId: string,
-  resolvedChain: string[]
-): string[] {
-  const rows = adapter
-    .prepare(
-      `
-        WITH RECURSIVE merged_chain(case_id, depth) AS (
-          SELECT case_id, 0
-            FROM case_truth
-           WHERE case_id = ?
-
-          UNION
-
-          SELECT ct.case_id, merged_chain.depth + 1
-            FROM case_truth ct
-            JOIN merged_chain ON ct.canonical_case_id = merged_chain.case_id
-           WHERE merged_chain.depth < 64
-        )
-        SELECT case_id
-          FROM merged_chain
-         ORDER BY depth ASC, case_id ASC
-      `
-    )
-    .all(terminalCaseId) as Array<{ case_id: string }>;
-
-  const chain: string[] = [];
-  for (const caseId of [...resolvedChain, ...rows.map((row) => row.case_id)]) {
-    if (!chain.includes(caseId)) {
-      chain.push(caseId);
-    }
-  }
-  return chain;
 }
 
 function loadCase(adapter: FreshnessAdapter, caseId: string): CaseFreshnessRow | null {

--- a/packages/mama-core/src/cases/freshness.ts
+++ b/packages/mama-core/src/cases/freshness.ts
@@ -67,6 +67,7 @@ interface CaseFreshnessRow {
   freshness_state: CaseFreshnessState | null;
   freshness_score_is_drifted: number;
   freshness_drift_threshold: number | null;
+  freshness_checked_at: string | null;
   freshness_reason_json: string | null;
 }
 
@@ -157,7 +158,7 @@ function loadCase(adapter: FreshnessAdapter, caseId: string): CaseFreshnessRow |
       `
         SELECT case_id, status, current_wiki_path, last_activity_at, state_updated_at,
                compiled_at, freshness_score, freshness_state, freshness_score_is_drifted,
-               freshness_drift_threshold, freshness_reason_json
+               freshness_drift_threshold, freshness_checked_at, freshness_reason_json
         FROM case_truth
         WHERE case_id = ?
       `

--- a/packages/mama-core/src/cases/freshness.ts
+++ b/packages/mama-core/src/cases/freshness.ts
@@ -305,7 +305,7 @@ export function sweepCaseFreshness(
       }
 
       if (TERMINAL_CASE_STATUSES.has(row.status)) {
-        if (input.case_ids && input.case_ids.length === 1) {
+        if (input.case_ids) {
           rejected.push({
             case_id: requestedCaseId,
             code: 'case.terminal_status',
@@ -413,6 +413,7 @@ export function listDriftedCases(
         FROM case_truth
         WHERE freshness_state = 'drifted'
           AND freshness_score_is_drifted = 1
+          AND status NOT IN ('merged','archived','split')
         ORDER BY freshness_score ASC, case_id ASC
       `
     )

--- a/packages/mama-core/src/cases/freshness.ts
+++ b/packages/mama-core/src/cases/freshness.ts
@@ -74,13 +74,23 @@ interface CaseFreshnessRow {
 const DEFAULT_DRIFT_THRESHOLD = 0.5;
 const TERMINAL_CASE_STATUSES = new Set(['merged', 'archived', 'split']);
 
+function parseRequiredTimestamp(value: string, errorMessage: string): number {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(errorMessage);
+  }
+  return parsed;
+}
+
 function normalizeNow(value?: string): string {
-  return value ?? new Date().toISOString();
+  if (value === undefined) {
+    return new Date().toISOString();
+  }
+  return new Date(parseRequiredTimestamp(value, 'invalid now timestamp')).toISOString();
 }
 
 function createdAtMs(value: string): number {
-  const parsed = Date.parse(value);
-  return Number.isFinite(parsed) ? parsed : Date.now();
+  return parseRequiredTimestamp(value, 'invalid now timestamp');
 }
 
 function timestampMs(value: string | null | undefined): number | null {

--- a/packages/mama-core/src/cases/freshness.ts
+++ b/packages/mama-core/src/cases/freshness.ts
@@ -1,0 +1,453 @@
+import { randomUUID } from 'node:crypto';
+
+import { canonicalizeJSON } from '../canonicalize.js';
+import type { DatabaseAdapter } from '../db-manager.js';
+import { runImmediateTransaction, type ImmediateTransactionAdapter } from './sqlite-transaction.js';
+import { resolveCanonicalCaseChain } from './store.js';
+import type { CanonicalCaseResolution } from './types.js';
+
+export type CaseFreshnessState = 'fresh' | 'stale' | 'drifted' | 'unknown';
+
+export interface CaseFreshnessReason {
+  code:
+    | 'missing_compile'
+    | 'activity_after_compile'
+    | 'state_update_after_compile'
+    | 'wiki_index_missing'
+    | 'timestamps_absent';
+  penalty: number;
+  detail?: string;
+}
+
+export interface CaseFreshnessCalculation {
+  freshness_score: number;
+  freshness_state: CaseFreshnessState;
+  freshness_score_is_drifted: 0 | 1;
+  freshness_drift_threshold: number;
+  reasons: CaseFreshnessReason[];
+  freshness_reason_json: string;
+}
+
+export interface CaseFreshnessResult extends CaseFreshnessCalculation {
+  case_id: string;
+  terminal_case_id: string;
+  resolved_via_case_id: string | null;
+  chain: string[];
+  freshness_checked_at: string;
+  changed: boolean;
+}
+
+export interface SweepCaseFreshnessInput {
+  case_ids?: string[];
+  now?: string;
+  drift_threshold?: number;
+}
+
+export interface SweepCaseFreshnessResult {
+  checked: number;
+  fresh: number;
+  stale: number;
+  drifted: number;
+  drifted_case_ids: string[];
+  results: CaseFreshnessResult[];
+  rejected?: Array<{ case_id: string; code: 'case.terminal_status'; message: string }>;
+}
+
+type FreshnessAdapter = Pick<DatabaseAdapter, 'prepare' | 'transaction'> &
+  Partial<Pick<ImmediateTransactionAdapter, 'exec'>>;
+
+interface CaseFreshnessRow {
+  case_id: string;
+  status: string;
+  current_wiki_path: string | null;
+  last_activity_at: string | null;
+  state_updated_at: string | null;
+  compiled_at: string | null;
+  freshness_score: number | null;
+  freshness_state: CaseFreshnessState | null;
+  freshness_score_is_drifted: number;
+  freshness_drift_threshold: number | null;
+  freshness_reason_json: string | null;
+}
+
+const DEFAULT_DRIFT_THRESHOLD = 0.5;
+const TERMINAL_CASE_STATUSES = new Set(['merged', 'archived', 'split']);
+
+function normalizeNow(value?: string): string {
+  return value ?? new Date().toISOString();
+}
+
+function createdAtMs(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+function timestampMs(value: string | null | undefined): number | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizedThreshold(value: number | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_DRIFT_THRESHOLD;
+  }
+  if (!Number.isFinite(value) || value < 0 || value > 1) {
+    throw new Error('freshness drift_threshold must be between 0 and 1.');
+  }
+  return Number(value.toFixed(4));
+}
+
+function score(value: number): number {
+  return Number(Math.max(0, Math.min(1, value)).toFixed(4));
+}
+
+function resolveChain(adapter: FreshnessAdapter, caseId: string): CanonicalCaseResolution | null {
+  try {
+    return resolveCanonicalCaseChain(adapter, caseId);
+  } catch (error) {
+    if (error instanceof Error && /not found/i.test(error.message)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function expandCaseChainForAssembly(
+  adapter: FreshnessAdapter,
+  terminalCaseId: string,
+  resolvedChain: string[]
+): string[] {
+  const rows = adapter
+    .prepare(
+      `
+        WITH RECURSIVE merged_chain(case_id, depth) AS (
+          SELECT case_id, 0
+            FROM case_truth
+           WHERE case_id = ?
+
+          UNION
+
+          SELECT ct.case_id, merged_chain.depth + 1
+            FROM case_truth ct
+            JOIN merged_chain ON ct.canonical_case_id = merged_chain.case_id
+           WHERE merged_chain.depth < 64
+        )
+        SELECT case_id
+          FROM merged_chain
+         ORDER BY depth ASC, case_id ASC
+      `
+    )
+    .all(terminalCaseId) as Array<{ case_id: string }>;
+
+  const chain: string[] = [];
+  for (const caseId of [...resolvedChain, ...rows.map((row) => row.case_id)]) {
+    if (!chain.includes(caseId)) {
+      chain.push(caseId);
+    }
+  }
+  return chain;
+}
+
+function loadCase(adapter: FreshnessAdapter, caseId: string): CaseFreshnessRow | null {
+  const row = adapter
+    .prepare(
+      `
+        SELECT case_id, status, current_wiki_path, last_activity_at, state_updated_at,
+               compiled_at, freshness_score, freshness_state, freshness_score_is_drifted,
+               freshness_drift_threshold, freshness_reason_json
+        FROM case_truth
+        WHERE case_id = ?
+      `
+    )
+    .get(caseId) as CaseFreshnessRow | undefined;
+
+  return row ?? null;
+}
+
+function wikiIndexUpdatedAt(adapter: FreshnessAdapter, caseId: string): string | null {
+  const row = adapter
+    .prepare(
+      `
+        SELECT updated_at
+        FROM wiki_page_index
+        WHERE case_id = ?
+          AND page_type = 'case'
+        ORDER BY updated_at DESC, page_id ASC
+        LIMIT 1
+      `
+    )
+    .get(caseId) as { updated_at: string } | undefined;
+
+  return row?.updated_at ?? null;
+}
+
+function allCandidateCaseIds(adapter: FreshnessAdapter): string[] {
+  const rows = adapter
+    .prepare(
+      `
+        SELECT case_id
+        FROM case_truth
+        WHERE status NOT IN ('merged','archived','split')
+        ORDER BY case_id ASC
+      `
+    )
+    .all() as Array<{ case_id: string }>;
+
+  return rows.map((row) => row.case_id);
+}
+
+function insertDriftEvent(input: {
+  adapter: FreshnessAdapter;
+  case_id: string;
+  result: CaseFreshnessCalculation;
+  now: string;
+}): void {
+  input.adapter
+    .prepare(
+      `
+        INSERT INTO memory_events (
+          event_id, event_type, actor, source_turn_id, memory_id, topic,
+          scope_refs, evidence_refs, reason, created_at
+        )
+        VALUES (?, 'case.freshness_drifted', 'system', NULL, NULL, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      `me_${randomUUID()}`,
+      `case:${input.case_id}`,
+      canonicalizeJSON([{ type: 'case', id: input.case_id }]),
+      canonicalizeJSON([input.case_id]),
+      canonicalizeJSON({
+        freshness_score: input.result.freshness_score,
+        freshness_drift_threshold: input.result.freshness_drift_threshold,
+        reasons: input.result.reasons,
+      }),
+      createdAtMs(input.now)
+    );
+}
+
+function hasFreshnessChanged(row: CaseFreshnessRow, result: CaseFreshnessCalculation): boolean {
+  return (
+    row.freshness_score !== result.freshness_score ||
+    row.freshness_state !== result.freshness_state ||
+    Number(row.freshness_score_is_drifted) !== result.freshness_score_is_drifted ||
+    row.freshness_drift_threshold !== result.freshness_drift_threshold ||
+    row.freshness_reason_json !== result.freshness_reason_json
+  );
+}
+
+export function calculateCaseFreshness(input: {
+  last_activity_at?: string | null;
+  state_updated_at?: string | null;
+  compiled_at?: string | null;
+  wiki_index_updated_at?: string | null;
+  current_wiki_path?: string | null;
+  drift_threshold?: number;
+  now?: string;
+}): CaseFreshnessCalculation {
+  const threshold = normalizedThreshold(input.drift_threshold);
+  const reasons: CaseFreshnessReason[] = [];
+  let value = 1.0;
+
+  const compiledMs = timestampMs(input.compiled_at);
+  const activityMs = timestampMs(input.last_activity_at);
+  const stateUpdatedMs = timestampMs(input.state_updated_at);
+  const wikiUpdatedMs = timestampMs(input.wiki_index_updated_at);
+  const hasWikiPath = Boolean(input.current_wiki_path && input.current_wiki_path.trim().length > 0);
+
+  if (compiledMs === null) {
+    value -= 0.5;
+    reasons.push({ code: 'missing_compile', penalty: 0.5 });
+  }
+
+  if (activityMs !== null && compiledMs !== null && activityMs > compiledMs) {
+    value -= 0.35;
+    reasons.push({ code: 'activity_after_compile', penalty: 0.35 });
+  }
+
+  if (stateUpdatedMs !== null && compiledMs !== null && stateUpdatedMs > compiledMs) {
+    value -= 0.25;
+    reasons.push({ code: 'state_update_after_compile', penalty: 0.25 });
+  }
+
+  if (hasWikiPath && wikiUpdatedMs === null) {
+    value -= 0.25;
+    reasons.push({
+      code: 'wiki_index_missing',
+      penalty: 0.25,
+      detail: input.current_wiki_path ?? '',
+    });
+  }
+
+  const timestampsAbsent = compiledMs === null && activityMs === null && stateUpdatedMs === null;
+  if (timestampsAbsent) {
+    reasons.push({ code: 'timestamps_absent', penalty: 0 });
+  }
+
+  const freshnessScore = score(value);
+  let state: CaseFreshnessState;
+  if (timestampsAbsent) {
+    state = 'unknown';
+  } else if (freshnessScore >= 0.8) {
+    state = 'fresh';
+  } else if (freshnessScore < threshold) {
+    state = 'drifted';
+  } else {
+    state = 'stale';
+  }
+
+  const result = {
+    freshness_score: freshnessScore,
+    freshness_state: state,
+    freshness_score_is_drifted: state === 'drifted' ? 1 : 0,
+    freshness_drift_threshold: threshold,
+    reasons,
+    freshness_reason_json: canonicalizeJSON(reasons),
+  } satisfies CaseFreshnessCalculation;
+
+  return result;
+}
+
+export function sweepCaseFreshness(
+  adapter: DatabaseAdapter,
+  input: SweepCaseFreshnessInput = {}
+): SweepCaseFreshnessResult {
+  const freshnessAdapter = adapter as unknown as FreshnessAdapter;
+
+  return runImmediateTransaction(freshnessAdapter, () => {
+    const now = normalizeNow(input.now);
+    const requestedCaseIds = input.case_ids ?? allCandidateCaseIds(freshnessAdapter);
+    const seenTerminalIds = new Set<string>();
+    const results: CaseFreshnessResult[] = [];
+    const rejected: Array<{ case_id: string; code: 'case.terminal_status'; message: string }> = [];
+
+    for (const requestedCaseId of requestedCaseIds) {
+      const resolution = resolveChain(freshnessAdapter, requestedCaseId);
+      if (!resolution) {
+        continue;
+      }
+
+      if (seenTerminalIds.has(resolution.terminal_case_id)) {
+        continue;
+      }
+
+      const row = loadCase(freshnessAdapter, resolution.terminal_case_id);
+      if (!row) {
+        continue;
+      }
+
+      if (TERMINAL_CASE_STATUSES.has(row.status)) {
+        if (input.case_ids && input.case_ids.length === 1) {
+          rejected.push({
+            case_id: requestedCaseId,
+            code: 'case.terminal_status',
+            message: `Freshness cannot be written to terminal case status ${row.status}.`,
+          });
+        }
+        continue;
+      }
+
+      seenTerminalIds.add(resolution.terminal_case_id);
+      const chain = expandCaseChainForAssembly(
+        freshnessAdapter,
+        resolution.terminal_case_id,
+        resolution.chain
+      );
+      const calculation = calculateCaseFreshness({
+        last_activity_at: row.last_activity_at,
+        state_updated_at: row.state_updated_at,
+        compiled_at: row.compiled_at,
+        wiki_index_updated_at: wikiIndexUpdatedAt(freshnessAdapter, resolution.terminal_case_id),
+        current_wiki_path: row.current_wiki_path,
+        drift_threshold: input.drift_threshold,
+        now,
+      });
+      const changed = hasFreshnessChanged(row, calculation);
+      const driftedTransition =
+        changed && row.freshness_state !== 'drifted' && calculation.freshness_state === 'drifted';
+
+      if (changed) {
+        freshnessAdapter
+          .prepare(
+            `
+              UPDATE case_truth
+              SET freshness_score = ?,
+                  freshness_state = ?,
+                  freshness_score_is_drifted = ?,
+                  freshness_drift_threshold = ?,
+                  freshness_checked_at = ?,
+                  freshness_reason_json = ?
+              WHERE case_id = ?
+            `
+          )
+          .run(
+            calculation.freshness_score,
+            calculation.freshness_state,
+            calculation.freshness_score_is_drifted,
+            calculation.freshness_drift_threshold,
+            now,
+            calculation.freshness_reason_json,
+            resolution.terminal_case_id
+          );
+
+        if (driftedTransition) {
+          insertDriftEvent({
+            adapter: freshnessAdapter,
+            case_id: resolution.terminal_case_id,
+            result: calculation,
+            now,
+          });
+        }
+      }
+
+      results.push({
+        case_id: requestedCaseId,
+        terminal_case_id: resolution.terminal_case_id,
+        resolved_via_case_id: resolution.resolved_via_case_id,
+        chain,
+        freshness_checked_at: changed
+          ? now
+          : ((row as { freshness_checked_at?: string | null }).freshness_checked_at ?? now),
+        changed,
+        ...calculation,
+      });
+    }
+
+    return {
+      checked: results.length,
+      fresh: results.filter((result) => result.freshness_state === 'fresh').length,
+      stale: results.filter((result) => result.freshness_state === 'stale').length,
+      drifted: results.filter((result) => result.freshness_state === 'drifted').length,
+      drifted_case_ids: results
+        .filter((result) => result.freshness_state === 'drifted')
+        .map((result) => result.terminal_case_id),
+      results,
+      ...(rejected.length > 0 ? { rejected } : {}),
+    };
+  });
+}
+
+export function listDriftedCases(
+  adapter: DatabaseAdapter
+): Array<{ case_id: string; freshness_score: number; freshness_checked_at: string | null }> {
+  const rows = adapter
+    .prepare(
+      `
+        SELECT case_id, freshness_score, freshness_checked_at
+        FROM case_truth
+        WHERE freshness_state = 'drifted'
+          AND freshness_score_is_drifted = 1
+        ORDER BY freshness_score ASC, case_id ASC
+      `
+    )
+    .all() as Array<{
+    case_id: string;
+    freshness_score: number;
+    freshness_checked_at: string | null;
+  }>;
+
+  return rows;
+}

--- a/packages/mama-core/src/cases/freshness.ts
+++ b/packages/mama-core/src/cases/freshness.ts
@@ -366,6 +366,16 @@ export function sweepCaseFreshness(
             now,
           });
         }
+      } else {
+        freshnessAdapter
+          .prepare(
+            `
+              UPDATE case_truth
+              SET freshness_checked_at = ?
+              WHERE case_id = ?
+            `
+          )
+          .run(now, resolution.terminal_case_id);
       }
 
       results.push({
@@ -373,9 +383,7 @@ export function sweepCaseFreshness(
         terminal_case_id: resolution.terminal_case_id,
         resolved_via_case_id: resolution.resolved_via_case_id,
         chain,
-        freshness_checked_at: changed
-          ? now
-          : ((row as { freshness_checked_at?: string | null }).freshness_checked_at ?? now),
+        freshness_checked_at: now,
         changed,
         ...calculation,
       });

--- a/packages/mama-core/src/cases/live-state.ts
+++ b/packages/mama-core/src/cases/live-state.ts
@@ -1,0 +1,480 @@
+import { randomUUID } from 'node:crypto';
+
+import { canonicalizeJSON } from '../canonicalize.js';
+import type { DatabaseAdapter } from '../db-manager.js';
+import {
+  buildCaseFieldTargetRef,
+  buildMembershipTargetRef,
+  canonicalTargetRef,
+  type CanonicalTargetRef,
+} from './target-ref.js';
+import { runImmediateTransaction, type ImmediateTransactionAdapter } from './sqlite-transaction.js';
+import type {
+  CaseCorrectionTargetKind,
+  CaseFastWriteStatus as CaseFastWriteStatusFromTypes,
+  CaseMembershipSourceType,
+} from './types.js';
+
+export type CaseFastWriteErrorCode =
+  | 'case.precompile_gap'
+  | 'case.lock_held'
+  | 'case.terminal_status'
+  | 'case.correction_active_conflict';
+
+export interface CaseMembershipWritePlan {
+  source_type: 'decision' | 'event' | 'observation' | 'artifact';
+  source_id: string;
+  role?: 'requester' | 'implementer' | 'reviewer' | 'observer' | 'affected' | null;
+  confidence: number;
+  reason: string;
+  status: 'active' | 'candidate';
+}
+
+type CaseFastWriteStatus = CaseFastWriteStatusFromTypes;
+
+export interface WriteCaseLiveStateInput {
+  case_id: string;
+  source_event_id: string;
+  source_type: 'event';
+  status?: CaseFastWriteStatus;
+  last_activity_at?: string;
+  membership?: CaseMembershipWritePlan;
+  actor?: 'memory_agent';
+  now?: string;
+}
+
+export type WriteCaseLiveStateResult =
+  | {
+      kind: 'applied';
+      case_id: string;
+      applied_targets: Array<{
+        target_kind: 'case_field' | 'membership';
+        target_ref_json: string;
+      }>;
+      skipped_targets: Array<{
+        target_kind: 'case_field' | 'membership';
+        target_ref_json: string;
+        correction_id: string;
+      }>;
+      audit_event_ids: string[];
+    }
+  | { kind: 'precompile_gap'; code: 'case.precompile_gap'; case_id: string }
+  | { kind: 'rejected'; code: CaseFastWriteErrorCode; message: string; case_id: string };
+
+type LiveStateAdapter = Pick<DatabaseAdapter, 'prepare' | 'transaction'> &
+  Partial<Pick<ImmediateTransactionAdapter, 'exec'>>;
+
+interface CaseTruthGateRow {
+  case_id: string;
+  status: string;
+}
+
+interface CaseChainRow {
+  case_id: string;
+}
+
+interface LockRow {
+  correction_id: string;
+  case_id: string;
+  target_kind: CaseCorrectionTargetKind;
+  field_name: string | null;
+  target_ref_json: string;
+  target_ref_hash: Uint8Array;
+}
+
+interface TargetPlan {
+  target_kind: 'case_field' | 'membership';
+  target_ref_json: string;
+  target_ref_hash: Buffer;
+}
+
+const TERMINAL_CASE_STATUSES = new Set(['merged', 'archived', 'split']);
+const FAST_WRITE_STATUSES = new Set<CaseFastWriteStatus>([
+  'active',
+  'blocked',
+  'resolved',
+  'stale',
+]);
+
+function isCaseFastWriteStatus(value: unknown): value is CaseFastWriteStatus {
+  return typeof value === 'string' && FAST_WRITE_STATUSES.has(value as CaseFastWriteStatus);
+}
+
+function normalizeNow(value?: string): string {
+  return value ?? new Date().toISOString();
+}
+
+function createdAtMs(now: string): number {
+  const parsed = Date.parse(now);
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+function placeholders(values: readonly unknown[]): string {
+  if (values.length === 0) {
+    throw new Error('Cannot build SQL IN clause for an empty value list.');
+  }
+  return values.map(() => '?').join(', ');
+}
+
+function toHashKey(value: Uint8Array | Buffer): string {
+  return Buffer.from(value).toString('hex');
+}
+
+function targetPlanForCanonical(
+  target_kind: 'case_field' | 'membership',
+  canonical: CanonicalTargetRef
+): TargetPlan {
+  return {
+    target_kind,
+    target_ref_json: canonical.json,
+    target_ref_hash: canonical.hash,
+  };
+}
+
+function buildTargetPlans(input: WriteCaseLiveStateInput): TargetPlan[] {
+  const targets: TargetPlan[] = [];
+
+  if (input.status !== undefined) {
+    targets.push(
+      targetPlanForCanonical('case_field', canonicalTargetRef(buildCaseFieldTargetRef('status')))
+    );
+  }
+
+  if (input.last_activity_at !== undefined) {
+    targets.push(
+      targetPlanForCanonical(
+        'case_field',
+        canonicalTargetRef(buildCaseFieldTargetRef('last_activity_at'))
+      )
+    );
+  }
+
+  if (input.membership) {
+    targets.push(
+      targetPlanForCanonical(
+        'membership',
+        canonicalTargetRef(
+          buildMembershipTargetRef(
+            input.membership.source_type as CaseMembershipSourceType,
+            input.membership.source_id
+          )
+        )
+      )
+    );
+  }
+
+  return targets;
+}
+
+function readCaseChain(adapter: LiveStateAdapter, caseId: string): string[] {
+  const rows = adapter
+    .prepare(
+      `
+        WITH RECURSIVE case_chain(case_id) AS (
+          SELECT case_id
+          FROM case_truth
+          WHERE case_id = ?
+
+          UNION
+
+          SELECT ct.case_id
+          FROM case_truth ct
+          JOIN case_chain cc ON ct.canonical_case_id = cc.case_id
+        )
+        SELECT case_id
+        FROM case_chain
+      `
+    )
+    .all(caseId) as CaseChainRow[];
+
+  return rows.map((row) => row.case_id);
+}
+
+function readActiveLocks(
+  adapter: LiveStateAdapter,
+  chainIds: string[],
+  targets: TargetPlan[]
+): Map<string, LockRow> {
+  if (chainIds.length === 0 || targets.length === 0) {
+    return new Map();
+  }
+
+  const targetHashes = targets.map((target) => target.target_ref_hash);
+  const rows = adapter
+    .prepare(
+      `
+        SELECT correction_id, case_id, target_kind, field_name, target_ref_json, target_ref_hash
+        FROM case_corrections
+        WHERE case_id IN (${placeholders(chainIds)})
+          AND is_lock_active = 1
+          AND reverted_at IS NULL
+          AND target_ref_hash IN (${placeholders(targetHashes)})
+      `
+    )
+    .all(...chainIds, ...targetHashes) as LockRow[];
+
+  const locks = new Map<string, LockRow>();
+  for (const row of rows) {
+    locks.set(toHashKey(row.target_ref_hash), row);
+  }
+  return locks;
+}
+
+function findTarget(
+  targets: TargetPlan[],
+  target_kind: 'case_field' | 'membership',
+  target_ref_json: string
+): TargetPlan | null {
+  return (
+    targets.find(
+      (target) => target.target_kind === target_kind && target.target_ref_json === target_ref_json
+    ) ?? null
+  );
+}
+
+function hasLock(locks: Map<string, LockRow>, target: TargetPlan | null): LockRow | null {
+  if (!target) {
+    return null;
+  }
+  return locks.get(toHashKey(target.target_ref_hash)) ?? null;
+}
+
+function insertSkippedAuditEvent(input: {
+  adapter: LiveStateAdapter;
+  case_id: string;
+  source_event_id: string;
+  skipped_targets: Array<{
+    target_kind: 'case_field' | 'membership';
+    target_ref_json: string;
+    correction_id: string;
+  }>;
+  now: string;
+}): string {
+  const eventId = `me_${randomUUID()}`;
+
+  input.adapter
+    .prepare(
+      `
+        INSERT INTO memory_events (
+          event_id, event_type, actor, source_turn_id, memory_id, topic,
+          scope_refs, evidence_refs, reason, created_at
+        )
+        VALUES (?, 'case.fast_write_lock_skipped', 'memory_agent', ?, NULL, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      eventId,
+      input.source_event_id,
+      `case:${input.case_id}`,
+      canonicalizeJSON([{ type: 'case', id: input.case_id }]),
+      canonicalizeJSON([input.source_event_id]),
+      canonicalizeJSON({ skipped_targets: input.skipped_targets }),
+      createdAtMs(input.now)
+    );
+
+  return eventId;
+}
+
+export function writeCaseLiveStateFromEvent(
+  adapter: DatabaseAdapter,
+  input: WriteCaseLiveStateInput
+): WriteCaseLiveStateResult {
+  const liveAdapter = adapter as unknown as LiveStateAdapter;
+
+  return runImmediateTransaction(liveAdapter, () => {
+    const caseRow = liveAdapter
+      .prepare(
+        `
+          SELECT case_id, status
+          FROM case_truth
+          WHERE case_id = ?
+        `
+      )
+      .get(input.case_id) as CaseTruthGateRow | undefined;
+
+    if (!caseRow) {
+      return { kind: 'precompile_gap', code: 'case.precompile_gap', case_id: input.case_id };
+    }
+
+    if (TERMINAL_CASE_STATUSES.has(caseRow.status)) {
+      return {
+        kind: 'rejected',
+        code: 'case.terminal_status',
+        message: `Memory-agent cannot update terminal case status ${caseRow.status}.`,
+        case_id: input.case_id,
+      };
+    }
+
+    if (input.status !== undefined && !isCaseFastWriteStatus(input.status)) {
+      return {
+        kind: 'rejected',
+        code: 'case.terminal_status',
+        message: `Memory-agent cannot write terminal case status ${String(input.status)}.`,
+        case_id: input.case_id,
+      };
+    }
+
+    const now = normalizeNow(input.now);
+    const chainIds = readCaseChain(liveAdapter, input.case_id);
+    const targets = buildTargetPlans(input);
+    const locks = readActiveLocks(liveAdapter, chainIds, targets);
+
+    const applied_targets: Array<{
+      target_kind: 'case_field' | 'membership';
+      target_ref_json: string;
+    }> = [];
+    const skipped_targets: Array<{
+      target_kind: 'case_field' | 'membership';
+      target_ref_json: string;
+      correction_id: string;
+    }> = [];
+
+    const statusTarget = targets[0] ?? null;
+    const lastActivityTarget =
+      input.status !== undefined ? (targets[1] ?? null) : (targets[0] ?? null);
+    const membershipTarget = input.membership
+      ? findTarget(
+          targets,
+          'membership',
+          canonicalTargetRef(
+            buildMembershipTargetRef(
+              input.membership.source_type as CaseMembershipSourceType,
+              input.membership.source_id
+            )
+          ).json
+        )
+      : null;
+
+    const statusLock = input.status !== undefined ? hasLock(locks, statusTarget) : null;
+    const lastActivityLock =
+      input.last_activity_at !== undefined ? hasLock(locks, lastActivityTarget) : null;
+    const membershipLock = input.membership ? hasLock(locks, membershipTarget) : null;
+
+    if (statusLock && statusTarget) {
+      skipped_targets.push({
+        target_kind: statusTarget.target_kind,
+        target_ref_json: statusTarget.target_ref_json,
+        correction_id: statusLock.correction_id,
+      });
+    }
+
+    if (lastActivityLock && lastActivityTarget) {
+      skipped_targets.push({
+        target_kind: lastActivityTarget.target_kind,
+        target_ref_json: lastActivityTarget.target_ref_json,
+        correction_id: lastActivityLock.correction_id,
+      });
+    }
+
+    if (membershipLock && membershipTarget) {
+      skipped_targets.push({
+        target_kind: membershipTarget.target_kind,
+        target_ref_json: membershipTarget.target_ref_json,
+        correction_id: membershipLock.correction_id,
+      });
+    }
+
+    const shouldWriteStatus = input.status !== undefined && !statusLock;
+    const shouldWriteLastActivity = input.last_activity_at !== undefined && !lastActivityLock;
+
+    if (shouldWriteStatus || shouldWriteLastActivity) {
+      const updateResult = liveAdapter
+        .prepare(
+          `
+            UPDATE case_truth
+               SET status = CASE WHEN ? = 1 THEN ? ELSE status END,
+                   last_activity_at = CASE WHEN ? = 1 THEN ? ELSE last_activity_at END,
+                   state_updated_at = ?,
+                   updated_at = ?
+             WHERE case_id = ?
+               AND status NOT IN ('merged','archived','split')
+          `
+        )
+        .run(
+          shouldWriteStatus ? 1 : 0,
+          input.status ?? null,
+          shouldWriteLastActivity ? 1 : 0,
+          input.last_activity_at ?? null,
+          now,
+          now,
+          input.case_id
+        );
+
+      if (updateResult.changes > 0) {
+        if (shouldWriteStatus && statusTarget) {
+          applied_targets.push({
+            target_kind: statusTarget.target_kind,
+            target_ref_json: statusTarget.target_ref_json,
+          });
+        }
+        if (shouldWriteLastActivity && lastActivityTarget) {
+          applied_targets.push({
+            target_kind: lastActivityTarget.target_kind,
+            target_ref_json: lastActivityTarget.target_ref_json,
+          });
+        }
+      }
+    }
+
+    if (input.membership && !membershipLock && membershipTarget) {
+      const membershipResult = liveAdapter
+        .prepare(
+          `
+            INSERT INTO case_memberships (
+              case_id, source_type, source_id, role, confidence, reason, status,
+              added_by, added_at, user_locked, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, 'memory-agent', ?, 0, ?)
+            ON CONFLICT(case_id, source_type, source_id) DO UPDATE SET
+              role = excluded.role,
+              confidence = excluded.confidence,
+              reason = excluded.reason,
+              status = excluded.status,
+              added_by = 'memory-agent',
+              updated_at = excluded.updated_at
+            WHERE case_memberships.user_locked = 0
+              AND case_memberships.status <> 'stale'
+          `
+        )
+        .run(
+          input.case_id,
+          input.membership.source_type,
+          input.membership.source_id,
+          input.membership.role ?? null,
+          input.membership.confidence,
+          input.membership.reason,
+          input.membership.status,
+          now,
+          now
+        );
+
+      if (membershipResult.changes > 0) {
+        applied_targets.push({
+          target_kind: membershipTarget.target_kind,
+          target_ref_json: membershipTarget.target_ref_json,
+        });
+      }
+    }
+
+    const audit_event_ids =
+      skipped_targets.length > 0
+        ? [
+            insertSkippedAuditEvent({
+              adapter: liveAdapter,
+              case_id: input.case_id,
+              source_event_id: input.source_event_id,
+              skipped_targets,
+              now,
+            }),
+          ]
+        : [];
+
+    return {
+      kind: 'applied',
+      case_id: input.case_id,
+      applied_targets,
+      skipped_targets,
+      audit_event_ids,
+    };
+  });
+}

--- a/packages/mama-core/src/cases/membership-explain.ts
+++ b/packages/mama-core/src/cases/membership-explain.ts
@@ -1,6 +1,6 @@
 import { canonicalizeJSON } from '../canonicalize.js';
 import type { DatabaseAdapter } from '../db-manager.js';
-import { resolveCanonicalCaseChain } from './store.js';
+import { expandCaseChainForAssembly, resolveCanonicalCaseChain } from './store.js';
 import type { CaseMembershipSourceType } from './types.js';
 
 export interface CaseMembershipScoreBreakdown {
@@ -81,42 +81,6 @@ function placeholders(values: readonly unknown[]): string {
     throw new Error('Cannot build SQL IN clause for an empty value list.');
   }
   return values.map(() => '?').join(', ');
-}
-
-function expandCaseChainForAssembly(
-  adapter: MembershipExplainAdapter,
-  terminalCaseId: string,
-  resolvedChain: string[]
-): string[] {
-  const rows = adapter
-    .prepare(
-      `
-        WITH RECURSIVE merged_chain(case_id, depth) AS (
-          SELECT case_id, 0
-            FROM case_truth
-           WHERE case_id = ?
-
-          UNION
-
-          SELECT ct.case_id, merged_chain.depth + 1
-            FROM case_truth ct
-            JOIN merged_chain ON ct.canonical_case_id = merged_chain.case_id
-           WHERE merged_chain.depth < 64
-        )
-        SELECT case_id
-          FROM merged_chain
-         ORDER BY depth ASC, case_id ASC
-      `
-    )
-    .all(terminalCaseId) as Array<{ case_id: string }>;
-
-  const chain: string[] = [];
-  for (const caseId of [...resolvedChain, ...rows.map((row) => row.case_id)]) {
-    if (!chain.includes(caseId)) {
-      chain.push(caseId);
-    }
-  }
-  return chain;
 }
 
 function loadMembership(

--- a/packages/mama-core/src/cases/membership-explain.ts
+++ b/packages/mama-core/src/cases/membership-explain.ts
@@ -1,0 +1,280 @@
+import { canonicalizeJSON } from '../canonicalize.js';
+import type { DatabaseAdapter } from '../db-manager.js';
+import { resolveCanonicalCaseChain } from './store.js';
+import type { CaseMembershipSourceType } from './types.js';
+
+export interface CaseMembershipScoreBreakdown {
+  entity_overlap: number | null;
+  embedding_similarity: number | null;
+  temporal_proximity: number | null;
+  explicit_from_wiki: number | null;
+}
+
+export interface CaseMembershipExplanation {
+  case_id: string;
+  terminal_case_id: string;
+  resolved_via_case_id: string | null;
+  chain: string[];
+  source_type: CaseMembershipSourceType;
+  source_id: string;
+  membership: {
+    status: string;
+    role: string | null;
+    confidence: number | null;
+    reason: string | null;
+    user_locked: boolean;
+    assignment_strategy: string | null;
+    assigned_at: string | null;
+  };
+  score_breakdown: CaseMembershipScoreBreakdown | null;
+  score_breakdown_reason?: 'breakdown_not_recorded' | 'breakdown_malformed';
+  source_locator: string | null;
+  explanation_updated_at: string | null;
+  warnings: string[];
+}
+
+export interface PopulateScoreBreakdownInput {
+  case_id: string;
+  source_type: CaseMembershipSourceType;
+  source_id: string;
+  assignment_strategy?: string | null;
+  source_locator?: string | null;
+  now?: string;
+}
+
+export type ExplainCaseMembershipResult =
+  | CaseMembershipExplanation
+  | {
+      kind: 'not_found';
+      code: 'case.membership_not_found';
+      message: string;
+      terminal_case_id: string;
+      resolved_via_case_id: string | null;
+      chain: string[];
+    };
+
+type MembershipExplainAdapter = Pick<DatabaseAdapter, 'prepare' | 'transaction'>;
+
+interface MembershipExplainRow {
+  case_id: string;
+  source_type: CaseMembershipSourceType;
+  source_id: string;
+  status: string;
+  role: string | null;
+  confidence: number | null;
+  reason: string | null;
+  user_locked: number;
+  assignment_strategy: string | null;
+  assigned_at: string | null;
+  score_breakdown_json: string | null;
+  source_locator: string | null;
+  explanation_updated_at: string | null;
+  updated_at: string;
+}
+
+function normalizeNow(value?: string): string {
+  return value ?? new Date().toISOString();
+}
+
+function placeholders(values: readonly unknown[]): string {
+  if (values.length === 0) {
+    throw new Error('Cannot build SQL IN clause for an empty value list.');
+  }
+  return values.map(() => '?').join(', ');
+}
+
+function expandCaseChainForAssembly(
+  adapter: MembershipExplainAdapter,
+  terminalCaseId: string,
+  resolvedChain: string[]
+): string[] {
+  const rows = adapter
+    .prepare(
+      `
+        WITH RECURSIVE merged_chain(case_id, depth) AS (
+          SELECT case_id, 0
+            FROM case_truth
+           WHERE case_id = ?
+
+          UNION
+
+          SELECT ct.case_id, merged_chain.depth + 1
+            FROM case_truth ct
+            JOIN merged_chain ON ct.canonical_case_id = merged_chain.case_id
+           WHERE merged_chain.depth < 64
+        )
+        SELECT case_id
+          FROM merged_chain
+         ORDER BY depth ASC, case_id ASC
+      `
+    )
+    .all(terminalCaseId) as Array<{ case_id: string }>;
+
+  const chain: string[] = [];
+  for (const caseId of [...resolvedChain, ...rows.map((row) => row.case_id)]) {
+    if (!chain.includes(caseId)) {
+      chain.push(caseId);
+    }
+  }
+  return chain;
+}
+
+function loadMembership(
+  adapter: MembershipExplainAdapter,
+  chain: string[],
+  sourceType: CaseMembershipSourceType,
+  sourceId: string
+): MembershipExplainRow | null {
+  const row = adapter
+    .prepare(
+      `
+        SELECT case_id, source_type, source_id, status, role, confidence, reason,
+               user_locked, assignment_strategy, added_at AS assigned_at,
+               score_breakdown_json, source_locator, explanation_updated_at, updated_at
+        FROM case_memberships
+        WHERE case_id IN (${placeholders(chain)})
+          AND source_type = ?
+          AND source_id = ?
+        ORDER BY
+          user_locked DESC,
+          updated_at DESC,
+          case_id ASC
+        LIMIT 1
+      `
+    )
+    .get(...chain, sourceType, sourceId) as MembershipExplainRow | undefined;
+
+  return row ?? null;
+}
+
+function nullableNumber(value: unknown): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function parseScoreBreakdown(value: string | null): {
+  breakdown: CaseMembershipScoreBreakdown | null;
+  reason?: 'breakdown_not_recorded' | 'breakdown_malformed';
+  warnings: string[];
+} {
+  if (value === null || value.trim().length === 0) {
+    return {
+      breakdown: null,
+      reason: 'breakdown_not_recorded',
+      warnings: ['breakdown_not_recorded'],
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {
+        breakdown: null,
+        reason: 'breakdown_malformed',
+        warnings: ['breakdown_malformed'],
+      };
+    }
+
+    const record = parsed as Record<string, unknown>;
+    return {
+      breakdown: {
+        entity_overlap: nullableNumber(record.entity_overlap),
+        embedding_similarity: nullableNumber(record.embedding_similarity),
+        temporal_proximity: nullableNumber(record.temporal_proximity),
+        explicit_from_wiki: nullableNumber(record.explicit_from_wiki),
+      },
+      warnings: [],
+    };
+  } catch {
+    return {
+      breakdown: null,
+      reason: 'breakdown_malformed',
+      warnings: ['breakdown_malformed'],
+    };
+  }
+}
+
+export function explainCaseMembership(
+  adapter: DatabaseAdapter,
+  input: { case_id: string; source_type: CaseMembershipSourceType; source_id: string }
+): ExplainCaseMembershipResult {
+  const explainAdapter = adapter as unknown as MembershipExplainAdapter;
+  const resolution = resolveCanonicalCaseChain(explainAdapter, input.case_id);
+  const chain = expandCaseChainForAssembly(
+    explainAdapter,
+    resolution.terminal_case_id,
+    resolution.chain
+  );
+  const row = loadMembership(explainAdapter, chain, input.source_type, input.source_id);
+
+  if (!row) {
+    return {
+      kind: 'not_found',
+      code: 'case.membership_not_found',
+      message: 'Membership row was not found in the canonical case chain.',
+      terminal_case_id: resolution.terminal_case_id,
+      resolved_via_case_id: resolution.resolved_via_case_id,
+      chain,
+    };
+  }
+
+  const parsedBreakdown = parseScoreBreakdown(row.score_breakdown_json);
+
+  return {
+    case_id: row.case_id,
+    terminal_case_id: resolution.terminal_case_id,
+    resolved_via_case_id: resolution.resolved_via_case_id,
+    chain,
+    source_type: row.source_type,
+    source_id: row.source_id,
+    membership: {
+      status: row.status,
+      role: row.role,
+      confidence: row.confidence,
+      reason: row.reason,
+      user_locked: Number(row.user_locked) === 1,
+      assignment_strategy: row.assignment_strategy,
+      assigned_at: row.assigned_at,
+    },
+    score_breakdown: parsedBreakdown.breakdown,
+    ...(parsedBreakdown.reason ? { score_breakdown_reason: parsedBreakdown.reason } : {}),
+    source_locator: row.source_locator,
+    explanation_updated_at: row.explanation_updated_at,
+    warnings: parsedBreakdown.warnings,
+  };
+}
+
+export function populateScoreBreakdown(
+  adapter: DatabaseAdapter,
+  membershipRow: PopulateScoreBreakdownInput,
+  breakdown: CaseMembershipScoreBreakdown
+): { kind: 'populated'; changes: number } {
+  const now = normalizeNow(membershipRow.now);
+  const result = adapter
+    .prepare(
+      `
+        UPDATE case_memberships
+        SET score_breakdown_json = ?,
+            source_locator = COALESCE(?, source_locator),
+            assignment_strategy = COALESCE(?, assignment_strategy),
+            explanation_updated_at = ?
+        WHERE case_id = ?
+          AND source_type = ?
+          AND source_id = ?
+      `
+    )
+    .run(
+      canonicalizeJSON(breakdown),
+      membershipRow.source_locator ?? null,
+      membershipRow.assignment_strategy ?? null,
+      now,
+      membershipRow.case_id,
+      membershipRow.source_type,
+      membershipRow.source_id
+    );
+
+  return { kind: 'populated', changes: result.changes };
+}

--- a/packages/mama-core/src/cases/membership-explain.ts
+++ b/packages/mama-core/src/cases/membership-explain.ts
@@ -136,6 +136,13 @@ function loadMembership(
           AND source_type = ?
           AND source_id = ?
         ORDER BY
+          CASE status
+            WHEN 'active' THEN 0
+            WHEN 'candidate' THEN 1
+            WHEN 'excluded' THEN 2
+            WHEN 'removed' THEN 3
+            ELSE 4
+          END ASC,
           user_locked DESC,
           updated_at DESC,
           case_id ASC

--- a/packages/mama-core/src/cases/membership-matcher.ts
+++ b/packages/mama-core/src/cases/membership-matcher.ts
@@ -1,0 +1,279 @@
+import type { DatabaseAdapter } from '../db-manager.js';
+import { vectorSearchWikiPages } from './wiki-page-index.js';
+
+export interface CaseMembershipMatchInput {
+  event_id: string;
+  event_text: string;
+  event_entities: string[];
+  observed_at: string;
+  explicit_case_id?: string | null;
+  query_embedding?: Float32Array | null;
+  now?: string;
+}
+
+export interface CaseMembershipMatch {
+  case_id: string;
+  score: number;
+  status: 'active' | 'candidate';
+  reason: string;
+}
+
+export type CaseMembershipMatchResult =
+  | CaseMembershipMatch[]
+  | { kind: 'precompile_gap'; code: 'case.precompile_gap'; case_id: string };
+
+type MatcherAdapter = Pick<DatabaseAdapter, 'prepare' | 'transaction'>;
+
+interface ExplicitCaseRow {
+  case_id: string;
+  status: string;
+}
+
+interface CandidateCaseRow {
+  case_id: string;
+  title: string;
+  primary_actors: string | null;
+  current_wiki_path: string | null;
+  last_activity_at: string | null;
+  compiled_at: string | null;
+  status: string;
+  confidence: string | null;
+}
+
+const ACTIVE_CASE_STATUSES = new Set(['active', 'blocked']);
+const ACTIVE_THRESHOLD = 0.7;
+const CANDIDATE_THRESHOLD = 0.52;
+const RECENCY_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
+
+function normalizeEntity(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function parsePrimaryActors(value: string | null): string[] {
+  if (!value || value.trim().length === 0) {
+    return [];
+  }
+
+  const parsed = JSON.parse(value) as unknown;
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+
+  const actorIds: string[] = [];
+  for (const item of parsed) {
+    if (typeof item === 'string') {
+      actorIds.push(item);
+      continue;
+    }
+    if (item && typeof item === 'object' && !Array.isArray(item)) {
+      const entityId = (item as { entity_id?: unknown }).entity_id;
+      if (typeof entityId === 'string' && entityId.trim().length > 0) {
+        actorIds.push(entityId);
+      }
+    }
+  }
+
+  return actorIds;
+}
+
+function overlapCount(left: string[], right: string[]): number {
+  const rightSet = new Set(right.map(normalizeEntity).filter(Boolean));
+  const seen = new Set<string>();
+  let count = 0;
+
+  for (const value of left) {
+    const normalized = normalizeEntity(value);
+    if (normalized.length === 0 || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    if (rightSet.has(normalized)) {
+      count += 1;
+    }
+  }
+
+  return count;
+}
+
+function timestampMs(value: string | null): number | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function hasRecentActivity(row: CandidateCaseRow, observedAt: string): boolean {
+  const observedMs = timestampMs(observedAt);
+  if (observedMs === null) {
+    return false;
+  }
+
+  const caseMs = timestampMs(row.last_activity_at) ?? timestampMs(row.compiled_at);
+  if (caseMs === null) {
+    return false;
+  }
+
+  return Math.abs(observedMs - caseMs) <= RECENCY_WINDOW_MS;
+}
+
+function wikiSimilarityByCase(
+  adapter: MatcherAdapter,
+  queryEmbedding?: Float32Array | null
+): Map<string, number> {
+  const scores = new Map<string, number>();
+  if (!queryEmbedding) {
+    return scores;
+  }
+
+  try {
+    const hits = vectorSearchWikiPages(adapter, queryEmbedding, 20);
+    for (const hit of hits) {
+      if (hit.record.page_type !== 'case' || !hit.record.case_id) {
+        continue;
+      }
+      const existing = scores.get(hit.record.case_id) ?? -Infinity;
+      if (hit.raw_score > existing) {
+        scores.set(hit.record.case_id, hit.raw_score);
+      }
+    }
+  } catch {
+    return scores;
+  }
+
+  return scores;
+}
+
+function scoreCandidate(input: {
+  row: CandidateCaseRow;
+  eventEntities: string[];
+  observedAt: string;
+  wikiScore: number;
+}): { score: number; signals: string[] } {
+  let score = 0;
+  const signals: string[] = [];
+
+  const actorOverlap = overlapCount(
+    input.eventEntities,
+    parsePrimaryActors(input.row.primary_actors)
+  );
+  if (actorOverlap > 0) {
+    const actorScore = Math.min(0.45 * actorOverlap, 0.9);
+    score += actorScore;
+    signals.push(`primary_actors_overlap:${actorOverlap}`);
+  }
+
+  if (input.wikiScore >= 0.82) {
+    score += 0.3;
+    signals.push(`wiki_embedding:${input.wikiScore.toFixed(3)}`);
+  } else if (input.wikiScore >= 0.74) {
+    score += 0.18;
+    signals.push(`wiki_embedding:${input.wikiScore.toFixed(3)}`);
+  }
+
+  if (hasRecentActivity(input.row, input.observedAt)) {
+    score += 0.15;
+    signals.push('recent_activity');
+  }
+
+  return { score, signals };
+}
+
+function toMatch(case_id: string, score: number, signals: string[]): CaseMembershipMatch | null {
+  if (score >= ACTIVE_THRESHOLD) {
+    return {
+      case_id,
+      score: Number(score.toFixed(4)),
+      status: 'active',
+      reason: signals.join(','),
+    };
+  }
+
+  if (score >= CANDIDATE_THRESHOLD) {
+    return {
+      case_id,
+      score: Number(score.toFixed(4)),
+      status: 'candidate',
+      reason: signals.join(','),
+    };
+  }
+
+  return null;
+}
+
+export function matchEventToExistingCases(
+  adapter: DatabaseAdapter,
+  input: CaseMembershipMatchInput
+): CaseMembershipMatchResult {
+  const matcherAdapter = adapter as unknown as MatcherAdapter;
+
+  if (input.explicit_case_id) {
+    const row = matcherAdapter
+      .prepare(
+        `
+          SELECT case_id, status
+          FROM case_truth
+          WHERE case_id = ?
+        `
+      )
+      .get(input.explicit_case_id) as ExplicitCaseRow | undefined;
+
+    if (!row) {
+      return {
+        kind: 'precompile_gap',
+        code: 'case.precompile_gap',
+        case_id: input.explicit_case_id,
+      };
+    }
+
+    if (!ACTIVE_CASE_STATUSES.has(row.status)) {
+      return [];
+    }
+
+    return [
+      {
+        case_id: row.case_id,
+        score: 1,
+        status: 'active',
+        reason: 'explicit_case_id',
+      },
+    ];
+  }
+
+  const rows = matcherAdapter
+    .prepare(
+      `
+        SELECT case_id, title, primary_actors, current_wiki_path, last_activity_at,
+               compiled_at, status, confidence
+        FROM case_truth
+        WHERE status IN ('active','blocked')
+        ORDER BY COALESCE(last_activity_at, compiled_at, created_at) DESC
+        LIMIT 200
+      `
+    )
+    .all() as CandidateCaseRow[];
+
+  const wikiScores = wikiSimilarityByCase(matcherAdapter, input.query_embedding);
+
+  const matches: CaseMembershipMatch[] = [];
+  for (const row of rows) {
+    const { score, signals } = scoreCandidate({
+      row,
+      eventEntities: input.event_entities,
+      observedAt: input.observed_at,
+      wikiScore: wikiScores.get(row.case_id) ?? 0,
+    });
+
+    const match = toMatch(row.case_id, score, signals);
+    if (match) {
+      matches.push(match);
+    }
+  }
+
+  return matches.sort((left, right) => {
+    if (right.score !== left.score) {
+      return right.score - left.score;
+    }
+    return left.case_id.localeCompare(right.case_id);
+  });
+}

--- a/packages/mama-core/src/cases/merge-split.ts
+++ b/packages/mama-core/src/cases/merge-split.ts
@@ -352,6 +352,8 @@ export function mergeCases(adapter: DatabaseAdapter, input: MergeCasesInput): Me
         message: 'loser and survivor resolve to the same canonical case.',
       };
     }
+    const canonicalLoserCaseId = loserResolution.terminal_case_id;
+    const canonicalSurvivorCaseId = survivorResolution.terminal_case_id;
 
     if (TERMINAL_CASE_STATUSES.has(loser.status) || TERMINAL_CASE_STATUSES.has(survivor.status)) {
       return {
@@ -362,7 +364,7 @@ export function mergeCases(adapter: DatabaseAdapter, input: MergeCasesInput): Me
     }
 
     insertCaseCorrectionLock(tx as unknown as DatabaseAdapter, {
-      case_id: input.loser_case_id,
+      case_id: canonicalLoserCaseId,
       target_kind: 'case_field',
       target_ref: { kind: 'case_field', field: 'canonical_case_id' },
       field_name: null,
@@ -372,7 +374,7 @@ export function mergeCases(adapter: DatabaseAdapter, input: MergeCasesInput): Me
       }),
       new_value_json: canonicalizeJSON({
         status: 'merged',
-        canonical_case_id: input.survivor_case_id,
+        canonical_case_id: canonicalSurvivorCaseId,
       }),
       reason: input.reason,
       applied_by: input.confirmed_by,
@@ -388,17 +390,17 @@ export function mergeCases(adapter: DatabaseAdapter, input: MergeCasesInput): Me
                updated_at = ?
          WHERE case_id = ?
       `
-    ).run(input.survivor_case_id, now, input.loser_case_id);
+    ).run(canonicalSurvivorCaseId, now, canonicalLoserCaseId);
 
     const auditEventId = insertMemoryEvent({
       adapter: tx,
       event_type: 'case.merged',
-      topic: `case:${input.survivor_case_id}`,
+      topic: `case:${canonicalSurvivorCaseId}`,
       scope_refs: [
-        { type: 'case', id: input.survivor_case_id },
-        { type: 'case', id: input.loser_case_id },
+        { type: 'case', id: canonicalSurvivorCaseId },
+        { type: 'case', id: canonicalLoserCaseId },
       ],
-      evidence_refs: [input.loser_case_id, input.survivor_case_id],
+      evidence_refs: [canonicalLoserCaseId, canonicalSurvivorCaseId],
       reason: {
         reason: input.reason,
         confirmed_by: input.confirmed_by,

--- a/packages/mama-core/src/cases/merge-split.ts
+++ b/packages/mama-core/src/cases/merge-split.ts
@@ -1,0 +1,583 @@
+import { randomUUID } from 'node:crypto';
+
+import { canonicalizeJSON } from '../canonicalize.js';
+import type { DatabaseAdapter } from '../db-manager.js';
+import { insertCaseCorrectionLock } from './corrections.js';
+import { runImmediateTransaction, type ImmediateTransactionAdapter } from './sqlite-transaction.js';
+import type { CaseMembershipSourceType } from './types.js';
+
+export type MergeCaseErrorCode =
+  | 'case.confirmation_required'
+  | 'case.merge_self'
+  | 'case.merge_chain_cycle'
+  | 'case.terminal_status';
+
+export interface MergeCasesInput {
+  loser_case_id: string;
+  survivor_case_id: string;
+  reason: string;
+  confirmed: true;
+  confirmed_by: string;
+  confirmation_summary: string;
+  now?: string;
+}
+
+export type MergeCasesResult =
+  | { kind: 'merged'; loser_case_id: string; survivor_case_id: string; audit_event_id: string }
+  | { kind: 'precompile_gap'; code: 'case.precompile_gap'; case_id: string }
+  | { kind: 'rejected'; code: MergeCaseErrorCode; message: string };
+
+export interface SplitCaseChildPlan {
+  title: string;
+  current_wiki_path?: string | null;
+  membership_sources: Array<{
+    source_type: 'decision' | 'event' | 'observation' | 'artifact';
+    source_id: string;
+    remove_from_parent?: boolean;
+  }>;
+}
+
+export interface SplitCaseInput {
+  parent_case_id: string;
+  children: SplitCaseChildPlan[];
+  trusted_child_case_ids: string[];
+  reason: string;
+  confirmed: true;
+  confirmed_by: string;
+  confirmation_summary: string;
+  now?: string;
+}
+
+export type SplitCaseResult =
+  | { kind: 'split'; parent_case_id: string; child_case_ids: string[]; audit_event_id: string }
+  | { kind: 'precompile_gap'; code: 'case.precompile_gap'; case_id: string }
+  | {
+      kind: 'rejected';
+      code:
+        | 'case.confirmation_required'
+        | 'case.terminal_status'
+        | 'case.split_requires_two_children'
+        | 'case.child_id_not_trusted'
+        | 'case.child_id_count_mismatch';
+      message: string;
+    };
+
+type MergeSplitAdapter = Pick<DatabaseAdapter, 'prepare' | 'transaction'> &
+  Partial<Pick<ImmediateTransactionAdapter, 'exec'>>;
+
+interface CaseTruthRow {
+  case_id: string;
+  current_wiki_path: string | null;
+  title: string;
+  status: string;
+  canonical_case_id: string | null;
+  split_from_case_id: string | null;
+  scope_refs: string | null;
+  confidence: string | null;
+}
+
+interface MembershipRow {
+  role: string | null;
+  confidence: number | null;
+  reason: string | null;
+  status: string;
+}
+
+type ChainResolution =
+  | { kind: 'resolved'; terminal_case_id: string; chain: string[] }
+  | { kind: 'precompile_gap'; case_id: string }
+  | { kind: 'cycle'; message: string };
+
+const TERMINAL_CASE_STATUSES = new Set(['merged', 'archived', 'split']);
+const CHILD_UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function normalizeNow(value?: string): string {
+  return value ?? new Date().toISOString();
+}
+
+function createdAtMs(now: string): number {
+  const parsed = Date.parse(now);
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+function nonEmpty(value: unknown): boolean {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function confirmed(input: {
+  confirmed?: boolean;
+  confirmed_by?: unknown;
+  confirmation_summary?: unknown;
+}): boolean {
+  return (
+    input.confirmed === true && nonEmpty(input.confirmed_by) && nonEmpty(input.confirmation_summary)
+  );
+}
+
+function readCase(adapter: MergeSplitAdapter, caseId: string): CaseTruthRow | null {
+  const row = adapter.prepare('SELECT * FROM case_truth WHERE case_id = ?').get(caseId) as
+    | CaseTruthRow
+    | undefined;
+  return row ?? null;
+}
+
+function resolveCanonicalChain(adapter: MergeSplitAdapter, caseId: string): ChainResolution {
+  const visited = new Set<string>();
+  const chain: string[] = [];
+  let current = caseId;
+
+  for (;;) {
+    const depth = chain.length + 1;
+    const cycleChain = [...chain, current];
+
+    if (visited.has(current) || depth > 64) {
+      return {
+        kind: 'cycle',
+        message: `Case merge chain cycle detected at depth ${depth} starting from case_id=${caseId}. Chain=${cycleChain.join(' -> ')}.`,
+      };
+    }
+
+    visited.add(current);
+    chain.push(current);
+
+    const row = readCase(adapter, current);
+    if (!row) {
+      return { kind: 'precompile_gap', case_id: current };
+    }
+
+    if (!row.canonical_case_id) {
+      return { kind: 'resolved', terminal_case_id: current, chain };
+    }
+
+    current = row.canonical_case_id;
+  }
+}
+
+function insertMemoryEvent(input: {
+  adapter: MergeSplitAdapter;
+  event_type: 'case.merged' | 'case.split';
+  topic: string;
+  scope_refs: unknown;
+  evidence_refs: unknown;
+  reason: unknown;
+  now: string;
+}): string {
+  const eventId = `me_${randomUUID()}`;
+
+  input.adapter
+    .prepare(
+      `
+        INSERT INTO memory_events (
+          event_id, event_type, actor, source_turn_id, memory_id, topic,
+          scope_refs, evidence_refs, reason, created_at
+        )
+        VALUES (?, ?, 'user', NULL, NULL, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      eventId,
+      input.event_type,
+      input.topic,
+      canonicalizeJSON(input.scope_refs),
+      canonicalizeJSON(input.evidence_refs),
+      canonicalizeJSON(input.reason),
+      createdAtMs(input.now)
+    );
+
+  return eventId;
+}
+
+function hasCallerChildCaseIds(children: SplitCaseChildPlan[]): boolean {
+  return children.some((child) => Object.prototype.hasOwnProperty.call(child, 'case_id'));
+}
+
+function trustedChildIdsAreValid(ids: string[]): boolean {
+  return ids.every((id) => CHILD_UUID_PATTERN.test(id) && !id.startsWith('case_'));
+}
+
+function childIdsAreUnique(ids: string[]): boolean {
+  return new Set(ids).size === ids.length;
+}
+
+function readParentMembership(
+  adapter: MergeSplitAdapter,
+  parentCaseId: string,
+  sourceType: CaseMembershipSourceType,
+  sourceId: string
+): MembershipRow | null {
+  const row = adapter
+    .prepare(
+      `
+        SELECT role, confidence, reason, status
+          FROM case_memberships
+         WHERE case_id = ?
+           AND source_type = ?
+           AND source_id = ?
+      `
+    )
+    .get(parentCaseId, sourceType, sourceId) as MembershipRow | undefined;
+
+  return row ?? null;
+}
+
+function upsertChildMembership(input: {
+  adapter: MergeSplitAdapter;
+  child_case_id: string;
+  source_type: CaseMembershipSourceType;
+  source_id: string;
+  parent_membership: MembershipRow | null;
+  now: string;
+}): void {
+  input.adapter
+    .prepare(
+      `
+        INSERT INTO case_memberships (
+          case_id, source_type, source_id, role, confidence, reason, status, added_by,
+          added_at, updated_at, user_locked
+        )
+        VALUES (?, ?, ?, ?, ?, ?, 'active', 'user-correction', ?, ?, 1)
+        ON CONFLICT(case_id, source_type, source_id) DO UPDATE SET
+          role = excluded.role,
+          confidence = excluded.confidence,
+          reason = excluded.reason,
+          status = 'active',
+          added_by = 'user-correction',
+          updated_at = excluded.updated_at,
+          user_locked = 1
+      `
+    )
+    .run(
+      input.child_case_id,
+      input.source_type,
+      input.source_id,
+      input.parent_membership?.role ?? null,
+      input.parent_membership?.confidence ?? null,
+      input.parent_membership?.reason ?? 'User assigned source during case split.',
+      input.now,
+      input.now
+    );
+}
+
+function removeParentMembership(input: {
+  adapter: MergeSplitAdapter;
+  parent_case_id: string;
+  source_type: CaseMembershipSourceType;
+  source_id: string;
+  now: string;
+}): void {
+  input.adapter
+    .prepare(
+      `
+        UPDATE case_memberships
+           SET status = 'removed',
+               user_locked = 1,
+               updated_at = ?
+         WHERE case_id = ?
+           AND source_type = ?
+           AND source_id = ?
+      `
+    )
+    .run(input.now, input.parent_case_id, input.source_type, input.source_id);
+}
+
+export function mergeCases(adapter: DatabaseAdapter, input: MergeCasesInput): MergeCasesResult {
+  const tx = adapter as unknown as MergeSplitAdapter;
+
+  if (!confirmed(input)) {
+    return {
+      kind: 'rejected',
+      code: 'case.confirmation_required',
+      message: 'confirmed=true, confirmed_by, and confirmation_summary are required.',
+    };
+  }
+
+  return runImmediateTransaction(tx, () => {
+    const now = normalizeNow(input.now);
+
+    if (input.loser_case_id === input.survivor_case_id) {
+      return {
+        kind: 'rejected',
+        code: 'case.merge_self',
+        message: 'loser_case_id and survivor_case_id must be different.',
+      };
+    }
+
+    const loser = readCase(tx, input.loser_case_id);
+    if (!loser) {
+      return { kind: 'precompile_gap', code: 'case.precompile_gap', case_id: input.loser_case_id };
+    }
+
+    const survivor = readCase(tx, input.survivor_case_id);
+    if (!survivor) {
+      return {
+        kind: 'precompile_gap',
+        code: 'case.precompile_gap',
+        case_id: input.survivor_case_id,
+      };
+    }
+
+    const loserResolution = resolveCanonicalChain(tx, input.loser_case_id);
+    if (loserResolution.kind === 'cycle') {
+      return { kind: 'rejected', code: 'case.merge_chain_cycle', message: loserResolution.message };
+    }
+    if (loserResolution.kind === 'precompile_gap') {
+      return {
+        kind: 'precompile_gap',
+        code: 'case.precompile_gap',
+        case_id: loserResolution.case_id,
+      };
+    }
+
+    const survivorResolution = resolveCanonicalChain(tx, input.survivor_case_id);
+    if (survivorResolution.kind === 'cycle') {
+      return {
+        kind: 'rejected',
+        code: 'case.merge_chain_cycle',
+        message: survivorResolution.message,
+      };
+    }
+    if (survivorResolution.kind === 'precompile_gap') {
+      return {
+        kind: 'precompile_gap',
+        code: 'case.precompile_gap',
+        case_id: survivorResolution.case_id,
+      };
+    }
+
+    if (loserResolution.terminal_case_id === survivorResolution.terminal_case_id) {
+      return {
+        kind: 'rejected',
+        code: 'case.merge_self',
+        message: 'loser and survivor resolve to the same canonical case.',
+      };
+    }
+
+    if (TERMINAL_CASE_STATUSES.has(loser.status) || TERMINAL_CASE_STATUSES.has(survivor.status)) {
+      return {
+        kind: 'rejected',
+        code: 'case.terminal_status',
+        message: 'Merged, archived, and split cases cannot be merge endpoints.',
+      };
+    }
+
+    insertCaseCorrectionLock(tx as unknown as DatabaseAdapter, {
+      case_id: input.loser_case_id,
+      target_kind: 'case_field',
+      target_ref: { kind: 'case_field', field: 'canonical_case_id' },
+      field_name: null,
+      old_value_json: canonicalizeJSON({
+        status: loser.status,
+        canonical_case_id: loser.canonical_case_id,
+      }),
+      new_value_json: canonicalizeJSON({
+        status: 'merged',
+        canonical_case_id: input.survivor_case_id,
+      }),
+      reason: input.reason,
+      applied_by: input.confirmed_by,
+      applied_at: now,
+      is_lock_active: 0,
+    });
+
+    tx.prepare(
+      `
+        UPDATE case_truth
+           SET status = 'merged',
+               canonical_case_id = ?,
+               updated_at = ?
+         WHERE case_id = ?
+      `
+    ).run(input.survivor_case_id, now, input.loser_case_id);
+
+    const auditEventId = insertMemoryEvent({
+      adapter: tx,
+      event_type: 'case.merged',
+      topic: `case:${input.survivor_case_id}`,
+      scope_refs: [
+        { type: 'case', id: input.survivor_case_id },
+        { type: 'case', id: input.loser_case_id },
+      ],
+      evidence_refs: [input.loser_case_id, input.survivor_case_id],
+      reason: {
+        reason: input.reason,
+        confirmed_by: input.confirmed_by,
+        confirmation_summary: input.confirmation_summary,
+      },
+      now,
+    });
+
+    return {
+      kind: 'merged',
+      loser_case_id: input.loser_case_id,
+      survivor_case_id: input.survivor_case_id,
+      audit_event_id: auditEventId,
+    };
+  });
+}
+
+export function splitCase(adapter: DatabaseAdapter, input: SplitCaseInput): SplitCaseResult {
+  const tx = adapter as unknown as MergeSplitAdapter;
+
+  if (!confirmed(input)) {
+    return {
+      kind: 'rejected',
+      code: 'case.confirmation_required',
+      message: 'confirmed=true, confirmed_by, and confirmation_summary are required.',
+    };
+  }
+
+  if (hasCallerChildCaseIds(input.children)) {
+    return {
+      kind: 'rejected',
+      code: 'case.child_id_not_trusted',
+      message: 'Child case IDs are runner-owned and must not be supplied in child payloads.',
+    };
+  }
+
+  if (input.children.length < 2) {
+    return {
+      kind: 'rejected',
+      code: 'case.split_requires_two_children',
+      message: 'A split requires at least two children.',
+    };
+  }
+
+  if (input.trusted_child_case_ids.length !== input.children.length) {
+    return {
+      kind: 'rejected',
+      code: 'case.child_id_count_mismatch',
+      message: 'trusted_child_case_ids length must match children length.',
+    };
+  }
+
+  if (
+    !childIdsAreUnique(input.trusted_child_case_ids) ||
+    !trustedChildIdsAreValid(input.trusted_child_case_ids)
+  ) {
+    return {
+      kind: 'rejected',
+      code: 'case.child_id_not_trusted',
+      message: 'trusted_child_case_ids must be unique UUIDs minted by the standalone runner.',
+    };
+  }
+
+  return runImmediateTransaction(tx, () => {
+    const now = normalizeNow(input.now);
+    const parent = readCase(tx, input.parent_case_id);
+
+    if (!parent) {
+      return { kind: 'precompile_gap', code: 'case.precompile_gap', case_id: input.parent_case_id };
+    }
+
+    if (TERMINAL_CASE_STATUSES.has(parent.status)) {
+      return {
+        kind: 'rejected',
+        code: 'case.terminal_status',
+        message: `Cannot split terminal case status ${parent.status}.`,
+      };
+    }
+
+    tx.prepare(
+      `
+        UPDATE case_truth
+           SET status = 'split',
+               updated_at = ?
+         WHERE case_id = ?
+      `
+    ).run(now, input.parent_case_id);
+
+    for (const [index, child] of input.children.entries()) {
+      const childCaseId = input.trusted_child_case_ids[index];
+
+      tx.prepare(
+        `
+          INSERT INTO case_truth (
+            case_id, current_wiki_path, title, status, split_from_case_id, wiki_path_history,
+            scope_refs, confidence, created_at, updated_at
+          )
+          VALUES (?, ?, ?, 'active', ?, '[]', ?, ?, ?, ?)
+        `
+      ).run(
+        childCaseId,
+        child.current_wiki_path ?? null,
+        child.title,
+        input.parent_case_id,
+        parent.scope_refs ?? '[]',
+        parent.confidence ?? null,
+        now,
+        now
+      );
+
+      for (const membership of child.membership_sources) {
+        const sourceType = membership.source_type as CaseMembershipSourceType;
+        const parentMembership = readParentMembership(
+          tx,
+          input.parent_case_id,
+          sourceType,
+          membership.source_id
+        );
+
+        upsertChildMembership({
+          adapter: tx,
+          child_case_id: childCaseId,
+          source_type: sourceType,
+          source_id: membership.source_id,
+          parent_membership: parentMembership,
+          now,
+        });
+
+        if (membership.remove_from_parent === true) {
+          removeParentMembership({
+            adapter: tx,
+            parent_case_id: input.parent_case_id,
+            source_type: sourceType,
+            source_id: membership.source_id,
+            now,
+          });
+        }
+      }
+    }
+
+    insertCaseCorrectionLock(tx as unknown as DatabaseAdapter, {
+      case_id: input.parent_case_id,
+      target_kind: 'case_field',
+      target_ref: { kind: 'case_field', field: 'status' },
+      field_name: 'status',
+      old_value_json: canonicalizeJSON(parent.status),
+      new_value_json: canonicalizeJSON({
+        status: 'split',
+        child_case_ids: input.trusted_child_case_ids,
+      }),
+      reason: input.reason,
+      applied_by: input.confirmed_by,
+      applied_at: now,
+      is_lock_active: 0,
+    });
+
+    const auditEventId = insertMemoryEvent({
+      adapter: tx,
+      event_type: 'case.split',
+      topic: `case:${input.parent_case_id}`,
+      scope_refs: [
+        { type: 'case', id: input.parent_case_id },
+        ...input.trusted_child_case_ids.map((id) => ({ type: 'case', id })),
+      ],
+      evidence_refs: input.trusted_child_case_ids,
+      reason: {
+        reason: input.reason,
+        confirmed_by: input.confirmed_by,
+        confirmation_summary: input.confirmation_summary,
+        child_case_ids: input.trusted_child_case_ids,
+      },
+      now,
+    });
+
+    return {
+      kind: 'split',
+      parent_case_id: input.parent_case_id,
+      child_case_ids: input.trusted_child_case_ids,
+      audit_event_id: auditEventId,
+    };
+  });
+}

--- a/packages/mama-core/src/cases/role-inference.ts
+++ b/packages/mama-core/src/cases/role-inference.ts
@@ -1,0 +1,114 @@
+export type InferredCaseRole = 'requester' | 'implementer' | 'reviewer' | 'observer' | 'affected';
+
+interface InferTimelineEventRoleInput {
+  userText: string;
+  assistantText?: string;
+  eventType?: string;
+  actorHints?: string[];
+}
+
+function hasPattern(text: string, patterns: RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+function joinText(parts: Array<string | undefined>): string {
+  return parts.filter((part): part is string => Boolean(part?.trim())).join('\n');
+}
+
+function mentionsActor(text: string, actorHints: string[]): boolean {
+  return actorHints.some((hint) => {
+    const trimmed = hint.trim();
+    return trimmed.length > 0 && text.toLowerCase().includes(trimmed.toLowerCase());
+  });
+}
+
+const REQUESTER_PATTERNS = [
+  /\b(ask|asks|asked|request|requests|requested|please|can you|could you|would you|help me)\b/i,
+  /요청|해줘|해주세요|부탁|해주시|해 줄래|해 주실/i, // Korean: keyword patterns
+];
+
+const IMPLEMENTER_PATTERNS = [
+  /\b(i|we)\s+(will\s+handle|can\s+handle|implemented|fixed|built|handled|completed|shipped|worked\s+on|am\s+working\s+on)\b/i,
+  /\b(i'll|we'll)\s+handle\b/i,
+  /\b(implemented|fixed|built|handled|completed|shipped)\b/i,
+  /제가\s*(작업|수정|구현|처리|담당)|작업했습니다|수정했습니다|구현했습니다|담당합니다/i, // Korean: keyword patterns
+];
+
+const ACTOR_IMPLEMENTER_PATTERNS = [
+  /\b(will\s+handle|implemented|fixed|built|handled|completed|shipped|worked\s+on|owns\s+the\s+work)\b/i,
+  /작업|수정|구현|처리|담당/i, // Korean: keyword patterns
+];
+
+const REVIEWER_PATTERNS = [
+  /\b(reviewed|reviewing|review|approved|approve|approval)\b/i,
+  /검토|승인|리뷰/i, // Korean: keyword patterns
+];
+
+const AFFECTED_PATTERNS = [
+  /\b(blocked|waiting|held\s+up|impacted|affected|deferred|on\s+hold)\b/i,
+  /막힘|막혔|보류|대기|영향/i, // Korean: keyword patterns
+];
+
+const OBSERVER_PATTERNS = [
+  /\b(fyi|for your information|status-only|status only|heads up|observing)\b/i,
+  /참고|공유만|상태\s*공유|관찰/i, // Korean: keyword patterns
+];
+
+const AMBIGUOUS_OWNER_BLOCKER_PATTERNS = [/\b(owner|blocker)\b/i, /오너|소유자|블로커/i]; // Korean: keyword patterns
+
+export function inferTimelineEventRole(
+  input: InferTimelineEventRoleInput
+): InferredCaseRole | null {
+  const userText = input.userText.trim();
+  const assistantText = input.assistantText?.trim() ?? '';
+  const eventType = input.eventType?.trim() ?? '';
+  const actorHints = input.actorHints ?? [];
+  const combinedText = joinText([userText, assistantText, eventType, actorHints.join(' ')]);
+
+  if (!combinedText) {
+    return null;
+  }
+
+  const roles = new Set<InferredCaseRole>();
+
+  if (hasPattern(userText, REQUESTER_PATTERNS)) {
+    roles.add('requester');
+  }
+
+  const implementerText = joinText([assistantText, eventType]);
+  if (hasPattern(implementerText, IMPLEMENTER_PATTERNS)) {
+    roles.add('implementer');
+  }
+  if (
+    mentionsActor(userText, actorHints) &&
+    hasPattern(userText, ACTOR_IMPLEMENTER_PATTERNS) &&
+    !hasPattern(userText, REQUESTER_PATTERNS)
+  ) {
+    roles.add('implementer');
+  }
+
+  if (hasPattern(joinText([assistantText, eventType]), REVIEWER_PATTERNS)) {
+    roles.add('reviewer');
+  }
+  if (mentionsActor(userText, actorHints) && hasPattern(userText, REVIEWER_PATTERNS)) {
+    roles.add('reviewer');
+  }
+
+  if (hasPattern(combinedText, AFFECTED_PATTERNS)) {
+    roles.add('affected');
+  }
+
+  if (hasPattern(combinedText, OBSERVER_PATTERNS)) {
+    roles.add('observer');
+  }
+
+  if (roles.size === 0 && hasPattern(combinedText, AMBIGUOUS_OWNER_BLOCKER_PATTERNS)) {
+    return null;
+  }
+
+  if (roles.size !== 1) {
+    return null;
+  }
+
+  return [...roles][0] ?? null;
+}

--- a/packages/mama-core/src/cases/search-rollup.ts
+++ b/packages/mama-core/src/cases/search-rollup.ts
@@ -204,7 +204,7 @@ function upsertCaseGroup(
   leaf: SearchRollupLeafHit,
   survivorCaseId: string
 ): void {
-  const dedupeKey = `${survivorCaseId}\0${leaf.source_id}`;
+  const dedupeKey = `${survivorCaseId}\0${leaf.source_type}\0${leaf.source_id}`;
   let group = groups.get(survivorCaseId);
   if (!group) {
     group = {
@@ -285,6 +285,7 @@ export function rollUpSearchHits(input: {
       if (leaf.case_id) {
         const survivorCaseId = upsertDirectCase(directCases, input.adapter, leaf, leaf.case_id);
         directCaseIds.add(survivorCaseId);
+        groupedCases.delete(survivorCaseId);
       } else {
         upsertOrphan(orphans, leaf);
       }
@@ -309,7 +310,9 @@ export function rollUpSearchHits(input: {
 
   return [
     ...Array.from(directCases.values()).map(groupToResult),
-    ...Array.from(groupedCases.values()).map(groupToResult),
+    ...Array.from(groupedCases.values())
+      .filter((group) => !directCaseIds.has(group.case_id))
+      .map(groupToResult),
     ...Array.from(orphans.values()),
   ].sort(compareResults);
 }

--- a/packages/mama-core/src/cases/search-rollup.ts
+++ b/packages/mama-core/src/cases/search-rollup.ts
@@ -1,0 +1,315 @@
+import type { AdapterLike } from './wiki-page-index.js';
+import { resolveCanonicalCaseChain } from './store.js';
+
+export type { AdapterLike };
+
+export interface SearchRollupLeafHit {
+  source_type: 'decision' | 'checkpoint' | 'wiki_page' | 'connector_event';
+  source_id: string;
+  fused_rank_score: number;
+  page_type?: 'case';
+  case_id?: string | null;
+  record: unknown;
+}
+
+export interface SearchRollupResult {
+  source_type: 'decision' | 'checkpoint' | 'wiki_page' | 'case' | 'standalone_connector_hit';
+  source_id: string;
+  case_id: string | null;
+  score: number;
+  contributing_leaves?: string[];
+  record: unknown;
+}
+
+interface CaseGroup {
+  case_id: string;
+  score: number;
+  max_leaf_score: number;
+  contributing_leaves: Set<string>;
+  dedupe_keys: Set<string>;
+  record: unknown;
+}
+
+function sourceKey(sourceType: string, sourceId: string): string {
+  return `${sourceType}:${sourceId}`;
+}
+
+function objectRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+function stringOrNull(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return String(value);
+}
+
+function placeholders(values: readonly unknown[]): string {
+  if (values.length === 0) {
+    throw new Error('Cannot build SQL IN clause for an empty value list.');
+  }
+  return values.map(() => '?').join(', ');
+}
+
+function withCaseId(record: unknown, caseId: string): unknown {
+  const object = objectRecord(record);
+  if (!object) {
+    return { case_id: caseId };
+  }
+  return { ...object, case_id: caseId };
+}
+
+function loadCaseRecord(adapter: AdapterLike, caseId: string): unknown {
+  const row = adapter.prepare('SELECT * FROM case_truth WHERE case_id = ?').get(caseId) as
+    | Record<string, unknown>
+    | undefined;
+
+  return row ?? { case_id: caseId };
+}
+
+function canonicalCaseId(adapter: AdapterLike, caseId: string): string {
+  return resolveCanonicalCaseChain(adapter, caseId).terminal_case_id;
+}
+
+function listActiveMembershipCaseIds(
+  adapter: AdapterLike,
+  sourceType: string,
+  sourceId: string
+): string[] {
+  const rows = adapter
+    .prepare(
+      `
+        SELECT case_id
+        FROM case_memberships
+        WHERE source_type = ?
+          AND source_id = ?
+          AND status = 'active'
+      `
+    )
+    .all(sourceType, sourceId) as Array<{ case_id: string }>;
+
+  return rows.map((row) => row.case_id);
+}
+
+function uniqueStrings(values: Array<string | null>): string[] {
+  return Array.from(new Set(values.filter((value): value is string => Boolean(value))));
+}
+
+function listConnectorEventMembershipCaseIds(
+  adapter: AdapterLike,
+  leaf: SearchRollupLeafHit
+): string[] {
+  const record = objectRecord(leaf.record) ?? {};
+  const sourceConnector = stringOrNull(record.source_connector);
+  const sourceLocator = stringOrNull(record.source_locator);
+  const artifactLocator = stringOrNull(record.artifact_locator);
+  const candidates = uniqueStrings([sourceLocator, artifactLocator]);
+
+  const caseIds = new Set<string>();
+
+  if (sourceConnector && sourceLocator) {
+    const observationRows = adapter
+      .prepare(
+        `
+          SELECT cm.case_id
+          FROM entity_observations eo
+          JOIN case_memberships cm
+            ON cm.source_type = 'observation'
+           AND cm.source_id = eo.id
+           AND cm.status = 'active'
+          WHERE eo.source_connector = ?
+            AND eo.source_locator = ?
+        `
+      )
+      .all(sourceConnector, sourceLocator) as Array<{ case_id: string }>;
+
+    for (const row of observationRows) {
+      caseIds.add(row.case_id);
+    }
+  }
+
+  if (candidates.length > 0) {
+    const artifactRows = adapter
+      .prepare(
+        `
+          SELECT case_id
+          FROM case_memberships
+          WHERE source_type = 'artifact'
+            AND status = 'active'
+            AND source_id IN (${placeholders(candidates)})
+        `
+      )
+      .all(...candidates) as Array<{ case_id: string }>;
+
+    for (const row of artifactRows) {
+      caseIds.add(row.case_id);
+    }
+  }
+
+  return Array.from(caseIds).sort((left, right) => left.localeCompare(right));
+}
+
+function membershipCaseIdsForLeaf(adapter: AdapterLike, leaf: SearchRollupLeafHit): string[] {
+  if (leaf.source_type === 'connector_event') {
+    return listConnectorEventMembershipCaseIds(adapter, leaf);
+  }
+  return listActiveMembershipCaseIds(adapter, leaf.source_type, leaf.source_id);
+}
+
+function upsertOrphan(orphans: Map<string, SearchRollupResult>, leaf: SearchRollupLeafHit): void {
+  const key = sourceKey(leaf.source_type, leaf.source_id);
+  const existing = orphans.get(key);
+  if (existing && existing.score >= leaf.fused_rank_score) {
+    return;
+  }
+
+  orphans.set(key, {
+    source_type:
+      leaf.source_type === 'connector_event' ? 'standalone_connector_hit' : leaf.source_type,
+    source_id: leaf.source_id,
+    case_id: null,
+    score: leaf.fused_rank_score,
+    record: leaf.record,
+  });
+}
+
+function upsertDirectCase(
+  directCases: Map<string, CaseGroup>,
+  adapter: AdapterLike,
+  leaf: SearchRollupLeafHit,
+  caseId: string
+): string {
+  const survivorCaseId = canonicalCaseId(adapter, caseId);
+  const existing = directCases.get(survivorCaseId);
+  if (!existing || leaf.fused_rank_score > existing.score) {
+    directCases.set(survivorCaseId, {
+      case_id: survivorCaseId,
+      score: leaf.fused_rank_score,
+      max_leaf_score: leaf.fused_rank_score,
+      contributing_leaves: new Set([leaf.source_id]),
+      dedupe_keys: new Set([leaf.source_id]),
+      record: withCaseId(leaf.record, survivorCaseId),
+    });
+  }
+  return survivorCaseId;
+}
+
+function upsertCaseGroup(
+  groups: Map<string, CaseGroup>,
+  adapter: AdapterLike,
+  leaf: SearchRollupLeafHit,
+  survivorCaseId: string
+): void {
+  const dedupeKey = `${survivorCaseId}\0${leaf.source_id}`;
+  let group = groups.get(survivorCaseId);
+  if (!group) {
+    group = {
+      case_id: survivorCaseId,
+      score: 0,
+      max_leaf_score: 0,
+      contributing_leaves: new Set(),
+      dedupe_keys: new Set(),
+      record: loadCaseRecord(adapter, survivorCaseId),
+    };
+    groups.set(survivorCaseId, group);
+  }
+
+  if (group.dedupe_keys.has(dedupeKey)) {
+    return;
+  }
+
+  group.dedupe_keys.add(dedupeKey);
+  group.contributing_leaves.add(leaf.source_id);
+  group.score += leaf.fused_rank_score;
+  group.max_leaf_score = Math.max(group.max_leaf_score, leaf.fused_rank_score);
+}
+
+function groupToResult(group: CaseGroup): SearchRollupResult {
+  const baseRecord = objectRecord(withCaseId(group.record, group.case_id)) ?? {
+    case_id: group.case_id,
+  };
+  const record = { ...baseRecord, max_leaf_score: group.max_leaf_score };
+  return {
+    source_type: 'case',
+    source_id: group.case_id,
+    case_id: group.case_id,
+    score: group.score,
+    contributing_leaves: Array.from(group.contributing_leaves).sort((left, right) =>
+      left.localeCompare(right)
+    ),
+    record,
+  };
+}
+
+function maxLeafScore(result: SearchRollupResult): number {
+  const object = objectRecord(result.record);
+  const value = object?.max_leaf_score;
+  return typeof value === 'number' && Number.isFinite(value) ? value : result.score;
+}
+
+function compareResults(left: SearchRollupResult, right: SearchRollupResult): number {
+  if (right.score !== left.score) {
+    return right.score - left.score;
+  }
+
+  const leafDelta = maxLeafScore(right) - maxLeafScore(left);
+  if (leafDelta !== 0) {
+    return leafDelta;
+  }
+
+  if (left.source_type === 'case' && right.source_type !== 'case') {
+    return -1;
+  }
+  if (left.source_type !== 'case' && right.source_type === 'case') {
+    return 1;
+  }
+
+  return left.source_id.localeCompare(right.source_id);
+}
+
+export function rollUpSearchHits(input: {
+  fusedHits: SearchRollupLeafHit[];
+  adapter: AdapterLike;
+}): SearchRollupResult[] {
+  const directCases = new Map<string, CaseGroup>();
+  const directCaseIds = new Set<string>();
+  const groupedCases = new Map<string, CaseGroup>();
+  const orphans = new Map<string, SearchRollupResult>();
+
+  for (const leaf of input.fusedHits) {
+    if (leaf.source_type === 'wiki_page' && leaf.page_type === 'case') {
+      if (leaf.case_id) {
+        const survivorCaseId = upsertDirectCase(directCases, input.adapter, leaf, leaf.case_id);
+        directCaseIds.add(survivorCaseId);
+      } else {
+        upsertOrphan(orphans, leaf);
+      }
+      continue;
+    }
+
+    const membershipCaseIds = membershipCaseIdsForLeaf(input.adapter, leaf);
+
+    if (membershipCaseIds.length === 0) {
+      upsertOrphan(orphans, leaf);
+      continue;
+    }
+
+    for (const membershipCaseId of membershipCaseIds) {
+      const survivorCaseId = canonicalCaseId(input.adapter, membershipCaseId);
+      if (directCaseIds.has(survivorCaseId)) {
+        continue;
+      }
+      upsertCaseGroup(groupedCases, input.adapter, leaf, survivorCaseId);
+    }
+  }
+
+  return [
+    ...Array.from(directCases.values()).map(groupToResult),
+    ...Array.from(groupedCases.values()).map(groupToResult),
+    ...Array.from(orphans.values()),
+  ].sort(compareResults);
+}

--- a/packages/mama-core/src/cases/sqlite-transaction.ts
+++ b/packages/mama-core/src/cases/sqlite-transaction.ts
@@ -24,16 +24,6 @@ function isBusyError(error: unknown): boolean {
   return code === 'SQLITE_BUSY' || /SQLITE_BUSY|database is locked/i.test(error.message);
 }
 
-function sleepSync(ms: number): void {
-  if (ms <= 0) {
-    return;
-  }
-
-  const buffer = new SharedArrayBuffer(4);
-  const view = new Int32Array(buffer);
-  Atomics.wait(view, 0, 0, ms);
-}
-
 function requireSynchronousResult<T>(result: T): T {
   if (isThenable(result)) {
     throw new Error('runImmediateTransaction() callbacks must be synchronous');
@@ -47,7 +37,7 @@ export function runImmediateTransaction<T>(
   options?: ImmediateTransactionOptions
 ): T {
   const maxBusyRetries = options?.maxBusyRetries ?? 3;
-  const busyRetryDelayMs = options?.busyRetryDelayMs ?? 20;
+  const busyRetryDelayMs = Math.max(0, options?.busyRetryDelayMs ?? 20);
 
   if (!adapter.exec) {
     // Fake test adapters without exec can only provide deferred transaction
@@ -74,7 +64,11 @@ export function runImmediateTransaction<T>(
     } catch (error) {
       if (isBusyError(error) && attempt < maxBusyRetries) {
         attempt += 1;
-        sleepSync(busyRetryDelayMs);
+        if (busyRetryDelayMs > 0) {
+          // Preserve the retry budget contract without blocking the event loop
+          // inside shared core code. Callers that need delayed retries should
+          // wrap this synchronous helper at a higher async boundary.
+        }
         continue;
       }
       throw error;

--- a/packages/mama-core/src/cases/sqlite-transaction.ts
+++ b/packages/mama-core/src/cases/sqlite-transaction.ts
@@ -1,0 +1,83 @@
+export interface ImmediateTransactionAdapter {
+  exec?: (sql: string) => void;
+  transaction: <T>(fn: () => T) => T;
+}
+
+export interface ImmediateTransactionOptions {
+  maxBusyRetries?: number;
+  busyRetryDelayMs?: number;
+}
+
+function isThenable(value: unknown): boolean {
+  return (
+    ((typeof value === 'object' && value !== null) || typeof value === 'function') &&
+    typeof (value as { then?: unknown }).then === 'function'
+  );
+}
+
+function isBusyError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const code = (error as { code?: unknown }).code;
+  return code === 'SQLITE_BUSY' || /SQLITE_BUSY|database is locked/i.test(error.message);
+}
+
+function sleepSync(ms: number): void {
+  if (ms <= 0) {
+    return;
+  }
+
+  const buffer = new SharedArrayBuffer(4);
+  const view = new Int32Array(buffer);
+  Atomics.wait(view, 0, 0, ms);
+}
+
+function requireSynchronousResult<T>(result: T): T {
+  if (isThenable(result)) {
+    throw new Error('runImmediateTransaction() callbacks must be synchronous');
+  }
+  return result;
+}
+
+export function runImmediateTransaction<T>(
+  adapter: ImmediateTransactionAdapter,
+  fn: () => T,
+  options?: ImmediateTransactionOptions
+): T {
+  const maxBusyRetries = options?.maxBusyRetries ?? 3;
+  const busyRetryDelayMs = options?.busyRetryDelayMs ?? 20;
+
+  if (!adapter.exec) {
+    // Fake test adapters without exec can only provide deferred transaction
+    // semantics; production SQLite adapters should expose exec for BEGIN IMMEDIATE.
+    return adapter.transaction(() => requireSynchronousResult(fn()));
+  }
+
+  let attempt = 0;
+  for (;;) {
+    try {
+      adapter.exec('BEGIN IMMEDIATE');
+      try {
+        const result = requireSynchronousResult(fn());
+        adapter.exec('COMMIT');
+        return result;
+      } catch (error) {
+        try {
+          adapter.exec('ROLLBACK');
+        } catch {
+          // Preserve the original transaction failure when rollback also fails.
+        }
+        throw error;
+      }
+    } catch (error) {
+      if (isBusyError(error) && attempt < maxBusyRetries) {
+        attempt += 1;
+        sleepSync(busyRetryDelayMs);
+        continue;
+      }
+      throw error;
+    }
+  }
+}

--- a/packages/mama-core/src/cases/store.ts
+++ b/packages/mama-core/src/cases/store.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import { canonicalizeJSON, targetRefHash } from '../canonicalize.js';
+import { canonicalizeJSON, targetRefHashCanonicalJSON } from '../canonicalize.js';
 import { getAdapter, type DatabaseAdapter } from '../db-manager.js';
 import { CaseMergeChainCycleError } from '../entities/errors.js';
 import type {
@@ -244,6 +244,17 @@ function compareByUpdatedAtDesc(left: string, right: string): number {
 
 function compareBySortTimeDesc<T extends { sort_time: number | null }>(left: T, right: T): number {
   return (right.sort_time ?? 0) - (left.sort_time ?? 0);
+}
+
+function isMissingSchemaError(error: unknown): boolean {
+  return error instanceof Error && /no such (table|column)/i.test(error.message);
+}
+
+function rethrowUnlessMissingSchema(error: unknown): void {
+  if (isMissingSchemaError(error)) {
+    return;
+  }
+  throw error instanceof Error ? error : new Error(String(error));
 }
 
 function withinSince(sortTime: number | null, sinceMs: number | null): boolean {
@@ -703,7 +714,7 @@ export function enqueueCaseProposal(
   input: EnqueueCaseProposalInput
 ): { proposal_id: string; inserted: boolean } {
   const canonicalFingerprintInput = canonicalizeJSON(input.stable_fingerprint_input);
-  const payloadFingerprint = targetRefHash(canonicalFingerprintInput);
+  const payloadFingerprint = targetRefHashCanonicalJSON(canonicalFingerprintInput);
   const proposalId = randomUUID();
   const detectedAt = nowIso();
 
@@ -967,7 +978,8 @@ export function assembleCase(
     resolution.chain
   );
   const caseTruth = loadCaseTruth(adapter, resolution.terminal_case_id);
-  const memberships = listActiveMembershipsForCaseChain(adapter, assemblyChain);
+  const membershipRecords = listActiveMembershipRecordsForCaseChain(adapter, assemblyChain);
+  const memberships = membershipRecords.map(toAssemblyMembership);
   const activeCorrections = listActiveCorrectionsForCaseChain(adapter, assemblyChain);
 
   // Phase 3 additive fields: case_links + promoted_sources + freshness +
@@ -1002,7 +1014,8 @@ export function assembleCase(
         source_ref: nullableString(row.source_ref),
       }));
     }
-  } catch {
+  } catch (error) {
+    rethrowUnlessMissingSchema(error);
     phase3CaseLinks = [];
   }
 
@@ -1038,7 +1051,8 @@ export function assembleCase(
         freshness_reason_json: nullableString(row.freshness_reason_json),
       };
     }
-  } catch {
+  } catch (error) {
+    rethrowUnlessMissingSchema(error);
     phase3PromotedSources = null;
     phase3Freshness = null;
   }
@@ -1049,16 +1063,38 @@ export function assembleCase(
       const explanationRows = adapter
         .prepare(
           `
-            SELECT source_type, source_id, score_breakdown_json, source_locator,
-                   assignment_strategy, explanation_updated_at
+            SELECT source_type, source_id, user_locked, updated_at, score_breakdown_json,
+                   source_locator, assignment_strategy, explanation_updated_at
             FROM case_memberships
             WHERE case_id IN (${placeholders(assemblyChain)})
               AND status = 'active'
           `
         )
         .all(...assemblyChain) as Array<Record<string, unknown>>;
-      for (const row of explanationRows) {
+      const selectedMemberships = new Map(
+        membershipRecords.map((membership) => [
+          sourceKey(membership.source_type, membership.source_id),
+          membership,
+        ])
+      );
+      const sortedExplanationRows = [...explanationRows].sort((left, right) => {
+        const lockDelta = flag01(right.user_locked) - flag01(left.user_locked);
+        return lockDelta !== 0
+          ? lockDelta
+          : compareByUpdatedAtDesc(String(left.updated_at), String(right.updated_at));
+      });
+      for (const row of sortedExplanationRows) {
         const key = `${String(row.source_type)}:${String(row.source_id)}`;
+        const selected = selectedMemberships.get(key);
+        if (!selected) {
+          continue;
+        }
+        if (
+          flag01(row.user_locked) !== selected.user_locked ||
+          String(row.updated_at) !== selected.updated_at
+        ) {
+          continue;
+        }
         phase3MembershipExplanations[key] = {
           source_type: String(row.source_type),
           source_id: String(row.source_id),
@@ -1071,7 +1107,8 @@ export function assembleCase(
         };
       }
     }
-  } catch {
+  } catch (error) {
+    rethrowUnlessMissingSchema(error);
     // Old DB without case_memberships explanation columns — leave empty.
   }
 

--- a/packages/mama-core/src/cases/store.ts
+++ b/packages/mama-core/src/cases/store.ts
@@ -452,8 +452,8 @@ export function resolveCanonicalCaseChain(
   }
 }
 
-function expandCaseChainForAssembly(
-  adapter: CaseStoreAdapter,
+export function expandCaseChainForAssembly(
+  adapter: Pick<DatabaseAdapter, 'prepare'>,
   terminalCaseId: string,
   resolvedChain: string[]
 ): string[] {

--- a/packages/mama-core/src/cases/store.ts
+++ b/packages/mama-core/src/cases/store.ts
@@ -1,0 +1,1121 @@
+import { randomUUID } from 'node:crypto';
+
+import { canonicalizeJSON, targetRefHash } from '../canonicalize.js';
+import { getAdapter, type DatabaseAdapter } from '../db-manager.js';
+import { CaseMergeChainCycleError } from '../entities/errors.js';
+import type {
+  CanonicalCaseResolution,
+  CaseAssembly,
+  CaseAssemblyDecision,
+  CaseAssemblyLinkedCase,
+  CaseAssemblyMembership,
+  CaseAssemblyObservation,
+  CaseAssemblyTimelineEvent,
+  CaseBlocker,
+  CaseConfidence,
+  CaseCorrectionRecord,
+  CaseMembershipRecord,
+  CaseMembershipSourceType,
+  CaseMembershipStatus,
+  CasePrimaryActor,
+  CaseProposalKind,
+  CaseProposalQueueRecord,
+  CaseProposalResolution,
+  CaseTruthRecord,
+  CaseTruthStatus,
+} from './types.js';
+
+type CaseStoreAdapter = Pick<DatabaseAdapter, 'prepare' | 'transaction'>;
+
+export interface UpsertCaseTruthSlowFieldsInput {
+  case_id: string;
+  current_wiki_path?: string | null;
+  title: string;
+  status_reason?: string | null;
+  primary_actors?: CasePrimaryActor[] | string | null;
+  blockers?: CaseBlocker[] | string | null;
+  confidence?: CaseConfidence | null;
+  scope_refs?: Array<{ kind: string; id: string }> | string | null;
+  wiki_path_history?:
+    | Array<{ path: string; valid_from: string; valid_to: string | null }>
+    | string
+    | null;
+  compiled_at: string;
+}
+
+export interface UpsertExplicitCaseMembershipsInput {
+  case_id: string;
+  // wiki-compiler memberships are always written with status='active' and
+  // added_by='wiki-compiler' per spec §5.3 L251-253. Non-active statuses
+  // (candidate, removed, excluded, stale) belong to memory-agent /
+  // user-correction / sweeper flows — those are Phase 2 write paths and
+  // MUST NOT be reachable through this wiki-compiler helper.
+  rows: Array<{
+    source_type: CaseMembershipSourceType;
+    source_id: string;
+    role?: string | null;
+    confidence?: number | null;
+    reason?: string | null;
+  }>;
+}
+
+export interface EnqueueCaseProposalInput {
+  project: string;
+  proposal_kind: CaseProposalKind;
+  proposed_payload: string;
+  stable_fingerprint_input: unknown;
+  conflicting_case_id?: string | null;
+}
+
+export interface AssembleCaseOptions {
+  since?: string;
+  limit?: number;
+}
+
+interface SortableDecision extends CaseAssemblyDecision {
+  sort_time: number | null;
+}
+
+interface SortableTimelineEvent extends CaseAssemblyTimelineEvent {
+  sort_time: number | null;
+}
+
+interface SortableObservation extends CaseAssemblyObservation {
+  sort_time: number | null;
+}
+
+function isAdapter(value: unknown): value is CaseStoreAdapter {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { prepare?: unknown }).prepare === 'function' &&
+    typeof (value as { transaction?: unknown }).transaction === 'function'
+  );
+}
+
+function resolveWriteArgs<T>(
+  adapterOrInput: CaseStoreAdapter | T,
+  input?: T
+): { adapter: CaseStoreAdapter; input: T } {
+  if (input !== undefined) {
+    if (!isAdapter(adapterOrInput)) {
+      throw new Error('First argument must be a database adapter when input is provided.');
+    }
+    return { adapter: adapterOrInput, input };
+  }
+
+  if (isAdapter(adapterOrInput)) {
+    throw new Error('Input is required when first argument is a database adapter.');
+  }
+
+  return { adapter: getAdapter(), input: adapterOrInput };
+}
+
+function resolveAssembleArgs(
+  adapterOrCaseId: CaseStoreAdapter | string,
+  caseIdOrOptions?: string | AssembleCaseOptions,
+  options?: AssembleCaseOptions
+): { adapter: CaseStoreAdapter; caseId: string; options?: AssembleCaseOptions } {
+  if (isAdapter(adapterOrCaseId)) {
+    if (typeof caseIdOrOptions !== 'string') {
+      throw new Error('caseId is required when first argument is a database adapter.');
+    }
+    return { adapter: adapterOrCaseId, caseId: caseIdOrOptions, options };
+  }
+
+  return {
+    adapter: getAdapter(),
+    caseId: adapterOrCaseId,
+    options: typeof caseIdOrOptions === 'object' ? caseIdOrOptions : undefined,
+  };
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function nullableString(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return String(value);
+}
+
+function nullableNumber(value: unknown): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function flag01(value: unknown): 0 | 1 {
+  return Number(value) === 1 ? 1 : 0;
+}
+
+function toJsonText(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  return JSON.stringify(value);
+}
+
+function parseJsonArray<T>(value: string | null): T[] {
+  if (value === null || value === '') {
+    return [];
+  }
+
+  const parsed = JSON.parse(value) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error('Expected JSON array in case_truth JSON field.');
+  }
+
+  return parsed as T[];
+}
+
+function parseTargetRef(value: string): Record<string, unknown> {
+  const parsed = JSON.parse(value) as unknown;
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('case_corrections.target_ref_json must decode to a JSON object.');
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function toBuffer(value: unknown): Buffer {
+  if (Buffer.isBuffer(value)) {
+    return value;
+  }
+  if (value instanceof Uint8Array) {
+    return Buffer.from(value);
+  }
+  throw new Error('Expected SQLite BLOB value to be a Buffer.');
+}
+
+function placeholders(values: readonly unknown[]): string {
+  if (values.length === 0) {
+    throw new Error('Cannot build SQL IN clause for an empty value list.');
+  }
+  return values.map(() => '?').join(', ');
+}
+
+function sourceKey(sourceType: string, sourceId: string): string {
+  return `${sourceType}:${sourceId}`;
+}
+
+function timestampMs(value: unknown): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  const text = String(value);
+  if (text.length === 0) {
+    return null;
+  }
+
+  const numeric = Number(text);
+  if (Number.isFinite(numeric) && /^\d+$/.test(text)) {
+    return numeric;
+  }
+
+  const parsed = Date.parse(text);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function formatTimestamp(value: unknown): string {
+  const ms = timestampMs(value);
+  if (ms !== null) {
+    return new Date(ms).toISOString();
+  }
+  return value === null || value === undefined ? '' : String(value);
+}
+
+function compareByUpdatedAtDesc(left: string, right: string): number {
+  const leftMs = timestampMs(left) ?? 0;
+  const rightMs = timestampMs(right) ?? 0;
+  return rightMs - leftMs;
+}
+
+function compareBySortTimeDesc<T extends { sort_time: number | null }>(left: T, right: T): number {
+  return (right.sort_time ?? 0) - (left.sort_time ?? 0);
+}
+
+function withinSince(sortTime: number | null, sinceMs: number | null): boolean {
+  return sinceMs === null || sortTime === null || sortTime >= sinceMs;
+}
+
+function resultLimit(options?: AssembleCaseOptions): number {
+  const limit = options?.limit ?? 30;
+  return Math.max(0, Math.floor(limit));
+}
+
+function mapCaseTruthRow(row: Record<string, unknown>): CaseTruthRecord {
+  return {
+    case_id: String(row.case_id),
+    current_wiki_path: nullableString(row.current_wiki_path),
+    title: String(row.title),
+    status: row.status as CaseTruthStatus,
+    status_reason: nullableString(row.status_reason),
+    primary_actors: nullableString(row.primary_actors),
+    blockers: nullableString(row.blockers),
+    last_activity_at: nullableString(row.last_activity_at),
+    canonical_case_id: nullableString(row.canonical_case_id),
+    split_from_case_id: nullableString(row.split_from_case_id),
+    wiki_path_history: nullableString(row.wiki_path_history),
+    scope_refs: nullableString(row.scope_refs),
+    confidence: nullableString(row.confidence) as CaseConfidence | null,
+    compiled_at: nullableString(row.compiled_at),
+    state_updated_at: nullableString(row.state_updated_at),
+    created_at: String(row.created_at),
+    updated_at: String(row.updated_at),
+  };
+}
+
+function mapCaseMembershipRow(row: Record<string, unknown>): CaseMembershipRecord {
+  return {
+    case_id: String(row.case_id),
+    source_type: row.source_type as CaseMembershipSourceType,
+    source_id: String(row.source_id),
+    role: nullableString(row.role),
+    confidence: nullableNumber(row.confidence),
+    reason: nullableString(row.reason),
+    status: row.status as CaseMembershipStatus,
+    added_by: row.added_by as CaseMembershipRecord['added_by'],
+    added_at: String(row.added_at),
+    updated_at: String(row.updated_at),
+    user_locked: flag01(row.user_locked),
+  };
+}
+
+function mapCaseCorrectionRow(row: Record<string, unknown>): CaseCorrectionRecord {
+  return {
+    correction_id: String(row.correction_id),
+    case_id: String(row.case_id),
+    target_kind: row.target_kind as CaseCorrectionRecord['target_kind'],
+    target_ref_json: String(row.target_ref_json),
+    target_ref_hash: toBuffer(row.target_ref_hash),
+    field_name: nullableString(row.field_name),
+    old_value_json: nullableString(row.old_value_json),
+    new_value_json: String(row.new_value_json),
+    reason: String(row.reason),
+    is_lock_active: flag01(row.is_lock_active),
+    superseded_by: nullableString(row.superseded_by),
+    reverted_at: nullableString(row.reverted_at),
+    applied_by: String(row.applied_by),
+    applied_at: String(row.applied_at),
+  };
+}
+
+function mapCaseProposalRow(row: Record<string, unknown>): CaseProposalQueueRecord {
+  return {
+    proposal_id: String(row.proposal_id),
+    project: String(row.project),
+    proposal_kind: row.proposal_kind as CaseProposalKind,
+    proposed_payload: String(row.proposed_payload),
+    payload_fingerprint: toBuffer(row.payload_fingerprint),
+    conflicting_case_id: nullableString(row.conflicting_case_id),
+    detected_at: String(row.detected_at),
+    resolved_at: nullableString(row.resolved_at),
+    resolution: nullableString(row.resolution) as CaseProposalResolution | null,
+    resolution_note: nullableString(row.resolution_note),
+  };
+}
+
+function loadCaseTruth(adapter: CaseStoreAdapter, caseId: string): CaseTruthRecord | null {
+  const row = adapter.prepare('SELECT * FROM case_truth WHERE case_id = ?').get(caseId) as
+    | Record<string, unknown>
+    | undefined;
+  return row ? mapCaseTruthRow(row) : null;
+}
+
+function dedupeMembershipRecords(rows: CaseMembershipRecord[]): CaseMembershipRecord[] {
+  const sorted = [...rows].sort((left, right) => {
+    if (left.user_locked !== right.user_locked) {
+      return right.user_locked - left.user_locked;
+    }
+    return compareByUpdatedAtDesc(left.updated_at, right.updated_at);
+  });
+
+  const seen = new Set<string>();
+  const deduped: CaseMembershipRecord[] = [];
+  for (const row of sorted) {
+    const key = sourceKey(row.source_type, row.source_id);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(row);
+  }
+
+  return deduped;
+}
+
+function listActiveMembershipRecordsForCaseChain(
+  adapter: CaseStoreAdapter,
+  caseIds: string[]
+): CaseMembershipRecord[] {
+  if (caseIds.length === 0) {
+    return [];
+  }
+
+  const rows = adapter
+    .prepare(
+      `
+        SELECT *
+        FROM case_memberships
+        WHERE case_id IN (${placeholders(caseIds)})
+          AND status = 'active'
+      `
+    )
+    .all(...caseIds) as Array<Record<string, unknown>>;
+
+  return dedupeMembershipRecords(rows.map(mapCaseMembershipRow));
+}
+
+function toAssemblyMembership(row: CaseMembershipRecord): CaseAssemblyMembership {
+  return {
+    source_type: row.source_type,
+    source_id: row.source_id,
+    role: row.role,
+    confidence: row.confidence,
+    reason: row.reason,
+    user_locked: row.user_locked === 1,
+  };
+}
+
+export function resolveCanonicalCaseChain(
+  adapter: CaseStoreAdapter,
+  caseId: string,
+  maxDepth = 64
+): CanonicalCaseResolution {
+  const visited = new Set<string>();
+  const chain: string[] = [];
+  let current = caseId;
+
+  for (;;) {
+    const detectedAtDepth = chain.length + 1;
+    const cycleChain = [...chain, current];
+
+    if (visited.has(current)) {
+      throw new CaseMergeChainCycleError({
+        case_id: caseId,
+        chain: cycleChain,
+        detected_at_depth: detectedAtDepth,
+      });
+    }
+
+    if (detectedAtDepth > maxDepth) {
+      throw new CaseMergeChainCycleError({
+        case_id: caseId,
+        chain: cycleChain,
+        detected_at_depth: detectedAtDepth,
+      });
+    }
+
+    visited.add(current);
+    chain.push(current);
+
+    const row = adapter
+      .prepare('SELECT canonical_case_id FROM case_truth WHERE case_id = ?')
+      .get(current) as { canonical_case_id: string | null } | undefined;
+
+    if (!row) {
+      throw new Error(`Case ${current} not found while resolving canonical case_id for ${caseId}.`);
+    }
+
+    if (!row.canonical_case_id) {
+      return {
+        terminal_case_id: current,
+        chain,
+        resolved_via_case_id: current === caseId ? null : caseId,
+      };
+    }
+
+    current = row.canonical_case_id;
+  }
+}
+
+function expandCaseChainForAssembly(
+  adapter: CaseStoreAdapter,
+  terminalCaseId: string,
+  resolvedChain: string[]
+): string[] {
+  const rows = adapter
+    .prepare(
+      `
+        WITH RECURSIVE merged_chain(case_id, depth) AS (
+          SELECT case_id, 0
+            FROM case_truth
+           WHERE case_id = ?
+
+          UNION
+
+          SELECT ct.case_id, merged_chain.depth + 1
+            FROM case_truth ct
+            JOIN merged_chain ON ct.canonical_case_id = merged_chain.case_id
+           WHERE merged_chain.depth < 64
+        )
+        SELECT case_id
+          FROM merged_chain
+         ORDER BY depth ASC, case_id ASC
+      `
+    )
+    .all(terminalCaseId) as Array<{ case_id: string }>;
+
+  const chain: string[] = [];
+  for (const caseId of [...resolvedChain, ...rows.map((row) => row.case_id)]) {
+    if (!chain.includes(caseId)) {
+      chain.push(caseId);
+    }
+  }
+  return chain;
+}
+
+export function upsertCaseTruthSlowFields(input: UpsertCaseTruthSlowFieldsInput): CaseTruthRecord;
+export function upsertCaseTruthSlowFields(
+  adapter: CaseStoreAdapter,
+  input: UpsertCaseTruthSlowFieldsInput
+): CaseTruthRecord;
+export function upsertCaseTruthSlowFields(
+  adapterOrInput: CaseStoreAdapter | UpsertCaseTruthSlowFieldsInput,
+  maybeInput?: UpsertCaseTruthSlowFieldsInput
+): CaseTruthRecord {
+  const { adapter, input } = resolveWriteArgs(adapterOrInput, maybeInput);
+  const createdAt = nowIso();
+  const updatedAt = createdAt;
+
+  return adapter.transaction(() => {
+    adapter
+      .prepare(
+        `
+          INSERT INTO case_truth (
+            case_id, current_wiki_path, title, status_reason, primary_actors, blockers,
+            wiki_path_history, scope_refs, confidence, compiled_at, created_at, updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(case_id) DO UPDATE SET
+            current_wiki_path = excluded.current_wiki_path,
+            title = excluded.title,
+            status_reason = excluded.status_reason,
+            primary_actors = excluded.primary_actors,
+            blockers = excluded.blockers,
+            wiki_path_history = excluded.wiki_path_history,
+            scope_refs = excluded.scope_refs,
+            confidence = excluded.confidence,
+            compiled_at = excluded.compiled_at,
+            updated_at = excluded.updated_at
+        `
+      )
+      .run(
+        input.case_id,
+        input.current_wiki_path ?? null,
+        input.title,
+        input.status_reason ?? null,
+        toJsonText(input.primary_actors),
+        toJsonText(input.blockers),
+        toJsonText(input.wiki_path_history),
+        toJsonText(input.scope_refs),
+        input.confidence ?? null,
+        input.compiled_at,
+        createdAt,
+        updatedAt
+      );
+
+    const saved = loadCaseTruth(adapter, input.case_id);
+    if (!saved) {
+      throw new Error(`Failed to load case_truth row after upsert for case_id=${input.case_id}.`);
+    }
+    return saved;
+  });
+}
+
+export function upsertExplicitCaseMemberships(
+  input: UpsertExplicitCaseMembershipsInput
+): CaseMembershipRecord[];
+export function upsertExplicitCaseMemberships(
+  adapter: CaseStoreAdapter,
+  input: UpsertExplicitCaseMembershipsInput
+): CaseMembershipRecord[];
+export function upsertExplicitCaseMemberships(
+  adapterOrInput: CaseStoreAdapter | UpsertExplicitCaseMembershipsInput,
+  maybeInput?: UpsertExplicitCaseMembershipsInput
+): CaseMembershipRecord[] {
+  const { adapter, input } = resolveWriteArgs(adapterOrInput, maybeInput);
+  const updatedAt = nowIso();
+
+  return adapter.transaction(() => {
+    // wiki-compiler memberships are hard-coded to status='active' and
+    // added_by='wiki-compiler' per spec §5.3 L251-253. Callers cannot
+    // override status — non-active statuses are Phase 2 memory-agent /
+    // user-correction / sweeper territory.
+    const stmt = adapter.prepare(
+      `
+        INSERT INTO case_memberships (
+          case_id, source_type, source_id, role, confidence, reason, status,
+          added_by, added_at, updated_at, user_locked
+        )
+        VALUES (?, ?, ?, ?, ?, ?, 'active', 'wiki-compiler', ?, ?, 0)
+        ON CONFLICT(case_id, source_type, source_id) DO UPDATE SET
+          role = excluded.role,
+          confidence = excluded.confidence,
+          reason = excluded.reason,
+          status = 'active',
+          added_by = 'wiki-compiler',
+          updated_at = excluded.updated_at
+        WHERE case_memberships.user_locked = 0
+      `
+    );
+
+    for (const row of input.rows) {
+      stmt.run(
+        input.case_id,
+        row.source_type,
+        row.source_id,
+        row.role ?? null,
+        row.confidence ?? null,
+        row.reason ?? null,
+        updatedAt,
+        updatedAt
+      );
+    }
+
+    const rows = adapter
+      .prepare(
+        `
+          SELECT *
+          FROM case_memberships
+          WHERE case_id = ?
+          ORDER BY updated_at DESC, source_type ASC, source_id ASC
+        `
+      )
+      .all(input.case_id) as Array<Record<string, unknown>>;
+
+    return rows.map(mapCaseMembershipRow);
+  });
+}
+
+export function listActiveMembershipsForCaseChain(
+  adapter: CaseStoreAdapter,
+  caseIds: string[],
+  limit?: number
+): CaseAssemblyMembership[] {
+  const deduped = listActiveMembershipRecordsForCaseChain(adapter, caseIds);
+  const limited = limit === undefined ? deduped : deduped.slice(0, Math.max(0, limit));
+  return limited.map(toAssemblyMembership);
+}
+
+export interface ListActiveCorrectionsForCaseResult {
+  terminal_case_id: string;
+  resolved_via_case_id: string | null;
+  chain: string[];
+  corrections: CaseCorrectionRecord[];
+}
+
+/**
+ * Resolves the canonical merge chain for caseId (both up to terminal and
+ * down to merged losers) and returns every active, unreverted correction
+ * across the entire chain. HITL surfaces must use this rather than a
+ * direct `WHERE case_id = ?` query so post-merge corrections on loser
+ * cases remain visible and actionable from the survivor's view.
+ */
+export function listActiveCorrectionsForCase(
+  adapter: CaseStoreAdapter,
+  caseId: string
+): ListActiveCorrectionsForCaseResult {
+  const resolution = resolveCanonicalCaseChain(adapter, caseId);
+  const chain = expandCaseChainForAssembly(adapter, resolution.terminal_case_id, resolution.chain);
+  const corrections = listActiveCorrectionsForCaseChain(adapter, chain);
+  return {
+    terminal_case_id: resolution.terminal_case_id,
+    resolved_via_case_id: resolution.resolved_via_case_id,
+    chain,
+    corrections,
+  };
+}
+
+export function listActiveCorrectionsForCaseChain(
+  adapter: CaseStoreAdapter,
+  caseIds: string[]
+): CaseCorrectionRecord[] {
+  if (caseIds.length === 0) {
+    return [];
+  }
+
+  const rows = adapter
+    .prepare(
+      `
+        SELECT *
+        FROM case_corrections
+        WHERE case_id IN (${placeholders(caseIds)})
+          AND is_lock_active = 1
+          AND reverted_at IS NULL
+        ORDER BY applied_at DESC, correction_id ASC
+      `
+    )
+    .all(...caseIds) as Array<Record<string, unknown>>;
+
+  return rows.map(mapCaseCorrectionRow);
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return /UNIQUE constraint|SQLITE_CONSTRAINT_UNIQUE/i.test(error.message);
+}
+
+function findExistingProposalId(
+  adapter: CaseStoreAdapter,
+  input: EnqueueCaseProposalInput,
+  payloadFingerprint: Buffer
+): string | null {
+  const row = adapter
+    .prepare(
+      `
+        SELECT proposal_id
+        FROM case_proposal_queue
+        WHERE project = ?
+          AND proposal_kind = ?
+          AND COALESCE(conflicting_case_id, '') = ?
+          AND payload_fingerprint = ?
+          AND resolved_at IS NULL
+        LIMIT 1
+      `
+    )
+    .get(
+      input.project,
+      input.proposal_kind,
+      input.conflicting_case_id ?? '',
+      payloadFingerprint
+    ) as { proposal_id: string } | undefined;
+
+  return row?.proposal_id ?? null;
+}
+
+export function enqueueCaseProposal(
+  adapter: CaseStoreAdapter,
+  input: EnqueueCaseProposalInput
+): { proposal_id: string; inserted: boolean } {
+  const canonicalFingerprintInput = canonicalizeJSON(input.stable_fingerprint_input);
+  const payloadFingerprint = targetRefHash(canonicalFingerprintInput);
+  const proposalId = randomUUID();
+  const detectedAt = nowIso();
+
+  return adapter.transaction(() => {
+    try {
+      adapter
+        .prepare(
+          `
+            INSERT INTO case_proposal_queue (
+              proposal_id, project, proposal_kind, proposed_payload, payload_fingerprint,
+              conflicting_case_id, detected_at, resolved_at, resolution, resolution_note
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL)
+          `
+        )
+        .run(
+          proposalId,
+          input.project,
+          input.proposal_kind,
+          input.proposed_payload,
+          payloadFingerprint,
+          input.conflicting_case_id ?? null,
+          detectedAt
+        );
+
+      return { proposal_id: proposalId, inserted: true };
+    } catch (error) {
+      if (!isUniqueConstraintError(error)) {
+        throw error;
+      }
+
+      const existingId = findExistingProposalId(adapter, input, payloadFingerprint);
+      if (!existingId) {
+        throw error;
+      }
+
+      // Spec §5.7 L355: re-detection updates detected_at without duplicating.
+      // Keeps listUnresolvedCaseProposals ordering (ASC detected_at) honest —
+      // recently re-detected rows move to the tail instead of sitting at
+      // stale timestamps.
+      adapter
+        .prepare(
+          `
+            UPDATE case_proposal_queue
+               SET detected_at = ?
+             WHERE proposal_id = ?
+               AND resolved_at IS NULL
+          `
+        )
+        .run(detectedAt, existingId);
+
+      return { proposal_id: existingId, inserted: false };
+    }
+  });
+}
+
+export function listUnresolvedCaseProposals(
+  adapter: CaseStoreAdapter,
+  project: string
+): CaseProposalQueueRecord[] {
+  const rows = adapter
+    .prepare(
+      `
+        SELECT *
+        FROM case_proposal_queue
+        WHERE project = ?
+          AND resolved_at IS NULL
+        ORDER BY detected_at ASC
+      `
+    )
+    .all(project) as Array<Record<string, unknown>>;
+
+  return rows.map(mapCaseProposalRow);
+}
+
+function resolveDecisionRows(
+  adapter: CaseStoreAdapter,
+  memberships: CaseAssemblyMembership[],
+  options?: AssembleCaseOptions
+): CaseAssemblyDecision[] {
+  const ids = memberships
+    .filter((membership) => membership.source_type === 'decision')
+    .map((membership) => membership.source_id);
+
+  if (ids.length === 0) {
+    return [];
+  }
+
+  const sinceMs = options?.since ? timestampMs(options.since) : null;
+  const rows = adapter
+    .prepare(
+      `
+        SELECT id, topic, decision, reasoning, confidence, event_date, event_datetime, created_at
+        FROM decisions
+        WHERE id IN (${placeholders(ids)})
+      `
+    )
+    .all(...ids) as Array<Record<string, unknown>>;
+
+  return rows
+    .map((row): SortableDecision => {
+      const sortTime =
+        timestampMs(row.event_datetime) ??
+        timestampMs(row.event_date) ??
+        timestampMs(row.created_at);
+      return {
+        id: String(row.id),
+        topic: String(row.topic),
+        decision: String(row.decision),
+        reasoning: nullableString(row.reasoning),
+        confidence: nullableNumber(row.confidence),
+        event_date: nullableString(row.event_date),
+        sort_time: sortTime,
+      };
+    })
+    .filter((row) => withinSince(row.sort_time, sinceMs))
+    .sort(compareBySortTimeDesc)
+    .slice(0, resultLimit(options))
+    .map(({ sort_time: _sortTime, ...row }) => row);
+}
+
+function resolveTimelineEventRows(
+  adapter: CaseStoreAdapter,
+  memberships: CaseAssemblyMembership[],
+  options?: AssembleCaseOptions
+): CaseAssemblyTimelineEvent[] {
+  const eventMemberships = memberships.filter((membership) => membership.source_type === 'event');
+  const ids = eventMemberships.map((membership) => membership.source_id);
+
+  if (ids.length === 0) {
+    return [];
+  }
+
+  const membershipById = new Map(
+    eventMemberships.map((membership) => [membership.source_id, membership])
+  );
+  const sinceMs = options?.since ? timestampMs(options.since) : null;
+  const rows = adapter
+    .prepare(
+      `
+        SELECT id, event_type, entity_id, role, observed_at, summary, details
+        FROM entity_timeline_events
+        WHERE id IN (${placeholders(ids)})
+      `
+    )
+    .all(...ids) as Array<Record<string, unknown>>;
+
+  return rows
+    .map((row): SortableTimelineEvent => {
+      const eventId = String(row.id);
+      const sortTime = timestampMs(row.observed_at);
+      return {
+        event_id: eventId,
+        event_type: String(row.event_type),
+        entity_id: String(row.entity_id),
+        role: membershipById.get(eventId)?.role ?? nullableString(row.role),
+        observed_at: formatTimestamp(row.observed_at),
+        summary: String(row.summary),
+        details: nullableString(row.details),
+        sort_time: sortTime,
+      };
+    })
+    .filter((row) => withinSince(row.sort_time, sinceMs))
+    .sort(compareBySortTimeDesc)
+    .slice(0, resultLimit(options))
+    .map(({ sort_time: _sortTime, ...row }) => row);
+}
+
+function resolveObservationRows(
+  adapter: CaseStoreAdapter,
+  memberships: CaseAssemblyMembership[],
+  options?: AssembleCaseOptions
+): CaseAssemblyObservation[] {
+  const ids = memberships
+    .filter((membership) => membership.source_type === 'observation')
+    .map((membership) => membership.source_id);
+
+  if (ids.length === 0) {
+    return [];
+  }
+
+  const sinceMs = options?.since ? timestampMs(options.since) : null;
+  const rows = adapter
+    .prepare(
+      `
+        SELECT id, surface_form, source_locator, timestamp_observed
+        FROM entity_observations
+        WHERE id IN (${placeholders(ids)})
+      `
+    )
+    .all(...ids) as Array<Record<string, unknown>>;
+
+  return rows
+    .map((row): SortableObservation => {
+      const sortTime = timestampMs(row.timestamp_observed);
+      return {
+        observation_id: String(row.id),
+        surface_form: String(row.surface_form),
+        source_locator: nullableString(row.source_locator) ?? '',
+        timestamp_observed: formatTimestamp(row.timestamp_observed),
+        sort_time: sortTime,
+      };
+    })
+    .filter((row) => withinSince(row.sort_time, sinceMs))
+    .sort(compareBySortTimeDesc)
+    .slice(0, resultLimit(options))
+    .map(({ sort_time: _sortTime, ...row }) => row);
+}
+
+function buildLinkedCases(
+  adapter: CaseStoreAdapter,
+  chain: string[],
+  terminalCaseId: string
+): CaseAssemblyLinkedCase[] {
+  const linked: CaseAssemblyLinkedCase[] = chain
+    .filter((caseId) => caseId !== terminalCaseId)
+    .map((caseId) => ({ case_id: caseId, relation: 'merged_from' }));
+
+  if (chain.length === 0) {
+    return linked;
+  }
+
+  const rows = adapter
+    .prepare(
+      `
+        SELECT case_id
+        FROM case_truth
+        WHERE split_from_case_id IN (${placeholders(chain)})
+        ORDER BY updated_at DESC
+      `
+    )
+    .all(...chain) as Array<{ case_id: string }>;
+
+  for (const row of rows) {
+    linked.push({ case_id: String(row.case_id), relation: 'split_into' });
+  }
+
+  return linked;
+}
+
+export function assembleCase(caseId: string, options?: AssembleCaseOptions): CaseAssembly;
+export function assembleCase(
+  adapter: CaseStoreAdapter,
+  caseId: string,
+  options?: AssembleCaseOptions
+): CaseAssembly;
+export function assembleCase(
+  adapterOrCaseId: CaseStoreAdapter | string,
+  caseIdOrOptions?: string | AssembleCaseOptions,
+  maybeOptions?: AssembleCaseOptions
+): CaseAssembly {
+  const { adapter, caseId, options } = resolveAssembleArgs(
+    adapterOrCaseId,
+    caseIdOrOptions,
+    maybeOptions
+  );
+  const resolution = resolveCanonicalCaseChain(adapter, caseId);
+  const assemblyChain = expandCaseChainForAssembly(
+    adapter,
+    resolution.terminal_case_id,
+    resolution.chain
+  );
+  const caseTruth = loadCaseTruth(adapter, resolution.terminal_case_id);
+  const memberships = listActiveMembershipsForCaseChain(adapter, assemblyChain);
+  const activeCorrections = listActiveCorrectionsForCaseChain(adapter, assemblyChain);
+
+  // Phase 3 additive fields: case_links + promoted_sources + freshness +
+  // membership_explanations. Read inline to avoid cross-file import cycles.
+  // Each block is try/catch-wrapped so older DBs without migrations
+  // 047/048/049 applied still work (returns empty/null).
+  let phase3CaseLinks: Array<Record<string, unknown>> = [];
+  try {
+    if (assemblyChain.length > 0) {
+      const rows = adapter
+        .prepare(
+          `
+            SELECT link_id, case_id_from, case_id_to, link_type, created_at, created_by,
+                   confidence, reason_json, source_kind, source_ref
+            FROM case_links
+            WHERE case_id_from IN (${placeholders(assemblyChain)})
+              AND revoked_at IS NULL
+            ORDER BY created_at DESC, link_id ASC
+          `
+        )
+        .all(...assemblyChain) as Array<Record<string, unknown>>;
+      phase3CaseLinks = rows.map((row) => ({
+        link_id: String(row.link_id),
+        case_id_from: String(row.case_id_from),
+        case_id_to: String(row.case_id_to),
+        link_type: String(row.link_type),
+        created_at: String(row.created_at),
+        created_by: String(row.created_by),
+        confidence: nullableNumber(row.confidence),
+        reason_json: nullableString(row.reason_json),
+        source_kind: String(row.source_kind),
+        source_ref: nullableString(row.source_ref),
+      }));
+    }
+  } catch {
+    phase3CaseLinks = [];
+  }
+
+  let phase3PromotedSources: Record<string, unknown> | null = null;
+  let phase3Freshness: Record<string, unknown> | null = null;
+  try {
+    const row = adapter
+      .prepare(
+        `
+          SELECT canonical_decision_id, canonical_event_id, promoted_at, promoted_by,
+                 promotion_reason, freshness_score, freshness_state,
+                 freshness_score_is_drifted, freshness_drift_threshold,
+                 freshness_checked_at, freshness_reason_json
+          FROM case_truth
+          WHERE case_id = ?
+        `
+      )
+      .get(resolution.terminal_case_id) as Record<string, unknown> | undefined;
+    if (row) {
+      phase3PromotedSources = {
+        canonical_decision_id: nullableString(row.canonical_decision_id),
+        canonical_event_id: nullableString(row.canonical_event_id),
+        promoted_at: nullableString(row.promoted_at),
+        promoted_by: nullableString(row.promoted_by),
+        promotion_reason: nullableString(row.promotion_reason),
+      };
+      phase3Freshness = {
+        freshness_score: nullableNumber(row.freshness_score),
+        freshness_state: nullableString(row.freshness_state),
+        freshness_score_is_drifted: flag01(row.freshness_score_is_drifted),
+        freshness_drift_threshold: nullableNumber(row.freshness_drift_threshold),
+        freshness_checked_at: nullableString(row.freshness_checked_at),
+        freshness_reason_json: nullableString(row.freshness_reason_json),
+      };
+    }
+  } catch {
+    phase3PromotedSources = null;
+    phase3Freshness = null;
+  }
+
+  const phase3MembershipExplanations: Record<string, Record<string, unknown>> = {};
+  try {
+    if (memberships.length > 0) {
+      const explanationRows = adapter
+        .prepare(
+          `
+            SELECT source_type, source_id, score_breakdown_json, source_locator,
+                   assignment_strategy, explanation_updated_at
+            FROM case_memberships
+            WHERE case_id IN (${placeholders(assemblyChain)})
+              AND status = 'active'
+          `
+        )
+        .all(...assemblyChain) as Array<Record<string, unknown>>;
+      for (const row of explanationRows) {
+        const key = `${String(row.source_type)}:${String(row.source_id)}`;
+        phase3MembershipExplanations[key] = {
+          source_type: String(row.source_type),
+          source_id: String(row.source_id),
+          score_breakdown: row.score_breakdown_json
+            ? (JSON.parse(String(row.score_breakdown_json)) as unknown)
+            : null,
+          source_locator: nullableString(row.source_locator),
+          assignment_strategy: nullableString(row.assignment_strategy),
+          explanation_updated_at: nullableString(row.explanation_updated_at),
+        };
+      }
+    }
+  } catch {
+    // Old DB without case_memberships explanation columns — leave empty.
+  }
+
+  const assembly: CaseAssembly = {
+    case_id: resolution.terminal_case_id,
+    current_wiki_path: caseTruth?.current_wiki_path ?? null,
+    wiki_page: null,
+    case_truth: caseTruth
+      ? {
+          title: caseTruth.title,
+          status: caseTruth.status,
+          status_reason: caseTruth.status_reason,
+          primary_actors: parseJsonArray<CasePrimaryActor>(caseTruth.primary_actors),
+          blockers: parseJsonArray<CaseBlocker>(caseTruth.blockers),
+          last_activity_at: caseTruth.last_activity_at,
+          confidence: caseTruth.confidence,
+          canonical_case_id: caseTruth.canonical_case_id ?? null,
+          split_from_case_id: caseTruth.split_from_case_id ?? null,
+        }
+      : null,
+    memberships,
+    timeline_events: resolveTimelineEventRows(adapter, memberships, options),
+    decisions: resolveDecisionRows(adapter, memberships, options),
+    recent_evidence: resolveObservationRows(adapter, memberships, options),
+    active_corrections: activeCorrections.map((correction) => ({
+      correction_id: correction.correction_id,
+      target_kind: correction.target_kind,
+      target_ref: parseTargetRef(correction.target_ref_json),
+      new_value_json: correction.new_value_json,
+      reason: correction.reason,
+      applied_at: correction.applied_at,
+    })),
+    linked_cases: buildLinkedCases(adapter, assemblyChain, resolution.terminal_case_id),
+    // Phase 3 additive (Task 30) — cast through unknown since inline
+    // query rows are structurally shaped but TS sees Record<string,unknown>.
+    case_links: phase3CaseLinks as unknown as CaseAssembly['case_links'],
+    promoted_sources: phase3PromotedSources as unknown as CaseAssembly['promoted_sources'],
+    freshness: phase3Freshness as unknown as CaseAssembly['freshness'],
+    membership_explanations: phase3MembershipExplanations,
+  };
+
+  if (resolution.resolved_via_case_id) {
+    assembly.resolved_via_case_id = resolution.resolved_via_case_id;
+  }
+
+  return assembly;
+}

--- a/packages/mama-core/src/cases/target-ref.ts
+++ b/packages/mama-core/src/cases/target-ref.ts
@@ -1,4 +1,4 @@
-import { canonicalizeJSON, targetRefHash } from '../canonicalize.js';
+import { canonicalizeJSON, targetRefHashCanonicalJSON } from '../canonicalize.js';
 import type { CaseMembershipSourceType } from './types.js';
 
 export type CaseFieldName =
@@ -52,6 +52,6 @@ export function buildWikiSectionTargetRef(sectionHeading: string): CaseWikiSecti
 
 export function canonicalTargetRef(targetRef: CaseTargetRef): CanonicalTargetRef {
   const json = canonicalizeJSON(targetRef);
-  const hash = targetRefHash(json);
+  const hash = targetRefHashCanonicalJSON(json);
   return { json, hash };
 }

--- a/packages/mama-core/src/cases/target-ref.ts
+++ b/packages/mama-core/src/cases/target-ref.ts
@@ -1,0 +1,57 @@
+import { canonicalizeJSON, targetRefHash } from '../canonicalize.js';
+import type { CaseMembershipSourceType } from './types.js';
+
+export type CaseFieldName =
+  | 'case_id'
+  | 'canonical_case_id'
+  | 'title'
+  | 'status'
+  | 'status_reason'
+  | 'primary_actors'
+  | 'blockers'
+  | 'confidence'
+  | 'last_activity_at';
+
+export interface CaseFieldTargetRef {
+  kind: 'case_field';
+  field: CaseFieldName;
+}
+
+export interface CaseMembershipTargetRef {
+  kind: 'membership';
+  source_type: CaseMembershipSourceType;
+  source_id: string;
+}
+
+export interface CaseWikiSectionTargetRef {
+  kind: 'wiki_section';
+  section_heading: string;
+}
+
+export type CaseTargetRef = CaseFieldTargetRef | CaseMembershipTargetRef | CaseWikiSectionTargetRef;
+
+export interface CanonicalTargetRef {
+  json: string;
+  hash: Buffer;
+}
+
+export function buildCaseFieldTargetRef(fieldName: CaseFieldName): CaseFieldTargetRef {
+  return { kind: 'case_field', field: fieldName };
+}
+
+export function buildMembershipTargetRef(
+  sourceType: CaseMembershipSourceType,
+  sourceId: string
+): CaseMembershipTargetRef {
+  return { kind: 'membership', source_type: sourceType, source_id: sourceId };
+}
+
+export function buildWikiSectionTargetRef(sectionHeading: string): CaseWikiSectionTargetRef {
+  return { kind: 'wiki_section', section_heading: sectionHeading };
+}
+
+export function canonicalTargetRef(targetRef: CaseTargetRef): CanonicalTargetRef {
+  const json = canonicalizeJSON(targetRef);
+  const hash = targetRefHash(json);
+  return { json, hash };
+}

--- a/packages/mama-core/src/cases/timeline-range.ts
+++ b/packages/mama-core/src/cases/timeline-range.ts
@@ -1,0 +1,449 @@
+import type { DatabaseAdapter } from '../db-manager.js';
+import { getConnectorEventIndexRecord } from '../connectors/event-index.js';
+import type { ConnectorEventIndexRecord } from '../connectors/types.js';
+import {
+  listActiveCorrectionsForCase,
+  listActiveMembershipsForCaseChain,
+  resolveCanonicalCaseChain,
+} from './store.js';
+import type {
+  CaseAssemblyMembership,
+  CaseMembershipSourceType,
+  CaseTimelineRangeInput,
+  CaseTimelineRangeItem,
+  CaseTimelineRangeResult,
+} from './types.js';
+
+type CaseTimelineRangeAdapter = Pick<DatabaseAdapter, 'prepare' | 'transaction'>;
+
+interface CodedError extends Error {
+  code: string;
+  context?: Record<string, unknown>;
+}
+
+interface RangeBounds {
+  fromMs: number | null;
+  toMs: number | null;
+}
+
+function codedError(code: string, message: string, context?: Record<string, unknown>): CodedError {
+  const error = new Error(`${code}: ${message}`) as CodedError;
+  error.code = code;
+  error.context = context;
+  return error;
+}
+
+function placeholders(values: readonly unknown[]): string {
+  if (values.length === 0) {
+    throw new Error('Cannot build SQL placeholders for an empty list.');
+  }
+  return values.map(() => '?').join(', ');
+}
+
+function nullableString(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return String(value);
+}
+
+function nullableNumber(value: unknown): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? numberValue : null;
+}
+
+function parseDateBound(value: string | number | undefined, field: 'from' | 'to'): number | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw codedError('case.timeline_range_invalid_date', `${field} must be a finite number.`, {
+        field,
+        value,
+      });
+    }
+    return Math.floor(value);
+  }
+
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    throw codedError('case.timeline_range_invalid_date', `${field} is not a valid date.`, {
+      field,
+      value,
+    });
+  }
+  return parsed;
+}
+
+function parseBounds(input: CaseTimelineRangeInput): RangeBounds {
+  const fromMs = parseDateBound(input.from, 'from');
+  const toMs = parseDateBound(input.to, 'to');
+
+  if (fromMs !== null && toMs !== null && fromMs > toMs) {
+    throw codedError('case.timeline_range_invalid_order', 'from must be before or equal to to.', {
+      from: input.from,
+      to: input.to,
+    });
+  }
+
+  return { fromMs, toMs };
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  if (limit === undefined) {
+    return 100;
+  }
+  return Math.min(500, Math.max(0, Math.floor(limit)));
+}
+
+function timestampMs(value: unknown): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  const text = String(value);
+  if (text.length === 0) {
+    return null;
+  }
+
+  const numeric = Number(text);
+  if (Number.isFinite(numeric) && /^\d+$/u.test(text)) {
+    return numeric;
+  }
+
+  const parsed = Date.parse(text);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function eventDateFromMs(ms: number | null): string | null {
+  if (ms === null) {
+    return null;
+  }
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+function withinBounds(ms: number | null, bounds: RangeBounds): boolean {
+  if (ms === null) {
+    return bounds.fromMs === null && bounds.toMs === null;
+  }
+  if (bounds.fromMs !== null && ms < bounds.fromMs) {
+    return false;
+  }
+  if (bounds.toMs !== null && ms > bounds.toMs) {
+    return false;
+  }
+  return true;
+}
+
+function compareItemsAsc(left: CaseTimelineRangeItem, right: CaseTimelineRangeItem): number {
+  const leftMs = left.event_datetime ?? Number.NEGATIVE_INFINITY;
+  const rightMs = right.event_datetime ?? Number.NEGATIVE_INFINITY;
+
+  if (leftMs !== rightMs) {
+    return leftMs - rightMs;
+  }
+
+  const itemDelta = left.item_type.localeCompare(right.item_type);
+  if (itemDelta !== 0) {
+    return itemDelta;
+  }
+
+  const sourceTypeDelta = left.source_type.localeCompare(right.source_type);
+  if (sourceTypeDelta !== 0) {
+    return sourceTypeDelta;
+  }
+
+  return left.source_id.localeCompare(right.source_id);
+}
+
+function connectorEventSnapshot(row: ConnectorEventIndexRecord | null) {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    event_index_id: row.event_index_id,
+    source_connector: row.source_connector,
+    source_id: row.source_id,
+    source_locator: row.source_locator,
+    artifact_locator: row.artifact_locator,
+    title: row.title,
+    content: row.content,
+    event_datetime: row.event_datetime,
+    event_date: row.event_date,
+  };
+}
+
+function membershipById(
+  memberships: CaseAssemblyMembership[],
+  sourceType: CaseMembershipSourceType
+): Map<string, CaseAssemblyMembership> {
+  return new Map(
+    memberships
+      .filter((membership) => membership.source_type === sourceType)
+      .map((membership) => [membership.source_id, membership])
+  );
+}
+
+function loadDecisionItems(
+  adapter: CaseTimelineRangeAdapter,
+  memberships: CaseAssemblyMembership[],
+  bounds: RangeBounds
+): CaseTimelineRangeItem[] {
+  const membershipMap = membershipById(memberships, 'decision');
+  const ids = Array.from(membershipMap.keys());
+  if (ids.length === 0) {
+    return [];
+  }
+
+  const rows = adapter
+    .prepare(
+      `
+        SELECT id, topic, decision, summary, reasoning, confidence, event_datetime, event_date, created_at
+        FROM decisions
+        WHERE id IN (${placeholders(ids)})
+      `
+    )
+    .all(...ids) as Array<Record<string, unknown>>;
+
+  return rows
+    .map((row): CaseTimelineRangeItem => {
+      const sourceId = String(row.id);
+      const membership = membershipMap.get(sourceId);
+      const eventDatetime =
+        timestampMs(row.event_datetime) ??
+        timestampMs(row.event_date) ??
+        timestampMs(row.created_at);
+      return {
+        item_type: 'decision',
+        source_type: 'decision',
+        source_id: sourceId,
+        source_locator: null,
+        event_datetime: eventDatetime,
+        event_date: nullableString(row.event_date) ?? eventDateFromMs(eventDatetime),
+        title: nullableString(row.topic),
+        summary: nullableString(row.summary ?? row.decision),
+        role: membership?.role ?? null,
+        confidence: membership?.confidence ?? nullableNumber(row.confidence),
+        membership_reason: membership?.reason ?? null,
+      };
+    })
+    .filter((item) => withinBounds(item.event_datetime, bounds));
+}
+
+function loadEventItems(
+  adapter: CaseTimelineRangeAdapter,
+  memberships: CaseAssemblyMembership[],
+  bounds: RangeBounds
+): CaseTimelineRangeItem[] {
+  const membershipMap = membershipById(memberships, 'event');
+  const ids = Array.from(membershipMap.keys());
+  if (ids.length === 0) {
+    return [];
+  }
+
+  const rows = adapter
+    .prepare(
+      `
+        SELECT id, event_type, role, observed_at, source_ref, summary, details, created_at
+        FROM entity_timeline_events
+        WHERE id IN (${placeholders(ids)})
+      `
+    )
+    .all(...ids) as Array<Record<string, unknown>>;
+
+  return rows
+    .map((row): CaseTimelineRangeItem => {
+      const sourceId = String(row.id);
+      const membership = membershipMap.get(sourceId);
+      const eventDatetime = timestampMs(row.observed_at) ?? timestampMs(row.created_at);
+      return {
+        item_type: 'event',
+        source_type: 'event',
+        source_id: sourceId,
+        source_locator: nullableString(row.source_ref),
+        event_datetime: eventDatetime,
+        event_date: eventDateFromMs(eventDatetime),
+        title: nullableString(row.event_type),
+        summary: nullableString(row.summary),
+        role: membership?.role ?? nullableString(row.role),
+        confidence: membership?.confidence ?? null,
+        membership_reason: membership?.reason ?? null,
+      };
+    })
+    .filter((item) => withinBounds(item.event_datetime, bounds));
+}
+
+function loadObservationItems(
+  adapter: CaseTimelineRangeAdapter,
+  memberships: CaseAssemblyMembership[],
+  bounds: RangeBounds,
+  includeConnectorEnrichments: boolean
+): CaseTimelineRangeItem[] {
+  const membershipMap = membershipById(memberships, 'observation');
+  const ids = Array.from(membershipMap.keys());
+  if (ids.length === 0) {
+    return [];
+  }
+
+  const rows = adapter
+    .prepare(
+      `
+        SELECT id, surface_form, context_summary, source_connector, source_raw_record_id,
+               source_locator, timestamp_observed, created_at
+        FROM entity_observations
+        WHERE id IN (${placeholders(ids)})
+      `
+    )
+    .all(...ids) as Array<Record<string, unknown>>;
+
+  return rows
+    .map((row): CaseTimelineRangeItem => {
+      const sourceId = String(row.id);
+      const membership = membershipMap.get(sourceId);
+      const eventDatetime = timestampMs(row.timestamp_observed) ?? timestampMs(row.created_at);
+      const connectorEvent =
+        includeConnectorEnrichments &&
+        typeof row.source_connector === 'string' &&
+        typeof row.source_raw_record_id === 'string'
+          ? getConnectorEventIndexRecord(
+              adapter,
+              String(row.source_connector),
+              String(row.source_raw_record_id)
+            )
+          : null;
+
+      return {
+        item_type: 'observation',
+        source_type: 'observation',
+        source_id: sourceId,
+        source_locator: nullableString(row.source_locator),
+        event_datetime: eventDatetime,
+        event_date: eventDateFromMs(eventDatetime),
+        title: nullableString(row.surface_form),
+        summary: nullableString(row.context_summary ?? row.surface_form),
+        role: membership?.role ?? null,
+        confidence: membership?.confidence ?? null,
+        membership_reason: membership?.reason ?? null,
+        ...(includeConnectorEnrichments
+          ? { connector_event: connectorEventSnapshot(connectorEvent) }
+          : {}),
+      };
+    })
+    .filter((item) => withinBounds(item.event_datetime, bounds));
+}
+
+function loadArtifactConnectorEvent(
+  adapter: CaseTimelineRangeAdapter,
+  sourceId: string
+): ConnectorEventIndexRecord | null {
+  const row = adapter
+    .prepare(
+      `
+        SELECT *
+        FROM connector_event_index
+        WHERE event_index_id = ?
+           OR artifact_locator = ?
+        ORDER BY event_datetime ASC, event_index_id ASC
+        LIMIT 1
+      `
+    )
+    .get(sourceId, sourceId) as Record<string, unknown> | undefined;
+
+  if (!row) {
+    return null;
+  }
+
+  const sourceConnector = String(row.source_connector);
+  const connectorSourceId = String(row.source_id);
+  return getConnectorEventIndexRecord(adapter, sourceConnector, connectorSourceId);
+}
+
+function loadArtifactItems(
+  adapter: CaseTimelineRangeAdapter,
+  memberships: CaseAssemblyMembership[],
+  bounds: RangeBounds,
+  includeConnectorEnrichments: boolean
+): CaseTimelineRangeItem[] {
+  const artifactMemberships = memberships.filter(
+    (membership) => membership.source_type === 'artifact'
+  );
+
+  return artifactMemberships
+    .map((membership): CaseTimelineRangeItem => {
+      const connectorEvent = loadArtifactConnectorEvent(adapter, membership.source_id);
+      const eventDatetime = connectorEvent?.event_datetime ?? null;
+      return {
+        item_type: 'artifact',
+        source_type: 'artifact',
+        source_id: membership.source_id,
+        source_locator:
+          connectorEvent?.artifact_locator ??
+          connectorEvent?.source_locator ??
+          membership.source_id,
+        event_datetime: eventDatetime,
+        event_date: connectorEvent?.event_date ?? eventDateFromMs(eventDatetime),
+        title: connectorEvent?.artifact_title ?? connectorEvent?.title ?? membership.source_id,
+        summary: connectorEvent?.content ?? null,
+        role: membership.role,
+        confidence: membership.confidence,
+        membership_reason: membership.reason,
+        ...(includeConnectorEnrichments
+          ? { connector_event: connectorEventSnapshot(connectorEvent) }
+          : {}),
+      };
+    })
+    .filter((item) => withinBounds(item.event_datetime, bounds));
+}
+
+export function caseTimelineRange(
+  adapter: CaseTimelineRangeAdapter,
+  input: CaseTimelineRangeInput
+): CaseTimelineRangeResult {
+  const bounds = parseBounds(input);
+  const limit = normalizeLimit(input.limit);
+  const resolution = resolveCanonicalCaseChain(adapter, input.case_id);
+  const chainResult = listActiveCorrectionsForCase(adapter, input.case_id);
+  const chain = chainResult.chain;
+  const memberships = listActiveMembershipsForCaseChain(adapter, chain);
+
+  const items = [
+    ...loadDecisionItems(adapter, memberships, bounds),
+    ...loadEventItems(adapter, memberships, bounds),
+    ...loadObservationItems(
+      adapter,
+      memberships,
+      bounds,
+      input.include_connector_enrichments === true
+    ),
+    ...loadArtifactItems(
+      adapter,
+      memberships,
+      bounds,
+      input.include_connector_enrichments === true
+    ),
+  ].sort(compareItemsAsc);
+
+  const orderedItems = input.order === 'desc' ? [...items].reverse() : items;
+
+  return {
+    terminal_case_id: resolution.terminal_case_id,
+    resolved_via_case_id: resolution.resolved_via_case_id,
+    chain,
+    items: orderedItems.slice(0, limit),
+  };
+}
+
+export type {
+  CaseTimelineRangeInput,
+  CaseTimelineRangeItem,
+  CaseTimelineRangeResult,
+} from './types.js';

--- a/packages/mama-core/src/cases/tombstone-sweeper.ts
+++ b/packages/mama-core/src/cases/tombstone-sweeper.ts
@@ -1,0 +1,233 @@
+import { randomUUID } from 'node:crypto';
+
+import { canonicalizeJSON } from '../canonicalize.js';
+import type { DatabaseAdapter } from '../db-manager.js';
+import { runImmediateTransaction, type ImmediateTransactionAdapter } from './sqlite-transaction.js';
+import type { CaseMembershipSourceType } from './types.js';
+
+export interface SweepStaleCaseMembershipsOptions {
+  now?: string;
+  limit?: number;
+}
+
+export interface SweepStaleCaseMembershipsResult {
+  scanned_count: number;
+  stale_count: number;
+  locked_stale_count: number;
+  audit_event_ids: string[];
+}
+
+type SweptSourceType = Exclude<CaseMembershipSourceType, 'artifact'>;
+
+type TombstoneSweeperAdapter = Pick<DatabaseAdapter, 'prepare' | 'transaction'> &
+  Partial<Pick<ImmediateTransactionAdapter, 'exec'>>;
+
+interface CandidateSourceRow {
+  source_type: string;
+  source_id: string;
+}
+
+interface CountRow {
+  count: number;
+  locked_count: number | null;
+}
+
+interface SourceRow {
+  id: string;
+}
+
+interface RunResultLike {
+  changes: number;
+}
+
+const SWEEP_SOURCE_TYPES: SweptSourceType[] = ['decision', 'event', 'observation'];
+
+const SOURCE_EXISTS_SQL: Record<SweptSourceType, string> = {
+  decision: 'SELECT 1 AS id FROM decisions WHERE id = ?',
+  event: 'SELECT 1 AS id FROM entity_timeline_events WHERE id = ?',
+  observation: 'SELECT 1 AS id FROM entity_observations WHERE id = ?',
+};
+
+function normalizeNow(value?: string): string {
+  return value ?? new Date().toISOString();
+}
+
+function createdAtMs(now: string): number {
+  const parsed = Date.parse(now);
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+function isSweptSourceType(value: string): value is SweptSourceType {
+  return (SWEEP_SOURCE_TYPES as string[]).includes(value);
+}
+
+function readCandidates(
+  adapter: TombstoneSweeperAdapter,
+  limit: number | undefined
+): CandidateSourceRow[] {
+  const sql = `
+    SELECT source_type, source_id
+      FROM case_memberships
+     WHERE status IN ('active', 'candidate', 'removed', 'excluded')
+       AND source_type IN ('decision', 'event', 'observation')
+     GROUP BY source_type, source_id
+     ORDER BY source_type ASC, source_id ASC
+     ${limit === undefined ? '' : 'LIMIT ?'}
+  `;
+
+  const stmt = adapter.prepare(sql);
+  return (limit === undefined ? stmt.all() : stmt.all(limit)) as CandidateSourceRow[];
+}
+
+function sourceExists(
+  adapter: TombstoneSweeperAdapter,
+  sourceType: SweptSourceType,
+  sourceId: string
+): boolean {
+  const row = adapter.prepare(SOURCE_EXISTS_SQL[sourceType]).get(sourceId) as SourceRow | undefined;
+  return row !== undefined;
+}
+
+function countTransitionTargets(
+  adapter: TombstoneSweeperAdapter,
+  sourceType: SweptSourceType,
+  sourceId: string
+): CountRow {
+  return adapter
+    .prepare(
+      `
+        SELECT COUNT(*) AS count,
+               SUM(CASE WHEN user_locked = 1 THEN 1 ELSE 0 END) AS locked_count
+          FROM case_memberships
+         WHERE status <> 'stale'
+           AND source_type = ?
+           AND source_id = ?
+      `
+    )
+    .get(sourceType, sourceId) as CountRow;
+}
+
+function markSourceStale(
+  adapter: TombstoneSweeperAdapter,
+  sourceType: SweptSourceType,
+  sourceId: string,
+  now: string
+): number {
+  const result = adapter
+    .prepare(
+      `
+        UPDATE case_memberships
+           SET status = 'stale',
+               updated_at = ?
+         WHERE status <> 'stale'
+           AND source_type = ?
+           AND source_id = ?
+           AND NOT EXISTS (${SOURCE_EXISTS_SQL[sourceType]})
+      `
+    )
+    .run(now, sourceType, sourceId, sourceId) as RunResultLike;
+
+  return result.changes;
+}
+
+function insertTombstoneAuditEvent(input: {
+  adapter: TombstoneSweeperAdapter;
+  now: string;
+  stale_count: number;
+  locked_stale_count: number;
+  sources: CandidateSourceRow[];
+}): string {
+  const eventId = `me_${randomUUID()}`;
+
+  input.adapter
+    .prepare(
+      `
+        INSERT INTO memory_events (
+          event_id, event_type, actor, source_turn_id, memory_id, topic,
+          scope_refs, evidence_refs, reason, created_at
+        )
+        VALUES (?, 'case.membership_tombstoned', 'system', NULL, NULL, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      eventId,
+      'case:tombstone-sweeper',
+      canonicalizeJSON([{ kind: 'project', id: 'case-first' }]),
+      canonicalizeJSON(input.sources),
+      canonicalizeJSON({
+        stale_count: input.stale_count,
+        locked_stale_count: input.locked_stale_count,
+      }),
+      createdAtMs(input.now)
+    );
+
+  return eventId;
+}
+
+export function sweepStaleCaseMemberships(
+  adapter: DatabaseAdapter,
+  options: SweepStaleCaseMembershipsOptions = {}
+): SweepStaleCaseMembershipsResult {
+  const sweepAdapter = adapter as unknown as TombstoneSweeperAdapter;
+
+  return runImmediateTransaction(sweepAdapter, () => {
+    const now = normalizeNow(options.now);
+    const candidates = readCandidates(sweepAdapter, options.limit);
+    let staleCount = 0;
+    let lockedStaleCount = 0;
+    const tombstonedSources: CandidateSourceRow[] = [];
+
+    for (const candidate of candidates) {
+      if (!isSweptSourceType(candidate.source_type)) {
+        continue;
+      }
+
+      if (sourceExists(sweepAdapter, candidate.source_type, candidate.source_id)) {
+        continue;
+      }
+
+      const before = countTransitionTargets(
+        sweepAdapter,
+        candidate.source_type,
+        candidate.source_id
+      );
+      if (before.count === 0) {
+        continue;
+      }
+
+      const changes = markSourceStale(
+        sweepAdapter,
+        candidate.source_type,
+        candidate.source_id,
+        now
+      );
+      if (changes === 0) {
+        continue;
+      }
+
+      staleCount += changes;
+      lockedStaleCount += Math.min(changes, before.locked_count ?? 0);
+      tombstonedSources.push(candidate);
+    }
+
+    const auditEventIds =
+      staleCount > 0
+        ? [
+            insertTombstoneAuditEvent({
+              adapter: sweepAdapter,
+              now,
+              stale_count: staleCount,
+              locked_stale_count: lockedStaleCount,
+              sources: tombstonedSources,
+            }),
+          ]
+        : [];
+
+    return {
+      scanned_count: candidates.length,
+      stale_count: staleCount,
+      locked_stale_count: lockedStaleCount,
+      audit_event_ids: auditEventIds,
+    };
+  });
+}

--- a/packages/mama-core/src/cases/types.ts
+++ b/packages/mama-core/src/cases/types.ts
@@ -1,0 +1,306 @@
+export const CASE_TRUTH_STATUSES = [
+  'active',
+  'blocked',
+  'resolved',
+  'stale',
+  'archived',
+  'merged',
+  'split',
+] as const;
+export type CaseTruthStatus = (typeof CASE_TRUTH_STATUSES)[number];
+
+export const CASE_FAST_WRITE_STATUSES = ['active', 'blocked', 'resolved', 'stale'] as const;
+export type CaseFastWriteStatus = (typeof CASE_FAST_WRITE_STATUSES)[number];
+
+export const CASE_MEMBERSHIP_SOURCE_TYPES = [
+  'decision',
+  'event',
+  'observation',
+  'artifact',
+] as const;
+export type CaseMembershipSourceType = (typeof CASE_MEMBERSHIP_SOURCE_TYPES)[number];
+
+export const CASE_MEMBERSHIP_STATUSES = [
+  'active',
+  'candidate',
+  'removed',
+  'excluded',
+  'stale',
+] as const;
+export type CaseMembershipStatus = (typeof CASE_MEMBERSHIP_STATUSES)[number];
+
+export const CASE_MEMBERSHIP_ADDED_BY = [
+  'wiki-compiler',
+  'memory-agent',
+  'user-correction',
+] as const;
+export type CaseMembershipAddedBy = (typeof CASE_MEMBERSHIP_ADDED_BY)[number];
+
+export const CASE_CORRECTION_TARGET_KINDS = ['case_field', 'membership', 'wiki_section'] as const;
+export type CaseCorrectionTargetKind = (typeof CASE_CORRECTION_TARGET_KINDS)[number];
+
+export const CASE_PROPOSAL_KINDS = [
+  'ambiguous_slug',
+  'duplicate_frontmatter',
+  'missing_frontmatter',
+  'unknown_case_id',
+  'stale_case_id',
+  'merged_target',
+  'archived_target',
+  'lock_conflict',
+  'corrupt_frontmatter',
+  'quarantined_accepted_case',
+] as const;
+export type CaseProposalKind = (typeof CASE_PROPOSAL_KINDS)[number];
+
+export const CASE_PROPOSAL_RESOLUTIONS = ['accepted', 'rejected', 'modified', 'merged'] as const;
+export type CaseProposalResolution = (typeof CASE_PROPOSAL_RESOLUTIONS)[number];
+
+export const CASE_CONFIDENCE_LEVELS = ['high', 'medium', 'low'] as const;
+export type CaseConfidence = (typeof CASE_CONFIDENCE_LEVELS)[number];
+
+export interface CaseTruthRecord {
+  case_id: string;
+  current_wiki_path: string | null;
+  title: string;
+  status: CaseTruthStatus;
+  status_reason: string | null;
+  primary_actors: string | null;
+  blockers: string | null;
+  last_activity_at: string | null;
+  canonical_case_id?: string | null;
+  split_from_case_id?: string | null;
+  wiki_path_history: string | null;
+  scope_refs: string | null;
+  confidence: CaseConfidence | null;
+  compiled_at: string | null;
+  state_updated_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CaseMembershipRecord {
+  case_id: string;
+  source_type: CaseMembershipSourceType;
+  source_id: string;
+  role: string | null;
+  confidence: number | null;
+  reason: string | null;
+  status: CaseMembershipStatus;
+  added_by: CaseMembershipAddedBy;
+  added_at: string;
+  updated_at: string;
+  user_locked: 0 | 1;
+}
+
+export interface CaseCorrectionRecord {
+  correction_id: string;
+  case_id: string;
+  target_kind: CaseCorrectionTargetKind;
+  target_ref_json: string;
+  target_ref_hash: Buffer;
+  field_name: string | null;
+  old_value_json: string | null;
+  new_value_json: string;
+  reason: string;
+  is_lock_active: 0 | 1;
+  superseded_by: string | null;
+  reverted_at: string | null;
+  applied_by: string;
+  applied_at: string;
+}
+
+export interface CaseCorrectionRequiresReconfirmResult {
+  kind: 'requires_reconfirm';
+  code: 'case.correction_requires_reconfirm';
+  case_id: string;
+  target_kind: CaseCorrectionTargetKind;
+  target_ref_json: string;
+  current_value_json: string;
+  old_value_json: string | null;
+  proposed_new_value_json: string;
+  reconfirm_token: string;
+  reconfirm_token_expires_at: string;
+  message: string;
+}
+
+export interface CaseProposalQueueRecord {
+  proposal_id: string;
+  project: string;
+  proposal_kind: CaseProposalKind;
+  proposed_payload: string;
+  payload_fingerprint: Buffer;
+  conflicting_case_id: string | null;
+  detected_at: string;
+  resolved_at: string | null;
+  resolution: CaseProposalResolution | null;
+  resolution_note: string | null;
+}
+
+export interface CasePrimaryActor {
+  entity_id: string;
+  role: string;
+}
+
+export interface CaseBlocker {
+  text: string;
+  source_decision_id?: string;
+  source_event_id?: string;
+}
+
+export interface CaseAssemblyMembership {
+  source_type: CaseMembershipSourceType;
+  source_id: string;
+  role: string | null;
+  confidence: number | null;
+  reason: string | null;
+  user_locked: boolean;
+}
+
+export interface CaseAssemblyDecision {
+  id: string;
+  topic: string;
+  decision: string;
+  reasoning: string | null;
+  confidence: number | null;
+  event_date: string | null;
+}
+
+export interface CaseAssemblyTimelineEvent {
+  event_id: string;
+  event_type: string;
+  entity_id: string;
+  role: string | null;
+  observed_at: string;
+  summary: string;
+  details: string | null;
+}
+
+export interface CaseAssemblyObservation {
+  observation_id: string;
+  surface_form: string;
+  source_locator: string;
+  timestamp_observed: string;
+}
+
+export interface CaseAssemblyCorrection {
+  correction_id: string;
+  target_kind: CaseCorrectionTargetKind;
+  target_ref: Record<string, unknown>;
+  new_value_json: string;
+  reason: string;
+  applied_at: string;
+}
+
+export interface CaseAssemblyLinkedCase {
+  case_id: string;
+  relation: 'merged_from' | 'split_into' | 'wikilink';
+}
+
+export interface WikiPageAssemblySnapshot {
+  title: string | null;
+  content: string | null;
+  confidence: CaseConfidence | null;
+  compiled_at: string | null;
+}
+
+export interface CaseAssembly {
+  case_id: string;
+  current_wiki_path: string | null;
+  wiki_page: WikiPageAssemblySnapshot | null;
+  case_truth: {
+    title: string;
+    status: CaseTruthStatus;
+    status_reason: string | null;
+    primary_actors: CasePrimaryActor[];
+    blockers: CaseBlocker[];
+    last_activity_at: string | null;
+    confidence: CaseConfidence | null;
+    canonical_case_id: string | null;
+    split_from_case_id: string | null;
+  } | null;
+  memberships: CaseAssemblyMembership[];
+  timeline_events: CaseAssemblyTimelineEvent[];
+  decisions: CaseAssemblyDecision[];
+  recent_evidence: CaseAssemblyObservation[];
+  active_corrections: CaseAssemblyCorrection[];
+  linked_cases: CaseAssemblyLinkedCase[];
+  resolved_via_case_id?: string;
+  // Phase 3 additive extensions (optional so existing consumers keep
+  // working; populated when the case-first substrate is present).
+  case_links?: Array<{
+    link_id: string;
+    case_id_from: string;
+    case_id_to: string;
+    link_type: string;
+    created_at: string;
+    created_by: string;
+    confidence: number | null;
+    reason_json: string | null;
+    source_kind: string;
+    source_ref: string | null;
+  }>;
+  promoted_sources?: {
+    canonical_decision_id: string | null;
+    canonical_event_id: string | null;
+    promoted_at: string | null;
+    promoted_by: string | null;
+    promotion_reason: string | null;
+  } | null;
+  freshness?: {
+    freshness_score: number | null;
+    freshness_state: string | null;
+    freshness_score_is_drifted: 0 | 1;
+    freshness_drift_threshold: number | null;
+    freshness_checked_at: string | null;
+    freshness_reason_json: string | null;
+  } | null;
+  membership_explanations?: Record<string, Record<string, unknown>>;
+}
+
+export interface CanonicalCaseResolution {
+  terminal_case_id: string;
+  chain: string[];
+  resolved_via_case_id: string | null;
+}
+
+export interface CaseTimelineRangeInput {
+  case_id: string;
+  from?: string | number;
+  to?: string | number;
+  order?: 'asc' | 'desc';
+  limit?: number;
+  include_connector_enrichments?: boolean;
+}
+
+export interface CaseTimelineRangeItem {
+  item_type: CaseMembershipSourceType;
+  source_type: CaseMembershipSourceType;
+  source_id: string;
+  source_locator: string | null;
+  event_datetime: number | null;
+  event_date: string | null;
+  title: string | null;
+  summary: string | null;
+  role: string | null;
+  confidence: number | null;
+  membership_reason: string | null;
+  connector_event?: {
+    event_index_id: string;
+    source_connector: string;
+    source_id: string;
+    source_locator: string | null;
+    artifact_locator: string | null;
+    title: string | null;
+    content: string;
+    event_datetime: number | null;
+    event_date: string | null;
+  } | null;
+}
+
+export interface CaseTimelineRangeResult {
+  terminal_case_id: string;
+  resolved_via_case_id: string | null;
+  chain: string[];
+  items: CaseTimelineRangeItem[];
+}

--- a/packages/mama-core/src/cases/wiki-page-index.ts
+++ b/packages/mama-core/src/cases/wiki-page-index.ts
@@ -1,0 +1,514 @@
+import crypto from 'node:crypto';
+
+import { MODEL_NAME, cosineSimilarity } from '../embeddings.js';
+import type { DatabaseAdapter as DBManagerAdapter } from '../db-manager.js';
+
+export type AdapterLike = Pick<DBManagerAdapter, 'prepare' | 'transaction'>;
+
+export interface WikiPageIndexRecord {
+  id: number;
+  source_locator: string;
+  page_type: 'entity' | 'lesson' | 'synthesis' | 'process' | 'case';
+  title: string;
+  content: string;
+  case_id: string | null;
+  source_ids: string[];
+  entity_refs: string[];
+  confidence: 'high' | 'medium' | 'low' | null;
+  compiled_at: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WikiPageSearchHit {
+  record: WikiPageIndexRecord;
+  rank: number;
+  raw_score: number;
+}
+
+export interface UpsertWikiPageIndexInput {
+  source_locator: string;
+  page_type: WikiPageIndexRecord['page_type'];
+  title: string;
+  content: string;
+  case_id?: string | null;
+  source_ids: string[];
+  entity_refs: string[];
+  confidence: WikiPageIndexRecord['confidence'];
+  compiled_at: string;
+  embedding?: Float32Array | null;
+  embedding_model?: string;
+}
+
+interface WikiPageIndexSchema {
+  hasIdColumn: boolean;
+  hasPageIdColumn: boolean;
+  hasSourceTypeColumn: boolean;
+  hasSourceIdsColumn: boolean;
+  hasEntityRefsColumn: boolean;
+  hasCreatedAtColumn: boolean;
+  embeddingUsesWikiPageId: boolean;
+  embeddingUsesVector: boolean;
+  embeddingHasModel: boolean;
+  embeddingHasDim: boolean;
+  embeddingHasCreatedAt: boolean;
+}
+
+interface WikiPageIndexRow {
+  id?: unknown;
+  page_id?: unknown;
+  source_locator?: unknown;
+  page_type?: unknown;
+  title?: unknown;
+  content?: unknown;
+  case_id?: unknown;
+  source_ids?: unknown;
+  entity_refs?: unknown;
+  confidence?: unknown;
+  compiled_at?: unknown;
+  created_at?: unknown;
+  updated_at?: unknown;
+}
+
+interface WikiPageEmbeddingRow extends WikiPageIndexRow {
+  vector?: unknown;
+  embedding?: unknown;
+}
+
+function tableColumns(adapter: AdapterLike, tableName: string): Set<string> {
+  const rows = adapter.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>;
+  return new Set(rows.map((row) => row.name));
+}
+
+function readSchema(adapter: AdapterLike): WikiPageIndexSchema {
+  const indexColumns = tableColumns(adapter, 'wiki_page_index');
+  const embeddingColumns = tableColumns(adapter, 'wiki_page_embeddings');
+
+  if (!indexColumns.has('id') && !indexColumns.has('page_id')) {
+    throw new Error('wiki_page_index schema is missing both id and page_id columns.');
+  }
+
+  return {
+    hasIdColumn: indexColumns.has('id'),
+    hasPageIdColumn: indexColumns.has('page_id'),
+    hasSourceTypeColumn: indexColumns.has('source_type'),
+    hasSourceIdsColumn: indexColumns.has('source_ids'),
+    hasEntityRefsColumn: indexColumns.has('entity_refs'),
+    hasCreatedAtColumn: indexColumns.has('created_at'),
+    embeddingUsesWikiPageId: embeddingColumns.has('wiki_page_id'),
+    embeddingUsesVector: embeddingColumns.has('vector'),
+    embeddingHasModel: embeddingColumns.has('model'),
+    embeddingHasDim: embeddingColumns.has('dim'),
+    embeddingHasCreatedAt: embeddingColumns.has('created_at'),
+  };
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function normalizeLimit(limit: number): number {
+  if (!Number.isFinite(limit)) {
+    return 10;
+  }
+  return Math.max(0, Math.floor(limit));
+}
+
+function pageIdForSourceLocator(sourceLocator: string): string {
+  const digest = crypto.createHash('sha256').update(sourceLocator).digest('hex').slice(0, 24);
+  return `wiki_page_${digest}`;
+}
+
+function parseJsonArray(value: unknown): string[] {
+  if (value === null || value === undefined || value === '') {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(String);
+  }
+
+  if (typeof value !== 'string') {
+    return [];
+  }
+
+  const parsed = JSON.parse(value) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error('wiki_page_index JSON array column decoded to a non-array value.');
+  }
+
+  return parsed.map(String);
+}
+
+function normalizeConfidence(value: unknown): WikiPageIndexRecord['confidence'] {
+  if (value === 'high' || value === 'medium' || value === 'low') {
+    return value;
+  }
+  return null;
+}
+
+function rowToRecord(row: WikiPageIndexRow): WikiPageIndexRecord {
+  const id = Number(row.id);
+  if (!Number.isFinite(id)) {
+    throw new Error('wiki_page_index row is missing a numeric id/rowid.');
+  }
+
+  return {
+    id,
+    source_locator: String(row.source_locator ?? ''),
+    page_type: row.page_type as WikiPageIndexRecord['page_type'],
+    title: String(row.title ?? ''),
+    content: String(row.content ?? ''),
+    case_id: row.case_id === null || row.case_id === undefined ? null : String(row.case_id),
+    source_ids: parseJsonArray(row.source_ids),
+    entity_refs: parseJsonArray(row.entity_refs),
+    confidence: normalizeConfidence(row.confidence),
+    compiled_at: String(row.compiled_at ?? ''),
+    created_at: String(row.created_at ?? row.updated_at ?? row.compiled_at ?? ''),
+    updated_at: String(row.updated_at ?? row.created_at ?? row.compiled_at ?? ''),
+  };
+}
+
+function selectByLocator(
+  adapter: AdapterLike,
+  schema: WikiPageIndexSchema,
+  sourceLocator: string
+): WikiPageIndexRecord | null {
+  const sql = schema.hasIdColumn
+    ? 'SELECT * FROM wiki_page_index WHERE source_locator = ?'
+    : 'SELECT rowid AS id, * FROM wiki_page_index WHERE source_locator = ?';
+
+  const row = adapter.prepare(sql).get(sourceLocator) as WikiPageIndexRow | undefined;
+  return row ? rowToRecord(row) : null;
+}
+
+function selectByFtsPageId(
+  adapter: AdapterLike,
+  schema: WikiPageIndexSchema,
+  pageId: unknown
+): WikiPageIndexRecord | null {
+  const sql = schema.hasIdColumn
+    ? 'SELECT * FROM wiki_page_index WHERE id = ?'
+    : 'SELECT rowid AS id, * FROM wiki_page_index WHERE page_id = ?';
+
+  const lookup = schema.hasIdColumn ? Number(pageId) : String(pageId);
+  const row = adapter.prepare(sql).get(lookup) as WikiPageIndexRow | undefined;
+  return row ? rowToRecord(row) : null;
+}
+
+function vectorToBuffer(embedding: Float32Array): Buffer {
+  return Buffer.from(embedding.buffer, embedding.byteOffset, embedding.byteLength);
+}
+
+function blobToVector(value: unknown): Float32Array | null {
+  if (!(value instanceof Uint8Array)) {
+    return null;
+  }
+
+  if (value.byteLength % 4 !== 0) {
+    return null;
+  }
+
+  const buffer = Buffer.isBuffer(value) ? value : Buffer.from(value);
+  const arrayBuffer = buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+  return new Float32Array(arrayBuffer);
+}
+
+function upsertEmbedding(
+  adapter: AdapterLike,
+  schema: WikiPageIndexSchema,
+  record: WikiPageIndexRecord,
+  input: UpsertWikiPageIndexInput
+): void {
+  if (!input.embedding) {
+    return;
+  }
+
+  const vector = vectorToBuffer(input.embedding);
+  const model = input.embedding_model ?? MODEL_NAME;
+  const dim = input.embedding.length;
+
+  if (schema.embeddingUsesWikiPageId && schema.embeddingUsesVector) {
+    adapter
+      .prepare(
+        `
+          INSERT INTO wiki_page_embeddings(wiki_page_id, vector, model, dim, created_at)
+          VALUES (?, ?, ?, ?, ?)
+          ON CONFLICT(wiki_page_id) DO UPDATE SET
+            vector = excluded.vector,
+            model = excluded.model,
+            dim = excluded.dim
+        `
+      )
+      .run(record.id, vector, model, dim, nowIso());
+    return;
+  }
+
+  adapter
+    .prepare(
+      `
+        INSERT INTO wiki_page_embeddings(page_id, embedding)
+        VALUES (?, ?)
+        ON CONFLICT(page_id) DO UPDATE SET
+          embedding = excluded.embedding
+      `
+    )
+    .run(pageIdForSourceLocator(record.source_locator), vector);
+}
+
+function buildFtsQuery(query: string): string {
+  const tokens = query
+    .toLowerCase()
+    .match(/[\p{L}\p{N}_]+/gu)
+    ?.filter((token) => token.length > 0);
+
+  if (!tokens || tokens.length === 0) {
+    return query;
+  }
+
+  return tokens.map((token) => `"${token.replace(/"/g, '""')}"`).join(' OR ');
+}
+
+function normalizeBm25Score(raw: unknown): number {
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  if (value < 0) {
+    return 1 + Math.abs(value);
+  }
+
+  return 1 / (1 + value);
+}
+
+function searchTableExists(adapter: AdapterLike, tableName: string): boolean {
+  const row = adapter
+    .prepare("SELECT name FROM sqlite_master WHERE name = ? AND type IN ('table','virtual table')")
+    .get(tableName) as { name: string } | undefined;
+  return row !== undefined;
+}
+
+export function upsertWikiPageIndexEntry(
+  adapter: AdapterLike,
+  input: UpsertWikiPageIndexInput
+): { id: number; created: boolean } {
+  const schema = readSchema(adapter);
+  const existing = selectByLocator(adapter, schema, input.source_locator);
+  const updatedAt = nowIso();
+
+  return adapter.transaction(() => {
+    if (schema.hasIdColumn) {
+      adapter
+        .prepare(
+          `
+            INSERT INTO wiki_page_index (
+              source_locator, page_type, title, content, case_id, source_ids,
+              confidence, entity_refs, compiled_at, created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(source_locator) DO UPDATE SET
+              page_type = excluded.page_type,
+              title = excluded.title,
+              content = excluded.content,
+              case_id = excluded.case_id,
+              source_ids = excluded.source_ids,
+              confidence = excluded.confidence,
+              entity_refs = excluded.entity_refs,
+              compiled_at = excluded.compiled_at,
+              updated_at = excluded.updated_at
+          `
+        )
+        .run(
+          input.source_locator,
+          input.page_type,
+          input.title,
+          input.content,
+          input.case_id ?? null,
+          JSON.stringify(input.source_ids),
+          input.confidence,
+          JSON.stringify(input.entity_refs),
+          input.compiled_at,
+          updatedAt,
+          updatedAt
+        );
+    } else {
+      adapter
+        .prepare(
+          `
+            INSERT INTO wiki_page_index (
+              page_id, source_type, source_locator, case_id, title, page_type,
+              content, confidence, compiled_at, updated_at
+            )
+            VALUES (?, 'wiki_page', ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(source_type, source_locator) DO UPDATE SET
+              case_id = excluded.case_id,
+              title = excluded.title,
+              page_type = excluded.page_type,
+              content = excluded.content,
+              confidence = excluded.confidence,
+              compiled_at = excluded.compiled_at,
+              updated_at = excluded.updated_at
+          `
+        )
+        .run(
+          pageIdForSourceLocator(input.source_locator),
+          input.source_locator,
+          input.case_id ?? null,
+          input.title,
+          input.page_type,
+          input.content,
+          input.confidence,
+          input.compiled_at,
+          updatedAt
+        );
+    }
+
+    const saved = selectByLocator(adapter, schema, input.source_locator);
+    if (!saved) {
+      throw new Error(`Failed to load wiki_page_index row for ${input.source_locator}.`);
+    }
+
+    upsertEmbedding(adapter, schema, saved, input);
+
+    return {
+      id: saved.id,
+      created: existing === null,
+    };
+  });
+}
+
+export function deleteWikiPageIndexEntry(
+  adapter: AdapterLike,
+  source_locator: string
+): { deleted: boolean } {
+  const result = adapter
+    .prepare('DELETE FROM wiki_page_index WHERE source_locator = ?')
+    .run(source_locator);
+  return { deleted: result.changes > 0 };
+}
+
+export function ftsSearchWikiPages(
+  adapter: AdapterLike,
+  query: string,
+  limit: number
+): WikiPageSearchHit[] {
+  const boundedLimit = normalizeLimit(limit);
+  if (boundedLimit === 0 || !query.trim()) {
+    return [];
+  }
+
+  if (!searchTableExists(adapter, 'wiki_pages_fts')) {
+    return [];
+  }
+
+  const schema = readSchema(adapter);
+  const rows = adapter
+    .prepare(
+      `
+        SELECT page_id, bm25(wiki_pages_fts) AS raw
+        FROM wiki_pages_fts
+        WHERE wiki_pages_fts MATCH ?
+        ORDER BY raw
+        LIMIT ?
+      `
+    )
+    .all(buildFtsQuery(query), boundedLimit) as Array<{ page_id: unknown; raw: unknown }>;
+
+  const hits: WikiPageSearchHit[] = [];
+  for (const row of rows) {
+    const record = selectByFtsPageId(adapter, schema, row.page_id);
+    if (!record) {
+      continue;
+    }
+
+    hits.push({
+      record,
+      rank: hits.length,
+      raw_score: normalizeBm25Score(row.raw),
+    });
+  }
+
+  return hits;
+}
+
+export function vectorSearchWikiPages(
+  adapter: AdapterLike,
+  queryEmbedding: Float32Array,
+  limit: number
+): WikiPageSearchHit[] {
+  const boundedLimit = normalizeLimit(limit);
+  if (boundedLimit === 0) {
+    return [];
+  }
+
+  const schema = readSchema(adapter);
+  const rows = schema.embeddingUsesWikiPageId
+    ? (adapter
+        .prepare(
+          `
+            SELECT i.*, e.vector
+            FROM wiki_page_embeddings e
+            JOIN wiki_page_index i ON i.id = e.wiki_page_id
+          `
+        )
+        .all() as WikiPageEmbeddingRow[])
+    : (adapter
+        .prepare(
+          `
+            SELECT i.rowid AS id, i.*, e.embedding
+            FROM wiki_page_embeddings e
+            JOIN wiki_page_index i ON i.page_id = e.page_id
+          `
+        )
+        .all() as WikiPageEmbeddingRow[]);
+
+  const scored: Array<{ record: WikiPageIndexRecord; score: number }> = [];
+  for (const row of rows) {
+    const candidate = blobToVector(schema.embeddingUsesVector ? row.vector : row.embedding);
+    if (!candidate || candidate.length !== queryEmbedding.length) {
+      continue;
+    }
+
+    const score = cosineSimilarity(candidate, queryEmbedding);
+    if (!Number.isFinite(score)) {
+      continue;
+    }
+
+    scored.push({ record: rowToRecord(row), score });
+  }
+
+  return scored
+    .sort((left, right) => right.score - left.score)
+    .slice(0, boundedLimit)
+    .map((entry, rank) => ({
+      record: entry.record,
+      rank,
+      raw_score: entry.score,
+    }));
+}
+
+export function searchWikiPages(input: {
+  adapter: AdapterLike;
+  query: string;
+  queryEmbedding?: Float32Array | null;
+  limit: number;
+}): WikiPageSearchHit[] {
+  const ftsHits = ftsSearchWikiPages(input.adapter, input.query, input.limit);
+  const vectorHits = input.queryEmbedding
+    ? vectorSearchWikiPages(input.adapter, input.queryEmbedding, input.limit)
+    : [];
+
+  const merged = new Map<number, WikiPageSearchHit>();
+  for (const hit of [...ftsHits, ...vectorHits]) {
+    const existing = merged.get(hit.record.id);
+    if (!existing || hit.raw_score > existing.raw_score) {
+      merged.set(hit.record.id, hit);
+    }
+  }
+
+  return Array.from(merged.values())
+    .sort((left, right) => right.raw_score - left.raw_score)
+    .slice(0, normalizeLimit(input.limit))
+    .map((hit, rank) => ({ ...hit, rank }));
+}

--- a/packages/mama-core/src/cases/wiki-page-index.ts
+++ b/packages/mama-core/src/cases/wiki-page-index.ts
@@ -332,6 +332,40 @@ export function upsertWikiPageIndexEntry(
           updatedAt,
           updatedAt
         );
+    } else if (schema.hasSourceIdsColumn && schema.hasEntityRefsColumn) {
+      adapter
+        .prepare(
+          `
+            INSERT INTO wiki_page_index (
+              page_id, source_type, source_locator, case_id, title, page_type,
+              content, confidence, source_ids, entity_refs, compiled_at, updated_at
+            )
+            VALUES (?, 'wiki_page', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(source_type, source_locator) DO UPDATE SET
+              case_id = excluded.case_id,
+              title = excluded.title,
+              page_type = excluded.page_type,
+              content = excluded.content,
+              confidence = excluded.confidence,
+              source_ids = excluded.source_ids,
+              entity_refs = excluded.entity_refs,
+              compiled_at = excluded.compiled_at,
+              updated_at = excluded.updated_at
+          `
+        )
+        .run(
+          pageIdForSourceLocator(input.source_locator),
+          input.source_locator,
+          input.case_id ?? null,
+          input.title,
+          input.page_type,
+          input.content,
+          input.confidence,
+          JSON.stringify(input.source_ids),
+          JSON.stringify(input.entity_refs),
+          input.compiled_at,
+          updatedAt
+        );
     } else {
       adapter
         .prepare(

--- a/packages/mama-core/src/connectors/event-index.ts
+++ b/packages/mama-core/src/connectors/event-index.ts
@@ -1,0 +1,520 @@
+import { createHash } from 'node:crypto';
+
+import { canonicalizeJSON } from '../canonicalize.js';
+import type { DatabaseAdapter } from '../db-manager.js';
+import type {
+  ConnectorEventIndexCursorRecord,
+  ConnectorEventIndexRecord,
+  ConnectorEventSearchHit,
+  ConnectorEventStalenessStatus,
+  UpsertConnectorEventIndexCursorInput,
+  UpsertConnectorEventIndexInput,
+} from './types.js';
+
+type ConnectorEventIndexAdapter = Pick<DatabaseAdapter, 'prepare' | 'transaction'>;
+
+interface ListConnectorEventsByDatetimeRangeInput {
+  fromMs: number;
+  toMs: number;
+  limit?: number;
+  connectors?: string[];
+  order?: 'asc' | 'desc';
+}
+
+interface SearchConnectorEventsOptions {
+  limit?: number;
+  connectors?: string[];
+}
+
+interface DeleteExpiredConnectorEventsInput {
+  nowMs: number;
+  retentionMs: number;
+  connectorName?: string;
+}
+
+interface StalenessOptions {
+  nowMs: number;
+  staleAfterMs?: number;
+  stalenessWarnAfterMs?: number;
+  unhealthyAfterMs?: number;
+}
+
+const DEFAULT_RANGE_LIMIT = 100;
+const DEFAULT_SEARCH_LIMIT = 25;
+const MAX_RANGE_LIMIT = 500;
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
+const FIFTEEN_MINUTES_MS = 15 * 60 * 1000;
+const SIXTY_MINUTES_MS = 60 * 60 * 1000;
+
+function placeholders(values: readonly unknown[]): string {
+  if (values.length === 0) {
+    throw new Error('Cannot build SQL placeholders for an empty list.');
+  }
+  return values.map(() => '?').join(', ');
+}
+
+function positiveLimit(value: number | undefined, fallback: number, max = MAX_RANGE_LIMIT): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(0, Math.floor(value)));
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function eventDateFromMs(ms: number | null): string | null {
+  if (ms === null || !Number.isFinite(ms)) {
+    return null;
+  }
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+function normalizeTimestampMs(input: UpsertConnectorEventIndexInput): number {
+  const timestamp = input.source_timestamp_ms ?? input.event_datetime;
+  if (typeof timestamp !== 'number' || !Number.isFinite(timestamp)) {
+    throw new Error('connector_event_index.source_timestamp_ms must be a finite number.');
+  }
+  return Math.floor(timestamp);
+}
+
+function normalizeEventDatetime(input: UpsertConnectorEventIndexInput): number | null {
+  if (input.event_datetime === null || input.event_datetime === undefined) {
+    return normalizeTimestampMs(input);
+  }
+  if (!Number.isFinite(input.event_datetime)) {
+    throw new Error('connector_event_index.event_datetime must be a finite number when provided.');
+  }
+  return Math.floor(input.event_datetime);
+}
+
+function normalizeMetadataJson(input: UpsertConnectorEventIndexInput): string | null {
+  if (input.metadata_json !== undefined) {
+    return input.metadata_json;
+  }
+  if (input.metadata === undefined || input.metadata === null) {
+    return null;
+  }
+  return canonicalizeJSON(input.metadata);
+}
+
+function toBuffer(value: unknown): Buffer {
+  if (Buffer.isBuffer(value)) {
+    return value;
+  }
+  if (value instanceof Uint8Array) {
+    return Buffer.from(value);
+  }
+  throw new Error('connector_event_index.content_hash must be a 32-byte Buffer.');
+}
+
+function mapConnectorEventIndexRow(row: Record<string, unknown>): ConnectorEventIndexRecord {
+  return {
+    event_index_id: String(row.event_index_id),
+    source_connector: String(row.source_connector),
+    source_type: String(row.source_type),
+    source_id: String(row.source_id),
+    source_locator: row.source_locator === null ? null : String(row.source_locator),
+    channel: row.channel === null ? null : String(row.channel),
+    author: row.author === null ? null : String(row.author),
+    title: row.title === null ? null : String(row.title),
+    content: String(row.content),
+    event_datetime:
+      typeof row.event_datetime === 'number' && Number.isFinite(row.event_datetime)
+        ? row.event_datetime
+        : null,
+    event_date: row.event_date === null ? null : String(row.event_date),
+    source_timestamp_ms: Number(row.source_timestamp_ms),
+    metadata_json: row.metadata_json === null ? null : String(row.metadata_json),
+    artifact_locator: row.artifact_locator === null ? null : String(row.artifact_locator),
+    artifact_title: row.artifact_title === null ? null : String(row.artifact_title),
+    content_hash: toBuffer(row.content_hash),
+    indexed_at: String(row.indexed_at),
+    updated_at: String(row.updated_at),
+    expires_at: row.expires_at === null ? null : String(row.expires_at),
+  };
+}
+
+function mapConnectorCursorRow(row: Record<string, unknown>): ConnectorEventIndexCursorRecord {
+  return {
+    connector_name: String(row.connector_name),
+    last_seen_timestamp_ms: Number(row.last_seen_timestamp_ms),
+    last_seen_source_id: String(row.last_seen_source_id),
+    last_sweep_at: row.last_sweep_at === null ? null : String(row.last_sweep_at),
+    last_success_at: row.last_success_at === null ? null : String(row.last_success_at),
+    last_error: row.last_error === null ? null : String(row.last_error),
+    last_error_at: row.last_error_at === null ? null : String(row.last_error_at),
+    indexed_count: Number(row.indexed_count),
+  };
+}
+
+function connectorFilterSql(connectors: readonly string[] | undefined, alias = ''): string {
+  if (!connectors || connectors.length === 0) {
+    return '';
+  }
+  const prefix = alias.length > 0 ? `${alias}.` : '';
+  return ` AND ${prefix}source_connector IN (${placeholders(connectors)})`;
+}
+
+function hasOwn(input: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(input, key);
+}
+
+export function connectorEventIndexId(sourceConnector: string, sourceId: string): string {
+  const digest = createHash('sha1').update(`${sourceConnector}\0${sourceId}`, 'utf8').digest('hex');
+  return `evt_${digest.slice(0, 16)}`;
+}
+
+export function connectorEventContentHash(input: {
+  source_connector: string;
+  source_id: string;
+  content: string;
+  event_datetime?: number | null;
+}): Buffer {
+  return createHash('sha256')
+    .update(
+      canonicalizeJSON({
+        source_connector: input.source_connector,
+        source_id: input.source_id,
+        content: input.content,
+        event_datetime: input.event_datetime ?? null,
+      }),
+      'utf8'
+    )
+    .digest();
+}
+
+export function upsertConnectorEventIndex(
+  adapter: ConnectorEventIndexAdapter,
+  input: UpsertConnectorEventIndexInput
+): ConnectorEventIndexRecord {
+  const sourceTimestampMs = normalizeTimestampMs(input);
+  const eventDatetime = normalizeEventDatetime(input);
+  const eventDate = input.event_date ?? eventDateFromMs(eventDatetime);
+  const timestamp = input.updated_at ?? nowIso();
+  const eventIndexId = connectorEventIndexId(input.source_connector, input.source_id);
+  const contentHash = input.content_hash
+    ? Buffer.from(input.content_hash)
+    : connectorEventContentHash({
+        source_connector: input.source_connector,
+        source_id: input.source_id,
+        content: input.content,
+        event_datetime: eventDatetime,
+      });
+
+  if (contentHash.byteLength !== 32) {
+    throw new Error('connector_event_index.content_hash must be exactly 32 bytes.');
+  }
+
+  const metadataJson = normalizeMetadataJson(input);
+
+  return adapter.transaction(() => {
+    adapter
+      .prepare(
+        `
+          INSERT INTO connector_event_index (
+            event_index_id, source_connector, source_type, source_id, source_locator,
+            channel, author, title, content, event_datetime, event_date, source_timestamp_ms,
+            metadata_json, artifact_locator, artifact_title, content_hash, indexed_at,
+            updated_at, expires_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(source_connector, source_id) DO UPDATE SET
+            source_type = excluded.source_type,
+            source_locator = excluded.source_locator,
+            channel = excluded.channel,
+            author = excluded.author,
+            title = excluded.title,
+            content = excluded.content,
+            event_datetime = excluded.event_datetime,
+            event_date = excluded.event_date,
+            source_timestamp_ms = excluded.source_timestamp_ms,
+            metadata_json = excluded.metadata_json,
+            artifact_locator = excluded.artifact_locator,
+            artifact_title = excluded.artifact_title,
+            content_hash = excluded.content_hash,
+            updated_at = excluded.updated_at,
+            expires_at = excluded.expires_at
+        `
+      )
+      .run(
+        eventIndexId,
+        input.source_connector,
+        input.source_type,
+        input.source_id,
+        input.source_locator ?? null,
+        input.channel ?? null,
+        input.author ?? null,
+        input.title ?? null,
+        input.content,
+        eventDatetime,
+        eventDate,
+        sourceTimestampMs,
+        metadataJson,
+        input.artifact_locator ?? null,
+        input.artifact_title ?? null,
+        contentHash,
+        input.indexed_at ?? timestamp,
+        timestamp,
+        input.expires_at ?? null
+      );
+
+    const saved = getConnectorEventIndexRecord(adapter, input.source_connector, input.source_id);
+    if (!saved) {
+      throw new Error(
+        `Failed to read connector_event_index row after upsert: ${input.source_connector}/${input.source_id}`
+      );
+    }
+    return saved;
+  });
+}
+
+export function getConnectorEventIndexRecord(
+  adapter: ConnectorEventIndexAdapter,
+  sourceConnector: string,
+  sourceId: string
+): ConnectorEventIndexRecord | null {
+  const row = adapter
+    .prepare(
+      `
+        SELECT *
+        FROM connector_event_index
+        WHERE source_connector = ?
+          AND source_id = ?
+        LIMIT 1
+      `
+    )
+    .get(sourceConnector, sourceId) as Record<string, unknown> | undefined;
+
+  return row ? mapConnectorEventIndexRow(row) : null;
+}
+
+export function listConnectorEventsByDatetimeRange(
+  adapter: ConnectorEventIndexAdapter,
+  input: ListConnectorEventsByDatetimeRangeInput
+): ConnectorEventIndexRecord[] {
+  const limit = positiveLimit(input.limit, DEFAULT_RANGE_LIMIT);
+  if (limit === 0) {
+    return [];
+  }
+
+  const order = input.order === 'desc' ? 'DESC' : 'ASC';
+  const connectors = input.connectors?.filter(Boolean) ?? [];
+  const params: unknown[] = [input.fromMs, input.toMs, ...connectors, limit];
+
+  const rows = adapter
+    .prepare(
+      `
+        SELECT *
+        FROM connector_event_index
+        WHERE event_datetime >= ?
+          AND event_datetime <= ?
+          ${connectorFilterSql(connectors)}
+        ORDER BY event_datetime ${order}, event_index_id ASC
+        LIMIT ?
+      `
+    )
+    .all(...params) as Array<Record<string, unknown>>;
+
+  return rows.map(mapConnectorEventIndexRow);
+}
+
+export function searchConnectorEventsByFTS(
+  adapter: ConnectorEventIndexAdapter,
+  query: string,
+  options: SearchConnectorEventsOptions = {}
+): ConnectorEventSearchHit[] {
+  const normalizedQuery = query.trim();
+  if (normalizedQuery.length === 0) {
+    return [];
+  }
+
+  const limit = positiveLimit(options.limit, DEFAULT_SEARCH_LIMIT, 100);
+  if (limit === 0) {
+    return [];
+  }
+
+  const connectors = options.connectors?.filter(Boolean) ?? [];
+  const params: unknown[] = [normalizedQuery, ...connectors, limit];
+
+  const rows = adapter
+    .prepare(
+      `
+        SELECT e.*, bm25(connector_event_index_fts) AS rank
+        FROM connector_event_index_fts
+        JOIN connector_event_index e
+          ON e.event_index_id = connector_event_index_fts.event_index_id
+        WHERE connector_event_index_fts MATCH ?
+          ${connectorFilterSql(connectors, 'e')}
+        ORDER BY rank ASC, e.event_datetime DESC, e.event_index_id ASC
+        LIMIT ?
+      `
+    )
+    .all(...params) as Array<Record<string, unknown> & { rank: number }>;
+
+  return rows.map((row) => {
+    const rank = Number(row.rank);
+    return {
+      ...mapConnectorEventIndexRow(row),
+      rank,
+      score: 1 / (1 + Math.max(0, rank)),
+    };
+  });
+}
+
+export function readConnectorCursor(
+  adapter: ConnectorEventIndexAdapter,
+  connectorName: string
+): ConnectorEventIndexCursorRecord | null {
+  const row = adapter
+    .prepare(
+      `
+        SELECT *
+        FROM connector_event_index_cursors
+        WHERE connector_name = ?
+        LIMIT 1
+      `
+    )
+    .get(connectorName) as Record<string, unknown> | undefined;
+
+  return row ? mapConnectorCursorRow(row) : null;
+}
+
+export function upsertConnectorCursor(
+  adapter: ConnectorEventIndexAdapter,
+  input: UpsertConnectorEventIndexCursorInput
+): ConnectorEventIndexCursorRecord {
+  const current = readConnectorCursor(adapter, input.connector_name);
+  const merged: ConnectorEventIndexCursorRecord = {
+    connector_name: input.connector_name,
+    last_seen_timestamp_ms: input.last_seen_timestamp_ms ?? current?.last_seen_timestamp_ms ?? 0,
+    last_seen_source_id: input.last_seen_source_id ?? current?.last_seen_source_id ?? '',
+    last_sweep_at: hasOwn(input, 'last_sweep_at')
+      ? (input.last_sweep_at ?? null)
+      : (current?.last_sweep_at ?? null),
+    last_success_at: hasOwn(input, 'last_success_at')
+      ? (input.last_success_at ?? null)
+      : (current?.last_success_at ?? null),
+    last_error: hasOwn(input, 'last_error')
+      ? (input.last_error ?? null)
+      : (current?.last_error ?? null),
+    last_error_at: hasOwn(input, 'last_error_at')
+      ? (input.last_error_at ?? null)
+      : (current?.last_error_at ?? null),
+    indexed_count: input.indexed_count ?? current?.indexed_count ?? 0,
+  };
+
+  adapter
+    .prepare(
+      `
+        INSERT INTO connector_event_index_cursors (
+          connector_name, last_seen_timestamp_ms, last_seen_source_id, last_sweep_at,
+          last_success_at, last_error, last_error_at, indexed_count
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(connector_name) DO UPDATE SET
+          last_seen_timestamp_ms = excluded.last_seen_timestamp_ms,
+          last_seen_source_id = excluded.last_seen_source_id,
+          last_sweep_at = excluded.last_sweep_at,
+          last_success_at = excluded.last_success_at,
+          last_error = excluded.last_error,
+          last_error_at = excluded.last_error_at,
+          indexed_count = excluded.indexed_count
+      `
+    )
+    .run(
+      merged.connector_name,
+      merged.last_seen_timestamp_ms,
+      merged.last_seen_source_id,
+      merged.last_sweep_at,
+      merged.last_success_at,
+      merged.last_error,
+      merged.last_error_at,
+      merged.indexed_count
+    );
+
+  const saved = readConnectorCursor(adapter, input.connector_name);
+  if (!saved) {
+    throw new Error(`Failed to read connector cursor after upsert: ${input.connector_name}`);
+  }
+  return saved;
+}
+
+export function deleteExpiredConnectorEvents(
+  adapter: ConnectorEventIndexAdapter,
+  input: DeleteExpiredConnectorEventsInput
+): { rows_deleted: number } {
+  const cutoffMs = input.nowMs - input.retentionMs;
+  const result = input.connectorName
+    ? adapter
+        .prepare(
+          `
+            DELETE FROM connector_event_index
+            WHERE source_connector = ?
+              AND event_datetime IS NOT NULL
+              AND event_datetime < ?
+              AND artifact_locator IS NULL
+          `
+        )
+        .run(input.connectorName, cutoffMs)
+    : adapter
+        .prepare(
+          `
+            DELETE FROM connector_event_index
+            WHERE event_datetime IS NOT NULL
+              AND event_datetime < ?
+              AND artifact_locator IS NULL
+          `
+        )
+        .run(cutoffMs);
+
+  return { rows_deleted: result.changes };
+}
+
+export function computeStalenessStatus(
+  cursor: ConnectorEventIndexCursorRecord | null,
+  options: StalenessOptions
+): ConnectorEventStalenessStatus {
+  if (!cursor) {
+    return 'never_swept';
+  }
+
+  if (cursor.last_error !== null) {
+    return 'unhealthy';
+  }
+
+  if (cursor.last_success_at === null) {
+    return 'never_swept';
+  }
+
+  const lastSuccessMs = Date.parse(cursor.last_success_at);
+  if (!Number.isFinite(lastSuccessMs)) {
+    return 'unhealthy';
+  }
+
+  const elapsedMs = options.nowMs - lastSuccessMs;
+  const staleAfterMs = options.staleAfterMs ?? FIVE_MINUTES_MS;
+  const warnAfterMs = options.stalenessWarnAfterMs ?? FIFTEEN_MINUTES_MS;
+  const unhealthyAfterMs = options.unhealthyAfterMs ?? SIXTY_MINUTES_MS;
+
+  if (elapsedMs > unhealthyAfterMs) {
+    return 'unhealthy';
+  }
+  if (elapsedMs > warnAfterMs) {
+    return 'warn';
+  }
+  if (elapsedMs > staleAfterMs) {
+    return 'stale-but-warming';
+  }
+  return 'healthy';
+}
+
+export type {
+  ConnectorEventIndexCursorRecord,
+  ConnectorEventIndexRecord,
+  ConnectorEventSearchHit,
+  ConnectorEventStalenessStatus,
+  UpsertConnectorEventIndexCursorInput,
+  UpsertConnectorEventIndexInput,
+} from './types.js';

--- a/packages/mama-core/src/connectors/event-index.ts
+++ b/packages/mama-core/src/connectors/event-index.ts
@@ -358,7 +358,7 @@ export function searchConnectorEventsByFTS(
     return {
       ...mapConnectorEventIndexRow(row),
       rank,
-      score: 1 / (1 + Math.max(0, rank)),
+      score: Number.isFinite(rank) ? 1 / (1 + Math.exp(rank)) : 0,
     };
   });
 }
@@ -445,6 +445,15 @@ export function deleteExpiredConnectorEvents(
   adapter: ConnectorEventIndexAdapter,
   input: DeleteExpiredConnectorEventsInput
 ): { rows_deleted: number } {
+  if (!Number.isFinite(input.nowMs)) {
+    throw new Error('deleteExpiredConnectorEvents.nowMs must be a finite number.');
+  }
+  if (!Number.isFinite(input.retentionMs) || input.retentionMs < 0) {
+    throw new Error(
+      'deleteExpiredConnectorEvents.retentionMs must be a non-negative finite number.'
+    );
+  }
+
   const cutoffMs = input.nowMs - input.retentionMs;
   const result = input.connectorName
     ? adapter

--- a/packages/mama-core/src/connectors/types.ts
+++ b/packages/mama-core/src/connectors/types.ts
@@ -1,0 +1,79 @@
+import type { Buffer } from 'node:buffer';
+
+export interface ConnectorEventIndexRecord {
+  event_index_id: string;
+  source_connector: string;
+  source_type: string;
+  source_id: string;
+  source_locator: string | null;
+  channel: string | null;
+  author: string | null;
+  title: string | null;
+  content: string;
+  event_datetime: number | null;
+  event_date: string | null;
+  source_timestamp_ms: number;
+  metadata_json: string | null;
+  artifact_locator: string | null;
+  artifact_title: string | null;
+  content_hash: Buffer;
+  indexed_at: string;
+  updated_at: string;
+  expires_at: string | null;
+}
+
+export interface UpsertConnectorEventIndexInput {
+  source_connector: string;
+  source_type: string;
+  source_id: string;
+  source_locator?: string | null;
+  channel?: string | null;
+  author?: string | null;
+  title?: string | null;
+  content: string;
+  event_datetime?: number | null;
+  event_date?: string | null;
+  source_timestamp_ms?: number | null;
+  metadata_json?: string | null;
+  metadata?: unknown;
+  artifact_locator?: string | null;
+  artifact_title?: string | null;
+  content_hash?: Buffer | Uint8Array | null;
+  indexed_at?: string;
+  updated_at?: string;
+  expires_at?: string | null;
+}
+
+export interface ConnectorEventIndexCursorRecord {
+  connector_name: string;
+  last_seen_timestamp_ms: number;
+  last_seen_source_id: string;
+  last_sweep_at: string | null;
+  last_success_at: string | null;
+  last_error: string | null;
+  last_error_at: string | null;
+  indexed_count: number;
+}
+
+export interface UpsertConnectorEventIndexCursorInput {
+  connector_name: string;
+  last_seen_timestamp_ms?: number;
+  last_seen_source_id?: string;
+  last_sweep_at?: string | null;
+  last_success_at?: string | null;
+  last_error?: string | null;
+  last_error_at?: string | null;
+  indexed_count?: number;
+}
+
+export interface ConnectorEventSearchHit extends ConnectorEventIndexRecord {
+  rank: number;
+  score: number;
+}
+
+export type ConnectorEventStalenessStatus =
+  | 'healthy'
+  | 'stale-but-warming'
+  | 'warn'
+  | 'unhealthy'
+  | 'never_swept';

--- a/packages/mama-core/src/db-manager.ts
+++ b/packages/mama-core/src/db-manager.ts
@@ -73,6 +73,8 @@ export interface DecisionRecord {
   edges?: DecisionEdgeRow[];
   /** ISO 8601 date when the event actually occurred. Null if not set. */
   event_date?: string | null;
+  /** Source event timestamp in milliseconds when known. Null if not set. */
+  event_datetime?: number | null;
 }
 
 export interface OutcomeData {
@@ -416,6 +418,8 @@ export interface DecisionInput {
   risks?: string | null;
   /** ISO 8601 date string for when the event actually occurred (e.g. "2023-01-15") */
   event_date?: string | null;
+  /** Source event timestamp in milliseconds when known. */
+  event_datetime?: number | null;
 }
 
 /**
@@ -436,6 +440,17 @@ export async function insertDecisionWithEmbedding(decision: DecisionInput): Prom
     const d = decision.event_date;
     if (!/^\d{4}-\d{2}-\d{2}$/.test(d) || isNaN(new Date(d).getTime())) {
       throw new Error(`Invalid event_date: must be ISO 8601 YYYY-MM-DD (got: ${d})`);
+    }
+  }
+  if (decision.event_datetime !== null && decision.event_datetime !== undefined) {
+    if (
+      typeof decision.event_datetime !== 'number' ||
+      !Number.isFinite(decision.event_datetime) ||
+      decision.event_datetime <= 0
+    ) {
+      throw new Error(
+        `Invalid event_datetime: must be a positive millisecond timestamp (got: ${decision.event_datetime})`
+      );
     }
   }
 
@@ -473,8 +488,8 @@ export async function insertDecisionWithEmbedding(decision: DecisionInput): Prom
           confidence, created_at, updated_at,
           needs_validation, validation_attempts, last_validated_at, usage_count,
           trust_context, usage_success, usage_failure, time_saved,
-          evidence, alternatives, risks, event_date
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          evidence, alternatives, risks, event_date, event_datetime
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
 
       const insertResult = stmt.run(
@@ -507,7 +522,8 @@ export async function insertDecisionWithEmbedding(decision: DecisionInput): Prom
         decision.evidence || null,
         decision.alternatives || null,
         decision.risks || null,
-        decision.event_date || null
+        decision.event_date || null,
+        decision.event_datetime ?? null
       );
 
       const rowid = Number(insertResult.lastInsertRowid);

--- a/packages/mama-core/src/decision-formatter.ts
+++ b/packages/mama-core/src/decision-formatter.ts
@@ -266,7 +266,7 @@ Top ${full.length} Most Relevant Decisions:
  * Format small decision history (3 or fewer)
  */
 function formatSmallHistory(current: DecisionForFormat, history: DecisionForFormat[]): string {
-  const duration = calculateDuration(current.created_at);
+  const duration = calculateDuration(getDecisionTimestamp(current));
 
   let context = `
 🧠 DECISION HISTORY: ${current.topic}

--- a/packages/mama-core/src/decision-formatter.ts
+++ b/packages/mama-core/src/decision-formatter.ts
@@ -41,6 +41,8 @@ export interface DecisionForFormat {
   risks?: string;
   /** ISO 8601 date when the event actually occurred. Null if not set. */
   event_date?: string | null;
+  /** Source event timestamp in milliseconds when known. Null if not set. */
+  event_datetime?: number | null;
 }
 
 /**
@@ -232,7 +234,7 @@ Top ${full.length} Most Relevant Decisions:
 
   for (let i = 0; i < full.length; i++) {
     const d = full[i];
-    const duration = calculateDuration(d.created_at);
+    const duration = calculateDuration(getDecisionTimestamp(d));
     const outcomeEmoji = getOutcomeEmoji(d.outcome ?? null);
     const relevancePercent = Math.round((d.relevanceScore || 0) * 100);
 
@@ -408,6 +410,12 @@ function calculateDuration(timestamp: number | string): string {
   }
 
   return `${diffDays} day${diffDays !== 1 ? 's' : ''} ago`;
+}
+
+function getDecisionTimestamp(
+  decision: Pick<DecisionForFormat, 'created_at' | 'event_datetime'>
+): number | string {
+  return decision.event_datetime ?? decision.created_at;
 }
 
 /**
@@ -751,7 +759,7 @@ function formatTeaserList(decisions: DecisionForFormat[], topN = 3): string | nu
 
     // Recency metadata (NEW - Gaussian Decay)
     if (d.recency_age_days !== undefined && d.created_at) {
-      const timeAgo = calculateDuration(d.created_at);
+      const timeAgo = calculateDuration(getDecisionTimestamp(d));
       const recencyScore = d.recency_score ? Math.round(d.recency_score * 100) : null;
       const finalScore = d.final_score ? Math.round(d.final_score * 100) : null;
 
@@ -779,7 +787,7 @@ export function formatTeaser(decision: DecisionForFormat | null): string | null 
     return null;
   }
 
-  const timeAgo = calculateDuration(decision.created_at);
+  const timeAgo = calculateDuration(getDecisionTimestamp(decision));
 
   // Extract preview (first 60 chars)
   const preview =
@@ -842,7 +850,7 @@ export function formatRecall(
  * Format single decision with full detail
  */
 function formatSingleDecision(decision: DecisionForFormat): string {
-  const timeAgo = calculateDuration(decision.created_at);
+  const timeAgo = calculateDuration(getDecisionTimestamp(decision));
   const confidencePercent = Math.round((decision.confidence || 0) * 100);
   const outcomeEmoji = getOutcomeEmoji(decision.outcome ?? null);
   const outcomeText = decision.outcome || 'Not yet tracked';
@@ -953,7 +961,7 @@ function formatDecisionHistory(
 📋 Decision History: ${topic}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Latest Decision (${calculateDuration(latest.created_at)}):
+Latest Decision (${calculateDuration(getDecisionTimestamp(latest))}):
 ${latest.decision}
 `.trim();
 
@@ -1013,7 +1021,7 @@ ${latest.decision}
 
     for (let i = 0; i < Math.min(older.length, 5); i++) {
       const d = older[i];
-      const timeAgo = calculateDuration(d.created_at);
+      const timeAgo = calculateDuration(getDecisionTimestamp(d));
       const emoji = getOutcomeEmoji(d.outcome ?? null);
       output += `\n${i + 2}. ${d.decision} (${timeAgo}) ${emoji}`;
 
@@ -1131,7 +1139,7 @@ export function formatList(decisions: DecisionForFormat[], options: FormatOption
 
   for (let i = 0; i < items.length; i++) {
     const d = items[i];
-    const timeAgo = calculateDuration(d.created_at);
+    const timeAgo = calculateDuration(getDecisionTimestamp(d));
     const type = d.user_involvement === 'approved' ? '👤 User' : '🤖 Assistant';
     const status = d.outcome ? getOutcomeEmoji(d.outcome) + ' ' + d.outcome : '⏳ Pending';
     const confidence = Math.round((d.confidence || 0) * 100);

--- a/packages/mama-core/src/entities/audit-metrics.ts
+++ b/packages/mama-core/src/entities/audit-metrics.ts
@@ -82,9 +82,10 @@ export function computeFalseMergeRate(candidates: AuditCandidateSnapshot[]): {
   return { rate, numerator, denominator };
 }
 
-export function computeCrossLanguageRecallAt10(
+export function computeCrossLanguageRecallAtK(
   goldPairs: AuditGoldPair[],
-  matches: AuditCandidateGoldLink[]
+  matches: AuditCandidateGoldLink[],
+  k: number
 ): { recall: number; numerator: number; denominator: number } {
   const denominator = goldPairs.length;
   if (denominator === 0) {
@@ -92,7 +93,7 @@ export function computeCrossLanguageRecallAt10(
   }
   const topRanked = [...matches]
     .sort((a, b) => b.score_total - a.score_total)
-    .slice(0, 10)
+    .slice(0, Math.max(0, k))
     .map((m) => m.matched_pair_key);
   const matched = new Set(topRanked);
   let numerator = 0;
@@ -101,6 +102,20 @@ export function computeCrossLanguageRecallAt10(
     if (matched.has(key)) numerator += 1;
   }
   return { recall: numerator / denominator, numerator, denominator };
+}
+
+export function computeCrossLanguageRecallAt5(
+  goldPairs: AuditGoldPair[],
+  matches: AuditCandidateGoldLink[]
+): { recall: number; numerator: number; denominator: number } {
+  return computeCrossLanguageRecallAtK(goldPairs, matches, 5);
+}
+
+export function computeCrossLanguageRecallAt10(
+  goldPairs: AuditGoldPair[],
+  matches: AuditCandidateGoldLink[]
+): { recall: number; numerator: number; denominator: number } {
+  return computeCrossLanguageRecallAtK(goldPairs, matches, 10);
 }
 
 export function computeOntologyViolationCount(candidates: AuditCandidateSnapshot[]): number {

--- a/packages/mama-core/src/entities/audit-metrics.ts
+++ b/packages/mama-core/src/entities/audit-metrics.ts
@@ -99,7 +99,9 @@ export function computeCrossLanguageRecallAtK(
   let numerator = 0;
   for (const pair of goldPairs) {
     const key = `${pair.canonical_id}:${pair.left_obs_id}:${pair.right_obs_id}`;
-    if (matched.has(key)) numerator += 1;
+    if (matched.has(key)) {
+      numerator += 1;
+    }
   }
   return { recall: numerator / denominator, numerator, denominator };
 }

--- a/packages/mama-core/src/entities/candidate-generator.ts
+++ b/packages/mama-core/src/entities/candidate-generator.ts
@@ -286,8 +286,13 @@ function dedupeCrossLanguageFamilies(
 
 function buildCrossScopeProbePairs(
   observations: EntityObservation[],
-  seenPairs: Set<string>
+  seenPairs: Set<string>,
+  maxPairs: number
 ): ScoredPair[] {
+  if (maxPairs <= 0) {
+    return [];
+  }
+
   const probes: ScoredPair[] = [];
 
   for (let i = 0; i < observations.length; i += 1) {
@@ -307,10 +312,13 @@ function buildCrossScopeProbePairs(
       }
 
       probes.push(scorePair(left, right, 'cross_scope'));
+      probes.sort(compareProbePairs);
+      if (probes.length > maxPairs) {
+        probes.length = maxPairs;
+      }
     }
   }
 
-  probes.sort(compareProbePairs);
   return probes;
 }
 
@@ -330,7 +338,7 @@ export function dedupeObservationsBySource(observations: EntityObservation[]): E
   for (const observation of observations) {
     const key = JSON.stringify([
       observation.source_connector,
-      observation.source_locator ?? '',
+      observation.source_locator ?? `missing-locator:${observation.id}`,
       observation.source_raw_record_id,
       observation.observation_type,
     ]);
@@ -403,7 +411,7 @@ export async function generateResolutionCandidates(
   const crossScopeBudget = options.embeddingScorer ? Math.max(0, pairBudget - topN.length) : 0;
   const crossScopePairs =
     options.embeddingScorer && crossScopeBudget > 0 && hasMultipleScopes(deduped)
-      ? buildCrossScopeProbePairs(deduped, seenPairs).slice(0, crossScopeBudget)
+      ? buildCrossScopeProbePairs(deduped, seenPairs, crossScopeBudget)
       : [];
   const candidates: EntityResolutionCandidate[] = [];
 

--- a/packages/mama-core/src/entities/candidate-generator.ts
+++ b/packages/mama-core/src/entities/candidate-generator.ts
@@ -305,12 +305,12 @@ function buildCrossScopeProbePairs(
       if (seenPairs.has(pairKey)) {
         continue;
       }
-      seenPairs.add(pairKey);
 
       if (!shouldConsiderCrossScopeProbe(left, right)) {
         continue;
       }
 
+      seenPairs.add(pairKey);
       probes.push(scorePair(left, right, 'cross_scope'));
       probes.sort(compareProbePairs);
       if (probes.length > maxPairs) {
@@ -385,12 +385,12 @@ export async function generateResolutionCandidates(
         if (seenPairs.has(pairKey)) {
           continue;
         }
-        seenPairs.add(pairKey);
 
         if (!shouldConsiderPair(left, right)) {
           continue;
         }
 
+        seenPairs.add(pairKey);
         const scored = scorePair(left, right, 'deterministic');
 
         if (scored.score_total <= 0 && !options.embeddingScorer) {

--- a/packages/mama-core/src/entities/candidate-generator.ts
+++ b/packages/mama-core/src/entities/candidate-generator.ts
@@ -4,6 +4,8 @@ import type { EntityObservation, EntityResolutionCandidate } from './types.js';
 
 export const ENTITY_EMBEDDING_TOPN = 50;
 const CROSS_SCOPE_PROBE_MIN_EMBEDDING_SCORE = 0.84;
+const MAX_DETERMINISTIC_SCOPE_BUCKET = 32;
+const MAX_CROSS_SCOPE_SCOPE_BUCKET = 8;
 
 export interface CandidateGeneratorOptions {
   embeddingScorer?: (left: EntityObservation, right: EntityObservation) => Promise<number>;
@@ -207,6 +209,47 @@ function buildPairKey(left: EntityObservation, right: EntityObservation): string
   return `${left.id}::${right.id}`;
 }
 
+function compareObservationForSampling(left: EntityObservation, right: EntityObservation): number {
+  const leftRelated = left.related_surface_forms.length;
+  const rightRelated = right.related_surface_forms.length;
+  if (rightRelated !== leftRelated) {
+    return rightRelated - leftRelated;
+  }
+
+  const leftContext = left.context_summary?.length ?? 0;
+  const rightContext = right.context_summary?.length ?? 0;
+  if (rightContext !== leftContext) {
+    return rightContext - leftContext;
+  }
+
+  const leftObserved = left.timestamp_observed ?? Number.NEGATIVE_INFINITY;
+  const rightObserved = right.timestamp_observed ?? Number.NEGATIVE_INFINITY;
+  if (rightObserved !== leftObserved) {
+    return rightObserved - leftObserved;
+  }
+
+  return left.id.localeCompare(right.id);
+}
+
+function capObservationGroup(
+  observations: EntityObservation[],
+  limit: number
+): EntityObservation[] {
+  if (observations.length <= limit) {
+    return observations;
+  }
+
+  return [...observations].sort(compareObservationForSampling).slice(0, limit);
+}
+
+function pushTopProbe(probes: ScoredPair[], candidate: ScoredPair, maxPairs: number): void {
+  probes.push(candidate);
+  probes.sort(compareProbePairs);
+  if (probes.length > maxPairs) {
+    probes.length = maxPairs;
+  }
+}
+
 function buildCrossLanguageFamilyKey(
   left: EntityObservation,
   right: EntityObservation
@@ -294,27 +337,55 @@ function buildCrossScopeProbePairs(
   }
 
   const probes: ScoredPair[] = [];
+  const bucketMap = new Map<string, EntityObservation[]>();
+  for (const observation of observations) {
+    if (!observation.entity_kind_hint) {
+      continue;
+    }
+    const bucketKey = JSON.stringify([
+      observation.entity_kind_hint,
+      observation.observation_type,
+      observation.scope_kind,
+    ]);
+    const bucket = bucketMap.get(bucketKey) ?? [];
+    bucket.push(observation);
+    bucketMap.set(bucketKey, bucket);
+  }
 
-  for (let i = 0; i < observations.length; i += 1) {
-    for (let j = i + 1; j < observations.length; j += 1) {
-      const first = observations[i]!;
-      const second = observations[j]!;
-      const [left, right] =
-        first.id.localeCompare(second.id) <= 0 ? [first, second] : [second, first];
-      const pairKey = buildPairKey(left, right);
-      if (seenPairs.has(pairKey)) {
-        continue;
-      }
+  for (const bucket of bucketMap.values()) {
+    const scopeBuckets = new Map<string, EntityObservation[]>();
+    for (const observation of bucket) {
+      const scopeKey = observation.scope_id ?? 'global';
+      const scopeBucket = scopeBuckets.get(scopeKey) ?? [];
+      scopeBucket.push(observation);
+      scopeBuckets.set(scopeKey, scopeBucket);
+    }
 
-      if (!shouldConsiderCrossScopeProbe(left, right)) {
-        continue;
-      }
+    const limitedScopeBuckets = Array.from(scopeBuckets.values())
+      .filter((scopeBucket) => scopeBucket.length > 0)
+      .map((scopeBucket) => capObservationGroup(scopeBucket, MAX_CROSS_SCOPE_SCOPE_BUCKET));
 
-      seenPairs.add(pairKey);
-      probes.push(scorePair(left, right, 'cross_scope'));
-      probes.sort(compareProbePairs);
-      if (probes.length > maxPairs) {
-        probes.length = maxPairs;
+    for (let i = 0; i < limitedScopeBuckets.length; i += 1) {
+      for (let j = i + 1; j < limitedScopeBuckets.length; j += 1) {
+        const leftBucket = limitedScopeBuckets[i]!;
+        const rightBucket = limitedScopeBuckets[j]!;
+        for (const first of leftBucket) {
+          for (const second of rightBucket) {
+            const [left, right] =
+              first.id.localeCompare(second.id) <= 0 ? [first, second] : [second, first];
+            const pairKey = buildPairKey(left, right);
+            if (seenPairs.has(pairKey)) {
+              continue;
+            }
+
+            if (!shouldConsiderCrossScopeProbe(left, right)) {
+              continue;
+            }
+
+            seenPairs.add(pairKey);
+            pushTopProbe(probes, scorePair(left, right, 'cross_scope'), maxPairs);
+          }
+        }
       }
     }
   }
@@ -375,29 +446,43 @@ export async function generateResolutionCandidates(
     if (bucket.length < 2) {
       continue;
     }
-    for (let i = 0; i < bucket.length; i += 1) {
-      for (let j = i + 1; j < bucket.length; j += 1) {
-        const first = bucket[i]!;
-        const second = bucket[j]!;
-        const [left, right] =
-          first.id.localeCompare(second.id) <= 0 ? [first, second] : [second, first];
-        const pairKey = `${left.id}::${right.id}`;
-        if (seenPairs.has(pairKey)) {
-          continue;
+    const scopeBuckets = new Map<string, EntityObservation[]>();
+    for (const observation of bucket) {
+      const scopeKey = `${observation.scope_kind}:${observation.scope_id ?? 'global'}`;
+      const scopeBucket = scopeBuckets.get(scopeKey) ?? [];
+      scopeBucket.push(observation);
+      scopeBuckets.set(scopeKey, scopeBucket);
+    }
+
+    for (const scopeBucket of scopeBuckets.values()) {
+      const limitedBucket = capObservationGroup(scopeBucket, MAX_DETERMINISTIC_SCOPE_BUCKET);
+      if (limitedBucket.length < 2) {
+        continue;
+      }
+      for (let i = 0; i < limitedBucket.length; i += 1) {
+        for (let j = i + 1; j < limitedBucket.length; j += 1) {
+          const first = limitedBucket[i]!;
+          const second = limitedBucket[j]!;
+          const [left, right] =
+            first.id.localeCompare(second.id) <= 0 ? [first, second] : [second, first];
+          const pairKey = `${left.id}::${right.id}`;
+          if (seenPairs.has(pairKey)) {
+            continue;
+          }
+
+          if (!shouldConsiderPair(left, right)) {
+            continue;
+          }
+
+          seenPairs.add(pairKey);
+          const scored = scorePair(left, right, 'deterministic');
+
+          if (scored.score_total <= 0 && !options.embeddingScorer) {
+            continue;
+          }
+
+          preliminary.push(scored);
         }
-
-        if (!shouldConsiderPair(left, right)) {
-          continue;
-        }
-
-        seenPairs.add(pairKey);
-        const scored = scorePair(left, right, 'deterministic');
-
-        if (scored.score_total <= 0 && !options.embeddingScorer) {
-          continue;
-        }
-
-        preliminary.push(scored);
       }
     }
   }

--- a/packages/mama-core/src/entities/candidate-generator.ts
+++ b/packages/mama-core/src/entities/candidate-generator.ts
@@ -1,8 +1,9 @@
 import { EmbeddingUnavailableError } from './errors.js';
-import { extractStructuredIdentifiers } from './normalization.js';
+import { extractStructuredIdentifiers, normalizeEntityLabel } from './normalization.js';
 import type { EntityObservation, EntityResolutionCandidate } from './types.js';
 
 export const ENTITY_EMBEDDING_TOPN = 50;
+const CROSS_SCOPE_PROBE_MIN_EMBEDDING_SCORE = 0.84;
 
 export interface CandidateGeneratorOptions {
   embeddingScorer?: (left: EntityObservation, right: EntityObservation) => Promise<number>;
@@ -17,6 +18,7 @@ interface ScoredPair {
   score_context: number;
   score_graph: number;
   score_total: number;
+  probe_kind: 'deterministic' | 'cross_scope';
 }
 
 function tokenize(input: string): string[] {
@@ -73,6 +75,29 @@ function stringScore(left: EntityObservation, right: EntityObservation): number 
   return sharedPrefix ? 0.1 : 0;
 }
 
+function scorePair(
+  left: EntityObservation,
+  right: EntityObservation,
+  probeKind: ScoredPair['probe_kind']
+): ScoredPair {
+  const score_structural = structuralScore(left, right);
+  const score_string = stringScore(left, right);
+  const score_context = contextScore(left, right);
+  const score_graph = 0;
+  const score_total = score_structural + score_string + score_context + score_graph;
+
+  return {
+    left,
+    right,
+    score_structural,
+    score_string,
+    score_context,
+    score_graph,
+    score_total,
+    probe_kind: probeKind,
+  };
+}
+
 function shouldConsiderPair(left: EntityObservation, right: EntityObservation): boolean {
   if (
     left.entity_kind_hint &&
@@ -87,6 +112,30 @@ function shouldConsiderPair(left: EntityObservation, right: EntityObservation): 
   }
 
   if (left.scope_id !== right.scope_id) {
+    return false;
+  }
+
+  return true;
+}
+
+function shouldConsiderCrossScopeProbe(left: EntityObservation, right: EntityObservation): boolean {
+  if (
+    !left.entity_kind_hint ||
+    !right.entity_kind_hint ||
+    left.entity_kind_hint !== right.entity_kind_hint
+  ) {
+    return false;
+  }
+
+  if (left.observation_type !== right.observation_type) {
+    return false;
+  }
+
+  if (left.scope_kind !== right.scope_kind) {
+    return false;
+  }
+
+  if (left.scope_id === right.scope_id) {
     return false;
   }
 
@@ -119,6 +168,161 @@ function buildBlockKeys(observation: EntityObservation): string[] {
   return Array.from(keys);
 }
 
+function normalizeSurfaceForm(value: string): string {
+  if (value.trim().length === 0) {
+    return '';
+  }
+
+  return normalizeEntityLabel(value).normalized;
+}
+
+function sharedNormalizedRelatedCount(left: EntityObservation, right: EntityObservation): number {
+  const leftRelated = new Set(
+    left.related_surface_forms.map((value) => normalizeSurfaceForm(value))
+  );
+  const rightRelated = new Set(
+    right.related_surface_forms.map((value) => normalizeSurfaceForm(value))
+  );
+  if (leftRelated.size === 0 || rightRelated.size === 0) {
+    return 0;
+  }
+
+  let overlap = 0;
+  for (const related of leftRelated) {
+    if (rightRelated.has(related)) {
+      overlap += 1;
+    }
+  }
+  return overlap;
+}
+
+function getTimestampDistance(left: EntityObservation, right: EntityObservation): number {
+  if (left.timestamp_observed === null || right.timestamp_observed === null) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return Math.abs(left.timestamp_observed - right.timestamp_observed);
+}
+
+function buildPairKey(left: EntityObservation, right: EntityObservation): string {
+  return `${left.id}::${right.id}`;
+}
+
+function buildCrossLanguageFamilyKey(
+  left: EntityObservation,
+  right: EntityObservation
+): string | null {
+  if (!left.lang || !right.lang || left.lang === right.lang) {
+    return null;
+  }
+
+  const forms = [
+    `${left.lang}:${left.normalized_form}`,
+    `${right.lang}:${right.normalized_form}`,
+  ].sort();
+  const observationTypes = [left.observation_type, right.observation_type].sort();
+
+  return JSON.stringify([
+    left.entity_kind_hint ?? right.entity_kind_hint ?? 'unknown',
+    observationTypes,
+    forms,
+  ]);
+}
+
+function compareProbePairs(left: ScoredPair, right: ScoredPair): number {
+  const relatedDelta =
+    sharedNormalizedRelatedCount(right.left, right.right) -
+    sharedNormalizedRelatedCount(left.left, left.right);
+  if (relatedDelta !== 0) {
+    return relatedDelta;
+  }
+
+  if (right.score_total !== left.score_total) {
+    return right.score_total - left.score_total;
+  }
+
+  const timestampDelta =
+    getTimestampDistance(left.left, left.right) - getTimestampDistance(right.left, right.right);
+  if (timestampDelta !== 0) {
+    return timestampDelta;
+  }
+
+  return buildPairKey(left.left, left.right).localeCompare(buildPairKey(right.left, right.right));
+}
+
+function dedupeCrossLanguageFamilies(
+  candidates: EntityResolutionCandidate[],
+  observationLookup: Map<string, EntityObservation>
+): EntityResolutionCandidate[] {
+  const deduped: EntityResolutionCandidate[] = [];
+  const bestByFamily = new Map<string, EntityResolutionCandidate>();
+
+  for (const candidate of candidates) {
+    const left = observationLookup.get(candidate.left_ref);
+    const right = observationLookup.get(candidate.right_ref);
+    if (!left || !right) {
+      deduped.push(candidate);
+      continue;
+    }
+
+    const familyKey = buildCrossLanguageFamilyKey(left, right);
+    if (!familyKey) {
+      deduped.push(candidate);
+      continue;
+    }
+
+    const existing = bestByFamily.get(familyKey);
+    if (
+      !existing ||
+      candidate.score_total > existing.score_total ||
+      (candidate.score_total === existing.score_total &&
+        candidate.id.localeCompare(existing.id) < 0)
+    ) {
+      bestByFamily.set(familyKey, candidate);
+    }
+  }
+
+  return deduped.concat(Array.from(bestByFamily.values()));
+}
+
+function buildCrossScopeProbePairs(
+  observations: EntityObservation[],
+  seenPairs: Set<string>
+): ScoredPair[] {
+  const probes: ScoredPair[] = [];
+
+  for (let i = 0; i < observations.length; i += 1) {
+    for (let j = i + 1; j < observations.length; j += 1) {
+      const first = observations[i]!;
+      const second = observations[j]!;
+      const [left, right] =
+        first.id.localeCompare(second.id) <= 0 ? [first, second] : [second, first];
+      const pairKey = buildPairKey(left, right);
+      if (seenPairs.has(pairKey)) {
+        continue;
+      }
+      seenPairs.add(pairKey);
+
+      if (!shouldConsiderCrossScopeProbe(left, right)) {
+        continue;
+      }
+
+      probes.push(scorePair(left, right, 'cross_scope'));
+    }
+  }
+
+  probes.sort(compareProbePairs);
+  return probes;
+}
+
+function hasMultipleScopes(observations: EntityObservation[]): boolean {
+  const scopes = new Set(
+    observations.map(
+      (observation) => `${observation.scope_kind}:${observation.scope_id ?? 'global'}`
+    )
+  );
+  return scopes.size > 1;
+}
+
 export function dedupeObservationsBySource(observations: EntityObservation[]): EntityObservation[] {
   const seen = new Set<string>();
   const deduped: EntityObservation[] = [];
@@ -126,7 +330,7 @@ export function dedupeObservationsBySource(observations: EntityObservation[]): E
   for (const observation of observations) {
     const key = JSON.stringify([
       observation.source_connector,
-      observation.source_raw_db_ref ?? '',
+      observation.source_locator ?? '',
       observation.source_raw_record_id,
       observation.observation_type,
     ]);
@@ -145,6 +349,7 @@ export async function generateResolutionCandidates(
   options: CandidateGeneratorOptions = {}
 ): Promise<EntityResolutionCandidate[]> {
   const deduped = dedupeObservationsBySource(observations);
+  const observationLookup = new Map(deduped.map((observation) => [observation.id, observation]));
   const blockMap = new Map<string, EntityObservation[]>();
   for (const observation of deduped) {
     const keys = buildBlockKeys(observation);
@@ -178,35 +383,31 @@ export async function generateResolutionCandidates(
           continue;
         }
 
-        const score_structural = structuralScore(left, right);
-        const score_string = stringScore(left, right);
-        const score_context = contextScore(left, right);
-        const score_graph = 0;
-        const score_total = score_structural + score_string + score_context + score_graph;
+        const scored = scorePair(left, right, 'deterministic');
 
-        if (score_total <= 0 && !options.embeddingScorer) {
+        if (scored.score_total <= 0 && !options.embeddingScorer) {
           continue;
         }
 
-        preliminary.push({
-          left,
-          right,
-          score_structural,
-          score_string,
-          score_context,
-          score_graph,
-          score_total,
-        });
+        preliminary.push(scored);
       }
     }
   }
 
   preliminary.sort((left, right) => right.score_total - left.score_total);
 
-  const topN = preliminary.slice(0, options.topN ?? ENTITY_EMBEDDING_TOPN);
+  const topNLimit = options.topN ?? ENTITY_EMBEDDING_TOPN;
+  const topN = preliminary.slice(0, topNLimit);
+  topN.sort((left, right) => right.score_total - left.score_total);
+  const pairBudget = Math.ceil(topNLimit ** 2 / 2);
+  const crossScopeBudget = options.embeddingScorer ? Math.max(0, pairBudget - topN.length) : 0;
+  const crossScopePairs =
+    options.embeddingScorer && crossScopeBudget > 0 && hasMultipleScopes(deduped)
+      ? buildCrossScopeProbePairs(deduped, seenPairs).slice(0, crossScopeBudget)
+      : [];
   const candidates: EntityResolutionCandidate[] = [];
 
-  for (const item of topN) {
+  for (const item of [...topN, ...crossScopePairs]) {
     let score_embedding = 0;
     if (options.embeddingScorer) {
       try {
@@ -221,6 +422,18 @@ export async function generateResolutionCandidates(
       }
     }
 
+    const finalScore = item.score_total + score_embedding;
+    if (finalScore <= 0) {
+      continue;
+    }
+
+    if (
+      item.probe_kind === 'cross_scope' &&
+      score_embedding < CROSS_SCOPE_PROBE_MIN_EMBEDDING_SCORE
+    ) {
+      continue;
+    }
+
     const createdAt = Date.now();
     candidates.push({
       id: `candidate_${item.left.id}_${item.right.id}`,
@@ -228,7 +441,7 @@ export async function generateResolutionCandidates(
       left_ref: item.left.id,
       right_ref: item.right.id,
       status: 'pending',
-      score_total: item.score_total + score_embedding,
+      score_total: finalScore,
       score_structural: item.score_structural,
       score_string: item.score_string,
       score_context: item.score_context,
@@ -247,5 +460,16 @@ export async function generateResolutionCandidates(
     });
   }
 
-  return candidates;
+  const dedupedFamilies = options.embeddingScorer
+    ? dedupeCrossLanguageFamilies(candidates, observationLookup)
+    : candidates;
+
+  dedupedFamilies.sort((left, right) => {
+    if (right.score_total !== left.score_total) {
+      return right.score_total - left.score_total;
+    }
+    return left.id.localeCompare(right.id);
+  });
+
+  return dedupedFamilies.slice(0, topNLimit);
 }

--- a/packages/mama-core/src/entities/entity-impact.ts
+++ b/packages/mama-core/src/entities/entity-impact.ts
@@ -1,0 +1,233 @@
+import { getAdapter, initDB } from '../db-manager.js';
+import { detectSourceLocatorKind, type SourceLocatorKind } from './source-locator.js';
+import type { EntityIngestRun, EntityLineageLink, EntityNode } from './types.js';
+
+interface InspectorDetail {
+  entity: EntityNode;
+  history_incomplete: boolean;
+}
+
+interface InspectorLineageRow extends EntityLineageLink {
+  source_connector: string;
+  source_raw_record_id: string;
+  source_locator: string | null;
+  source_locator_kind: SourceLocatorKind;
+  surface_form: string;
+}
+
+interface InspectorLineageResult {
+  rows: InspectorLineageRow[];
+  history_incomplete: boolean;
+}
+
+interface ImpactMemoryRow {
+  id: string;
+  topic: string;
+  summary: string;
+  created_at: number;
+}
+
+interface ImpactAuditRunRow {
+  id: string;
+  classification: string | null;
+  status: string;
+  created_at: number;
+  completed_at: number | null;
+}
+
+interface EntityImpactResult {
+  related_memories: ImpactMemoryRow[];
+  ingest_runs: EntityIngestRun[];
+  audit_runs: ImpactAuditRunRow[];
+}
+
+function mapEntityNode(row: Record<string, unknown>): EntityNode {
+  return {
+    id: String(row.id),
+    kind: row.kind as EntityNode['kind'],
+    preferred_label: String(row.preferred_label),
+    status: row.status as EntityNode['status'],
+    scope_kind: row.scope_kind as EntityNode['scope_kind'],
+    scope_id: typeof row.scope_id === 'string' ? row.scope_id : null,
+    merged_into: typeof row.merged_into === 'string' ? row.merged_into : null,
+    created_at: Number(row.created_at),
+    updated_at: Number(row.updated_at),
+  };
+}
+
+function mapIngestRun(row: Record<string, unknown>): EntityIngestRun {
+  return {
+    id: String(row.id),
+    connector: String(row.connector),
+    run_kind: row.run_kind as EntityIngestRun['run_kind'],
+    status: row.status as EntityIngestRun['status'],
+    scope_key: String(row.scope_key),
+    source_window_start:
+      typeof row.source_window_start === 'number' ? row.source_window_start : null,
+    source_window_end: typeof row.source_window_end === 'number' ? row.source_window_end : null,
+    raw_count: Number(row.raw_count ?? 0),
+    observation_count: Number(row.observation_count ?? 0),
+    candidate_count: Number(row.candidate_count ?? 0),
+    reviewable_count: Number(row.reviewable_count ?? 0),
+    audit_run_id: typeof row.audit_run_id === 'string' ? row.audit_run_id : null,
+    audit_classification:
+      typeof row.audit_classification === 'string'
+        ? (row.audit_classification as EntityIngestRun['audit_classification'])
+        : null,
+    error_reason: typeof row.error_reason === 'string' ? row.error_reason : null,
+    created_at: Number(row.created_at),
+    completed_at: typeof row.completed_at === 'number' ? row.completed_at : null,
+  };
+}
+
+export async function getEntityInspectorDetail(entityId: string): Promise<InspectorDetail> {
+  await initDB();
+  const adapter = getAdapter();
+  const row = adapter.prepare(`SELECT * FROM entity_nodes WHERE id = ?`).get(entityId) as
+    | Record<string, unknown>
+    | undefined;
+  if (!row) {
+    throw new Error(`Entity not found: ${entityId}`);
+  }
+
+  const lineageCount = adapter
+    .prepare(
+      `
+        SELECT COUNT(*) AS total
+        FROM entity_lineage_links
+        WHERE canonical_entity_id = ?
+          AND status = 'active'
+      `
+    )
+    .get(entityId) as { total: number };
+
+  return {
+    entity: mapEntityNode(row),
+    history_incomplete: lineageCount.total === 0,
+  };
+}
+
+export async function listEntityLineageForInspector(
+  entityId: string,
+  limit = 50
+): Promise<InspectorLineageResult> {
+  await initDB();
+  const adapter = getAdapter();
+  const rows = adapter
+    .prepare(
+      `
+        SELECT
+          l.*,
+          o.source_connector,
+          o.source_raw_record_id,
+          o.source_locator,
+          o.surface_form
+        FROM entity_lineage_links l
+        JOIN entity_observations o ON o.id = l.entity_observation_id
+        WHERE l.canonical_entity_id = ?
+          AND l.status = 'active'
+        ORDER BY l.created_at ASC
+        LIMIT ?
+      `
+    )
+    .all(entityId, limit) as Array<Record<string, unknown>>;
+
+  return {
+    rows: rows.map((row) => ({
+      id: String(row.id),
+      canonical_entity_id: String(row.canonical_entity_id),
+      entity_observation_id: String(row.entity_observation_id),
+      source_entity_id: typeof row.source_entity_id === 'string' ? row.source_entity_id : null,
+      contribution_kind: row.contribution_kind as EntityLineageLink['contribution_kind'],
+      run_id: typeof row.run_id === 'string' ? row.run_id : null,
+      candidate_id: typeof row.candidate_id === 'string' ? row.candidate_id : null,
+      review_action_id: typeof row.review_action_id === 'string' ? row.review_action_id : null,
+      status: row.status as EntityLineageLink['status'],
+      capture_mode: row.capture_mode as EntityLineageLink['capture_mode'],
+      confidence: Number(row.confidence),
+      created_at: Number(row.created_at),
+      superseded_at: typeof row.superseded_at === 'number' ? row.superseded_at : null,
+      source_connector: String(row.source_connector),
+      source_raw_record_id: String(row.source_raw_record_id),
+      source_locator: typeof row.source_locator === 'string' ? row.source_locator : null,
+      source_locator_kind: detectSourceLocatorKind(
+        typeof row.source_locator === 'string' ? row.source_locator : null
+      ),
+      surface_form: String(row.surface_form),
+    })),
+    history_incomplete: rows.length === 0,
+  };
+}
+
+export async function getEntityImpact(entityId: string): Promise<EntityImpactResult> {
+  await initDB();
+  const adapter = getAdapter();
+
+  const relatedMemories = adapter
+    .prepare(
+      `
+        SELECT DISTINCT d.id, d.topic, d.summary, d.created_at
+        FROM entity_lineage_links l
+        JOIN decision_entity_sources des ON des.entity_observation_id = l.entity_observation_id
+        JOIN decisions d ON d.id = des.decision_id
+        WHERE l.canonical_entity_id = ?
+          AND l.status = 'active'
+        ORDER BY d.created_at DESC
+      `
+    )
+    .all(entityId) as Array<{
+    id: string;
+    topic: string;
+    summary: string | null;
+    created_at: number;
+  }>;
+
+  const ingestRuns = adapter
+    .prepare(
+      `
+        SELECT DISTINCT ir.*
+        FROM entity_lineage_links l
+        JOIN entity_ingest_runs ir ON ir.id = l.run_id
+        WHERE l.canonical_entity_id = ?
+        ORDER BY ir.created_at DESC
+      `
+    )
+    .all(entityId) as Array<Record<string, unknown>>;
+
+  const auditRuns = adapter
+    .prepare(
+      `
+        SELECT id, classification, status, created_at, completed_at
+        FROM entity_audit_runs
+        ORDER BY created_at DESC
+        LIMIT 10
+      `
+    )
+    .all() as Array<{
+    id: string;
+    classification: string | null;
+    status: string;
+    created_at: number;
+    completed_at: number | null;
+  }>;
+
+  return {
+    related_memories: relatedMemories.map((row) => ({
+      id: row.id,
+      topic: row.topic,
+      summary: row.summary ?? row.topic,
+      created_at: row.created_at,
+    })),
+    ingest_runs: ingestRuns.map(mapIngestRun),
+    audit_runs: auditRuns,
+  };
+}
+
+export async function getEntityIngestRun(runId: string): Promise<EntityIngestRun | null> {
+  await initDB();
+  const adapter = getAdapter();
+  const row = adapter.prepare(`SELECT * FROM entity_ingest_runs WHERE id = ?`).get(runId) as
+    | Record<string, unknown>
+    | undefined;
+  return row ? mapIngestRun(row) : null;
+}

--- a/packages/mama-core/src/entities/entity-impact.ts
+++ b/packages/mama-core/src/entities/entity-impact.ts
@@ -113,6 +113,7 @@ export async function listEntityLineageForInspector(
 ): Promise<InspectorLineageResult> {
   await initDB();
   const adapter = getAdapter();
+  const safeLimit = Math.max(1, Math.min(limit, 500));
   const rows = adapter
     .prepare(
       `
@@ -130,7 +131,7 @@ export async function listEntityLineageForInspector(
         LIMIT ?
       `
     )
-    .all(entityId, limit) as Array<Record<string, unknown>>;
+    .all(entityId, safeLimit) as Array<Record<string, unknown>>;
 
   return {
     rows: rows.map((row) => ({
@@ -189,6 +190,7 @@ export async function getEntityImpact(entityId: string): Promise<EntityImpactRes
         FROM entity_lineage_links l
         JOIN entity_ingest_runs ir ON ir.id = l.run_id
         WHERE l.canonical_entity_id = ?
+          AND l.status = 'active'
         ORDER BY ir.created_at DESC
       `
     )
@@ -202,6 +204,7 @@ export async function getEntityImpact(entityId: string): Promise<EntityImpactRes
         JOIN entity_ingest_runs ir ON ir.id = l.run_id
         JOIN entity_audit_runs ar ON ar.id = ir.audit_run_id
         WHERE l.canonical_entity_id = ?
+          AND l.status = 'active'
         ORDER BY ar.created_at DESC
         LIMIT 10
       `

--- a/packages/mama-core/src/entities/entity-impact.ts
+++ b/packages/mama-core/src/entities/entity-impact.ts
@@ -197,13 +197,16 @@ export async function getEntityImpact(entityId: string): Promise<EntityImpactRes
   const auditRuns = adapter
     .prepare(
       `
-        SELECT id, classification, status, created_at, completed_at
-        FROM entity_audit_runs
-        ORDER BY created_at DESC
+        SELECT DISTINCT ar.id, ar.classification, ar.status, ar.created_at, ar.completed_at
+        FROM entity_lineage_links l
+        JOIN entity_ingest_runs ir ON ir.id = l.run_id
+        JOIN entity_audit_runs ar ON ar.id = ir.audit_run_id
+        WHERE l.canonical_entity_id = ?
+        ORDER BY ar.created_at DESC
         LIMIT 10
       `
     )
-    .all() as Array<{
+    .all(entityId) as Array<{
     id: string;
     classification: string | null;
     status: string;

--- a/packages/mama-core/src/entities/entity-impact.ts
+++ b/packages/mama-core/src/entities/entity-impact.ts
@@ -1,5 +1,6 @@
 import { getAdapter, initDB } from '../db-manager.js';
 import { detectSourceLocatorKind, type SourceLocatorKind } from './source-locator.js';
+import { parseEntityIngestRunRow } from './lineage-store.js';
 import type { EntityIngestRun, EntityLineageLink, EntityNode } from './types.js';
 
 interface InspectorDetail {
@@ -47,36 +48,12 @@ function mapEntityNode(row: Record<string, unknown>): EntityNode {
     kind: row.kind as EntityNode['kind'],
     preferred_label: String(row.preferred_label),
     status: row.status as EntityNode['status'],
-    scope_kind: row.scope_kind as EntityNode['scope_kind'],
+    scope_kind:
+      typeof row.scope_kind === 'string' ? (row.scope_kind as EntityNode['scope_kind']) : null,
     scope_id: typeof row.scope_id === 'string' ? row.scope_id : null,
     merged_into: typeof row.merged_into === 'string' ? row.merged_into : null,
     created_at: Number(row.created_at),
     updated_at: Number(row.updated_at),
-  };
-}
-
-function mapIngestRun(row: Record<string, unknown>): EntityIngestRun {
-  return {
-    id: String(row.id),
-    connector: String(row.connector),
-    run_kind: row.run_kind as EntityIngestRun['run_kind'],
-    status: row.status as EntityIngestRun['status'],
-    scope_key: String(row.scope_key),
-    source_window_start:
-      typeof row.source_window_start === 'number' ? row.source_window_start : null,
-    source_window_end: typeof row.source_window_end === 'number' ? row.source_window_end : null,
-    raw_count: Number(row.raw_count ?? 0),
-    observation_count: Number(row.observation_count ?? 0),
-    candidate_count: Number(row.candidate_count ?? 0),
-    reviewable_count: Number(row.reviewable_count ?? 0),
-    audit_run_id: typeof row.audit_run_id === 'string' ? row.audit_run_id : null,
-    audit_classification:
-      typeof row.audit_classification === 'string'
-        ? (row.audit_classification as EntityIngestRun['audit_classification'])
-        : null,
-    error_reason: typeof row.error_reason === 'string' ? row.error_reason : null,
-    created_at: Number(row.created_at),
-    completed_at: typeof row.completed_at === 'number' ? row.completed_at : null,
   };
 }
 
@@ -224,7 +201,7 @@ export async function getEntityImpact(entityId: string): Promise<EntityImpactRes
       summary: row.summary ?? row.topic,
       created_at: row.created_at,
     })),
-    ingest_runs: ingestRuns.map(mapIngestRun),
+    ingest_runs: ingestRuns.map(parseEntityIngestRunRow),
     audit_runs: auditRuns,
   };
 }
@@ -235,5 +212,5 @@ export async function getEntityIngestRun(runId: string): Promise<EntityIngestRun
   const row = adapter.prepare(`SELECT * FROM entity_ingest_runs WHERE id = ?`).get(runId) as
     | Record<string, unknown>
     | undefined;
-  return row ? mapIngestRun(row) : null;
+  return row ? parseEntityIngestRunRow(row) : null;
 }

--- a/packages/mama-core/src/entities/entity-linked-decision-counts.js
+++ b/packages/mama-core/src/entities/entity-linked-decision-counts.js
@@ -1,0 +1,31 @@
+export function loadLinkedDecisionCounts(adapter, entityIds) {
+  const uniqueIds = Array.from(
+    new Set(entityIds.filter((entityId) => typeof entityId === 'string' && entityId.length > 0))
+  );
+  if (uniqueIds.length === 0) {
+    return new Map();
+  }
+
+  const placeholders = uniqueIds.map(() => '?').join(', ');
+  const rows = adapter
+    .prepare(
+      `
+        SELECT
+          l.canonical_entity_id AS entity_id,
+          COUNT(DISTINCT des.decision_id) AS linked_decision_count
+        FROM entity_lineage_links l
+        INNER JOIN decision_entity_sources des
+          ON des.entity_observation_id = l.entity_observation_id
+        WHERE l.status = 'active'
+          AND l.canonical_entity_id IN (${placeholders})
+        GROUP BY l.canonical_entity_id
+      `
+    )
+    .all(...uniqueIds);
+
+  const counts = new Map(uniqueIds.map((entityId) => [entityId, 0]));
+  for (const row of rows) {
+    counts.set(row.entity_id, Number(row.linked_decision_count) || 0);
+  }
+  return counts;
+}

--- a/packages/mama-core/src/entities/entity-list.ts
+++ b/packages/mama-core/src/entities/entity-list.ts
@@ -1,0 +1,138 @@
+import { getAdapter, initDB } from '../db-manager.js';
+import { loadLinkedDecisionCounts } from './entity-linked-decision-counts.js';
+import type { EntityNode } from './types.js';
+
+export interface ListCanonicalEntitiesInput {
+  limit: number;
+  cursor?: string | null;
+  include_noisy?: boolean;
+}
+
+export interface CanonicalEntityListRow {
+  id: string;
+  kind: EntityNode['kind'];
+  preferred_label: string;
+  scope_kind: EntityNode['scope_kind'];
+  scope_id: string | null;
+  created_at: number;
+  linked_decision_count: number;
+}
+
+type CanonicalEntityListBaseRow = Omit<CanonicalEntityListRow, 'linked_decision_count'>;
+
+export interface ListCanonicalEntitiesResult {
+  entities: CanonicalEntityListRow[];
+  next_cursor: string | null;
+  total_count: number;
+  visible_count: number;
+}
+
+function normalizeBrowseLabel(input: string): string {
+  return input.normalize('NFKC').trim().replace(/\s+/gu, ' ').toLowerCase();
+}
+
+function buildBrowseCollapseKey(row: CanonicalEntityListBaseRow): string {
+  return JSON.stringify([
+    row.kind,
+    row.scope_kind,
+    row.scope_id ?? '',
+    normalizeBrowseLabel(row.preferred_label),
+  ]);
+}
+
+function compareCanonicalRows(
+  left: CanonicalEntityListBaseRow,
+  right: CanonicalEntityListBaseRow
+): number {
+  if (right.created_at !== left.created_at) {
+    return right.created_at - left.created_at;
+  }
+  const labelCompare = left.preferred_label.localeCompare(right.preferred_label);
+  if (labelCompare !== 0) {
+    return labelCompare;
+  }
+  return left.id.localeCompare(right.id);
+}
+
+function decodeCursor(cursor: string | null | undefined): number {
+  if (!cursor) {
+    return 0;
+  }
+  try {
+    const decoded = Number(Buffer.from(cursor, 'base64').toString('utf8'));
+    return Number.isFinite(decoded) && decoded >= 0 ? decoded : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function encodeCursor(offset: number): string {
+  return Buffer.from(String(offset), 'utf8').toString('base64');
+}
+
+function isNoisyCanonicalEntity(row: CanonicalEntityListBaseRow): boolean {
+  const label = row.preferred_label.trim().toLowerCase();
+  if (row.kind === 'person') {
+    return label === 'user' || label === 'claude';
+  }
+  if (row.kind === 'project') {
+    return label === 'workspace';
+  }
+  return false;
+}
+
+export async function listCanonicalEntities(
+  input: ListCanonicalEntitiesInput
+): Promise<ListCanonicalEntitiesResult> {
+  await initDB();
+  const adapter = getAdapter();
+  const rows = adapter
+    .prepare(
+      `
+        SELECT id, kind, preferred_label, scope_kind, scope_id, created_at
+        FROM entity_nodes
+        WHERE status = 'active'
+          AND merged_into IS NULL
+      `
+    )
+    .all() as CanonicalEntityListBaseRow[];
+
+  const sorted = rows.sort(compareCanonicalRows);
+  const collapsedByKey = new Map<string, CanonicalEntityListBaseRow>();
+  for (const row of sorted) {
+    const key = buildBrowseCollapseKey(row);
+    const existing = collapsedByKey.get(key);
+    if (!existing) {
+      collapsedByKey.set(key, row);
+      continue;
+    }
+    if (
+      row.created_at < existing.created_at ||
+      (row.created_at === existing.created_at && row.id.localeCompare(existing.id) < 0)
+    ) {
+      collapsedByKey.set(key, row);
+    }
+  }
+  const collapsed = Array.from(collapsedByKey.values()).sort(compareCanonicalRows);
+
+  const totalCount = sorted.length;
+  const visibleBase =
+    input.include_noisy === false ? collapsed.filter((row) => !isNoisyCanonicalEntity(row)) : collapsed;
+  const linkedCounts = loadLinkedDecisionCounts(adapter, visibleBase.map((row) => row.id));
+  const visible = visibleBase.map((row) => ({
+    ...row,
+    linked_decision_count: linkedCounts.get(row.id) ?? 0,
+  }));
+  const visibleCount = visible.length;
+  const offset = decodeCursor(input.cursor);
+  const limit = Math.max(1, input.limit);
+  const entities = visible.slice(offset, offset + limit);
+  const nextCursor = offset + limit < visible.length ? encodeCursor(offset + limit) : null;
+
+  return {
+    entities,
+    next_cursor: nextCursor,
+    total_count: totalCount,
+    visible_count: visibleCount,
+  };
+}

--- a/packages/mama-core/src/entities/entity-list.ts
+++ b/packages/mama-core/src/entities/entity-list.ts
@@ -120,19 +120,19 @@ export async function listCanonicalEntities(
     input.include_noisy === false
       ? collapsed.filter((row) => !isNoisyCanonicalEntity(row))
       : collapsed;
+  const offset = decodeCursor(input.cursor);
+  const limit = Math.max(1, input.limit);
+  const page = visibleBase.slice(offset, offset + limit);
   const linkedCounts = loadLinkedDecisionCounts(
     adapter,
-    visibleBase.map((row) => row.id)
+    page.map((row) => row.id)
   );
-  const visible = visibleBase.map((row) => ({
+  const entities = page.map((row) => ({
     ...row,
     linked_decision_count: linkedCounts.get(row.id) ?? 0,
   }));
-  const visibleCount = visible.length;
-  const offset = decodeCursor(input.cursor);
-  const limit = Math.max(1, input.limit);
-  const entities = visible.slice(offset, offset + limit);
-  const nextCursor = offset + limit < visible.length ? encodeCursor(offset + limit) : null;
+  const visibleCount = visibleBase.length;
+  const nextCursor = offset + limit < visibleBase.length ? encodeCursor(offset + limit) : null;
 
   return {
     entities,

--- a/packages/mama-core/src/entities/entity-list.ts
+++ b/packages/mama-core/src/entities/entity-list.ts
@@ -107,7 +107,7 @@ export async function listCanonicalEntities(
       continue;
     }
     if (
-      row.created_at < existing.created_at ||
+      row.created_at > existing.created_at ||
       (row.created_at === existing.created_at && row.id.localeCompare(existing.id) < 0)
     ) {
       collapsedByKey.set(key, row);
@@ -117,8 +117,13 @@ export async function listCanonicalEntities(
 
   const totalCount = sorted.length;
   const visibleBase =
-    input.include_noisy === false ? collapsed.filter((row) => !isNoisyCanonicalEntity(row)) : collapsed;
-  const linkedCounts = loadLinkedDecisionCounts(adapter, visibleBase.map((row) => row.id));
+    input.include_noisy === false
+      ? collapsed.filter((row) => !isNoisyCanonicalEntity(row))
+      : collapsed;
+  const linkedCounts = loadLinkedDecisionCounts(
+    adapter,
+    visibleBase.map((row) => row.id)
+  );
   const visible = visibleBase.map((row) => ({
     ...row,
     linked_decision_count: linkedCounts.get(row.id) ?? 0,

--- a/packages/mama-core/src/entities/entity-orphan-list.ts
+++ b/packages/mama-core/src/entities/entity-orphan-list.ts
@@ -1,0 +1,151 @@
+import { getAdapter } from '../db-manager.js';
+import { loadLinkedDecisionCounts } from './entity-linked-decision-counts.js';
+import type { EntityNode } from './types.js';
+
+export interface CanonicalEntityOrphanRow {
+  entity_id: string;
+  title: string;
+  kind: EntityNode['kind'];
+  scope_kind: EntityNode['scope_kind'];
+  scope_id: string | null;
+  scope_label: string;
+  created_at: number;
+  linked_decision_count: number;
+  evidence_summary: {
+    lineage_rows: number;
+    raw_evidence_rows: number;
+    last_seen_at: number | null;
+  };
+}
+
+interface ReadAdapter {
+  prepare(sql: string): {
+    all: (...params: unknown[]) => unknown[];
+  };
+}
+
+function buildScopeLabel(
+  scopeKind: EntityNode['scope_kind'],
+  scopeId: string | null | undefined
+): string {
+  return scopeKind ? `${scopeKind}:${scopeId ?? ''}` : 'global';
+}
+
+function isNoisyCanonicalEntity(row: Pick<CanonicalEntityOrphanRow, 'kind' | 'title'>): boolean {
+  const label = row.title.trim().toLowerCase();
+  if (row.kind === 'person') {
+    return label === 'user' || label === 'claude';
+  }
+  if (row.kind === 'project') {
+    return label === 'workspace';
+  }
+  return false;
+}
+
+function compareOrphanRows(
+  left: CanonicalEntityOrphanRow,
+  right: CanonicalEntityOrphanRow
+): number {
+  const leftSeen =
+    typeof left.evidence_summary.last_seen_at === 'number' ? left.evidence_summary.last_seen_at : 0;
+  const rightSeen =
+    typeof right.evidence_summary.last_seen_at === 'number'
+      ? right.evidence_summary.last_seen_at
+      : 0;
+  if (rightSeen !== leftSeen) {
+    return rightSeen - leftSeen;
+  }
+  return left.entity_id.localeCompare(right.entity_id);
+}
+
+export function listCanonicalEntityOrphans(
+  adapter: ReadAdapter = getAdapter() as never,
+  options: { min_age_ms?: number | null } = {}
+): CanonicalEntityOrphanRow[] {
+  const minAgeMs =
+    typeof options.min_age_ms === 'number' && Number.isFinite(options.min_age_ms)
+      ? Math.max(0, options.min_age_ms)
+      : 0;
+  const minCreatedAt = Date.now() - minAgeMs;
+
+  const rows = adapter
+    .prepare(
+      `
+        SELECT
+          n.id AS entity_id,
+          n.kind AS kind,
+          n.preferred_label AS title,
+          n.scope_kind AS scope_kind,
+          n.scope_id AS scope_id,
+          n.created_at AS created_at,
+          COUNT(DISTINCT l.entity_observation_id) AS lineage_rows,
+          COUNT(
+            DISTINCT CASE
+              WHEN COALESCE(o.source_raw_record_id, '') <> '' THEN l.entity_observation_id
+              ELSE NULL
+            END
+          ) AS raw_evidence_rows,
+          MAX(COALESCE(o.timestamp_observed, o.created_at)) AS last_seen_at
+        FROM entity_nodes n
+        INNER JOIN entity_lineage_links l
+          ON l.canonical_entity_id = n.id
+         AND l.status = 'active'
+        INNER JOIN entity_observations o
+          ON o.id = l.entity_observation_id
+        WHERE n.status = 'active'
+          AND n.merged_into IS NULL
+          AND n.created_at <= ?
+        GROUP BY n.id, n.kind, n.preferred_label, n.scope_kind, n.scope_id, n.created_at
+      `
+    )
+    .all(minCreatedAt) as Array<{
+    entity_id: string;
+    title: string;
+    kind: EntityNode['kind'];
+    scope_kind: EntityNode['scope_kind'];
+    scope_id: string | null;
+    created_at: number;
+    lineage_rows: number;
+    raw_evidence_rows: number;
+    last_seen_at: number | null;
+  }>;
+
+  const orphanRows = rows.map(
+    (row): CanonicalEntityOrphanRow => ({
+      entity_id: row.entity_id,
+      title: row.title,
+      kind: row.kind,
+      scope_kind: row.scope_kind,
+      scope_id: row.scope_id,
+      scope_label: buildScopeLabel(row.scope_kind, row.scope_id),
+      created_at: Number(row.created_at),
+      linked_decision_count: 0,
+      evidence_summary: {
+        lineage_rows: Number(row.lineage_rows ?? 0),
+        raw_evidence_rows: Number(row.raw_evidence_rows ?? 0),
+        last_seen_at:
+          row.last_seen_at === null || row.last_seen_at === undefined
+            ? null
+            : Number(row.last_seen_at),
+      },
+    })
+  );
+
+  const linkedCounts = loadLinkedDecisionCounts(
+    adapter as never,
+    orphanRows.map((row) => row.entity_id)
+  );
+
+  return orphanRows
+    .map((row) => ({
+      ...row,
+      linked_decision_count: linkedCounts.get(row.entity_id) ?? 0,
+    }))
+    .filter(
+      (row) =>
+        row.evidence_summary.lineage_rows > 0 &&
+        row.linked_decision_count === 0 &&
+        !isNoisyCanonicalEntity(row)
+    )
+    .sort(compareOrphanRows);
+}

--- a/packages/mama-core/src/entities/entity-search.ts
+++ b/packages/mama-core/src/entities/entity-search.ts
@@ -3,13 +3,13 @@ import { loadLinkedDecisionCounts } from './entity-linked-decision-counts.js';
 import { EntityMergeError, resolveCanonicalEntityId } from './store.js';
 import type { EntityNode } from './types.js';
 
-interface SearchCanonicalEntitiesInput {
+export interface SearchCanonicalEntitiesInput {
   query: string;
   limit: number;
   cursor?: string | null;
 }
 
-interface EntitySearchRow {
+export interface EntitySearchRow {
   id: string;
   kind: EntityNode['kind'];
   preferred_label: string;
@@ -19,7 +19,7 @@ interface EntitySearchRow {
   linked_decision_count: number;
 }
 
-interface SearchCanonicalEntitiesResult {
+export interface SearchCanonicalEntitiesResult {
   entities: EntitySearchRow[];
   next_cursor: string | null;
 }
@@ -68,6 +68,7 @@ export async function searchCanonicalEntities(
   }
 
   const escaped = escapeLikeQuery(query);
+  const normalizedQuery = normalizeSearchLabel(query);
   const rows = adapter
     .prepare(
       `
@@ -100,46 +101,65 @@ export async function searchCanonicalEntities(
     observation_surface_form: string | null;
   }>;
 
-  const canonicalRows = new Map<string, EntitySearchRow>();
-  for (const row of rows) {
-    let canonicalId: string;
+  const canonicalIdByMatchedId = new Map<string, string>();
+  for (const matchedId of new Set(rows.map((row) => row.matched_id))) {
     try {
-      canonicalId = resolveCanonicalEntityId(adapter, row.matched_id);
+      canonicalIdByMatchedId.set(matchedId, resolveCanonicalEntityId(adapter, matchedId));
     } catch (error) {
       if (error instanceof EntityMergeError) {
         continue;
       }
       throw error;
     }
+  }
 
-    const canonical = adapter
+  const canonicalIds = Array.from(new Set(canonicalIdByMatchedId.values()));
+  const canonicalLookup = new Map<
+    string,
+    {
+      id: string;
+      kind: EntityNode['kind'];
+      preferred_label: string;
+      scope_kind: EntityNode['scope_kind'];
+      scope_id: string | null;
+    }
+  >();
+  if (canonicalIds.length > 0) {
+    const fetched = adapter
       .prepare(
         `
           SELECT id, kind, preferred_label, scope_kind, scope_id
           FROM entity_nodes
-          WHERE id = ?
+          WHERE id IN (${canonicalIds.map(() => '?').join(', ')})
             AND status = 'active'
             AND merged_into IS NULL
         `
       )
-      .get(canonicalId) as
-      | {
-          id: string;
-          kind: EntityNode['kind'];
-          preferred_label: string;
-          scope_kind: EntityNode['scope_kind'];
-          scope_id: string | null;
-        }
-      | undefined;
+      .all(...canonicalIds) as Array<{
+      id: string;
+      kind: EntityNode['kind'];
+      preferred_label: string;
+      scope_kind: EntityNode['scope_kind'];
+      scope_id: string | null;
+    }>;
+    for (const row of fetched) {
+      canonicalLookup.set(row.id, row);
+    }
+  }
+
+  const canonicalRows = new Map<string, EntitySearchRow>();
+  for (const row of rows) {
+    const canonicalId = canonicalIdByMatchedId.get(row.matched_id);
+    const canonical = canonicalId ? canonicalLookup.get(canonicalId) : undefined;
     if (!canonical) {
       continue;
     }
 
-    const score = row.preferred_label.toLowerCase().includes(query.toLowerCase())
+    const score = normalizeSearchLabel(row.preferred_label).includes(normalizedQuery)
       ? 3
-      : row.alias_label?.toLowerCase().includes(query.toLowerCase())
+      : row.alias_label && normalizeSearchLabel(row.alias_label).includes(normalizedQuery)
         ? 2
-        : 1;
+      : 1;
     const existing = canonicalRows.get(canonical.id);
     if (!existing || score > existing.score) {
       canonicalRows.set(canonical.id, {

--- a/packages/mama-core/src/entities/entity-search.ts
+++ b/packages/mama-core/src/entities/entity-search.ts
@@ -1,0 +1,194 @@
+import { getAdapter, initDB } from '../db-manager.js';
+import { loadLinkedDecisionCounts } from './entity-linked-decision-counts.js';
+import { EntityMergeError, resolveCanonicalEntityId } from './store.js';
+import type { EntityNode } from './types.js';
+
+interface SearchCanonicalEntitiesInput {
+  query: string;
+  limit: number;
+  cursor?: string | null;
+}
+
+interface EntitySearchRow {
+  id: string;
+  kind: EntityNode['kind'];
+  preferred_label: string;
+  scope_kind: EntityNode['scope_kind'];
+  scope_id: string | null;
+  score: number;
+  linked_decision_count: number;
+}
+
+interface SearchCanonicalEntitiesResult {
+  entities: EntitySearchRow[];
+  next_cursor: string | null;
+}
+
+function normalizeSearchLabel(input: string): string {
+  return input.normalize('NFKC').trim().replace(/\s+/gu, ' ').toLowerCase();
+}
+
+function buildSearchCollapseKey(row: EntitySearchRow): string {
+  return JSON.stringify([
+    row.kind,
+    row.scope_kind,
+    row.scope_id ?? '',
+    normalizeSearchLabel(row.preferred_label),
+  ]);
+}
+
+function escapeLikeQuery(query: string): string {
+  return query.replace(/[\\%_]/g, '\\$&');
+}
+
+function decodeCursor(cursor: string | null | undefined): number {
+  if (!cursor) {
+    return 0;
+  }
+  try {
+    const decoded = Number(Buffer.from(cursor, 'base64').toString('utf8'));
+    return Number.isFinite(decoded) && decoded >= 0 ? decoded : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function encodeCursor(offset: number): string {
+  return Buffer.from(String(offset), 'utf8').toString('base64');
+}
+
+export async function searchCanonicalEntities(
+  input: SearchCanonicalEntitiesInput
+): Promise<SearchCanonicalEntitiesResult> {
+  await initDB();
+  const adapter = getAdapter();
+  const query = input.query.trim();
+  if (!query) {
+    return { entities: [], next_cursor: null };
+  }
+
+  const escaped = escapeLikeQuery(query);
+  const rows = adapter
+    .prepare(
+      `
+        SELECT
+          n.id AS matched_id,
+          n.preferred_label,
+          n.kind,
+          n.scope_kind,
+          n.scope_id,
+          a.label AS alias_label,
+          o.surface_form AS observation_surface_form
+        FROM entity_nodes n
+        LEFT JOIN entity_aliases a ON a.entity_id = n.id
+        LEFT JOIN entity_lineage_links l ON l.canonical_entity_id = n.id AND l.status = 'active'
+        LEFT JOIN entity_observations o ON o.id = l.entity_observation_id
+        WHERE (
+          lower(n.preferred_label) LIKE '%' || lower(?) || '%' ESCAPE '\\'
+          OR lower(COALESCE(a.label, '')) LIKE '%' || lower(?) || '%' ESCAPE '\\'
+          OR lower(COALESCE(o.surface_form, '')) LIKE '%' || lower(?) || '%' ESCAPE '\\'
+        )
+      `
+    )
+    .all(escaped, escaped, escaped) as Array<{
+    matched_id: string;
+    preferred_label: string;
+    kind: EntityNode['kind'];
+    scope_kind: EntityNode['scope_kind'];
+    scope_id: string | null;
+    alias_label: string | null;
+    observation_surface_form: string | null;
+  }>;
+
+  const canonicalRows = new Map<string, EntitySearchRow>();
+  for (const row of rows) {
+    let canonicalId: string;
+    try {
+      canonicalId = resolveCanonicalEntityId(adapter, row.matched_id);
+    } catch (error) {
+      if (error instanceof EntityMergeError) {
+        continue;
+      }
+      throw error;
+    }
+
+    const canonical = adapter
+      .prepare(
+        `
+          SELECT id, kind, preferred_label, scope_kind, scope_id
+          FROM entity_nodes
+          WHERE id = ?
+            AND status = 'active'
+            AND merged_into IS NULL
+        `
+      )
+      .get(canonicalId) as
+      | {
+          id: string;
+          kind: EntityNode['kind'];
+          preferred_label: string;
+          scope_kind: EntityNode['scope_kind'];
+          scope_id: string | null;
+        }
+      | undefined;
+    if (!canonical) {
+      continue;
+    }
+
+    const score = row.preferred_label.toLowerCase().includes(query.toLowerCase())
+      ? 3
+      : row.alias_label?.toLowerCase().includes(query.toLowerCase())
+        ? 2
+        : 1;
+    const existing = canonicalRows.get(canonical.id);
+    if (!existing || score > existing.score) {
+      canonicalRows.set(canonical.id, {
+        id: canonical.id,
+        kind: canonical.kind,
+        preferred_label: canonical.preferred_label,
+        scope_kind: canonical.scope_kind,
+        scope_id: canonical.scope_id,
+        score,
+        linked_decision_count: 0,
+      });
+    }
+  }
+
+  const collapsedRows = new Map<string, EntitySearchRow>();
+  for (const row of canonicalRows.values()) {
+    const key = buildSearchCollapseKey(row);
+    const existing = collapsedRows.get(key);
+    if (
+      !existing ||
+      row.score > existing.score ||
+      (row.score === existing.score && row.id.localeCompare(existing.id) < 0)
+    ) {
+      collapsedRows.set(key, row);
+    }
+  }
+
+  const sorted = Array.from(collapsedRows.values()).sort((left, right) => {
+    if (right.score !== left.score) {
+      return right.score - left.score;
+    }
+    const labelCompare = left.preferred_label.localeCompare(right.preferred_label);
+    if (labelCompare !== 0) {
+      return labelCompare;
+    }
+    return left.id.localeCompare(right.id);
+  });
+
+  const offset = decodeCursor(input.cursor);
+  const limit = Math.max(1, input.limit);
+  const linkedCounts = loadLinkedDecisionCounts(
+    adapter,
+    sorted.map((row) => row.id)
+  );
+  const entities = sorted.slice(offset, offset + limit).map((row) => ({
+    ...row,
+    linked_decision_count: linkedCounts.get(row.id) ?? 0,
+  }));
+  const next_cursor = offset + limit < sorted.length ? encodeCursor(offset + limit) : null;
+
+  return { entities, next_cursor };
+}

--- a/packages/mama-core/src/entities/entity-search.ts
+++ b/packages/mama-core/src/entities/entity-search.ts
@@ -180,11 +180,12 @@ export async function searchCanonicalEntities(
 
   const offset = decodeCursor(input.cursor);
   const limit = Math.max(1, input.limit);
+  const page = sorted.slice(offset, offset + limit);
   const linkedCounts = loadLinkedDecisionCounts(
     adapter,
-    sorted.map((row) => row.id)
+    page.map((row) => row.id)
   );
-  const entities = sorted.slice(offset, offset + limit).map((row) => ({
+  const entities = page.map((row) => ({
     ...row,
     linked_decision_count: linkedCounts.get(row.id) ?? 0,
   }));

--- a/packages/mama-core/src/entities/errors.ts
+++ b/packages/mama-core/src/entities/errors.ts
@@ -126,3 +126,16 @@ export class AuditRunInProgressError extends EntityError {
     });
   }
 }
+
+export class CaseMergeChainCycleError extends EntityError {
+  readonly code = 'case.merge_chain_cycle';
+  readonly doc_section = '#case-merge-chain-cycle';
+
+  constructor(context: { case_id: string; chain: string[]; detected_at_depth: number }) {
+    super({
+      message: `Case merge chain cycle detected at depth ${context.detected_at_depth} starting from case_id=${context.case_id}. Chain=${context.chain.join(' -> ')}.`,
+      context,
+      hint: 'Inspect case_truth.canonical_case_id links and remove the cycle before retrying.',
+    });
+  }
+}

--- a/packages/mama-core/src/entities/exact-merge-backfill.ts
+++ b/packages/mama-core/src/entities/exact-merge-backfill.ts
@@ -76,11 +76,23 @@ export async function backfillExactDuplicateCanonicals(
   const rows = adapter
     .prepare(
       `
-        SELECT n.id, n.kind, n.preferred_label, n.scope_kind, n.scope_id, n.created_at, o.normalized_form
+        SELECT
+          n.id,
+          n.kind,
+          n.preferred_label,
+          n.scope_kind,
+          n.scope_id,
+          n.created_at,
+          MIN(o.normalized_form) AS normalized_form
         FROM entity_nodes n
-        LEFT JOIN entity_observations o ON o.id = n.id
+        LEFT JOIN entity_lineage_links l
+          ON l.canonical_entity_id = n.id
+         AND l.status = 'active'
+        LEFT JOIN entity_observations o
+          ON o.id = l.entity_observation_id
         WHERE n.status = 'active'
           AND n.merged_into IS NULL
+        GROUP BY n.id, n.kind, n.preferred_label, n.scope_kind, n.scope_id, n.created_at
       `
     )
     .all() as ExactDuplicateRow[];

--- a/packages/mama-core/src/entities/exact-merge-backfill.ts
+++ b/packages/mama-core/src/entities/exact-merge-backfill.ts
@@ -54,6 +54,14 @@ function compareRows(left: ExactDuplicateRow, right: ExactDuplicateRow): number 
   return left.id.localeCompare(right.id);
 }
 
+function runAdapterTransaction<T>(
+  adapter: { transaction: <U>(fn: () => U) => U | (() => U) },
+  fn: () => T
+): T {
+  const result = adapter.transaction(fn);
+  return typeof result === 'function' ? (result as () => T)() : result;
+}
+
 export async function backfillExactDuplicateCanonicals(
   opts: ExactMergeBackfillOptions = {}
 ): Promise<ExactMergeBackfillResult> {
@@ -121,7 +129,7 @@ export async function backfillExactDuplicateCanonicals(
 
     try {
       if ('transaction' in adapter && typeof adapter.transaction === 'function') {
-        adapter.transaction(() => {
+        runAdapterTransaction(adapter, () => {
           for (const source of sources) {
             const mergeResult = mergeEntityNodes({
               adapter,

--- a/packages/mama-core/src/entities/exact-merge-backfill.ts
+++ b/packages/mama-core/src/entities/exact-merge-backfill.ts
@@ -1,6 +1,6 @@
 import { getAdapter, initDB } from '../db-manager.js';
 import { EntityMergeError, mergeEntityNodes } from './store.js';
-import { adoptLineageAfterMerge } from './lineage-store.js';
+import { adoptLineageAfterMergeSync } from './lineage-store.js';
 import type { EntityNode } from './types.js';
 
 export interface ExactMergeBackfillOptions {
@@ -158,7 +158,7 @@ export async function backfillExactDuplicateCanonicals(
                 target_id: target.id,
               }),
             });
-            adoptLineageAfterMerge({
+            adoptLineageAfterMergeSync({
               adapter,
               source_entity_id: source.id,
               target_entity_id: target.id,
@@ -184,7 +184,7 @@ export async function backfillExactDuplicateCanonicals(
               target_id: target.id,
             }),
           });
-          adoptLineageAfterMerge({
+          adoptLineageAfterMergeSync({
             adapter,
             source_entity_id: source.id,
             target_entity_id: target.id,

--- a/packages/mama-core/src/entities/exact-merge-backfill.ts
+++ b/packages/mama-core/src/entities/exact-merge-backfill.ts
@@ -1,0 +1,192 @@
+import { getAdapter, initDB } from '../db-manager.js';
+import { EntityMergeError, mergeEntityNodes } from './store.js';
+import { adoptLineageAfterMerge } from './lineage-store.js';
+import type { EntityNode } from './types.js';
+
+export interface ExactMergeBackfillOptions {
+  dryRun?: boolean;
+}
+
+export interface ExactMergeBackfillResult {
+  groups: number;
+  merged: number;
+  incomplete: number;
+  skipped: number;
+}
+
+interface ExactDuplicateRow {
+  id: string;
+  kind: EntityNode['kind'];
+  preferred_label: string;
+  scope_kind: EntityNode['scope_kind'];
+  scope_id: string | null;
+  created_at: number;
+  normalized_form: string | null;
+}
+
+function normalizeExactLabel(input: string): string {
+  return input.normalize('NFKC').trim().replace(/\s+/gu, ' ').toLowerCase();
+}
+
+function buildExactGroupKey(
+  row: ExactDuplicateRow
+): { key: string; fromObservation: boolean } | null {
+  if (row.normalized_form) {
+    return {
+      key: JSON.stringify([row.kind, row.scope_kind, row.scope_id ?? '', row.normalized_form]),
+      fromObservation: true,
+    };
+  }
+  const fallback = normalizeExactLabel(row.preferred_label);
+  if (!fallback) {
+    return null;
+  }
+  return {
+    key: JSON.stringify([row.kind, row.scope_kind, row.scope_id ?? '', fallback]),
+    fromObservation: false,
+  };
+}
+
+function compareRows(left: ExactDuplicateRow, right: ExactDuplicateRow): number {
+  if (left.created_at !== right.created_at) {
+    return left.created_at - right.created_at;
+  }
+  return left.id.localeCompare(right.id);
+}
+
+export async function backfillExactDuplicateCanonicals(
+  opts: ExactMergeBackfillOptions = {}
+): Promise<ExactMergeBackfillResult> {
+  await initDB();
+  const adapter = getAdapter();
+  const dryRun = opts.dryRun === true;
+  let groups = 0;
+  let merged = 0;
+  let incomplete = 0;
+  let skipped = 0;
+
+  const rows = adapter
+    .prepare(
+      `
+        SELECT n.id, n.kind, n.preferred_label, n.scope_kind, n.scope_id, n.created_at, o.normalized_form
+        FROM entity_nodes n
+        LEFT JOIN entity_observations o ON o.id = n.id
+        WHERE n.status = 'active'
+          AND n.merged_into IS NULL
+      `
+    )
+    .all() as ExactDuplicateRow[];
+
+  const grouped = new Map<string, ExactDuplicateRow[]>();
+  const fallbackRows = new Set<string>();
+  for (const row of rows) {
+    const keyInfo = buildExactGroupKey(row);
+    if (!keyInfo) {
+      incomplete += 1;
+      continue;
+    }
+    if (!keyInfo.fromObservation) {
+      fallbackRows.add(row.id);
+    }
+    const bucket = grouped.get(keyInfo.key) ?? [];
+    bucket.push(row);
+    grouped.set(keyInfo.key, bucket);
+  }
+
+  for (const bucket of grouped.values()) {
+    if (bucket.length >= 2) {
+      continue;
+    }
+    for (const row of bucket) {
+      if (fallbackRows.has(row.id)) {
+        incomplete += 1;
+      }
+    }
+  }
+
+  for (const [groupKey, bucket] of grouped.entries()) {
+    if (bucket.length < 2) {
+      continue;
+    }
+
+    groups += 1;
+    const sorted = [...bucket].sort(compareRows);
+    const target = sorted[0]!;
+    const sources = sorted.slice(1);
+
+    if (dryRun) {
+      merged += sources.length;
+      continue;
+    }
+
+    try {
+      if ('transaction' in adapter && typeof adapter.transaction === 'function') {
+        adapter.transaction(() => {
+          for (const source of sources) {
+            const mergeResult = mergeEntityNodes({
+              adapter,
+              source_id: source.id,
+              target_id: target.id,
+              actor_type: 'system',
+              actor_id: 'exact-duplicate-backfill',
+              reason: 'Exact duplicate canonical backfill',
+              candidate_id: null,
+              evidence_json: JSON.stringify({
+                strategy: 'exact_duplicate_backfill',
+                group_key: groupKey,
+                normalized_form: source.normalized_form,
+                target_id: target.id,
+              }),
+            });
+            adoptLineageAfterMerge({
+              adapter,
+              source_entity_id: source.id,
+              target_entity_id: target.id,
+              candidate_id: null,
+              review_action_id: mergeResult.merge_action_id,
+            });
+          }
+        });
+      } else {
+        for (const source of sources) {
+          const mergeResult = mergeEntityNodes({
+            adapter,
+            source_id: source.id,
+            target_id: target.id,
+            actor_type: 'system',
+            actor_id: 'exact-duplicate-backfill',
+            reason: 'Exact duplicate canonical backfill',
+            candidate_id: null,
+            evidence_json: JSON.stringify({
+              strategy: 'exact_duplicate_backfill',
+              group_key: groupKey,
+              normalized_form: source.normalized_form,
+              target_id: target.id,
+            }),
+          });
+          adoptLineageAfterMerge({
+            adapter,
+            source_entity_id: source.id,
+            target_entity_id: target.id,
+            candidate_id: null,
+            review_action_id: mergeResult.merge_action_id,
+          });
+        }
+      }
+      merged += sources.length;
+    } catch (error) {
+      if (error instanceof EntityMergeError) {
+        skipped += sources.length;
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  return {
+    groups,
+    merged,
+    incomplete,
+    skipped,
+  };
+}

--- a/packages/mama-core/src/entities/exact-merge-backfill.ts
+++ b/packages/mama-core/src/entities/exact-merge-backfill.ts
@@ -62,6 +62,45 @@ function runAdapterTransaction<T>(
   return typeof result === 'function' ? (result as () => T)() : result;
 }
 
+function requireTransactionAdapter(adapter: Pick<ReturnType<typeof getAdapter>, 'transaction'>): {
+  transaction: <U>(fn: () => U) => U | (() => U);
+} {
+  if (!('transaction' in adapter) || typeof adapter.transaction !== 'function') {
+    throw new Error('exact-merge-backfill requires adapter.transaction');
+  }
+  return adapter as { transaction: <U>(fn: () => U) => U | (() => U) };
+}
+
+function mergeAndAdoptLineage(input: {
+  adapter: ReturnType<typeof getAdapter>;
+  source: ExactDuplicateRow;
+  target: ExactDuplicateRow;
+  groupKey: string;
+}): void {
+  const mergeResult = mergeEntityNodes({
+    adapter: input.adapter,
+    source_id: input.source.id,
+    target_id: input.target.id,
+    actor_type: 'system',
+    actor_id: 'exact-duplicate-backfill',
+    reason: 'Exact duplicate canonical backfill',
+    candidate_id: null,
+    evidence_json: JSON.stringify({
+      strategy: 'exact_duplicate_backfill',
+      group_key: input.groupKey,
+      normalized_form: input.source.normalized_form,
+      target_id: input.target.id,
+    }),
+  });
+  adoptLineageAfterMergeSync({
+    adapter: input.adapter,
+    source_entity_id: input.source.id,
+    target_entity_id: input.target.id,
+    candidate_id: null,
+    review_action_id: mergeResult.merge_action_id,
+  });
+}
+
 export async function backfillExactDuplicateCanonicals(
   opts: ExactMergeBackfillOptions = {}
 ): Promise<ExactMergeBackfillResult> {
@@ -140,59 +179,17 @@ export async function backfillExactDuplicateCanonicals(
     }
 
     try {
-      if ('transaction' in adapter && typeof adapter.transaction === 'function') {
-        runAdapterTransaction(adapter, () => {
-          for (const source of sources) {
-            const mergeResult = mergeEntityNodes({
-              adapter,
-              source_id: source.id,
-              target_id: target.id,
-              actor_type: 'system',
-              actor_id: 'exact-duplicate-backfill',
-              reason: 'Exact duplicate canonical backfill',
-              candidate_id: null,
-              evidence_json: JSON.stringify({
-                strategy: 'exact_duplicate_backfill',
-                group_key: groupKey,
-                normalized_form: source.normalized_form,
-                target_id: target.id,
-              }),
-            });
-            adoptLineageAfterMergeSync({
-              adapter,
-              source_entity_id: source.id,
-              target_entity_id: target.id,
-              candidate_id: null,
-              review_action_id: mergeResult.merge_action_id,
-            });
-          }
-        });
-      } else {
+      const transactionalAdapter = requireTransactionAdapter(adapter);
+      runAdapterTransaction(transactionalAdapter, () => {
         for (const source of sources) {
-          const mergeResult = mergeEntityNodes({
+          mergeAndAdoptLineage({
             adapter,
-            source_id: source.id,
-            target_id: target.id,
-            actor_type: 'system',
-            actor_id: 'exact-duplicate-backfill',
-            reason: 'Exact duplicate canonical backfill',
-            candidate_id: null,
-            evidence_json: JSON.stringify({
-              strategy: 'exact_duplicate_backfill',
-              group_key: groupKey,
-              normalized_form: source.normalized_form,
-              target_id: target.id,
-            }),
-          });
-          adoptLineageAfterMergeSync({
-            adapter,
-            source_entity_id: source.id,
-            target_entity_id: target.id,
-            candidate_id: null,
-            review_action_id: mergeResult.merge_action_id,
+            source,
+            target,
+            groupKey,
           });
         }
-      }
+      });
       merged += sources.length;
     } catch (error) {
       if (error instanceof EntityMergeError) {

--- a/packages/mama-core/src/entities/lineage-backfill.ts
+++ b/packages/mama-core/src/entities/lineage-backfill.ts
@@ -1,0 +1,129 @@
+import { getAdapter, initDB } from '../db-manager.js';
+import { appendEntityLineageLink } from './lineage-store.js';
+
+interface BackfillEntityLineageOptions {
+  dryRun?: boolean;
+  now?: number;
+}
+
+interface BackfillEntityLineageResult {
+  seeded: number;
+  adopted: number;
+  incomplete: number;
+}
+
+export async function backfillEntityLineage(
+  opts: BackfillEntityLineageOptions = {}
+): Promise<BackfillEntityLineageResult> {
+  await initDB();
+  const adapter = getAdapter();
+  const dryRun = opts.dryRun === true;
+  const seedConfidence = 0.75;
+  const adoptConfidence = 0.6;
+
+  let seeded = 0;
+  let adopted = 0;
+  let incomplete = 0;
+
+  const activeRows = adapter
+    .prepare(
+      `
+        SELECT n.id, o.id AS observation_id
+        FROM entity_nodes n
+        LEFT JOIN entity_observations o ON o.id = n.id
+        WHERE n.status = 'active'
+          AND n.merged_into IS NULL
+      `
+    )
+    .all() as Array<{ id: string; observation_id: string | null }>;
+
+  for (const row of activeRows) {
+    if (!row.observation_id) {
+      incomplete += 1;
+      continue;
+    }
+    const existing = adapter
+      .prepare(
+        `
+          SELECT id
+          FROM entity_lineage_links
+          WHERE canonical_entity_id = ?
+            AND entity_observation_id = ?
+            AND status = 'active'
+          LIMIT 1
+        `
+      )
+      .get(row.id, row.observation_id) as { id: string } | undefined;
+    if (existing) {
+      continue;
+    }
+    seeded += 1;
+    if (!dryRun) {
+      await appendEntityLineageLink({
+        canonical_entity_id: row.id,
+        entity_observation_id: row.observation_id,
+        source_entity_id: null,
+        contribution_kind: 'seed',
+        run_id: null,
+        candidate_id: null,
+        review_action_id: null,
+        capture_mode: 'backfilled',
+        confidence: seedConfidence,
+      });
+    }
+  }
+
+  const mergedRows = adapter
+    .prepare(
+      `
+        SELECT n.id AS source_entity_id, n.merged_into AS target_entity_id, o.id AS observation_id
+        FROM entity_nodes n
+        LEFT JOIN entity_observations o ON o.id = n.id
+        WHERE n.status = 'merged'
+          AND n.merged_into IS NOT NULL
+      `
+    )
+    .all() as Array<{
+    source_entity_id: string;
+    target_entity_id: string;
+    observation_id: string | null;
+  }>;
+
+  for (const row of mergedRows) {
+    if (!row.observation_id) {
+      incomplete += 1;
+      continue;
+    }
+    const existing = adapter
+      .prepare(
+        `
+          SELECT id
+          FROM entity_lineage_links
+          WHERE canonical_entity_id = ?
+            AND entity_observation_id = ?
+            AND status = 'active'
+          LIMIT 1
+        `
+      )
+      .get(row.target_entity_id, row.observation_id) as { id: string } | undefined;
+    if (existing) {
+      continue;
+    }
+    adopted += 1;
+    if (!dryRun) {
+      await appendEntityLineageLink({
+        canonical_entity_id: row.target_entity_id,
+        entity_observation_id: row.observation_id,
+        source_entity_id: row.source_entity_id,
+        contribution_kind: 'merge_adopt',
+        run_id: null,
+        candidate_id: null,
+        review_action_id: null,
+        capture_mode: 'backfilled',
+        confidence: adoptConfidence,
+      });
+    }
+  }
+
+  return { seeded, adopted, incomplete };
+}

--- a/packages/mama-core/src/entities/lineage-store.ts
+++ b/packages/mama-core/src/entities/lineage-store.ts
@@ -340,17 +340,20 @@ function runLineageTransaction<T>(adapter: LineageMutationAdapter, fn: () => T):
   }
 }
 
-export function adoptLineageAfterMerge(
+export async function adoptLineageAfterMerge(
   input: AdoptLineageAfterMergeInput
 ): Promise<EntityLineageLink[]> {
   if (!input.adapter) {
-    return initDB().then(() =>
-      runLineageTransaction(getAdapter(), () => adoptLineageAfterMergeWithAdapter(getAdapter(), input))
+    await initDB();
+    const adapter = getAdapter();
+    return await runLineageTransaction(adapter, () =>
+      adoptLineageAfterMergeWithAdapter(adapter, input)
     );
   }
 
-  return Promise.resolve(
-    runLineageTransaction(input.adapter, () => adoptLineageAfterMergeWithAdapter(input.adapter!, input))
+  const adapter = input.adapter;
+  return await runLineageTransaction(adapter, () =>
+    adoptLineageAfterMergeWithAdapter(adapter, input)
   );
 }
 

--- a/packages/mama-core/src/entities/lineage-store.ts
+++ b/packages/mama-core/src/entities/lineage-store.ts
@@ -51,6 +51,10 @@ export interface AppendEntityLineageLinkResult {
   created: boolean;
 }
 
+interface AdoptLineageAfterMergeSyncInput extends Omit<AdoptLineageAfterMergeInput, 'adapter'> {
+  adapter: LineageMutationAdapter;
+}
+
 function now(): number {
   return Date.now();
 }
@@ -346,14 +350,17 @@ export async function adoptLineageAfterMerge(
   if (!input.adapter) {
     await initDB();
     const adapter = getAdapter();
-    return await runLineageTransaction(adapter, () =>
-      adoptLineageAfterMergeWithAdapter(adapter, input)
-    );
+    return adoptLineageAfterMergeSync({ ...input, adapter });
   }
 
-  const adapter = input.adapter;
-  return await runLineageTransaction(adapter, () =>
-    adoptLineageAfterMergeWithAdapter(adapter, input)
+  return adoptLineageAfterMergeSync(input as AdoptLineageAfterMergeSyncInput);
+}
+
+export function adoptLineageAfterMergeSync(
+  input: AdoptLineageAfterMergeSyncInput
+): EntityLineageLink[] {
+  return runLineageTransaction(input.adapter, () =>
+    adoptLineageAfterMergeWithAdapter(input.adapter, input)
   );
 }
 

--- a/packages/mama-core/src/entities/lineage-store.ts
+++ b/packages/mama-core/src/entities/lineage-store.ts
@@ -1,0 +1,428 @@
+import { randomUUID } from 'node:crypto';
+import { getAdapter, initDB } from '../db-manager.js';
+import type { EntityIngestRun, EntityLineageLink } from './types.js';
+import type { EntityStoreAdapter } from './store.js';
+
+type CreateEntityIngestRunInput = Omit<
+  EntityIngestRun,
+  | 'status'
+  | 'raw_count'
+  | 'observation_count'
+  | 'candidate_count'
+  | 'reviewable_count'
+  | 'audit_run_id'
+  | 'audit_classification'
+  | 'error_reason'
+  | 'created_at'
+  | 'completed_at'
+> & {
+  id?: string;
+};
+
+type AppendEntityLineageLinkInput = Omit<
+  EntityLineageLink,
+  'id' | 'status' | 'created_at' | 'superseded_at'
+>;
+
+interface CompleteEntityIngestRunInput {
+  raw_count: number;
+  observation_count: number;
+  candidate_count: number;
+  reviewable_count: number;
+  audit_run_id?: string | null;
+  audit_classification?: EntityIngestRun['audit_classification'];
+}
+
+interface SupersedeEntityLineageOptions {
+  replacement_entity_id?: string | null;
+}
+
+interface AdoptLineageAfterMergeInput {
+  adapter?: ReturnType<typeof getAdapter>;
+  source_entity_id: string;
+  target_entity_id: string;
+  candidate_id?: string | null;
+  review_action_id?: string | null;
+  confidence?: number;
+  capture_mode?: EntityLineageLink['capture_mode'];
+}
+
+function now(): number {
+  return Date.now();
+}
+
+function parseEntityIngestRunRow(row: Record<string, unknown>): EntityIngestRun {
+  return {
+    id: String(row.id),
+    connector: String(row.connector),
+    run_kind: row.run_kind as EntityIngestRun['run_kind'],
+    status: row.status as EntityIngestRun['status'],
+    scope_key: String(row.scope_key),
+    source_window_start:
+      typeof row.source_window_start === 'number' ? row.source_window_start : null,
+    source_window_end: typeof row.source_window_end === 'number' ? row.source_window_end : null,
+    raw_count: Number(row.raw_count ?? 0),
+    observation_count: Number(row.observation_count ?? 0),
+    candidate_count: Number(row.candidate_count ?? 0),
+    reviewable_count: Number(row.reviewable_count ?? 0),
+    audit_run_id: typeof row.audit_run_id === 'string' ? row.audit_run_id : null,
+    audit_classification:
+      typeof row.audit_classification === 'string'
+        ? (row.audit_classification as EntityIngestRun['audit_classification'])
+        : null,
+    error_reason: typeof row.error_reason === 'string' ? row.error_reason : null,
+    created_at: Number(row.created_at),
+    completed_at: typeof row.completed_at === 'number' ? row.completed_at : null,
+  };
+}
+
+function parseEntityLineageLinkRow(row: Record<string, unknown>): EntityLineageLink {
+  return {
+    id: String(row.id),
+    canonical_entity_id: String(row.canonical_entity_id),
+    entity_observation_id: String(row.entity_observation_id),
+    source_entity_id: typeof row.source_entity_id === 'string' ? row.source_entity_id : null,
+    contribution_kind: row.contribution_kind as EntityLineageLink['contribution_kind'],
+    run_id: typeof row.run_id === 'string' ? row.run_id : null,
+    candidate_id: typeof row.candidate_id === 'string' ? row.candidate_id : null,
+    review_action_id: typeof row.review_action_id === 'string' ? row.review_action_id : null,
+    status: row.status as EntityLineageLink['status'],
+    capture_mode: row.capture_mode as EntityLineageLink['capture_mode'],
+    confidence: Number(row.confidence),
+    created_at: Number(row.created_at),
+    superseded_at: typeof row.superseded_at === 'number' ? row.superseded_at : null,
+  };
+}
+
+export async function createEntityIngestRun(
+  input: CreateEntityIngestRunInput
+): Promise<EntityIngestRun> {
+  await initDB();
+  const adapter = getAdapter();
+  const createdAt = now();
+  const id = input.id || `eir_${randomUUID()}`;
+
+  adapter
+    .prepare(
+      `
+        INSERT INTO entity_ingest_runs (
+          id, connector, run_kind, status, scope_key, source_window_start, source_window_end,
+          raw_count, observation_count, candidate_count, reviewable_count, audit_run_id,
+          audit_classification, error_reason, created_at, completed_at
+        ) VALUES (?, ?, ?, 'running', ?, ?, ?, 0, 0, 0, 0, NULL, NULL, NULL, ?, NULL)
+      `
+    )
+    .run(
+      id,
+      input.connector,
+      input.run_kind,
+      input.scope_key,
+      input.source_window_start,
+      input.source_window_end,
+      createdAt
+    );
+
+  const row = adapter.prepare(`SELECT * FROM entity_ingest_runs WHERE id = ?`).get(id) as Record<
+    string,
+    unknown
+  >;
+  return parseEntityIngestRunRow(row);
+}
+
+export async function completeEntityIngestRun(
+  id: string,
+  input: CompleteEntityIngestRunInput
+): Promise<EntityIngestRun> {
+  await initDB();
+  const adapter = getAdapter();
+  const completedAt = now();
+
+  adapter
+    .prepare(
+      `
+        UPDATE entity_ingest_runs
+        SET status = 'complete',
+            raw_count = ?,
+            observation_count = ?,
+            candidate_count = ?,
+            reviewable_count = ?,
+            audit_run_id = ?,
+            audit_classification = ?,
+            error_reason = NULL,
+            completed_at = ?
+        WHERE id = ?
+      `
+    )
+    .run(
+      input.raw_count,
+      input.observation_count,
+      input.candidate_count,
+      input.reviewable_count,
+      input.audit_run_id ?? null,
+      input.audit_classification ?? null,
+      completedAt,
+      id
+    );
+
+  const row = adapter.prepare(`SELECT * FROM entity_ingest_runs WHERE id = ?`).get(id) as Record<
+    string,
+    unknown
+  >;
+  return parseEntityIngestRunRow(row);
+}
+
+export async function failEntityIngestRun(
+  id: string,
+  errorReason: string
+): Promise<EntityIngestRun> {
+  await initDB();
+  const adapter = getAdapter();
+  const completedAt = now();
+
+  adapter
+    .prepare(
+      `
+        UPDATE entity_ingest_runs
+        SET status = 'failed',
+            error_reason = ?,
+            completed_at = ?
+        WHERE id = ?
+      `
+    )
+    .run(errorReason, completedAt, id);
+
+  const row = adapter.prepare(`SELECT * FROM entity_ingest_runs WHERE id = ?`).get(id) as Record<
+    string,
+    unknown
+  >;
+  return parseEntityIngestRunRow(row);
+}
+
+export async function appendEntityLineageLink(
+  input: AppendEntityLineageLinkInput
+): Promise<EntityLineageLink> {
+  await initDB();
+  const adapter = getAdapter();
+
+  const existing = adapter
+    .prepare(
+      `
+        SELECT *
+        FROM entity_lineage_links
+        WHERE canonical_entity_id = ?
+          AND entity_observation_id = ?
+          AND status = 'active'
+        LIMIT 1
+      `
+    )
+    .get(input.canonical_entity_id, input.entity_observation_id) as
+    | Record<string, unknown>
+    | undefined;
+
+  if (existing) {
+    return parseEntityLineageLinkRow(existing);
+  }
+
+  const id = `elin_${randomUUID()}`;
+  const createdAt = now();
+
+  adapter
+    .prepare(
+      `
+        INSERT INTO entity_lineage_links (
+          id, canonical_entity_id, entity_observation_id, source_entity_id,
+          contribution_kind, run_id, candidate_id, review_action_id,
+          status, capture_mode, confidence, created_at, superseded_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?, NULL)
+      `
+    )
+    .run(
+      id,
+      input.canonical_entity_id,
+      input.entity_observation_id,
+      input.source_entity_id,
+      input.contribution_kind,
+      input.run_id,
+      input.candidate_id,
+      input.review_action_id,
+      input.capture_mode,
+      input.confidence,
+      createdAt
+    );
+
+  const row = adapter.prepare(`SELECT * FROM entity_lineage_links WHERE id = ?`).get(id) as Record<
+    string,
+    unknown
+  >;
+  return parseEntityLineageLinkRow(row);
+}
+
+export async function supersedeEntityLineageForEntity(
+  entityId: string,
+  _options: SupersedeEntityLineageOptions = {}
+): Promise<number> {
+  await initDB();
+  const adapter = getAdapter();
+  const supersededAt = now();
+  const result = adapter
+    .prepare(
+      `
+        UPDATE entity_lineage_links
+        SET status = 'superseded',
+            superseded_at = ?
+        WHERE canonical_entity_id = ?
+          AND status = 'active'
+      `
+    )
+    .run(supersededAt, entityId);
+
+  return Number(result.changes ?? 0);
+}
+
+export async function seedLineageForEntityMaterialization(input: {
+  canonical_entity_id: string;
+  entity_observation_id: string;
+  run_id?: string | null;
+  confidence?: number;
+  capture_mode?: EntityLineageLink['capture_mode'];
+}): Promise<EntityLineageLink> {
+  return appendEntityLineageLink({
+    canonical_entity_id: input.canonical_entity_id,
+    entity_observation_id: input.entity_observation_id,
+    source_entity_id: null,
+    contribution_kind: 'seed',
+    run_id: input.run_id ?? null,
+    candidate_id: null,
+    review_action_id: null,
+    capture_mode: input.capture_mode ?? 'direct',
+    confidence: input.confidence ?? 1,
+  });
+}
+
+export function adoptLineageAfterMerge(input: AdoptLineageAfterMergeInput): EntityLineageLink[] {
+  const adapter = input.adapter ?? getAdapter();
+  const createdAt = now();
+  const supersededAt = now();
+
+  const sourceRows = adapter
+    .prepare(
+      `
+        SELECT *
+        FROM entity_lineage_links
+        WHERE canonical_entity_id = ?
+          AND status = 'active'
+        ORDER BY created_at ASC
+      `
+    )
+    .all(input.source_entity_id) as Array<Record<string, unknown>>;
+
+  adapter
+    .prepare(
+      `
+        UPDATE entity_lineage_links
+        SET status = 'superseded',
+            superseded_at = ?
+        WHERE canonical_entity_id = ?
+          AND status = 'active'
+      `
+    )
+    .run(supersededAt, input.source_entity_id);
+
+  const adopted: EntityLineageLink[] = [];
+  for (const row of sourceRows) {
+    const observationId = String(row.entity_observation_id);
+    const existing = adapter
+      .prepare(
+        `
+          SELECT *
+          FROM entity_lineage_links
+          WHERE canonical_entity_id = ?
+            AND entity_observation_id = ?
+            AND status = 'active'
+          LIMIT 1
+        `
+      )
+      .get(input.target_entity_id, observationId) as Record<string, unknown> | undefined;
+
+    if (existing) {
+      adopted.push(parseEntityLineageLinkRow(existing));
+      continue;
+    }
+
+    const id = `elin_${randomUUID()}`;
+    adapter
+      .prepare(
+        `
+          INSERT INTO entity_lineage_links (
+            id, canonical_entity_id, entity_observation_id, source_entity_id,
+            contribution_kind, run_id, candidate_id, review_action_id,
+            status, capture_mode, confidence, created_at, superseded_at
+          ) VALUES (?, ?, ?, ?, 'merge_adopt', ?, ?, ?, 'active', ?, ?, ?, NULL)
+        `
+      )
+      .run(
+        id,
+        input.target_entity_id,
+        observationId,
+        input.source_entity_id,
+        typeof row.run_id === 'string' ? row.run_id : null,
+        input.candidate_id ?? null,
+        input.review_action_id ?? null,
+        input.capture_mode ?? 'direct',
+        input.confidence ?? Number(row.confidence ?? 1),
+        createdAt
+      );
+
+    const created = adapter
+      .prepare(`SELECT * FROM entity_lineage_links WHERE id = ?`)
+      .get(id) as Record<string, unknown>;
+    adopted.push(parseEntityLineageLinkRow(created));
+  }
+
+  return adopted;
+}
+
+export async function listActiveEntityLineage(
+  entityId: string,
+  adapter?: EntityStoreAdapter
+): Promise<EntityLineageLink[]> {
+  if (!adapter) {
+    await initDB();
+  }
+  const effectiveAdapter = adapter ?? getAdapter();
+  const rows = effectiveAdapter
+    .prepare(
+      `
+        SELECT *
+        FROM entity_lineage_links
+        WHERE canonical_entity_id = ?
+          AND status = 'active'
+        ORDER BY created_at ASC
+      `
+    )
+    .all(entityId) as Array<Record<string, unknown>>;
+
+  return rows.map(parseEntityLineageLinkRow);
+}
+
+export async function listEntityLineageHistory(
+  entityId: string,
+  adapter?: EntityStoreAdapter
+): Promise<EntityLineageLink[]> {
+  if (!adapter) {
+    await initDB();
+  }
+  const effectiveAdapter = adapter ?? getAdapter();
+  const rows = effectiveAdapter
+    .prepare(
+      `
+        SELECT *
+        FROM entity_lineage_links
+        WHERE canonical_entity_id = ?
+        ORDER BY created_at ASC
+      `
+    )
+    .all(entityId) as Array<Record<string, unknown>>;
+
+  return rows.map(parseEntityLineageLinkRow);
+}

--- a/packages/mama-core/src/entities/lineage-store.ts
+++ b/packages/mama-core/src/entities/lineage-store.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { getAdapter, initDB } from '../db-manager.js';
+import type { DatabaseAdapter } from '../db-manager.js';
 import type { EntityIngestRun, EntityLineageLink } from './types.js';
 import type { EntityStoreAdapter } from './store.js';
 
@@ -33,12 +34,8 @@ interface CompleteEntityIngestRunInput {
   audit_classification?: EntityIngestRun['audit_classification'];
 }
 
-interface SupersedeEntityLineageOptions {
-  replacement_entity_id?: string | null;
-}
-
 interface AdoptLineageAfterMergeInput {
-  adapter?: ReturnType<typeof getAdapter>;
+  adapter?: LineageMutationAdapter;
   source_entity_id: string;
   target_entity_id: string;
   candidate_id?: string | null;
@@ -47,11 +44,18 @@ interface AdoptLineageAfterMergeInput {
   capture_mode?: EntityLineageLink['capture_mode'];
 }
 
+type LineageMutationAdapter = Pick<DatabaseAdapter, 'prepare'>;
+
+export interface AppendEntityLineageLinkResult {
+  link: EntityLineageLink;
+  created: boolean;
+}
+
 function now(): number {
   return Date.now();
 }
 
-function parseEntityIngestRunRow(row: Record<string, unknown>): EntityIngestRun {
+export function parseEntityIngestRunRow(row: Record<string, unknown>): EntityIngestRun {
   return {
     id: String(row.id),
     connector: String(row.connector),
@@ -206,7 +210,7 @@ export async function failEntityIngestRun(
 
 export async function appendEntityLineageLink(
   input: AppendEntityLineageLinkInput
-): Promise<EntityLineageLink> {
+): Promise<AppendEntityLineageLinkResult> {
   await initDB();
   const adapter = getAdapter();
 
@@ -225,8 +229,14 @@ export async function appendEntityLineageLink(
     | Record<string, unknown>
     | undefined;
 
+  // Idempotent by (canonical_entity_id, entity_observation_id, status='active').
+  // If an active row already exists for the pair, the existing row is returned
+  // and the caller-provided metadata is ignored.
   if (existing) {
-    return parseEntityLineageLinkRow(existing);
+    return {
+      link: parseEntityLineageLinkRow(existing),
+      created: false,
+    };
   }
 
   const id = `elin_${randomUUID()}`;
@@ -260,12 +270,14 @@ export async function appendEntityLineageLink(
     string,
     unknown
   >;
-  return parseEntityLineageLinkRow(row);
+  return {
+    link: parseEntityLineageLinkRow(row),
+    created: true,
+  };
 }
 
 export async function supersedeEntityLineageForEntity(
-  entityId: string,
-  _options: SupersedeEntityLineageOptions = {}
+  entityId: string
 ): Promise<number> {
   await initDB();
   const adapter = getAdapter();
@@ -292,7 +304,7 @@ export async function seedLineageForEntityMaterialization(input: {
   confidence?: number;
   capture_mode?: EntityLineageLink['capture_mode'];
 }): Promise<EntityLineageLink> {
-  return appendEntityLineageLink({
+  const result = await appendEntityLineageLink({
     canonical_entity_id: input.canonical_entity_id,
     entity_observation_id: input.entity_observation_id,
     source_entity_id: null,
@@ -303,13 +315,51 @@ export async function seedLineageForEntityMaterialization(input: {
     capture_mode: input.capture_mode ?? 'direct',
     confidence: input.confidence ?? 1,
   });
+  return result.link;
 }
 
-export function adoptLineageAfterMerge(input: AdoptLineageAfterMergeInput): EntityLineageLink[] {
-  const adapter = input.adapter ?? getAdapter();
+function runLineageTransaction<T>(adapter: LineageMutationAdapter, fn: () => T): T {
+  const savepoint = `adopt_lineage_${randomUUID().replace(/-/g, '')}`;
+  adapter.prepare(`SAVEPOINT ${savepoint}`).run();
+  try {
+    const result = fn();
+    adapter.prepare(`RELEASE SAVEPOINT ${savepoint}`).run();
+    return result;
+  } catch (error) {
+    try {
+      adapter.prepare(`ROLLBACK TO SAVEPOINT ${savepoint}`).run();
+    } catch {
+      // Ignore rollback errors when the connection already unwound the savepoint.
+    }
+    try {
+      adapter.prepare(`RELEASE SAVEPOINT ${savepoint}`).run();
+    } catch {
+      // Ignore cleanup failures after rollback.
+    }
+    throw error;
+  }
+}
+
+export function adoptLineageAfterMerge(
+  input: AdoptLineageAfterMergeInput
+): Promise<EntityLineageLink[]> {
+  if (!input.adapter) {
+    return initDB().then(() =>
+      runLineageTransaction(getAdapter(), () => adoptLineageAfterMergeWithAdapter(getAdapter(), input))
+    );
+  }
+
+  return Promise.resolve(
+    runLineageTransaction(input.adapter, () => adoptLineageAfterMergeWithAdapter(input.adapter!, input))
+  );
+}
+
+function adoptLineageAfterMergeWithAdapter(
+  adapter: LineageMutationAdapter,
+  input: AdoptLineageAfterMergeInput
+): EntityLineageLink[] {
   const createdAt = now();
   const supersededAt = now();
-
   const sourceRows = adapter
     .prepare(
       `

--- a/packages/mama-core/src/entities/lineage-store.ts
+++ b/packages/mama-core/src/entities/lineage-store.ts
@@ -137,7 +137,7 @@ export async function completeEntityIngestRun(
   const adapter = getAdapter();
   const completedAt = now();
 
-  adapter
+  const completion = adapter
     .prepare(
       `
         UPDATE entity_ingest_runs
@@ -163,6 +163,9 @@ export async function completeEntityIngestRun(
       completedAt,
       id
     );
+  if (completion.changes !== 1) {
+    throw new Error(`Entity ingest run not found: ${id}`);
+  }
 
   const row = adapter.prepare(`SELECT * FROM entity_ingest_runs WHERE id = ?`).get(id) as Record<
     string,
@@ -179,7 +182,7 @@ export async function failEntityIngestRun(
   const adapter = getAdapter();
   const completedAt = now();
 
-  adapter
+  const completion = adapter
     .prepare(
       `
         UPDATE entity_ingest_runs
@@ -190,6 +193,9 @@ export async function failEntityIngestRun(
       `
     )
     .run(errorReason, completedAt, id);
+  if (completion.changes !== 1) {
+    throw new Error(`Entity ingest run not found: ${id}`);
+  }
 
   const row = adapter.prepare(`SELECT * FROM entity_ingest_runs WHERE id = ?`).get(id) as Record<
     string,

--- a/packages/mama-core/src/entities/policy-store.ts
+++ b/packages/mama-core/src/entities/policy-store.ts
@@ -235,10 +235,6 @@ export function upsertEntityRoleBinding(
   adapter: PolicyStoreAdapter = getAdapter()
 ): void {
   const timestamp = now();
-  const existing = adapter
-    .prepare('SELECT created_at FROM entity_role_bindings WHERE actor_id = ? LIMIT 1')
-    .get(input.actor_id) as { created_at: number } | undefined;
-
   adapter
     .prepare(
       `
@@ -250,7 +246,7 @@ export function upsertEntityRoleBinding(
           updated_at = excluded.updated_at
       `
     )
-    .run(input.actor_id, input.role, existing?.created_at ?? timestamp, timestamp);
+    .run(input.actor_id, input.role, timestamp, timestamp);
 }
 
 export function resolveEntityRoleForActor(
@@ -324,7 +320,6 @@ export function approveEntityPolicyProposal(
 
     const existingPolicy = getEntityPolicy(proposal.policy_key, adapter);
     const version = existingPolicy ? existingPolicy.version + 1 : 1;
-    const createdAt = existingPolicy?.created_at ?? approvedAt;
 
     adapter
       .prepare(
@@ -344,7 +339,7 @@ export function approveEntityPolicyProposal(
         proposal.policy_kind,
         proposal.proposed_value_json,
         version,
-        createdAt,
+        approvedAt,
         approvedAt
       );
 

--- a/packages/mama-core/src/entities/policy-store.ts
+++ b/packages/mama-core/src/entities/policy-store.ts
@@ -1,0 +1,368 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+
+import { getAdapter, initDB } from '../db-manager.js';
+import type { DatabaseAdapter } from '../db-manager.js';
+import {
+  createDefaultEntityPolicyBootstrap,
+  isEntityPolicyKind,
+  isEntityPolicyProposalStatus,
+  isEntityRole,
+  type EntityPolicyApprovalInput,
+  type EntityPolicyBootstrapDocument,
+  type EntityPolicyKind,
+  type EntityPolicyProposalInput,
+  type EntityPolicyProposalRow,
+  type EntityPolicyRow,
+  type EntityRole,
+  type EntityRoleBinding,
+  type EntityRoleBindingInput,
+} from './policy-types.js';
+
+type PolicyStoreAdapter = Pick<DatabaseAdapter, 'prepare' | 'transaction'>;
+
+function now(): number {
+  return Date.now();
+}
+
+function parseJsonObject(raw: string, label: string): Record<string, unknown> {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`${label} must be a JSON object`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function parsePolicyRow(row: Record<string, unknown>): EntityPolicyRow {
+  const policyKind = String(row.policy_kind);
+  if (!isEntityPolicyKind(policyKind)) {
+    throw new Error(`Invalid entity policy row: policy_kind=${policyKind}`);
+  }
+
+  const valueJson = String(row.value_json);
+  return {
+    policy_key: String(row.policy_key),
+    policy_kind: policyKind,
+    value_json: valueJson,
+    value: parseJsonObject(valueJson, 'entity_policy.value_json'),
+    version: Number(row.version),
+    created_at: Number(row.created_at),
+    updated_at: Number(row.updated_at),
+  };
+}
+
+function parseRoleBindingRow(row: Record<string, unknown>): EntityRoleBinding {
+  const role = String(row.role);
+  if (!isEntityRole(role)) {
+    throw new Error(`Invalid entity role binding row: role=${role}`);
+  }
+
+  return {
+    actor_id: String(row.actor_id),
+    role,
+    created_at: Number(row.created_at),
+    updated_at: Number(row.updated_at),
+  };
+}
+
+function parseProposalRow(row: Record<string, unknown>): EntityPolicyProposalRow {
+  const policyKind = String(row.policy_kind);
+  if (!isEntityPolicyKind(policyKind)) {
+    throw new Error(`Invalid entity policy proposal row: policy_kind=${policyKind}`);
+  }
+
+  const status = String(row.status);
+  if (!isEntityPolicyProposalStatus(status)) {
+    throw new Error(`Invalid entity policy proposal row: status=${status}`);
+  }
+
+  const proposedValueJson = String(row.proposed_value_json);
+  return {
+    proposal_id: String(row.proposal_id),
+    policy_key: String(row.policy_key),
+    policy_kind: policyKind,
+    proposed_value_json: proposedValueJson,
+    proposed_value: parseJsonObject(
+      proposedValueJson,
+      'entity_policy_proposals.proposed_value_json'
+    ),
+    proposer_actor: String(row.proposer_actor),
+    approver_actor: typeof row.approver_actor === 'string' ? row.approver_actor : null,
+    reason: String(row.reason),
+    status,
+    created_at: Number(row.created_at),
+    approved_at: typeof row.approved_at === 'number' ? row.approved_at : null,
+  };
+}
+
+function readBootstrapDocument(bootstrapPath: string): EntityPolicyBootstrapDocument {
+  const raw = fs.readFileSync(bootstrapPath, 'utf-8');
+  const parsed = JSON.parse(raw) as Partial<EntityPolicyBootstrapDocument>;
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('Entity policy bootstrap must be a JSON object');
+  }
+  if (typeof parsed.version !== 'number') {
+    throw new Error('Entity policy bootstrap must include numeric version');
+  }
+  if (!Array.isArray(parsed.policies)) {
+    throw new Error('Entity policy bootstrap must include policies[]');
+  }
+  if (!Array.isArray(parsed.role_bindings)) {
+    throw new Error('Entity policy bootstrap must include role_bindings[]');
+  }
+
+  for (const policy of parsed.policies) {
+    if (!policy || typeof policy !== 'object' || Array.isArray(policy)) {
+      throw new Error('Entity policy bootstrap policies must be objects');
+    }
+    if (
+      typeof policy.policy_key !== 'string' ||
+      !isEntityPolicyKind(String(policy.policy_kind)) ||
+      !policy.value ||
+      typeof policy.value !== 'object' ||
+      Array.isArray(policy.value)
+    ) {
+      throw new Error('Entity policy bootstrap policy rows are invalid');
+    }
+  }
+
+  for (const binding of parsed.role_bindings) {
+    if (!binding || typeof binding !== 'object' || Array.isArray(binding)) {
+      throw new Error('Entity policy bootstrap role_bindings must be objects');
+    }
+    if (typeof binding.actor_id !== 'string' || !isEntityRole(String(binding.role))) {
+      throw new Error('Entity policy bootstrap role binding rows are invalid');
+    }
+  }
+
+  return parsed as EntityPolicyBootstrapDocument;
+}
+
+function countRows(
+  tableName: 'entity_policy' | 'entity_role_bindings' | 'entity_policy_proposals',
+  adapter: PolicyStoreAdapter
+): number {
+  const row = adapter.prepare(`SELECT COUNT(*) AS total FROM ${tableName}`).get() as {
+    total: number;
+  };
+  return Number(row.total ?? 0);
+}
+
+export async function ensureEntityPolicyBootstrap(args: {
+  bootstrapPath: string;
+  now?: () => number;
+}): Promise<void> {
+  await initDB();
+  const adapter = getAdapter();
+  const document = readBootstrapDocument(args.bootstrapPath);
+  const timestamp = args.now?.() ?? now();
+
+  adapter.transaction(() => {
+    if (countRows('entity_policy', adapter) === 0) {
+      for (const policy of document.policies) {
+        adapter
+          .prepare(
+            `
+              INSERT INTO entity_policy (
+                policy_key, policy_kind, value_json, version, created_at, updated_at
+              ) VALUES (?, ?, ?, 1, ?, ?)
+            `
+          )
+          .run(
+            policy.policy_key,
+            policy.policy_kind,
+            JSON.stringify(policy.value),
+            timestamp,
+            timestamp
+          );
+      }
+    }
+
+    if (countRows('entity_role_bindings', adapter) === 0) {
+      for (const binding of document.role_bindings) {
+        adapter
+          .prepare(
+            `
+              INSERT INTO entity_role_bindings (
+                actor_id, role, created_at, updated_at
+              ) VALUES (?, ?, ?, ?)
+            `
+          )
+          .run(binding.actor_id, binding.role, timestamp, timestamp);
+      }
+    }
+  });
+}
+
+export function listEntityPolicies(adapter: PolicyStoreAdapter = getAdapter()): EntityPolicyRow[] {
+  const rows = adapter
+    .prepare('SELECT * FROM entity_policy ORDER BY policy_key ASC')
+    .all() as Array<Record<string, unknown>>;
+  return rows.map(parsePolicyRow);
+}
+
+export function getEntityPolicy(
+  policyKey: string,
+  adapter: PolicyStoreAdapter = getAdapter()
+): EntityPolicyRow | null {
+  const row = adapter
+    .prepare('SELECT * FROM entity_policy WHERE policy_key = ? LIMIT 1')
+    .get(policyKey) as Record<string, unknown> | undefined;
+  return row ? parsePolicyRow(row) : null;
+}
+
+export function listEntityRoleBindings(
+  adapter: PolicyStoreAdapter = getAdapter()
+): EntityRoleBinding[] {
+  const rows = adapter
+    .prepare('SELECT * FROM entity_role_bindings ORDER BY actor_id ASC')
+    .all() as Array<Record<string, unknown>>;
+  return rows.map(parseRoleBindingRow);
+}
+
+export function upsertEntityRoleBinding(
+  input: EntityRoleBindingInput,
+  adapter: PolicyStoreAdapter = getAdapter()
+): void {
+  const timestamp = now();
+  const existing = adapter
+    .prepare('SELECT created_at FROM entity_role_bindings WHERE actor_id = ? LIMIT 1')
+    .get(input.actor_id) as { created_at: number } | undefined;
+
+  adapter
+    .prepare(
+      `
+        INSERT INTO entity_role_bindings (
+          actor_id, role, created_at, updated_at
+        ) VALUES (?, ?, ?, ?)
+        ON CONFLICT(actor_id) DO UPDATE SET
+          role = excluded.role,
+          updated_at = excluded.updated_at
+      `
+    )
+    .run(input.actor_id, input.role, existing?.created_at ?? timestamp, timestamp);
+}
+
+export function resolveEntityRoleForActor(
+  actorId: string,
+  adapter: PolicyStoreAdapter = getAdapter()
+): EntityRole {
+  const row = adapter
+    .prepare('SELECT role FROM entity_role_bindings WHERE actor_id = ? LIMIT 1')
+    .get(actorId) as { role?: string } | undefined;
+  return row?.role && isEntityRole(row.role) ? row.role : 'viewer';
+}
+
+export function createEntityPolicyProposal(
+  input: EntityPolicyProposalInput,
+  adapter: PolicyStoreAdapter = getAdapter()
+): string {
+  const proposalId = input.proposal_id ?? `epol_${randomUUID()}`;
+  const createdAt = input.created_at ?? now();
+  adapter
+    .prepare(
+      `
+        INSERT INTO entity_policy_proposals (
+          proposal_id, policy_key, policy_kind, proposed_value_json, proposer_actor,
+          approver_actor, reason, status, created_at, approved_at
+        ) VALUES (?, ?, ?, ?, ?, NULL, ?, 'pending', ?, NULL)
+      `
+    )
+    .run(
+      proposalId,
+      input.policy_key,
+      input.policy_kind,
+      JSON.stringify(input.proposed_value),
+      input.proposer_actor,
+      input.reason,
+      createdAt
+    );
+  return proposalId;
+}
+
+export function getEntityPolicyProposal(
+  proposalId: string,
+  adapter: PolicyStoreAdapter = getAdapter()
+): EntityPolicyProposalRow | null {
+  const row = adapter
+    .prepare('SELECT * FROM entity_policy_proposals WHERE proposal_id = ? LIMIT 1')
+    .get(proposalId) as Record<string, unknown> | undefined;
+  return row ? parseProposalRow(row) : null;
+}
+
+export function approveEntityPolicyProposal(
+  input: EntityPolicyApprovalInput,
+  adapter: PolicyStoreAdapter = getAdapter()
+): EntityPolicyProposalRow {
+  const approvedAt = input.approved_at ?? now();
+
+  return adapter.transaction(() => {
+    const proposal = getEntityPolicyProposal(input.proposal_id, adapter);
+    if (!proposal) {
+      throw new Error(`Entity policy proposal not found: ${input.proposal_id}`);
+    }
+    if (proposal.status !== 'pending') {
+      throw new Error(`Entity policy proposal is not pending: ${input.proposal_id}`);
+    }
+    if (proposal.proposer_actor === input.approver_actor) {
+      throw new Error('Entity policy proposal requires a different approver');
+    }
+
+    const existingPolicy = getEntityPolicy(proposal.policy_key, adapter);
+    const version = existingPolicy ? existingPolicy.version + 1 : 1;
+    const createdAt = existingPolicy?.created_at ?? approvedAt;
+
+    adapter
+      .prepare(
+        `
+          INSERT INTO entity_policy (
+            policy_key, policy_kind, value_json, version, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?)
+          ON CONFLICT(policy_key) DO UPDATE SET
+            policy_kind = excluded.policy_kind,
+            value_json = excluded.value_json,
+            version = excluded.version,
+            updated_at = excluded.updated_at
+        `
+      )
+      .run(
+        proposal.policy_key,
+        proposal.policy_kind,
+        proposal.proposed_value_json,
+        version,
+        createdAt,
+        approvedAt
+      );
+
+    adapter
+      .prepare(
+        `
+          UPDATE entity_policy_proposals
+          SET approver_actor = ?,
+              status = 'approved',
+              approved_at = ?
+          WHERE proposal_id = ?
+        `
+      )
+      .run(input.approver_actor, approvedAt, input.proposal_id);
+
+    const approved = getEntityPolicyProposal(input.proposal_id, adapter);
+    if (!approved) {
+      throw new Error(`Failed to reload approved entity policy proposal: ${input.proposal_id}`);
+    }
+    return approved;
+  });
+}
+
+export {
+  createDefaultEntityPolicyBootstrap,
+  type EntityPolicyApprovalInput,
+  type EntityPolicyBootstrapDocument,
+  type EntityPolicyKind,
+  type EntityPolicyProposalInput,
+  type EntityPolicyProposalRow,
+  type EntityPolicyRow,
+  type EntityRole,
+  type EntityRoleBinding,
+  type EntityRoleBindingInput,
+};

--- a/packages/mama-core/src/entities/policy-store.ts
+++ b/packages/mama-core/src/entities/policy-store.ts
@@ -307,6 +307,10 @@ export function approveEntityPolicyProposal(
     if (proposal.proposer_actor === input.approver_actor) {
       throw new Error('Entity policy proposal requires a different approver');
     }
+    const approverRole = resolveEntityRoleForActor(input.approver_actor, adapter);
+    if (approverRole !== 'admin') {
+      throw new Error('Entity policy proposal approval requires an admin approver');
+    }
 
     const existingPolicy = getEntityPolicy(proposal.policy_key, adapter);
     const version = existingPolicy ? existingPolicy.version + 1 : 1;

--- a/packages/mama-core/src/entities/policy-store.ts
+++ b/packages/mama-core/src/entities/policy-store.ts
@@ -117,7 +117,8 @@ function readBootstrapDocument(bootstrapPath: string): EntityPolicyBootstrapDocu
     }
     if (
       typeof policy.policy_key !== 'string' ||
-      !isEntityPolicyKind(String(policy.policy_kind)) ||
+      typeof policy.policy_kind !== 'string' ||
+      !isEntityPolicyKind(policy.policy_kind) ||
       !policy.value ||
       typeof policy.value !== 'object' ||
       Array.isArray(policy.value)
@@ -130,7 +131,11 @@ function readBootstrapDocument(bootstrapPath: string): EntityPolicyBootstrapDocu
     if (!binding || typeof binding !== 'object' || Array.isArray(binding)) {
       throw new Error('Entity policy bootstrap role_bindings must be objects');
     }
-    if (typeof binding.actor_id !== 'string' || !isEntityRole(String(binding.role))) {
+    if (
+      typeof binding.actor_id !== 'string' ||
+      typeof binding.role !== 'string' ||
+      !isEntityRole(binding.role)
+    ) {
       throw new Error('Entity policy bootstrap role binding rows are invalid');
     }
   }

--- a/packages/mama-core/src/entities/policy-store.ts
+++ b/packages/mama-core/src/entities/policy-store.ts
@@ -163,7 +163,15 @@ export async function ensureEntityPolicyBootstrap(args: {
   const timestamp = args.now?.() ?? now();
 
   adapter.transaction(() => {
-    if (countRows('entity_policy', adapter) === 0) {
+    const policyCount = countRows('entity_policy', adapter);
+    const roleBindingCount = countRows('entity_role_bindings', adapter);
+    if ((policyCount === 0) !== (roleBindingCount === 0)) {
+      throw new Error(
+        'Entity policy bootstrap tables are out of sync: entity_policy and entity_role_bindings must be seeded together.'
+      );
+    }
+
+    if (policyCount === 0 && roleBindingCount === 0) {
       for (const policy of document.policies) {
         adapter
           .prepare(
@@ -181,9 +189,6 @@ export async function ensureEntityPolicyBootstrap(args: {
             timestamp
           );
       }
-    }
-
-    if (countRows('entity_role_bindings', adapter) === 0) {
       for (const binding of document.role_bindings) {
         adapter
           .prepare(

--- a/packages/mama-core/src/entities/policy-types.ts
+++ b/packages/mama-core/src/entities/policy-types.ts
@@ -1,0 +1,132 @@
+export const ENTITY_POLICY_ROLES = ['viewer', 'operator', 'admin'] as const;
+export type EntityRole = (typeof ENTITY_POLICY_ROLES)[number];
+
+export const ENTITY_POLICY_KINDS = [
+  'entity_kind',
+  'merge_guardrails',
+  'review_thresholds',
+  'connector_policy',
+] as const;
+export type EntityPolicyKind = (typeof ENTITY_POLICY_KINDS)[number];
+
+export const ENTITY_POLICY_PROPOSAL_STATUSES = ['pending', 'approved', 'rejected'] as const;
+export type EntityPolicyProposalStatus = (typeof ENTITY_POLICY_PROPOSAL_STATUSES)[number];
+
+export interface EntityPolicyRow {
+  policy_key: string;
+  policy_kind: EntityPolicyKind;
+  value_json: string;
+  value: Record<string, unknown>;
+  version: number;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface EntityRoleBinding {
+  actor_id: string;
+  role: EntityRole;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface EntityRoleBindingInput {
+  actor_id: string;
+  role: EntityRole;
+}
+
+export interface EntityPolicyProposalRow {
+  proposal_id: string;
+  policy_key: string;
+  policy_kind: EntityPolicyKind;
+  proposed_value_json: string;
+  proposed_value: Record<string, unknown>;
+  proposer_actor: string;
+  approver_actor: string | null;
+  reason: string;
+  status: EntityPolicyProposalStatus;
+  created_at: number;
+  approved_at: number | null;
+}
+
+export interface EntityPolicyProposalInput {
+  policy_key: string;
+  policy_kind: EntityPolicyKind;
+  proposed_value: Record<string, unknown>;
+  proposer_actor: string;
+  reason: string;
+  proposal_id?: string;
+  created_at?: number;
+}
+
+export interface EntityPolicyApprovalInput {
+  proposal_id: string;
+  approver_actor: string;
+  approved_at?: number;
+}
+
+export interface EntityPolicyBootstrapPolicy {
+  policy_key: string;
+  policy_kind: EntityPolicyKind;
+  value: Record<string, unknown>;
+}
+
+export interface EntityPolicyBootstrapRoleBinding {
+  actor_id: string;
+  role: EntityRole;
+}
+
+export interface EntityPolicyBootstrapDocument {
+  version: number;
+  policies: EntityPolicyBootstrapPolicy[];
+  role_bindings: EntityPolicyBootstrapRoleBinding[];
+}
+
+export const ENTITY_ROLE_ORDER: Record<EntityRole, number> = {
+  viewer: 0,
+  operator: 1,
+  admin: 2,
+};
+
+export function isEntityRole(value: string): value is EntityRole {
+  return ENTITY_POLICY_ROLES.includes(value as EntityRole);
+}
+
+export function isEntityPolicyKind(value: string): value is EntityPolicyKind {
+  return ENTITY_POLICY_KINDS.includes(value as EntityPolicyKind);
+}
+
+export function isEntityPolicyProposalStatus(value: string): value is EntityPolicyProposalStatus {
+  return ENTITY_POLICY_PROPOSAL_STATUSES.includes(value as EntityPolicyProposalStatus);
+}
+
+export function createDefaultEntityPolicyBootstrap(
+  adminActor = 'local:viewer'
+): EntityPolicyBootstrapDocument {
+  return {
+    version: 1,
+    policies: [
+      {
+        policy_key: 'merge_guardrails.default',
+        policy_kind: 'merge_guardrails',
+        value: {
+          max_false_merge_rate: 0.02,
+          require_review_for_cross_scope: true,
+        },
+      },
+      {
+        policy_key: 'review_thresholds.default',
+        policy_kind: 'review_thresholds',
+        value: {
+          approve_score_min: 0.92,
+          defer_score_min: 0.78,
+        },
+      },
+    ],
+    role_bindings: [
+      {
+        actor_id: adminActor,
+        role: 'admin',
+      },
+    ],
+  };
+}

--- a/packages/mama-core/src/entities/projection.ts
+++ b/packages/mama-core/src/entities/projection.ts
@@ -6,6 +6,39 @@ interface ProjectionOptions {
   nodeLookup?: Record<string, EntityNode>;
 }
 
+function formatTimelineEventForRecall(latestEvent: EntityTimelineEvent | null): string | null {
+  if (!latestEvent) {
+    return null;
+  }
+
+  const parts: string[] = [];
+  const eventType = latestEvent.event_type.trim();
+  const summary = latestEvent.summary.trim();
+  const details = latestEvent.details?.trim() ?? '';
+
+  if (eventType.length > 0) {
+    parts.push(eventType);
+  }
+  if (summary.length > 0) {
+    parts.push(summary);
+  }
+
+  if (details.length > 0 && details !== summary) {
+    try {
+      const parsed = JSON.parse(details) as unknown;
+      if (parsed && typeof parsed === 'object') {
+        parts.push(JSON.stringify(parsed));
+      } else {
+        parts.push(details);
+      }
+    } catch {
+      parts.push(details);
+    }
+  }
+
+  return parts.length > 0 ? parts.join('\n') : null;
+}
+
 function assertNoCircularMerge(node: EntityNode, options?: ProjectionOptions): void {
   if (!options?.nodeLookup) {
     return;
@@ -41,7 +74,7 @@ export function projectEntityToRecallSummary(
   assertNoCircularMerge(node, options);
 
   const aliasText = aliases.map((alias) => alias.label).join(', ');
-  const detailParts = [latestEvent?.summary, latestEvent?.details, aliasText].filter(
+  const detailParts = [formatTimelineEventForRecall(latestEvent), aliasText].filter(
     (value): value is string => Boolean(value)
   );
 

--- a/packages/mama-core/src/entities/projection.ts
+++ b/packages/mama-core/src/entities/projection.ts
@@ -77,6 +77,8 @@ export function projectEntityToRecallSummary(
   const detailParts = [formatTimelineEventForRecall(latestEvent), aliasText].filter(
     (value): value is string => Boolean(value)
   );
+  const scopeKind = node.scope_kind ?? 'global';
+  const scopeId = node.scope_kind === null ? 'global' : (node.scope_id ?? 'global');
 
   return {
     id: node.id,
@@ -86,7 +88,7 @@ export function projectEntityToRecallSummary(
     details: detailParts.join('\n'),
     confidence: 0.9,
     status: 'active',
-    scopes: [{ kind: node.scope_kind, id: node.scope_id ?? 'global' }],
+    scopes: [{ kind: scopeKind, id: scopeId }],
     source: {
       package: 'mama-core',
       source_type: 'entity_canonical',

--- a/packages/mama-core/src/entities/provenance-query.ts
+++ b/packages/mama-core/src/entities/provenance-query.ts
@@ -1,0 +1,266 @@
+import { getAdapter, initDB } from '../db-manager.js';
+import { detectSourceLocatorKind, type SourceLocatorKind } from './source-locator.js';
+import type {
+  MemoryKind,
+  MemoryRecord,
+  MemoryScopeKind,
+  MemoryScopeRef,
+  MemoryStatus,
+} from '../memory/types.js';
+
+interface DecisionRow {
+  id: string;
+  topic: string;
+  decision: string;
+  reasoning: string | null;
+  confidence: number | null;
+  created_at: number;
+  updated_at: number | null;
+  trust_context: string | null;
+  kind: string | null;
+  status: string | null;
+  summary: string | null;
+  event_date: string | null;
+}
+
+interface ScopeRow {
+  memory_id: string;
+  kind: string;
+  external_id: string;
+}
+
+interface ObservationRow {
+  id: string;
+  observation_type: string;
+  entity_kind_hint: string | null;
+  surface_form: string;
+  normalized_form: string;
+  lang: string | null;
+  script: string | null;
+  context_summary: string | null;
+  scope_kind: string;
+  scope_id: string | null;
+  extractor_version: string;
+  embedding_model_version: string | null;
+  source_connector: string;
+  source_locator: string | null;
+  source_raw_record_id: string;
+  created_at: number;
+}
+
+interface MemoryEventRow {
+  event_type: 'provenance.empty_batch' | 'provenance.link_write_failed';
+  reason: string | null;
+  created_at: number;
+}
+
+export interface ProvenanceObservationSummary {
+  id: string;
+  observation_type: string;
+  entity_kind_hint: string | null;
+  surface_form: string;
+  normalized_form: string;
+  lang: string | null;
+  script: string | null;
+  context_summary: string | null;
+  scope_kind: string;
+  scope_id: string | null;
+  extractor_version: string;
+  embedding_model_version: string | null;
+  source_connector: string;
+  source_locator: string | null;
+  source_locator_kind: SourceLocatorKind;
+  source_raw_record_id: string;
+  created_at: number;
+}
+
+export interface MemoryProvenanceResult {
+  status: 'legacy' | 'manual' | 'dropped' | 'resolved';
+  memory: MemoryRecord;
+  observations: ProvenanceObservationSummary[];
+  audit: {
+    event_type: 'provenance.empty_batch' | 'provenance.link_write_failed';
+    reason: string | null;
+    created_at: number;
+  } | null;
+}
+
+function parseSource(trustContext: string | null): MemoryRecord['source'] {
+  if (typeof trustContext !== 'string' || trustContext.length === 0) {
+    return { package: 'mama-core', source_type: 'db' };
+  }
+  try {
+    const parsed = JSON.parse(trustContext) as { source?: MemoryRecord['source'] };
+    if (parsed?.source && typeof parsed.source === 'object') {
+      return parsed.source;
+    }
+  } catch {
+    // ignore malformed trust_context
+  }
+  return { package: 'mama-core', source_type: 'db' };
+}
+
+function mapMemoryRecord(row: DecisionRow, scopes: MemoryScopeRef[]): MemoryRecord {
+  return {
+    id: row.id,
+    topic: row.topic,
+    kind: ((row.kind as MemoryKind | null) ?? 'decision') as MemoryKind,
+    summary: row.summary ?? row.decision,
+    details: row.reasoning ?? row.decision,
+    confidence: row.confidence ?? 0.5,
+    status: ((row.status as MemoryStatus | null) ?? 'active') as MemoryStatus,
+    scopes,
+    source: parseSource(row.trust_context),
+    created_at: row.created_at,
+    updated_at: row.updated_at ?? row.created_at,
+    event_date: row.event_date,
+  };
+}
+
+function loadScopes(memoryId: string): MemoryScopeRef[] {
+  const adapter = getAdapter();
+  const rows = adapter
+    .prepare(
+      `
+        SELECT msb.memory_id, ms.kind, ms.external_id
+        FROM memory_scope_bindings msb
+        JOIN memory_scopes ms ON ms.id = msb.scope_id
+        WHERE msb.memory_id = ?
+        ORDER BY msb.is_primary DESC
+      `
+    )
+    .all(memoryId) as ScopeRow[];
+
+  return rows.map((row) => ({
+    kind: row.kind as MemoryScopeKind,
+    id: row.external_id,
+  }));
+}
+
+function loadObservations(memoryId: string): ProvenanceObservationSummary[] {
+  const adapter = getAdapter();
+  const rows = adapter
+    .prepare(
+      `
+        SELECT
+          o.id,
+          o.observation_type,
+          o.entity_kind_hint,
+          o.surface_form,
+          o.normalized_form,
+          o.lang,
+          o.script,
+          o.context_summary,
+          o.scope_kind,
+          o.scope_id,
+          o.extractor_version,
+          o.embedding_model_version,
+          o.source_connector,
+          o.source_locator,
+          o.source_raw_record_id,
+          o.created_at
+        FROM decision_entity_sources des
+        JOIN entity_observations o ON o.id = des.entity_observation_id
+        WHERE des.decision_id = ?
+        ORDER BY des.created_at ASC, o.created_at ASC
+      `
+    )
+    .all(memoryId) as ObservationRow[];
+
+  return rows.map((row) => ({
+    id: row.id,
+    observation_type: row.observation_type,
+    entity_kind_hint: row.entity_kind_hint,
+    surface_form: row.surface_form,
+    normalized_form: row.normalized_form,
+    lang: row.lang,
+    script: row.script,
+    context_summary: row.context_summary,
+    scope_kind: row.scope_kind,
+    scope_id: row.scope_id,
+    extractor_version: row.extractor_version,
+    embedding_model_version: row.embedding_model_version,
+    source_connector: row.source_connector,
+    source_locator: row.source_locator,
+    source_locator_kind: detectSourceLocatorKind(row.source_locator),
+    source_raw_record_id: row.source_raw_record_id,
+    created_at: row.created_at,
+  }));
+}
+
+function loadProvenanceAudit(memoryId: string): MemoryProvenanceResult['audit'] {
+  const adapter = getAdapter();
+  const row = adapter
+    .prepare(
+      `
+        SELECT event_type, reason, created_at
+        FROM memory_events
+        WHERE memory_id = ?
+          AND event_type IN ('provenance.empty_batch', 'provenance.link_write_failed')
+        ORDER BY created_at DESC
+        LIMIT 1
+      `
+    )
+    .get(memoryId) as MemoryEventRow | undefined;
+
+  if (!row) {
+    return null;
+  }
+
+  return {
+    event_type: row.event_type,
+    reason: row.reason,
+    created_at: row.created_at,
+  };
+}
+
+export async function queryProvenanceForMemory(memoryId: string): Promise<MemoryProvenanceResult> {
+  await initDB();
+  const adapter = getAdapter();
+  const row = adapter
+    .prepare(
+      `
+        SELECT
+          id,
+          topic,
+          decision,
+          reasoning,
+          confidence,
+          created_at,
+          updated_at,
+          trust_context,
+          kind,
+          status,
+          summary,
+          event_date
+        FROM decisions
+        WHERE id = ?
+      `
+    )
+    .get(memoryId) as DecisionRow | undefined;
+
+  if (!row) {
+    throw new Error(`Decision not found: ${memoryId}`);
+  }
+
+  const scopes = loadScopes(memoryId);
+  const memory = mapMemoryRecord(row, scopes);
+  const observations = loadObservations(memoryId);
+  const audit = loadProvenanceAudit(memoryId);
+
+  let status: MemoryProvenanceResult['status'] = 'legacy';
+  if (observations.length > 0) {
+    status = 'resolved';
+  } else if (audit?.event_type === 'provenance.link_write_failed') {
+    status = 'dropped';
+  } else if (audit?.event_type === 'provenance.empty_batch') {
+    status = 'manual';
+  }
+
+  return {
+    status,
+    memory,
+    observations,
+    audit,
+  };
+}

--- a/packages/mama-core/src/entities/read-identity.ts
+++ b/packages/mama-core/src/entities/read-identity.ts
@@ -1,0 +1,377 @@
+import { getAdapter, initDB } from '../db-manager.js';
+import type { MemoryRecord } from '../memory/types.js';
+
+export interface CanonicalReadEntity {
+  id: string;
+  label: string;
+  kind: string;
+}
+
+export type ReadIdentity =
+  | {
+      kind: 'canonical';
+      entities: CanonicalReadEntity[];
+      primaryEntity: CanonicalReadEntity;
+      legacyTopic: string | null;
+      shadowConflict: boolean;
+      displaySubject?: string | null;
+      displayTopic?: string | null;
+      displaySuffix?: string | null;
+    }
+  | {
+      kind: 'topic';
+      topic: string;
+      displaySubject?: string | null;
+      displayTopic?: string | null;
+      displaySuffix?: string | null;
+    }
+  | {
+      kind: 'raw';
+      label: string;
+      displaySubject?: string | null;
+      displayTopic?: string | null;
+      displaySuffix?: string | null;
+    };
+
+function normalizeText(value: string): string {
+  return value.normalize('NFKC').trim().replace(/\s+/gu, ' ').toLowerCase();
+}
+
+function normalizeLooseText(value: string | null | undefined): string {
+  return normalizeText(value ?? '')
+    .replace(/[_-]+/gu, ' ')
+    .replace(/[^\p{Letter}\p{Number}\s/]+/gu, ' ')
+    .replace(/\s+/gu, ' ')
+    .trim();
+}
+
+function humanizeTopicSegment(segment: string): string {
+  return segment.normalize('NFKC').replace(/[_]+/gu, ' ').replace(/\s+/gu, ' ').trim();
+}
+
+function humanizeTopicLabel(topic: string | null | undefined): string | null {
+  if (typeof topic !== 'string') {
+    return null;
+  }
+
+  const segments = topic
+    .split('/')
+    .map((segment) => humanizeTopicSegment(segment))
+    .filter((segment) => segment.length > 0);
+
+  if (segments.length === 0) {
+    const fallback = humanizeTopicSegment(topic);
+    return fallback.length > 0 ? fallback : null;
+  }
+
+  return segments.join(' / ');
+}
+
+function hasProjectishSignal(label: string | null | undefined): boolean {
+  return /(?:案件|相談|窓|民泊|project|room|board|launch|client|feedback|delivery)/iu.test(
+    label ?? ''
+  );
+}
+
+function looksLikeMachineGeneratedLabel(label: string | null | undefined): boolean {
+  return /^(slack|chatwork|telegram|line|kakao)(:|$)/iu.test(label ?? '');
+}
+
+function looksLikeParticipantLabel(label: string | null | undefined): boolean {
+  if (!label) {
+    return false;
+  }
+  const trimmed = label.trim();
+
+  if (/^(kagemusha|system)$/iu.test(trimmed)) {
+    return true;
+  }
+  if (hasProjectishSignal(trimmed)) {
+    return false;
+  }
+  if (/[·,]/u.test(trimmed)) {
+    return true;
+  }
+  if (trimmed.length === 0 || trimmed.length > 20) {
+    return false;
+  }
+  if (/[A-Za-z0-9]/u.test(trimmed)) {
+    return false;
+  }
+
+  return /^[\p{Script=Hangul}\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\s()]+$/u.test(
+    trimmed
+  );
+}
+
+function hasNonEmptyTopic(record: Pick<MemoryRecord, 'topic'>): boolean {
+  return typeof record.topic === 'string' && record.topic.trim().length > 0;
+}
+
+function sortCanonicalReadEntities(entities: CanonicalReadEntity[]): CanonicalReadEntity[] {
+  return [...entities].sort((left, right) => {
+    if (left.kind !== right.kind) {
+      return left.kind.localeCompare(right.kind);
+    }
+    if (left.label !== right.label) {
+      return left.label.localeCompare(right.label);
+    }
+    return left.id.localeCompare(right.id);
+  });
+}
+
+function hasShadowConflict(
+  record: Pick<MemoryRecord, 'topic' | 'summary'>,
+  primaryEntity: CanonicalReadEntity
+): boolean {
+  if (!hasNonEmptyTopic(record)) {
+    return false;
+  }
+
+  const summary = normalizeText(record.summary ?? '');
+  const label = normalizeText(primaryEntity.label);
+  if (!summary || !label) {
+    return false;
+  }
+  if (summary === label) {
+    return false;
+  }
+  if (summary.includes(label) || label.includes(summary)) {
+    return false;
+  }
+  return true;
+}
+
+function getLegacyTopic(record: Pick<MemoryRecord, 'topic'>): string | null {
+  return hasNonEmptyTopic(record) ? record.topic.trim() : null;
+}
+
+function getLegacyNamespace(record: Pick<MemoryRecord, 'topic'>): string | null {
+  const legacyTopic = getLegacyTopic(record);
+  if (!legacyTopic) {
+    return null;
+  }
+  const humanized = humanizeTopicSegment(legacyTopic.split('/')[0] ?? '');
+  if (normalizeLooseText(humanized) === 'entity') {
+    return null;
+  }
+  return humanized || null;
+}
+
+function selectDisplayEntity(
+  entities: CanonicalReadEntity[],
+  primaryEntity: CanonicalReadEntity
+): CanonicalReadEntity {
+  return (
+    entities.find((entity) => ['project', 'work_item', 'organization'].includes(entity.kind)) ??
+    primaryEntity
+  );
+}
+
+function buildDisplaySubject(
+  record: Pick<MemoryRecord, 'topic' | 'summary'>,
+  entities: CanonicalReadEntity[],
+  primaryEntity: CanonicalReadEntity
+): string | null {
+  const preferredEntity = selectDisplayEntity(entities, primaryEntity);
+  const preferredLabel = preferredEntity.label?.trim();
+  const legacyNamespace = getLegacyNamespace(record);
+  const summary = record.summary?.trim();
+
+  if (summary && typeof record.topic === 'string' && record.topic.startsWith('entity/')) {
+    return summary;
+  }
+  if (
+    legacyNamespace &&
+    preferredLabel &&
+    normalizeLooseText(preferredLabel) !== normalizeLooseText(legacyNamespace) &&
+    (looksLikeMachineGeneratedLabel(preferredLabel) || looksLikeParticipantLabel(preferredLabel))
+  ) {
+    return legacyNamespace;
+  }
+  if (preferredLabel && !looksLikeMachineGeneratedLabel(preferredLabel)) {
+    return preferredLabel;
+  }
+  if (legacyNamespace) {
+    return legacyNamespace;
+  }
+  return summary || humanizeTopicLabel(getLegacyTopic(record)) || preferredLabel || null;
+}
+
+function buildDisplayTopic(
+  record: Pick<MemoryRecord, 'topic' | 'summary'>,
+  entities: CanonicalReadEntity[],
+  primaryEntity: CanonicalReadEntity
+): string | null {
+  const summary = record.summary?.trim();
+  if (summary && typeof record.topic === 'string' && record.topic.startsWith('entity/')) {
+    return summary;
+  }
+
+  const preferredEntity = selectDisplayEntity(entities, primaryEntity);
+  const subjectLabel =
+    preferredEntity.kind !== 'person' && preferredEntity.label.trim().length > 0
+      ? preferredEntity.label.trim()
+      : '';
+  const humanizedTopic = humanizeTopicLabel(getLegacyTopic(record));
+
+  if (!subjectLabel) {
+    return humanizedTopic || summary || null;
+  }
+  if (!humanizedTopic) {
+    return subjectLabel;
+  }
+
+  const normalizedSubject = normalizeLooseText(subjectLabel);
+  const normalizedTopic = normalizeLooseText(humanizedTopic);
+  const tokens = normalizedTopic.split(' ').filter((token) => token.length > 0);
+  const genericTokens = new Set(['spine', 'fb', 'fix', 'pdf', 'sd', 'ex', 'ar', 'r18', 'sp']);
+  const informativeTokens = tokens.filter(
+    (token) => !genericTokens.has(token) && !/^\d+$/u.test(token) && token.length > 1
+  );
+  const lowSignalTopic = normalizedTopic.length === 0 || informativeTokens.length === 0;
+
+  if (lowSignalTopic || normalizedTopic === normalizedSubject) {
+    return subjectLabel;
+  }
+  return humanizedTopic;
+}
+
+function buildDisplaySuffix(
+  record: Pick<MemoryRecord, 'topic' | 'summary'>,
+  entities: CanonicalReadEntity[],
+  primaryEntity: CanonicalReadEntity
+): string | null {
+  const displaySubject = buildDisplaySubject(record, entities, primaryEntity);
+  const displayTopic = buildDisplayTopic(record, entities, primaryEntity);
+
+  if (!displaySubject || !displayTopic) {
+    return null;
+  }
+
+  const normalizedSubject = normalizeLooseText(displaySubject);
+  const normalizedTopic = normalizeLooseText(displayTopic);
+  if (!normalizedTopic || normalizedTopic === normalizedSubject) {
+    return null;
+  }
+
+  const subjectParts = displaySubject
+    .split('/')
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const topicParts = displayTopic
+    .split('/')
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (topicParts.length > 1 && subjectParts.length > 0) {
+    const firstTopicPart = topicParts[0] ?? '';
+    const firstSubjectPart = subjectParts[subjectParts.length - 1] ?? '';
+    if (normalizeLooseText(firstTopicPart) === normalizeLooseText(firstSubjectPart)) {
+      const suffix = topicParts.slice(1).join(' / ').trim();
+      return suffix.length > 0 ? suffix : null;
+    }
+  }
+
+  return displayTopic;
+}
+
+export function resolveReadIdentity(
+  record: Pick<MemoryRecord, 'topic' | 'summary'>,
+  entities: CanonicalReadEntity[]
+): ReadIdentity {
+  if (entities.length > 0) {
+    const sortedEntities = sortCanonicalReadEntities(entities);
+    const primaryEntity = sortedEntities[0]!;
+    return {
+      kind: 'canonical',
+      entities: sortedEntities,
+      primaryEntity,
+      legacyTopic: getLegacyTopic(record),
+      shadowConflict: hasShadowConflict(record, primaryEntity),
+      displaySubject: buildDisplaySubject(record, sortedEntities, primaryEntity),
+      displayTopic: buildDisplayTopic(record, sortedEntities, primaryEntity),
+      displaySuffix: buildDisplaySuffix(record, sortedEntities, primaryEntity),
+    };
+  }
+
+  if (hasNonEmptyTopic(record)) {
+    return {
+      kind: 'topic',
+      topic: record.topic.trim(),
+      displaySubject: null,
+      displayTopic: humanizeTopicLabel(record.topic),
+      displaySuffix: null,
+    };
+  }
+
+  return {
+    kind: 'raw',
+    label: record.summary.trim() || '<unknown>',
+    displaySubject: null,
+    displayTopic: record.summary.trim() || '<unknown>',
+    displaySuffix: null,
+  };
+}
+
+export async function loadDecisionReadIdentityIndex(
+  decisionIds: string[]
+): Promise<Map<string, CanonicalReadEntity[]>> {
+  await initDB();
+
+  const uniqueDecisionIds = Array.from(
+    new Set(
+      decisionIds
+        .filter((decisionId): decisionId is string => typeof decisionId === 'string')
+        .map((decisionId) => decisionId.trim())
+        .filter((decisionId) => decisionId.length > 0)
+    )
+  );
+  const index = new Map<string, CanonicalReadEntity[]>();
+  if (uniqueDecisionIds.length === 0) {
+    return index;
+  }
+
+  const placeholders = uniqueDecisionIds.map(() => '?').join(', ');
+  const rows = getAdapter()
+    .prepare(
+      `
+        SELECT
+          des.decision_id,
+          n.id AS entity_id,
+          n.preferred_label AS entity_label,
+          n.kind AS entity_kind
+        FROM decision_entity_sources des
+        JOIN entity_lineage_links l
+          ON l.entity_observation_id = des.entity_observation_id
+         AND l.status = 'active'
+        JOIN entity_nodes n
+          ON n.id = l.canonical_entity_id
+        WHERE des.decision_id IN (${placeholders})
+          AND n.status = 'active'
+          AND n.merged_into IS NULL
+        GROUP BY des.decision_id, n.id, n.preferred_label, n.kind
+      `
+    )
+    .all(...uniqueDecisionIds) as Array<{
+    decision_id: string;
+    entity_id: string;
+    entity_label: string;
+    entity_kind: string;
+  }>;
+
+  for (const row of rows) {
+    const existing = index.get(row.decision_id) ?? [];
+    existing.push({
+      id: row.entity_id,
+      label: row.entity_label,
+      kind: row.entity_kind,
+    });
+    index.set(row.decision_id, existing);
+  }
+
+  for (const [decisionId, entities] of index.entries()) {
+    index.set(decisionId, sortCanonicalReadEntities(entities));
+  }
+
+  return index;
+}

--- a/packages/mama-core/src/entities/recall-bridge.ts
+++ b/packages/mama-core/src/entities/recall-bridge.ts
@@ -11,7 +11,8 @@ function mapNode(row: Record<string, unknown>): EntityNode {
     kind: row.kind as EntityNode['kind'],
     preferred_label: String(row.preferred_label),
     status: row.status as EntityNode['status'],
-    scope_kind: row.scope_kind as EntityNode['scope_kind'],
+    scope_kind:
+      typeof row.scope_kind === 'string' ? (row.scope_kind as EntityNode['scope_kind']) : null,
     scope_id: typeof row.scope_id === 'string' ? row.scope_id : null,
     merged_into: typeof row.merged_into === 'string' ? row.merged_into : null,
     created_at: Number(row.created_at),

--- a/packages/mama-core/src/entities/recall-bridge.ts
+++ b/packages/mama-core/src/entities/recall-bridge.ts
@@ -1,6 +1,7 @@
 import { getAdapter, initDB } from '../db-manager.js';
 import type { MemoryRecord, MemoryScopeRef } from '../memory/types.js';
 import { projectEntityToRecallSummary } from './projection.js';
+import { resolveReadIdentity } from './read-identity.js';
 import { EntityMergeError, resolveCanonicalEntityId } from './store.js';
 import type { EntityAlias, EntityNode, EntityTimelineEvent } from './types.js';
 
@@ -67,21 +68,24 @@ export async function queryCanonicalEntities(
   // then chain-walk each match to its canonical terminal. Without this,
   // searching by the old name of a merged entity returns nothing because the
   // filter `n.status='active' AND n.merged_into IS NULL` would drop the
-  // source row. Matches Policy A2 in
-  // docs/superpowers/specs/2026-04-13-canonical-entity-merge-design.md.
+  // source row. Matches the read-time chain-walking approach in the canonical
+  // entity ontology implementation plan.
   const matchedRows = adapter
     .prepare(
       `
         SELECT DISTINCT n.id AS matched_id
         FROM entity_nodes n
         LEFT JOIN entity_aliases a ON a.entity_id = n.id
+        LEFT JOIN entity_lineage_links l ON l.canonical_entity_id = n.id AND l.status = 'active'
+        LEFT JOIN entity_observations o ON o.id = l.entity_observation_id
         WHERE (
           lower(n.preferred_label) LIKE '%' || lower(?) || '%' ESCAPE '\\'
           OR lower(COALESCE(a.label, '')) LIKE '%' || lower(?) || '%' ESCAPE '\\'
+          OR lower(COALESCE(o.surface_form, '')) LIKE '%' || lower(?) || '%' ESCAPE '\\'
         )
       `
     )
-    .all(escapedQuery, escapedQuery) as Array<{ matched_id: string }>;
+    .all(escapedQuery, escapedQuery, escapedQuery) as Array<{ matched_id: string }>;
 
   const canonicalIdSet = new Set<string>();
   for (const match of matchedRows) {
@@ -119,8 +123,18 @@ export async function queryCanonicalEntities(
   const scopedRows =
     scopes.length === 0
       ? rows
-      : rows.filter((row) =>
-          scopes.some((scope) => scope.kind === row.scope_kind && row.scope_id === scope.id)
+      : rows.filter(
+          (row) =>
+            // Fix 2 part B (P0): globally-scoped entities are not bound to
+            // any narrower scope and must surface in every scoped query.
+            // Without this passthrough, switching person observations from
+            // channel-scope to global-scope (Fix 2 part A in
+            // history-extractor.ts) would make persons invisible to scoped
+            // recall callers, breaking the time-travel use case the fix is
+            // meant to enable. scope_id is intentionally not compared for
+            // globals — the global predicate is `scope_kind='global'` alone.
+            row.scope_kind === 'global' ||
+            scopes.some((scope) => scope.kind === row.scope_kind && row.scope_id === scope.id)
         );
 
   const limitedRows = scopedRows.slice(0, options.limit ?? 10);
@@ -174,14 +188,16 @@ export async function queryCanonicalEntities(
   const result: MemoryRecord[] = [];
   for (const row of limitedRows) {
     const node = mapNode(row);
-    result.push(
-      projectEntityToRecallSummary(
-        node,
-        aliasesByEntity.get(node.id) ?? [],
-        latestTimelineByEntity.get(node.id) ?? null,
-        { nodeLookup }
-      )
+    const projected = projectEntityToRecallSummary(
+      node,
+      aliasesByEntity.get(node.id) ?? [],
+      latestTimelineByEntity.get(node.id) ?? null,
+      { nodeLookup }
     );
+    projected.read_identity = resolveReadIdentity(projected, [
+      { id: node.id, label: node.preferred_label, kind: node.kind },
+    ]);
+    result.push(projected);
   }
 
   return result;

--- a/packages/mama-core/src/entities/rollback-preview.ts
+++ b/packages/mama-core/src/entities/rollback-preview.ts
@@ -1,0 +1,340 @@
+import { getAdapter, initDB } from '../db-manager.js';
+import { projectEntityToRecallSummary } from './projection.js';
+import { getEntityNode, listEntityAliases, type EntityStoreAdapter } from './store.js';
+import { listActiveEntityLineage, listEntityLineageHistory } from './lineage-store.js';
+import type { EntityLineageLink, EntityNode, EntityTimelineEvent } from './types.js';
+
+export interface RollbackPreviewInput {
+  entityId: string;
+  mergeActionId?: string;
+  observationId?: string;
+  maxAffectedRows?: number;
+}
+
+export interface RollbackPreviewEntityChange {
+  entity_id: string;
+  label: string;
+  status_after: 'active' | 'merged';
+  active_lineage_after: number;
+  summary: string;
+}
+
+export interface RollbackPreviewMemoryChange {
+  id: string;
+  topic: string;
+  summary: string;
+  created_at: number;
+}
+
+export interface RollbackPreviewMetricMovement {
+  metric: 'false_merge_rate' | 'projection_fragmentation_rate';
+  direction: 'increase' | 'decrease';
+  reason: string;
+}
+
+export interface RollbackPreviewResult {
+  entity_id: string;
+  merge_action_id: string | null;
+  preview_unavailable: boolean;
+  history_incomplete: boolean;
+  truncated: boolean;
+  changed_entities: RollbackPreviewEntityChange[];
+  changed_memories: RollbackPreviewMemoryChange[];
+  metric_movement: RollbackPreviewMetricMovement[];
+}
+
+interface MergeActionRow {
+  id: string;
+  source_entity_id: string;
+  target_entity_id: string;
+  created_at: number;
+}
+
+function unavailableResult(
+  entityId: string,
+  mergeActionId: string | null,
+  historyIncomplete: boolean
+): RollbackPreviewResult {
+  return {
+    entity_id: entityId,
+    merge_action_id: mergeActionId,
+    preview_unavailable: true,
+    history_incomplete: historyIncomplete,
+    truncated: false,
+    changed_entities: [],
+    changed_memories: [],
+    metric_movement: [],
+  };
+}
+
+function uniqueStrings(values: Array<string | null | undefined>): string[] {
+  return Array.from(new Set(values.filter((value): value is string => Boolean(value))));
+}
+
+function getLatestTimeline(
+  adapter: EntityStoreAdapter,
+  entityId: string
+): EntityTimelineEvent | null {
+  const row = adapter
+    .prepare(
+      `
+        SELECT *
+        FROM entity_timeline_events
+        WHERE entity_id = ?
+        ORDER BY COALESCE(observed_at, created_at) DESC
+        LIMIT 1
+      `
+    )
+    .get(entityId) as Record<string, unknown> | undefined;
+
+  if (!row) {
+    return null;
+  }
+
+  return {
+    id: String(row.id),
+    entity_id: String(row.entity_id),
+    event_type: row.event_type as EntityTimelineEvent['event_type'],
+    valid_from: typeof row.valid_from === 'number' ? row.valid_from : null,
+    valid_to: typeof row.valid_to === 'number' ? row.valid_to : null,
+    observed_at: typeof row.observed_at === 'number' ? row.observed_at : null,
+    source_ref: typeof row.source_ref === 'string' ? row.source_ref : null,
+    summary: String(row.summary ?? ''),
+    details: typeof row.details === 'string' ? row.details : null,
+    created_at: Number(row.created_at),
+  };
+}
+
+function projectLabel(adapter: EntityStoreAdapter, node: EntityNode): string {
+  const summary = projectEntityToRecallSummary(
+    node,
+    listEntityAliases(node.id, adapter),
+    getLatestTimeline(adapter, node.id),
+    { nodeLookup: { [node.id]: node } }
+  );
+  return summary.summary;
+}
+
+function loadMergeAction(
+  adapter: EntityStoreAdapter,
+  entityId: string,
+  mergeActionId?: string
+): MergeActionRow | null {
+  const sql = mergeActionId
+    ? `
+        SELECT id, source_entity_id, target_entity_id, created_at
+        FROM entity_merge_actions
+        WHERE id = ?
+        LIMIT 1
+      `
+    : `
+        SELECT id, source_entity_id, target_entity_id, created_at
+        FROM entity_merge_actions
+        WHERE target_entity_id = ?
+        ORDER BY created_at DESC
+        LIMIT 1
+      `;
+  const row = adapter.prepare(sql).get(mergeActionId ?? entityId) as MergeActionRow | undefined;
+  return row ?? null;
+}
+
+function resolveMergePreviewRows(input: {
+  sourceHistory: EntityLineageLink[];
+  targetActive: EntityLineageLink[];
+  sourceEntityId: string;
+}): { restoredRows: EntityLineageLink[]; removedRows: EntityLineageLink[] } {
+  const restoredRows = input.sourceHistory.filter((row) => row.status === 'superseded');
+  let removedRows = input.targetActive.filter(
+    (row) => row.source_entity_id === input.sourceEntityId
+  );
+
+  if (removedRows.length === 0 && restoredRows.length > 0) {
+    const restorableObservationIds = new Set(restoredRows.map((row) => row.entity_observation_id));
+    removedRows = input.targetActive.filter((row) =>
+      restorableObservationIds.has(row.entity_observation_id)
+    );
+  }
+
+  return { restoredRows, removedRows };
+}
+
+function loadChangedMemories(
+  adapter: EntityStoreAdapter,
+  observationIds: string[]
+): RollbackPreviewMemoryChange[] {
+  if (observationIds.length === 0) {
+    return [];
+  }
+
+  const placeholders = observationIds.map(() => '?').join(', ');
+  const rows = adapter
+    .prepare(
+      `
+        SELECT DISTINCT d.id, d.topic, d.summary, d.created_at
+        FROM decision_entity_sources des
+        JOIN decisions d ON d.id = des.decision_id
+        WHERE des.entity_observation_id IN (${placeholders})
+        ORDER BY d.created_at DESC
+      `
+    )
+    .all(...observationIds) as Array<{
+    id: string;
+    topic: string;
+    summary: string | null;
+    created_at: number;
+  }>;
+
+  return rows.map((row) => ({
+    id: row.id,
+    topic: row.topic,
+    summary: row.summary ?? row.topic,
+    created_at: row.created_at,
+  }));
+}
+
+function buildMetricMovement(sourceLabel: string): RollbackPreviewMetricMovement[] {
+  return [
+    {
+      metric: 'false_merge_rate',
+      direction: 'decrease',
+      reason: `Splitting ${sourceLabel} back out would likely reduce false merge pressure.`,
+    },
+    {
+      metric: 'projection_fragmentation_rate',
+      direction: 'increase',
+      reason: `Reactivating a second canonical entity likely increases projection fragmentation.`,
+    },
+  ];
+}
+
+async function previewMergeRollback(
+  adapter: EntityStoreAdapter,
+  input: RollbackPreviewInput,
+  mergeAction: MergeActionRow
+): Promise<RollbackPreviewResult> {
+  const sourceNode = getEntityNode(mergeAction.source_entity_id, adapter);
+  const targetNode = getEntityNode(mergeAction.target_entity_id, adapter);
+  if (!sourceNode || !targetNode) {
+    return unavailableResult(input.entityId, mergeAction.id, true);
+  }
+
+  const sourceHistory = await listEntityLineageHistory(sourceNode.id, adapter);
+  const targetActive = await listActiveEntityLineage(targetNode.id, adapter);
+  const { restoredRows, removedRows } = resolveMergePreviewRows({
+    sourceHistory,
+    targetActive,
+    sourceEntityId: sourceNode.id,
+  });
+
+  if (restoredRows.length === 0 || removedRows.length === 0) {
+    return unavailableResult(input.entityId, mergeAction.id, true);
+  }
+
+  const affectedObservationIds = uniqueStrings([
+    ...restoredRows.map((row) => row.entity_observation_id),
+    ...removedRows.map((row) => row.entity_observation_id),
+  ]);
+  const allChangedMemories = loadChangedMemories(adapter, affectedObservationIds);
+  const maxAffectedRows = Math.max(1, input.maxAffectedRows ?? 50);
+  const truncated = allChangedMemories.length > maxAffectedRows;
+
+  return {
+    entity_id: input.entityId,
+    merge_action_id: mergeAction.id,
+    preview_unavailable: false,
+    history_incomplete: false,
+    truncated,
+    changed_entities: [
+      {
+        entity_id: sourceNode.id,
+        label: sourceNode.preferred_label,
+        status_after: 'active',
+        active_lineage_after: restoredRows.length,
+        summary: projectLabel(adapter, { ...sourceNode, status: 'active', merged_into: null }),
+      },
+      {
+        entity_id: targetNode.id,
+        label: targetNode.preferred_label,
+        status_after: 'active',
+        active_lineage_after: Math.max(0, targetActive.length - removedRows.length),
+        summary: projectLabel(adapter, targetNode),
+      },
+    ],
+    changed_memories: allChangedMemories.slice(0, maxAffectedRows),
+    metric_movement: buildMetricMovement(sourceNode.preferred_label),
+  };
+}
+
+async function previewObservationDetach(
+  adapter: EntityStoreAdapter,
+  input: RollbackPreviewInput
+): Promise<RollbackPreviewResult> {
+  const activeTarget = await listActiveEntityLineage(input.entityId, adapter);
+  const targetNode = getEntityNode(input.entityId, adapter);
+  if (!targetNode) {
+    return unavailableResult(input.entityId, null, false);
+  }
+
+  const row = activeTarget.find(
+    (candidate) => candidate.entity_observation_id === input.observationId
+  );
+  if (!row) {
+    return unavailableResult(input.entityId, null, true);
+  }
+
+  const changedMemories = loadChangedMemories(adapter, [row.entity_observation_id]);
+  const maxAffectedRows = Math.max(1, input.maxAffectedRows ?? 50);
+
+  return {
+    entity_id: input.entityId,
+    merge_action_id: null,
+    preview_unavailable: false,
+    history_incomplete: false,
+    truncated: changedMemories.length > maxAffectedRows,
+    changed_entities: [
+      {
+        entity_id: targetNode.id,
+        label: targetNode.preferred_label,
+        status_after: 'active',
+        active_lineage_after: Math.max(0, activeTarget.length - 1),
+        summary: projectLabel(adapter, targetNode),
+      },
+    ],
+    changed_memories: changedMemories.slice(0, maxAffectedRows),
+    metric_movement: [
+      {
+        metric: 'false_merge_rate',
+        direction: 'decrease',
+        reason:
+          'Removing one supporting observation may reduce merge confidence for the current entity.',
+      },
+      {
+        metric: 'projection_fragmentation_rate',
+        direction: 'increase',
+        reason:
+          'Detaching one observation may increase fragmentation if it needs a separate entity later.',
+      },
+    ],
+  };
+}
+
+export async function previewEntityRollback(
+  input: RollbackPreviewInput,
+  options: { adapter?: EntityStoreAdapter } = {}
+): Promise<RollbackPreviewResult> {
+  if (!options.adapter) {
+    await initDB();
+  }
+  const adapter = options.adapter ?? getAdapter();
+
+  if (input.observationId) {
+    return previewObservationDetach(adapter, input);
+  }
+
+  const mergeAction = loadMergeAction(adapter, input.entityId, input.mergeActionId);
+  if (!mergeAction) {
+    return unavailableResult(input.entityId, input.mergeActionId ?? null, false);
+  }
+
+  return previewMergeRollback(adapter, input, mergeAction);
+}

--- a/packages/mama-core/src/entities/rollback-preview.ts
+++ b/packages/mama-core/src/entities/rollback-preview.ts
@@ -95,6 +95,7 @@ function getLatestTimeline(
     id: String(row.id),
     entity_id: String(row.entity_id),
     event_type: row.event_type as EntityTimelineEvent['event_type'],
+    role: typeof row.role === 'string' ? row.role : null,
     valid_from: typeof row.valid_from === 'number' ? row.valid_from : null,
     valid_to: typeof row.valid_to === 'number' ? row.valid_to : null,
     observed_at: typeof row.observed_at === 'number' ? row.observed_at : null,
@@ -103,6 +104,12 @@ function getLatestTimeline(
     details: typeof row.details === 'string' ? row.details : null,
     created_at: Number(row.created_at),
   };
+}
+
+const DEFAULT_MAX_AFFECTED_ROWS = 50;
+
+function normalizeMaxAffectedRows(input: RollbackPreviewInput): number {
+  return Math.max(1, input.maxAffectedRows ?? DEFAULT_MAX_AFFECTED_ROWS);
 }
 
 function projectLabel(adapter: EntityStoreAdapter, node: EntityNode): string {
@@ -240,7 +247,7 @@ async function previewMergeRollback(
     ...removedRows.map((row) => row.entity_observation_id),
   ]);
   const allChangedMemories = loadChangedMemories(adapter, affectedObservationIds);
-  const maxAffectedRows = Math.max(1, input.maxAffectedRows ?? 50);
+  const maxAffectedRows = normalizeMaxAffectedRows(input);
   const truncated = allChangedMemories.length > maxAffectedRows;
 
   return {
@@ -284,11 +291,11 @@ async function previewObservationDetach(
     (candidate) => candidate.entity_observation_id === input.observationId
   );
   if (!row) {
-    return unavailableResult(input.entityId, null, true);
+    return unavailableResult(input.entityId, null, false);
   }
 
   const changedMemories = loadChangedMemories(adapter, [row.entity_observation_id]);
-  const maxAffectedRows = Math.max(1, input.maxAffectedRows ?? 50);
+  const maxAffectedRows = normalizeMaxAffectedRows(input);
 
   return {
     entity_id: input.entityId,

--- a/packages/mama-core/src/entities/rollback-preview.ts
+++ b/packages/mama-core/src/entities/rollback-preview.ts
@@ -154,16 +154,28 @@ function resolveMergePreviewRows(input: {
   sourceHistory: EntityLineageLink[];
   targetActive: EntityLineageLink[];
   sourceEntityId: string;
+  mergeActionId?: string;
 }): { restoredRows: EntityLineageLink[]; removedRows: EntityLineageLink[] } {
-  const restoredRows = input.sourceHistory.filter((row) => row.status === 'superseded');
   let removedRows = input.targetActive.filter(
-    (row) => row.source_entity_id === input.sourceEntityId
+    (row) =>
+      row.source_entity_id === input.sourceEntityId &&
+      (!input.mergeActionId || row.review_action_id === input.mergeActionId)
+  );
+  const removedObservationIds = new Set(removedRows.map((row) => row.entity_observation_id));
+  const restoredRows = input.sourceHistory.filter(
+    (row) =>
+      row.status === 'superseded' &&
+      (!input.mergeActionId ||
+        row.review_action_id === input.mergeActionId ||
+        removedObservationIds.has(row.entity_observation_id))
   );
 
   if (removedRows.length === 0 && restoredRows.length > 0) {
     const restorableObservationIds = new Set(restoredRows.map((row) => row.entity_observation_id));
-    removedRows = input.targetActive.filter((row) =>
-      restorableObservationIds.has(row.entity_observation_id)
+    removedRows = input.targetActive.filter(
+      (row) =>
+        restorableObservationIds.has(row.entity_observation_id) &&
+        (!input.mergeActionId || row.review_action_id === input.mergeActionId)
     );
   }
 
@@ -236,6 +248,7 @@ async function previewMergeRollback(
     sourceHistory,
     targetActive,
     sourceEntityId: sourceNode.id,
+    mergeActionId: input.mergeActionId,
   });
 
   if (restoredRows.length === 0 || removedRows.length === 0) {

--- a/packages/mama-core/src/entities/rollback-preview.ts
+++ b/packages/mama-core/src/entities/rollback-preview.ts
@@ -125,6 +125,7 @@ function loadMergeAction(
         SELECT id, source_entity_id, target_entity_id, created_at
         FROM entity_merge_actions
         WHERE id = ?
+          AND (source_entity_id = ? OR target_entity_id = ?)
         LIMIT 1
       `
     : `
@@ -134,7 +135,11 @@ function loadMergeAction(
         ORDER BY created_at DESC
         LIMIT 1
       `;
-  const row = adapter.prepare(sql).get(mergeActionId ?? entityId) as MergeActionRow | undefined;
+  const row = (
+    mergeActionId
+      ? adapter.prepare(sql).get(mergeActionId, entityId, entityId)
+      : adapter.prepare(sql).get(entityId)
+  ) as MergeActionRow | undefined;
   return row ?? null;
 }
 

--- a/packages/mama-core/src/entities/source-locator.ts
+++ b/packages/mama-core/src/entities/source-locator.ts
@@ -1,0 +1,37 @@
+export type SourceLocatorKind = 'db' | 'file' | 'url' | 'connector' | 'unknown';
+
+export function detectSourceLocatorKind(locator: string | null | undefined): SourceLocatorKind {
+  if (typeof locator !== 'string' || locator.trim().length === 0) {
+    return 'unknown';
+  }
+
+  const trimmed = locator.trim();
+  const normalized = trimmed.toLowerCase();
+
+  if (normalized.startsWith('http://') || normalized.startsWith('https://')) {
+    return 'url';
+  }
+  if (normalized.startsWith('file://')) {
+    return 'file';
+  }
+  if (
+    normalized.startsWith('drive://') ||
+    normalized.startsWith('gmail://') ||
+    normalized.startsWith('calendar://') ||
+    normalized.startsWith('sheets://')
+  ) {
+    return 'connector';
+  }
+  if (
+    normalized.endsWith('.db') ||
+    normalized.includes('/raw.db') ||
+    normalized.includes('\\raw.db')
+  ) {
+    return 'db';
+  }
+  if (trimmed.startsWith('/') || trimmed.startsWith('~/') || /^[A-Za-z]:[\\/]/.test(trimmed)) {
+    return 'file';
+  }
+
+  return 'unknown';
+}

--- a/packages/mama-core/src/entities/store.ts
+++ b/packages/mama-core/src/entities/store.ts
@@ -393,104 +393,7 @@ export async function upsertEntityObservations(
   await initDB();
   const adapter = getAdapter();
   const observations: UpsertEntityObservationResult[] = [];
-  const runBatch =
-    'transaction' in adapter && typeof adapter.transaction === 'function'
-      ? adapter.transaction(() => {
-          for (const input of inputs) {
-            const createdAt = now();
-            const normalizedSourceLocator = normalizeSourceLocator(input.source_locator);
-            const existing = adapter
-              .prepare(
-                `
-                  SELECT id FROM entity_observations
-                  WHERE source_connector = ? AND source_locator = ? AND source_raw_record_id = ? AND observation_type = ?
-                `
-              )
-              .get(
-                input.source_connector,
-                normalizedSourceLocator,
-                input.source_raw_record_id,
-                input.observation_type
-              ) as Record<string, unknown> | undefined;
-            adapter
-              .prepare(
-                `
-                  INSERT INTO entity_observations (
-                    id, observation_type, entity_kind_hint, surface_form, normalized_form, lang, script,
-                    context_summary, related_surface_forms, timestamp_observed, scope_kind, scope_id,
-                    extractor_version, embedding_model_version, source_connector, source_locator,
-                    source_raw_record_id, created_at
-                  )
-                  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                  ON CONFLICT(source_connector, source_locator, source_raw_record_id, observation_type)
-                  DO UPDATE SET
-                    entity_kind_hint = excluded.entity_kind_hint,
-                    surface_form = excluded.surface_form,
-                    normalized_form = excluded.normalized_form,
-                    lang = excluded.lang,
-                    script = excluded.script,
-                    context_summary = excluded.context_summary,
-                    related_surface_forms = excluded.related_surface_forms,
-                    timestamp_observed = excluded.timestamp_observed,
-                    scope_kind = excluded.scope_kind,
-                    scope_id = excluded.scope_id,
-                    extractor_version = excluded.extractor_version,
-                    embedding_model_version = excluded.embedding_model_version,
-                    source_locator = excluded.source_locator,
-                    created_at = entity_observations.created_at
-                `
-              )
-              .run(
-                input.id,
-                input.observation_type,
-                input.entity_kind_hint,
-                input.surface_form,
-                input.normalized_form,
-                input.lang,
-                input.script,
-                input.context_summary,
-                JSON.stringify(input.related_surface_forms),
-                input.timestamp_observed,
-                input.scope_kind,
-                input.scope_id,
-                input.extractor_version,
-                input.embedding_model_version,
-                input.source_connector,
-                normalizedSourceLocator,
-                input.source_raw_record_id,
-                createdAt
-              );
-
-            const saved = adapter
-              .prepare(
-                `
-                  SELECT * FROM entity_observations
-                  WHERE source_connector = ? AND source_locator = ? AND source_raw_record_id = ? AND observation_type = ?
-                `
-              )
-              .get(
-                input.source_connector,
-                normalizedSourceLocator,
-                input.source_raw_record_id,
-                input.observation_type
-              ) as Record<string, unknown>;
-            observations.push({
-              id: requireStringField(saved, 'id'),
-              created: !existing,
-            });
-          }
-        })
-      : null;
-
-  if (runBatch) {
-    const txResult = runBatch as unknown;
-    if (typeof txResult === 'function') {
-      txResult();
-    }
-    return observations;
-  }
-
-  for (const input of inputs) {
+  const upsertOne = (input: UpsertEntityObservationInput): void => {
     const normalizedSourceLocator = normalizeSourceLocator(input.source_locator);
     const existing = adapter
       .prepare(
@@ -505,11 +408,89 @@ export async function upsertEntityObservations(
         input.source_raw_record_id,
         input.observation_type
       ) as Record<string, unknown> | undefined;
-    const saved = await upsertEntityObservation(input);
+    const createdAt = now();
+    adapter
+      .prepare(
+        `
+          INSERT INTO entity_observations (
+            id, observation_type, entity_kind_hint, surface_form, normalized_form, lang, script,
+            context_summary, related_surface_forms, timestamp_observed, scope_kind, scope_id,
+            extractor_version, embedding_model_version, source_connector, source_locator,
+            source_raw_record_id, created_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(source_connector, source_locator, source_raw_record_id, observation_type)
+          DO UPDATE SET
+            entity_kind_hint = excluded.entity_kind_hint,
+            surface_form = excluded.surface_form,
+            normalized_form = excluded.normalized_form,
+            lang = excluded.lang,
+            script = excluded.script,
+            context_summary = excluded.context_summary,
+            related_surface_forms = excluded.related_surface_forms,
+            timestamp_observed = excluded.timestamp_observed,
+            scope_kind = excluded.scope_kind,
+            scope_id = excluded.scope_id,
+            extractor_version = excluded.extractor_version,
+            embedding_model_version = excluded.embedding_model_version,
+            source_locator = excluded.source_locator,
+            created_at = entity_observations.created_at
+        `
+      )
+      .run(
+        input.id,
+        input.observation_type,
+        input.entity_kind_hint,
+        input.surface_form,
+        input.normalized_form,
+        input.lang,
+        input.script,
+        input.context_summary,
+        JSON.stringify(input.related_surface_forms),
+        input.timestamp_observed,
+        input.scope_kind,
+        input.scope_id,
+        input.extractor_version,
+        input.embedding_model_version,
+        input.source_connector,
+        normalizedSourceLocator,
+        input.source_raw_record_id,
+        createdAt
+      );
+
+    const saved = adapter
+      .prepare(
+        `
+          SELECT * FROM entity_observations
+          WHERE source_connector = ? AND source_locator = ? AND source_raw_record_id = ? AND observation_type = ?
+        `
+      )
+      .get(
+        input.source_connector,
+        normalizedSourceLocator,
+        input.source_raw_record_id,
+        input.observation_type
+      ) as Record<string, unknown>;
     observations.push({
-      id: saved.id,
+      id: requireStringField(saved, 'id'),
       created: !existing,
     });
+  };
+
+  if ('transaction' in adapter && typeof adapter.transaction === 'function') {
+    const txResult = adapter.transaction(() => {
+      for (const input of inputs) {
+        upsertOne(input);
+      }
+    }) as unknown;
+    if (typeof txResult === 'function') {
+      txResult();
+    }
+    return observations;
+  }
+
+  for (const input of inputs) {
+    upsertOne(input);
   }
   return observations;
 }

--- a/packages/mama-core/src/entities/store.ts
+++ b/packages/mama-core/src/entities/store.ts
@@ -7,6 +7,7 @@ import {
   type EntityAlias,
   type EntityNode,
   type EntityObservation,
+  type EntityTimelineEvent,
 } from './types.js';
 
 export interface EntityStoreAdapter {
@@ -32,12 +33,24 @@ const MAX_MERGE_CHAIN_DEPTH = 8;
 type CreateEntityNodeInput = Omit<EntityNode, 'created_at' | 'updated_at'>;
 type AttachEntityAliasInput = Omit<EntityAlias, 'created_at'>;
 type UpsertEntityObservationInput = Omit<EntityObservation, 'created_at'>;
+type AppendEntityTimelineEventInput = {
+  event: Omit<EntityTimelineEvent, 'id' | 'created_at'> & {
+    id?: string;
+    created_at?: number;
+  };
+  adapter?: EntityStoreAdapter;
+};
+
+export interface UpsertEntityObservationResult {
+  id: string;
+  created: boolean;
+}
 
 function now(): number {
   return Date.now();
 }
 
-function normalizeSourceRawDbRef(value: string | null): string {
+function normalizeSourceLocator(value: string | null | undefined): string {
   return value ?? '';
 }
 
@@ -51,6 +64,22 @@ function requireStringField(row: Record<string, unknown>, field: string): string
 function optionalStringField(row: Record<string, unknown>, field: string): string | null {
   if (!Object.prototype.hasOwnProperty.call(row, field)) {
     throw new Error(`Invalid entity observation row: ${field} must be present`);
+  }
+  if (row[field] === null) {
+    return null;
+  }
+  if (typeof row[field] !== 'string') {
+    throw new Error(`Invalid entity observation row: ${field} must be a string or null`);
+  }
+  return row[field] as string;
+}
+
+function optionalStringFieldIfPresent(
+  row: Record<string, unknown>,
+  field: string
+): string | null | undefined {
+  if (!Object.prototype.hasOwnProperty.call(row, field)) {
+    return undefined;
   }
   if (row[field] === null) {
     return null;
@@ -120,7 +149,10 @@ export function parseObservationRow(row: Record<string, unknown>): EntityObserva
     );
   }
 
-  const sourceRawDbRef = optionalStringField(row, 'source_raw_db_ref');
+  const sourceLocator = optionalStringFieldIfPresent(row, 'source_locator');
+  if (sourceLocator === undefined) {
+    throw new Error('Invalid entity observation row: source_locator must be present');
+  }
 
   return {
     id,
@@ -138,7 +170,7 @@ export function parseObservationRow(row: Record<string, unknown>): EntityObserva
     extractor_version: requireStringField(row, 'extractor_version'),
     embedding_model_version: optionalStringField(row, 'embedding_model_version'),
     source_connector: requireStringField(row, 'source_connector'),
-    source_raw_db_ref: sourceRawDbRef && sourceRawDbRef.length > 0 ? sourceRawDbRef : null,
+    source_locator: sourceLocator && sourceLocator.length > 0 ? sourceLocator : null,
     source_raw_record_id: requireStringField(row, 'source_raw_record_id'),
     created_at: createdAt,
   };
@@ -177,8 +209,10 @@ export async function createEntityNode(input: CreateEntityNodeInput): Promise<En
   };
 }
 
-export function getEntityNode(id: string): EntityNode | null {
-  const adapter = getAdapter();
+export function getEntityNode(
+  id: string,
+  adapter: EntityStoreAdapter = getAdapter()
+): EntityNode | null {
   const row = adapter.prepare('SELECT * FROM entity_nodes WHERE id = ?').get(id) as
     | Record<string, unknown>
     | undefined;
@@ -254,8 +288,10 @@ export async function attachEntityAlias(input: AttachEntityAliasInput): Promise<
   };
 }
 
-export function listEntityAliases(entityId: string): EntityAlias[] {
-  const adapter = getAdapter();
+export function listEntityAliases(
+  entityId: string,
+  adapter: EntityStoreAdapter = getAdapter()
+): EntityAlias[] {
   const rows = adapter
     .prepare('SELECT * FROM entity_aliases WHERE entity_id = ? ORDER BY created_at ASC')
     .all(entityId) as Array<Record<string, unknown>>;
@@ -282,18 +318,18 @@ export async function upsertEntityObservation(
   await initDB();
   const adapter = getAdapter();
   const createdAt = now();
-  const normalizedRawDbRef = normalizeSourceRawDbRef(input.source_raw_db_ref);
+  const normalizedSourceLocator = normalizeSourceLocator(input.source_locator);
   adapter
     .prepare(
       `
         INSERT INTO entity_observations (
           id, observation_type, entity_kind_hint, surface_form, normalized_form, lang, script,
           context_summary, related_surface_forms, timestamp_observed, scope_kind, scope_id,
-          extractor_version, embedding_model_version, source_connector, source_raw_db_ref,
+          extractor_version, embedding_model_version, source_connector, source_locator,
           source_raw_record_id, created_at
         )
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT(source_connector, source_raw_db_ref, source_raw_record_id, observation_type)
+        ON CONFLICT(source_connector, source_locator, source_raw_record_id, observation_type)
         DO UPDATE SET
           entity_kind_hint = excluded.entity_kind_hint,
           surface_form = excluded.surface_form,
@@ -307,6 +343,7 @@ export async function upsertEntityObservation(
           scope_id = excluded.scope_id,
           extractor_version = excluded.extractor_version,
           embedding_model_version = excluded.embedding_model_version,
+          source_locator = excluded.source_locator,
           created_at = entity_observations.created_at
       `
     )
@@ -326,7 +363,7 @@ export async function upsertEntityObservation(
       input.extractor_version,
       input.embedding_model_version,
       input.source_connector,
-      normalizedRawDbRef,
+      normalizedSourceLocator,
       input.source_raw_record_id,
       createdAt
     );
@@ -335,12 +372,12 @@ export async function upsertEntityObservation(
     .prepare(
       `
         SELECT * FROM entity_observations
-        WHERE source_connector = ? AND source_raw_db_ref = ? AND source_raw_record_id = ? AND observation_type = ?
+        WHERE source_connector = ? AND source_locator = ? AND source_raw_record_id = ? AND observation_type = ?
       `
     )
     .get(
       input.source_connector,
-      normalizedRawDbRef,
+      normalizedSourceLocator,
       input.source_raw_record_id,
       input.observation_type
     ) as Record<string, unknown>;
@@ -350,27 +387,40 @@ export async function upsertEntityObservation(
 
 export async function upsertEntityObservations(
   inputs: UpsertEntityObservationInput[]
-): Promise<EntityObservation[]> {
+): Promise<UpsertEntityObservationResult[]> {
   await initDB();
   const adapter = getAdapter();
-  const observations: EntityObservation[] = [];
+  const observations: UpsertEntityObservationResult[] = [];
   const runBatch =
     'transaction' in adapter && typeof adapter.transaction === 'function'
       ? adapter.transaction(() => {
           for (const input of inputs) {
             const createdAt = now();
-            const normalizedRawDbRef = normalizeSourceRawDbRef(input.source_raw_db_ref);
+            const normalizedSourceLocator = normalizeSourceLocator(input.source_locator);
+            const existing = adapter
+              .prepare(
+                `
+                  SELECT id FROM entity_observations
+                  WHERE source_connector = ? AND source_locator = ? AND source_raw_record_id = ? AND observation_type = ?
+                `
+              )
+              .get(
+                input.source_connector,
+                normalizedSourceLocator,
+                input.source_raw_record_id,
+                input.observation_type
+              ) as Record<string, unknown> | undefined;
             adapter
               .prepare(
                 `
                   INSERT INTO entity_observations (
                     id, observation_type, entity_kind_hint, surface_form, normalized_form, lang, script,
                     context_summary, related_surface_forms, timestamp_observed, scope_kind, scope_id,
-                    extractor_version, embedding_model_version, source_connector, source_raw_db_ref,
+                    extractor_version, embedding_model_version, source_connector, source_locator,
                     source_raw_record_id, created_at
                   )
                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                  ON CONFLICT(source_connector, source_raw_db_ref, source_raw_record_id, observation_type)
+                  ON CONFLICT(source_connector, source_locator, source_raw_record_id, observation_type)
                   DO UPDATE SET
                     entity_kind_hint = excluded.entity_kind_hint,
                     surface_form = excluded.surface_form,
@@ -384,6 +434,7 @@ export async function upsertEntityObservations(
                     scope_id = excluded.scope_id,
                     extractor_version = excluded.extractor_version,
                     embedding_model_version = excluded.embedding_model_version,
+                    source_locator = excluded.source_locator,
                     created_at = entity_observations.created_at
                 `
               )
@@ -403,7 +454,7 @@ export async function upsertEntityObservations(
                 input.extractor_version,
                 input.embedding_model_version,
                 input.source_connector,
-                normalizedRawDbRef,
+                normalizedSourceLocator,
                 input.source_raw_record_id,
                 createdAt
               );
@@ -412,16 +463,19 @@ export async function upsertEntityObservations(
               .prepare(
                 `
                   SELECT * FROM entity_observations
-                  WHERE source_connector = ? AND source_raw_db_ref = ? AND source_raw_record_id = ? AND observation_type = ?
+                  WHERE source_connector = ? AND source_locator = ? AND source_raw_record_id = ? AND observation_type = ?
                 `
               )
               .get(
                 input.source_connector,
-                normalizedRawDbRef,
+                normalizedSourceLocator,
                 input.source_raw_record_id,
                 input.observation_type
               ) as Record<string, unknown>;
-            observations.push(parseObservationRow(saved));
+            observations.push({
+              id: requireStringField(saved, 'id'),
+              created: !existing,
+            });
           }
         })
       : null;
@@ -435,17 +489,84 @@ export async function upsertEntityObservations(
   }
 
   for (const input of inputs) {
-    observations.push(await upsertEntityObservation(input));
+    const normalizedSourceLocator = normalizeSourceLocator(input.source_locator);
+    const existing = adapter
+      .prepare(
+        `
+          SELECT id FROM entity_observations
+          WHERE source_connector = ? AND source_locator = ? AND source_raw_record_id = ? AND observation_type = ?
+        `
+      )
+      .get(
+        input.source_connector,
+        normalizedSourceLocator,
+        input.source_raw_record_id,
+        input.observation_type
+      ) as Record<string, unknown> | undefined;
+    const saved = await upsertEntityObservation(input);
+    observations.push({
+      id: saved.id,
+      created: !existing,
+    });
   }
   return observations;
+}
+
+export async function appendEntityTimelineEvent(
+  input: AppendEntityTimelineEventInput
+): Promise<EntityTimelineEvent> {
+  if (!input.adapter) {
+    await initDB();
+  }
+  const adapter = input.adapter ?? getAdapter();
+  const eventId = input.event.id ?? `et_${randomUUID()}`;
+  const createdAt = input.event.created_at ?? now();
+
+  adapter
+    .prepare(
+      `
+        INSERT INTO entity_timeline_events (
+          id, entity_id, event_type, role, valid_from, valid_to, observed_at,
+          source_ref, summary, details, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      eventId,
+      input.event.entity_id,
+      input.event.event_type,
+      input.event.role ?? null,
+      input.event.valid_from ?? null,
+      input.event.valid_to ?? null,
+      input.event.observed_at ?? null,
+      input.event.source_ref ?? null,
+      input.event.summary,
+      input.event.details ?? null,
+      createdAt
+    );
+
+  return {
+    id: eventId,
+    entity_id: input.event.entity_id,
+    event_type: input.event.event_type,
+    role: input.event.role ?? null,
+    valid_from: input.event.valid_from ?? null,
+    valid_to: input.event.valid_to ?? null,
+    observed_at: input.event.observed_at ?? null,
+    source_ref: input.event.source_ref ?? null,
+    summary: input.event.summary,
+    details: input.event.details ?? null,
+    created_at: createdAt,
+  };
 }
 
 /**
  * Walks the `entity_nodes.merged_into` chain from the given id and returns the
  * terminal (unmerged) entity id. Detects cycles and caps depth. Read-only.
  *
- * Matches the chain-walking design decided in
- * `docs/superpowers/specs/2026-04-13-canonical-entity-merge-design.md` (Policy A2).
+ * Matches the read-time chain-walking approach described in the canonical
+ * entity ontology implementation plan.
  */
 export function resolveCanonicalEntityId(adapter: EntityStoreAdapter, id: string): string {
   const seen = new Set<string>();
@@ -587,9 +708,9 @@ export function mergeEntityNodes(input: MergeEntityNodesInput): MergeEntityNodes
     .prepare(
       `
         INSERT INTO entity_timeline_events (
-          id, entity_id, event_type, observed_at, source_ref, summary, details, created_at
+          id, entity_id, event_type, role, observed_at, source_ref, summary, details, created_at
         )
-        VALUES (?, ?, 'merged', ?, ?, ?, ?, ?)
+        VALUES (?, ?, 'merged', NULL, ?, ?, ?, ?, ?)
       `
     )
     .run(

--- a/packages/mama-core/src/entities/store.ts
+++ b/packages/mama-core/src/entities/store.ts
@@ -225,7 +225,8 @@ export function getEntityNode(
     kind: row.kind as EntityNode['kind'],
     preferred_label: String(row.preferred_label),
     status: row.status as EntityNode['status'],
-    scope_kind: row.scope_kind as EntityNode['scope_kind'],
+    scope_kind:
+      typeof row.scope_kind === 'string' ? (row.scope_kind as EntityNode['scope_kind']) : null,
     scope_id: typeof row.scope_id === 'string' ? row.scope_id : null,
     merged_into: typeof row.merged_into === 'string' ? row.merged_into : null,
     created_at: Number(row.created_at),
@@ -244,7 +245,8 @@ export function listEntityNodes(): EntityNode[] {
     kind: row.kind as EntityNode['kind'],
     preferred_label: String(row.preferred_label),
     status: row.status as EntityNode['status'],
-    scope_kind: row.scope_kind as EntityNode['scope_kind'],
+    scope_kind:
+      typeof row.scope_kind === 'string' ? (row.scope_kind as EntityNode['scope_kind']) : null,
     scope_id: typeof row.scope_id === 'string' ? row.scope_id : null,
     merged_into: typeof row.merged_into === 'string' ? row.merged_into : null,
     created_at: Number(row.created_at),

--- a/packages/mama-core/src/entities/store.ts
+++ b/packages/mama-core/src/entities/store.ts
@@ -51,6 +51,7 @@ function now(): number {
 }
 
 function normalizeSourceLocator(value: string | null | undefined): string {
+  // Write empty-string as the null sentinel so SQLite UNIQUE can collapse null-like locators; parseObservationRow maps it back to null on read.
   return value ?? '';
 }
 

--- a/packages/mama-core/src/entities/types.ts
+++ b/packages/mama-core/src/entities/types.ts
@@ -34,6 +34,26 @@ export type EntityCandidateKind = (typeof ENTITY_CANDIDATE_KINDS)[number];
 export const ENTITY_ACTOR_TYPES = ['system', 'user', 'agent'] as const;
 export type EntityActorType = (typeof ENTITY_ACTOR_TYPES)[number];
 
+export const ENTITY_INGEST_RUN_STATUSES = ['running', 'complete', 'failed'] as const;
+export type EntityIngestRunStatus = (typeof ENTITY_INGEST_RUN_STATUSES)[number];
+
+export const ENTITY_INGEST_RUN_KINDS = ['live', 'replay', 'backfill'] as const;
+export type EntityIngestRunKind = (typeof ENTITY_INGEST_RUN_KINDS)[number];
+
+export const ENTITY_LINEAGE_CONTRIBUTION_KINDS = [
+  'seed',
+  'merge_adopt',
+  'manual_attach',
+  'rollback_restore',
+] as const;
+export type EntityLineageContributionKind = (typeof ENTITY_LINEAGE_CONTRIBUTION_KINDS)[number];
+
+export const ENTITY_LINEAGE_STATUSES = ['active', 'superseded', 'rolled_back'] as const;
+export type EntityLineageStatus = (typeof ENTITY_LINEAGE_STATUSES)[number];
+
+export const ENTITY_LINEAGE_CAPTURE_MODES = ['direct', 'backfilled'] as const;
+export type EntityLineageCaptureMode = (typeof ENTITY_LINEAGE_CAPTURE_MODES)[number];
+
 export interface EntityNode {
   id: string;
   kind: EntityKind;
@@ -77,7 +97,7 @@ export interface EntityObservation {
   extractor_version: string;
   embedding_model_version: string | null;
   source_connector: string;
-  source_raw_db_ref: string | null;
+  source_locator: string | null;
   source_raw_record_id: string;
   created_at: number;
 }
@@ -116,6 +136,7 @@ export interface EntityTimelineEvent {
   id: string;
   entity_id: string;
   event_type: string;
+  role?: string | null;
   valid_from: number | null;
   valid_to: number | null;
   observed_at: number | null;
@@ -136,4 +157,39 @@ export interface EntityMergeAction {
   reason: string;
   evidence_json: string;
   created_at: number;
+}
+
+export interface EntityIngestRun {
+  id: string;
+  connector: string;
+  run_kind: EntityIngestRunKind;
+  status: EntityIngestRunStatus;
+  scope_key: string;
+  source_window_start: number | null;
+  source_window_end: number | null;
+  raw_count: number;
+  observation_count: number;
+  candidate_count: number;
+  reviewable_count: number;
+  audit_run_id: string | null;
+  audit_classification: 'improved' | 'stable' | 'regressed' | 'inconclusive' | null;
+  error_reason: string | null;
+  created_at: number;
+  completed_at: number | null;
+}
+
+export interface EntityLineageLink {
+  id: string;
+  canonical_entity_id: string;
+  entity_observation_id: string;
+  source_entity_id: string | null;
+  contribution_kind: EntityLineageContributionKind;
+  run_id: string | null;
+  candidate_id: string | null;
+  review_action_id: string | null;
+  status: EntityLineageStatus;
+  capture_mode: EntityLineageCaptureMode;
+  confidence: number;
+  created_at: number;
+  superseded_at: number | null;
 }

--- a/packages/mama-core/src/entities/types.ts
+++ b/packages/mama-core/src/entities/types.ts
@@ -59,7 +59,7 @@ export interface EntityNode {
   kind: EntityKind;
   preferred_label: string;
   status: EntityNodeStatus;
-  scope_kind: EntityScopeKind;
+  scope_kind: EntityScopeKind | null;
   scope_id: string | null;
   merged_into: string | null;
   created_at: number;

--- a/packages/mama-core/src/index.ts
+++ b/packages/mama-core/src/index.ts
@@ -8,7 +8,6 @@
  * @version 1.0.0
  */
 
-// Embeddings
 export {
   generateEmbedding,
   generateEnhancedEmbedding,
@@ -19,10 +18,8 @@ export {
   MODEL_NAME,
 } from './embeddings.js';
 
-// Embedding cache
 export { EmbeddingCache } from './embedding-cache.js';
 
-// Embedding client
 export {
   getEmbeddingFromServer,
   getServerStatus,
@@ -34,7 +31,6 @@ export {
   type ServerStatus,
 } from './embedding-client.js';
 
-// Database manager
 export {
   initDB,
   getDB,
@@ -61,7 +57,6 @@ export {
   type DecisionInput,
 } from './db-manager.js';
 
-// Database adapter
 export {
   createAdapter,
   DatabaseAdapter,
@@ -72,7 +67,6 @@ export {
   type RunResult,
 } from './db-adapter/index.js';
 
-// Memory store
 export {
   getSessionDecisions,
   incrementUsageSuccess,
@@ -85,11 +79,9 @@ export {
   DEFAULT_DB_PATH,
 } from './memory-store.js';
 
-// MAMA API
 import mama from './mama-api.js';
 export { mama };
 
-// Memory V2
 export {
   MEMORY_SCOPE_KINDS,
   MEMORY_KINDS,
@@ -102,6 +94,7 @@ export {
   type MemoryEdgeType,
   type MemoryScopeRef,
   type MemoryRecord,
+  type MemorySearchResultHit,
   type MemoryEdge,
   type ProfileSnapshot,
   type RecallBundle,
@@ -125,16 +118,34 @@ export {
   getChannelSummary,
 } from './memory/api.js';
 export { buildExtractionPrompt, parseExtractionResponse } from './memory/extraction-prompt.js';
-export { listRecentMemoryEvents } from './memory/event-store.js';
+export { appendMemoryEvent, listRecentMemoryEvents } from './memory/event-store.js';
 export * from './entities/types.js';
 export * from './entities/errors.js';
 export * from './entities/store.js';
 export * from './entities/normalization.js';
 export * from './entities/projection.js';
 export * from './entities/recall-bridge.js';
+export * from './entities/read-identity.js';
 export * from './entities/audit-metrics.js';
+export * from './entities/provenance-query.js';
+export * from './entities/lineage-store.js';
+export * from './entities/lineage-backfill.js';
+export * from './entities/exact-merge-backfill.js';
+export * from './entities/entity-search.js';
+export * from './entities/entity-list.js';
+export * from './entities/entity-orphan-list.js';
+export * from './entities/entity-impact.js';
+export * from './entities/rollback-preview.js';
+export * from './entities/source-locator.js';
+export * from './entities/policy-types.js';
+export * from './entities/policy-store.js';
+export {
+  canonicalizeJSON,
+  targetRefHash,
+  CanonicalizeError,
+  type CanonicalizeErrorCode,
+} from './canonicalize.js';
 
-// Config loader
 export {
   loadConfig,
   getModelName,
@@ -147,7 +158,6 @@ export {
   type ConfigUpdates,
 } from './config-loader.js';
 
-// Relevance scorer
 export {
   calculateRelevance,
   selectTopDecisions,
@@ -159,7 +169,6 @@ export {
   type TestResult,
 } from './relevance-scorer.js';
 
-// Decision tracker
 export {
   learnDecision,
   generateDecisionId,
@@ -183,7 +192,6 @@ export {
   type EvidenceItem,
 } from './decision-tracker.js';
 
-// Tier validator
 export {
   validateTier,
   checkNodeVersion,
@@ -197,7 +205,6 @@ export {
   type NamedCheckResult,
 } from './tier-validator.js';
 
-// Progress indicator
 export {
   logProgress,
   logComplete,
@@ -208,13 +215,10 @@ export {
   logSearching,
 } from './progress-indicator.js';
 
-// Debug logger
 export { debug, info, warn, error, DebugLogger } from './debug-logger.js';
 
-// Time formatter
 export { formatTimeAgo } from './time-formatter.js';
 
-// Errors
 export {
   MAMAError,
   NotFoundError,
@@ -234,7 +238,6 @@ export {
   type ErrorCode,
 } from './errors.js';
 
-// Decision formatter
 export {
   formatContext,
   formatLegacyContext,
@@ -253,7 +256,6 @@ export {
   type FormatOptions,
 } from './decision-formatter.js';
 
-// Outcome tracker
 export {
   analyzeOutcome,
   matchesFailureIndicators,
@@ -273,10 +275,8 @@ export {
   type OutcomeType,
 } from './outcome-tracker.js';
 
-// Memory inject
 export { injectDecisionContext } from './memory-inject.js';
 
-// Query intent
 export {
   analyzeIntent,
   extractTopicKeywords,
@@ -284,7 +284,6 @@ export {
   type AnalyzeOptions,
 } from './query-intent.js';
 
-// Ollama client
 export {
   generate,
   analyzeDecision,
@@ -298,5 +297,29 @@ export {
   type QueryIntentResult,
 } from './ollama-client.js';
 
-// Notification manager
 export { notifyInsight } from './notification-manager.js';
+
+export * from './cases/types.js';
+export * from './cases/store.js';
+export * from './cases/role-inference.js';
+export * from './cases/target-ref.js';
+export * from './cases/corrections.js';
+export * from './cases/sqlite-transaction.js';
+export * from './cases/live-state.js';
+export * from './cases/tombstone-sweeper.js';
+export * from './cases/merge-split.js';
+export * from './cases/membership-matcher.js';
+export * from './cases/search-rollup.js';
+export * from './cases/timeline-range.js';
+export * from './cases/wiki-page-index.js';
+export * from './cases/case-links.js';
+export * from './cases/composition-overrides.js';
+export * from './cases/freshness.js';
+export * from './cases/membership-explain.js';
+export * from './connectors/event-index.js';
+export * from './connectors/types.js';
+export * from './search/question-type.js';
+export * from './search/feedback-store.js';
+export * from './search/ranker-features.js';
+export * from './search/ranker-trainer.js';
+export * from './search/ranker-rescore.js';

--- a/packages/mama-core/src/mama-api.ts
+++ b/packages/mama-core/src/mama-api.ts
@@ -699,6 +699,9 @@ async function save({
         if (searchResults && typeof searchResults === 'object' && 'results' in searchResults) {
           // Filter out the decision we just saved
           similar_decisions = (searchResults.results as SimilarDecision[])
+            .filter(
+              (d: SimilarDecision & { source_type?: string }) => d.source_type === 'decision'
+            )
             .filter((d: SimilarDecision) => d.id !== decisionId)
             .map((d: SimilarDecision) => ({
               id: d.id,
@@ -1942,27 +1945,6 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
 
     const rerankCandidateResults = results.slice(0, rerankPoolLimit);
 
-    // Markdown format (for human display)
-    if (format === 'markdown') {
-      const context = formatContext(rerankCandidateResults.slice(0, limit), { maxTokens: 500 });
-
-      // Add graph expansion summary if applicable
-      let graphSummary = '';
-      if (searchMethod.includes('graph')) {
-        const primaryCount = rerankCandidateResults
-          .slice(0, limit)
-          .filter((r) => r.graph_source === 'primary').length;
-        const expandedCount = rerankCandidateResults
-          .slice(0, limit)
-          .filter((r) => r.graph_source !== 'primary').length;
-
-        graphSummary = `\n📊 Graph expansion: ${primaryCount} primary + ${expandedCount} related (supersedes/refines/contradicts)\n`;
-      }
-
-      return `🔍 Search method: ${searchMethod}${graphSummary}\n${context}`;
-    }
-
-    // JSON format (default - LLM-first)
     const vectorRows = rerankCandidateResults.map((r) => ({
       id: r.id,
       topic: r.topic,
@@ -1971,6 +1953,8 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
       confidence: r.confidence,
       similarity: r.similarity,
       created_at: r.created_at,
+      event_date: r.event_date ?? null,
+      event_datetime: r.event_datetime ?? null,
       // Recency metadata (NEW - Gaussian Decay)
       recency_score: r.recency_score,
       recency_age_days: r.recency_age_days,
@@ -1986,6 +1970,22 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
     }));
     const { results: rankedVectorRows, meta: rankerMeta } = applyLearnedRanker(vectorRows);
     const finalResults = rankedVectorRows.slice(0, limit);
+
+    // Markdown format (for human display)
+    if (format === 'markdown') {
+      const context = formatContext(finalResults, { maxTokens: 500 });
+
+      // Add graph expansion summary if applicable
+      let graphSummary = '';
+      if (searchMethod.includes('graph')) {
+        const primaryCount = finalResults.filter((r) => r.graph_source === 'primary').length;
+        const expandedCount = finalResults.filter((r) => r.graph_source !== 'primary').length;
+
+        graphSummary = `\n📊 Graph expansion: ${primaryCount} primary + ${expandedCount} related (supersedes/refines/contradicts)\n`;
+      }
+
+      return `🔍 Search method: ${searchMethod}${graphSummary}\n${context}`;
+    }
 
     // Calculate graph expansion stats
     const graphStats = {

--- a/packages/mama-core/src/mama-api.ts
+++ b/packages/mama-core/src/mama-api.ts
@@ -1435,7 +1435,9 @@ function buildRankerMeta(
     applied,
     mode: 'offline',
   };
-  if (skippedReason) meta.skipped_reason = skippedReason;
+  if (skippedReason) {
+    meta.skipped_reason = skippedReason;
+  }
   return meta;
 }
 

--- a/packages/mama-core/src/mama-api.ts
+++ b/packages/mama-core/src/mama-api.ts
@@ -53,6 +53,13 @@ import {
 } from './memory/api.js';
 import { listOpenAuditFindings } from './memory/finding-store.js';
 import { listRecentMemoryEvents } from './memory/event-store.js';
+import {
+  rollUpSearchHits,
+  type SearchRollupLeafHit,
+  type SearchRollupResult,
+} from './cases/search-rollup.js';
+import { isSearchRankerEnabled, rescoreSearchResults } from './search/ranker-rescore.js';
+import { SEARCH_RANKER_FEATURE_SET_VERSION } from './search/ranker-features.js';
 
 // ════════════════════════════════════════════════════════════════════════════
 // Type Definitions
@@ -75,6 +82,18 @@ interface SaveParams {
   scopes?: Array<{ kind: 'global' | 'user' | 'channel' | 'project'; id: string }>;
   /** ISO 8601 date string for when the event actually occurred (e.g. "2023-01-15") */
   event_date?: string | null;
+  timelineEvent?: {
+    id?: string;
+    entity_id?: string;
+    event_type: string;
+    role?: string | null;
+    valid_from?: number | null;
+    valid_to?: number | null;
+    observed_at?: number | null;
+    source_ref?: string | null;
+    summary: string;
+    details?: string | null;
+  };
 }
 
 /**
@@ -86,8 +105,10 @@ interface SimilarDecision {
   decision: string;
   reasoning?: string;
   similarity?: number;
+  retrieval_score?: number | null;
   created_at?: number | string;
   event_date?: string | null;
+  event_datetime?: number | null;
 }
 
 /**
@@ -146,6 +167,9 @@ interface ReasoningGraphInfo {
 interface SaveResult {
   success: boolean;
   id: string;
+  saved_decision_id?: string;
+  timeline_event_id?: string | null;
+  timeline_event_ids?: string[];
   similar_decisions?: SimilarDecision[];
   warning?: string;
   collaboration_hint?: string;
@@ -502,6 +526,7 @@ async function save({
   is_static,
   scopes: inputScopes,
   event_date,
+  timelineEvent,
 }: SaveParams): Promise<SaveResult> {
   // Validate required fields
   if (!topic || typeof topic !== 'string') {
@@ -564,7 +589,11 @@ async function save({
   const _userInvolvement = type === 'user_decision' ? 'approved' : null;
 
   logProgress(`Saving decision: ${topic.substring(0, 30)}...`);
-  const { id: decisionId } = await saveMemory({
+  const {
+    id: decisionId,
+    timeline_event_id: timelineEventId,
+    timeline_event_ids: timelineEventIds,
+  } = await saveMemory({
     topic,
     kind: is_static === 1 ? 'preference' : 'decision',
     summary: decision,
@@ -576,6 +605,7 @@ async function save({
       source_type: 'legacy_save',
     },
     eventDate: event_date ?? undefined,
+    timelineEvent,
   });
   logComplete(`Decision saved: ${decisionId.substring(0, 20)}...`);
 
@@ -675,7 +705,10 @@ async function save({
               topic: d.topic,
               decision: d.decision,
               similarity: d.similarity,
+              retrieval_score: d.retrieval_score ?? null,
               created_at: d.created_at,
+              event_date: d.event_date ?? null,
+              event_datetime: d.event_datetime ?? null,
             }));
 
           if (similar_decisions.length > 0) {
@@ -727,6 +760,9 @@ async function save({
   return {
     success: true,
     id: decisionId,
+    saved_decision_id: decisionId,
+    timeline_event_id: timelineEventId ?? null,
+    timeline_event_ids: timelineEventIds ?? [],
     ...(similar_decisions.length > 0 && { similar_decisions }),
     ...(warning && { warning }),
     ...(collaboration_hint && { collaboration_hint }),
@@ -1377,12 +1413,110 @@ interface SuggestFunctionOptions {
   limit?: number;
   threshold?: number;
   useReranking?: boolean;
+  /** Phase 3 Task 33: apply learned offline ranker rescoring. */
+  rerankWithLearned?: boolean;
   recencyWeight?: number;
   recencyScale?: number;
   recencyDecay?: number;
   disableRecency?: boolean;
   topicPrefix?: string;
   scopes?: Array<{ kind: 'global' | 'user' | 'channel' | 'project'; id: string }>;
+}
+
+/** Phase 3 Task 33: learned-ranker meta attached to mama.suggest response. */
+function buildRankerMeta(
+  applied: boolean,
+  modelId: string | null,
+  skippedReason?: string
+): Record<string, unknown> {
+  const meta: Record<string, unknown> = {
+    model_id: modelId,
+    feature_set_version: SEARCH_RANKER_FEATURE_SET_VERSION,
+    applied,
+    mode: 'offline',
+  };
+  if (skippedReason) meta.skipped_reason = skippedReason;
+  return meta;
+}
+
+function resultRecord(result: SearchRollupResult): Record<string, unknown> {
+  if (
+    typeof result.record === 'object' &&
+    result.record !== null &&
+    !Array.isArray(result.record)
+  ) {
+    return result.record as Record<string, unknown>;
+  }
+  return {};
+}
+
+function stringOrNull(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return String(value);
+}
+
+function numberOrNull(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null;
+  }
+  return value;
+}
+
+function confidenceValue(record: Record<string, unknown>, fallback: number): number {
+  const numeric = numberOrNull(record.confidence);
+  if (numeric !== null) {
+    return numeric;
+  }
+
+  switch (record.confidence) {
+    case 'high':
+      return 0.9;
+    case 'medium':
+      return 0.6;
+    case 'low':
+      return 0.3;
+    default:
+      return fallback;
+  }
+}
+
+function mapRolledUpResult(result: SearchRollupResult) {
+  const record = resultRecord(result);
+  const topic = stringOrNull(record.topic ?? record.title) ?? result.source_id;
+  // For wiki_page leaves, prefer the markdown body (`content`) in `decision` so
+  // downstream consumers see the meaningful body rather than the short title.
+  // Decision/checkpoint records use their own fields (summary/decision).
+  const isWikiPageLeaf = result.source_type === 'wiki_page';
+  const decision = isWikiPageLeaf
+    ? (stringOrNull(record.content ?? record.summary ?? record.decision ?? record.title) ??
+      result.source_id)
+    : (stringOrNull(record.summary ?? record.decision ?? record.title ?? record.content) ??
+      result.source_id);
+  const reasoning =
+    stringOrNull(record.details ?? record.reasoning ?? record.status_reason ?? record.content) ??
+    '';
+
+  return {
+    id: result.source_id,
+    topic,
+    decision,
+    reasoning,
+    confidence: confidenceValue(record, result.score),
+    similarity: null,
+    retrieval_score: result.score,
+    created_at: record.created_at ?? null,
+    event_date: record.event_date ?? null,
+    event_datetime: record.event_datetime ?? null,
+    graph_source: 'primary',
+    graph_rank: 1,
+    related_to: null,
+    edge_reason: null,
+    case_id: result.case_id,
+    source_type: result.source_type,
+    contributing_leaves: result.contributing_leaves ?? null,
+  };
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1396,6 +1530,7 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
     limit = 5,
     threshold,
     useReranking = false,
+    rerankWithLearned = false,
     // Recency boosting parameters (Gaussian Decay - Elasticsearch style)
     recencyWeight = 0.3, // 0-1: How much to weight recency (0.3 = 70% semantic, 30% recency)
     recencyScale = 7, // Days until recency score drops to 50%
@@ -1407,24 +1542,80 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
     const bundle = await recallMemory(userQuestion, {
       includeProfile: false,
       topicPrefix: options.topicPrefix,
+      limit,
       ...(options.scopes && { scopes: options.scopes }),
     });
-    if (bundle.memories.length > 0) {
-      // recallMemory uses RRF fusion — confidence is overwritten with the normalized
-      // retrieval score (0-1 range, where 1.0 = best match in this result set).
-      // The original stored confidence is lost after RRF normalization.
-      // We capture the retrieval score separately so `similarity` reflects search
-      // relevance while `confidence` is passed through as-is from the bundle.
-      let filteredMemories = bundle.memories;
+    const fusedHits = (bundle as { fused_hits?: SearchRollupLeafHit[] }).fused_hits ?? [];
+    const rolledUp =
+      fusedHits.length > 0 ? rollUpSearchHits({ fusedHits, adapter: getAdapter() }) : [];
 
-      // Apply limit
-      filteredMemories = filteredMemories.slice(0, limit);
+    // Phase 3 Task 33: compute base ranker meta once so every return path
+    // (rolledUp, memories fallback, vector-search fallback) can attach it.
+    // rerankWithLearned-driven rescoring still only applies to result arrays
+    // that match the ranker's expected shape (id + source_type + case_id).
+    const baseRankerMeta = useReranking
+      ? buildRankerMeta(false, null, 'llm_reranking_requested')
+      : rerankWithLearned
+        ? null // marker: rescoring requested, actual meta set per-path after rescore
+        : buildRankerMeta(false, null, 'feature_disabled');
+
+    const applyLearnedRanker = <
+      T extends {
+        id: string;
+        source_type?: string;
+        case_id?: string | null;
+        retrieval_score?: number | null;
+        final_score?: number | null;
+      },
+    >(
+      results: T[]
+    ): { results: T[]; meta: Record<string, unknown> } => {
+      if (baseRankerMeta !== null) {
+        return { results, meta: baseRankerMeta };
+      }
+      // Phase 3 Task 33: the caller opted in via rerankWithLearned, but the
+      // runtime `search_ranker_enabled` gate still has final say. This lets
+      // operators disable the learned ranker globally during rollback without
+      // touching any caller code.
+      let runtimeEnabled = true;
+      try {
+        runtimeEnabled = isSearchRankerEnabled(getAdapter() as never);
+      } catch (err) {
+        logWarn(`[mama.suggest] isSearchRankerEnabled check failed: ${String(err)}`);
+      }
+      if (!runtimeEnabled) {
+        return { results, meta: buildRankerMeta(false, null, 'feature_disabled') };
+      }
+      try {
+        const rescored = rescoreSearchResults(getAdapter() as never, {
+          query: userQuestion,
+          results,
+        });
+        return {
+          results: rescored.results as T[],
+          meta: buildRankerMeta(
+            rescored.skipped_reason === undefined,
+            rescored.model_id,
+            rescored.skipped_reason
+          ),
+        };
+      } catch (err) {
+        logWarn(`[mama.suggest] learned-ranker rescore failed: ${String(err)}`);
+        return { results, meta: buildRankerMeta(false, null, 'rescore_error') };
+      }
+    };
+
+    if (rolledUp.length > 0) {
+      const filteredResults = rolledUp.slice(0, limit);
+      const { results: mappedResults, meta: rankerMeta } = applyLearnedRanker(
+        filteredResults.map(mapRolledUpResult)
+      );
 
       if (format === 'markdown') {
-        const context = filteredMemories
+        const context = mappedResults
           .map(
-            (memory, index) =>
-              `${index + 1}. [${memory.topic}] ${memory.summary}\n   ${memory.details}`
+            (result, index) =>
+              `${index + 1}. [${result.topic}] ${result.decision}\n   ${result.reasoning}`
           )
           .join('\n');
         return `🔍 Search method: memory_v2\n${context}`;
@@ -1432,25 +1623,9 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
 
       return {
         query: userQuestion,
-        results: filteredMemories.map((memory, idx) => ({
-          id: memory.id,
-          topic: memory.topic,
-          decision: memory.summary,
-          reasoning: memory.details,
-          confidence: memory.confidence,
-          // memory.confidence is the normalized RRF retrieval score (0-1) after
-          // recallMemory.  Use it as similarity so the field reflects search relevance
-          // rather than the original stored trust score.
-          similarity: memory.confidence ?? 1 - idx * 0.01,
-          created_at: memory.created_at,
-          event_date: memory.event_date ?? null,
-          graph_source: 'primary',
-          graph_rank: 1,
-          related_to: null,
-          edge_reason: null,
-        })),
+        results: mappedResults,
         meta: {
-          count: filteredMemories.length,
+          count: mappedResults.length,
           search_method: 'memory_v2',
           threshold: threshold || 'adaptive',
           recency_boost: disableRecency
@@ -1461,7 +1636,7 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
                 decay: recencyDecay,
               },
           graph_expansion: {
-            total_results: filteredMemories.length,
+            total_results: mappedResults.length,
             primary_count: bundle.graph_context.primary.length,
             expanded_count: bundle.graph_context.expanded.length,
             sources: {
@@ -1472,6 +1647,76 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
               contradicts: 0,
             },
           },
+          ranker: rankerMeta,
+        },
+      };
+    }
+
+    if (bundle.memories.length > 0) {
+      // recallMemory uses RRF fusion — confidence is overwritten with the normalized
+      // retrieval score (0-1 range, where 1.0 = best match in this result set).
+      // The original stored confidence is lost after RRF normalization.
+      // We capture the retrieval score separately so `similarity` reflects search
+      // relevance while `confidence` is passed through as-is from the bundle.
+      const filteredMemories = bundle.memories.slice(0, limit);
+      const baseRows = filteredMemories.map((memory) => ({
+        id: memory.id,
+        topic: memory.topic,
+        decision: memory.summary,
+        reasoning: memory.details,
+        confidence: memory.confidence,
+        // recallMemory currently normalizes fused retrieval rank into `confidence`.
+        // Keep that value visible as retrieval_score, but do not pretend it is
+        // semantic similarity; save-time warning logic keys off `similarity`.
+        similarity: null,
+        retrieval_score: memory.confidence ?? null,
+        final_score: memory.confidence ?? null,
+        created_at: memory.created_at,
+        event_date: memory.event_date ?? null,
+        event_datetime: memory.event_datetime ?? null,
+        graph_source: 'primary',
+        graph_rank: 1,
+        related_to: null,
+        edge_reason: null,
+        case_id: null as string | null,
+        source_type: 'decision',
+      }));
+      const { results: rankedRows, meta: rankerMeta } = applyLearnedRanker(baseRows);
+
+      if (format === 'markdown') {
+        const context = rankedRows
+          .map((row, index) => `${index + 1}. [${row.topic}] ${row.decision}\n   ${row.reasoning}`)
+          .join('\n');
+        return `🔍 Search method: memory_v2\n${context}`;
+      }
+
+      return {
+        query: userQuestion,
+        results: rankedRows,
+        meta: {
+          count: rankedRows.length,
+          search_method: 'memory_v2',
+          threshold: threshold || 'adaptive',
+          recency_boost: disableRecency
+            ? null
+            : {
+                weight: recencyWeight,
+                scale: recencyScale,
+                decay: recencyDecay,
+              },
+          graph_expansion: {
+            total_results: rankedRows.length,
+            primary_count: bundle.graph_context.primary.length,
+            expanded_count: bundle.graph_context.expanded.length,
+            sources: {
+              primary: bundle.graph_context.primary.length,
+              supersedes_chain: 0,
+              refines: 0,
+              refined_by: 0,
+              contradicts: 0,
+            },
+          },
+          ranker: rankerMeta,
         },
       };
     }
@@ -1720,28 +1965,34 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
     };
 
     // JSON format (default - LLM-first)
+    const vectorRows = finalResults.map((r) => ({
+      id: r.id,
+      topic: r.topic,
+      decision: r.decision,
+      reasoning: r.reasoning,
+      confidence: r.confidence,
+      similarity: r.similarity,
+      created_at: r.created_at,
+      // Recency metadata (NEW - Gaussian Decay)
+      recency_score: r.recency_score,
+      recency_age_days: r.recency_age_days,
+      final_score: r.final_score || r.similarity, // Falls back to similarity if no recency
+      retrieval_score: r.similarity ?? null,
+      // Graph metadata (NEW - Phase 1)
+      graph_source: r.graph_source || 'primary',
+      graph_rank: r.graph_rank || 1.0,
+      related_to: r.related_to || null,
+      edge_reason: r.edge_reason || null,
+      case_id: null as string | null,
+      source_type: 'decision',
+    }));
+    const { results: rankedVectorRows, meta: rankerMeta } = applyLearnedRanker(vectorRows);
+
     return {
       query: userQuestion,
-      results: finalResults.map((r) => ({
-        id: r.id,
-        topic: r.topic,
-        decision: r.decision,
-        reasoning: r.reasoning,
-        confidence: r.confidence,
-        similarity: r.similarity,
-        created_at: r.created_at,
-        // Recency metadata (NEW - Gaussian Decay)
-        recency_score: r.recency_score,
-        recency_age_days: r.recency_age_days,
-        final_score: r.final_score || r.similarity, // Falls back to similarity if no recency
-        // Graph metadata (NEW - Phase 1)
-        graph_source: r.graph_source || 'primary',
-        graph_rank: r.graph_rank || 1.0,
-        related_to: r.related_to || null,
-        edge_reason: r.edge_reason || null,
-      })),
+      results: rankedVectorRows,
       meta: {
-        count: finalResults.length,
+        count: rankedVectorRows.length,
         search_method: searchMethod,
         threshold: threshold || 'adaptive',
         // Recency boosting config (NEW - Gaussian Decay)
@@ -1754,6 +2005,7 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
             },
         // Graph expansion stats (NEW - Phase 1)
         graph_expansion: searchMethod.includes('graph') ? graphStats : null,
+        ranker: rankerMeta,
       },
     };
   } catch (error: unknown) {
@@ -1839,7 +2091,7 @@ async function listDecisions(
         JOIN memory_scope_bindings msb ON msb.memory_id = d.id
         WHERE msb.scope_id IN (${placeholders})
           AND d.superseded_by IS NULL
-        ORDER BY d.created_at DESC
+        ORDER BY COALESCE(d.event_datetime, d.created_at) DESC, d.created_at DESC
         LIMIT ?
       `);
       decisions = await stmt.all(...scopeIds, limit);
@@ -1847,7 +2099,7 @@ async function listDecisions(
       const stmt = adapter.prepare(`
         SELECT * FROM decisions
         WHERE superseded_by IS NULL
-        ORDER BY created_at DESC
+        ORDER BY COALESCE(event_datetime, created_at) DESC, created_at DESC
         LIMIT ?
       `);
       decisions = await stmt.all(limit);

--- a/packages/mama-core/src/mama-api.ts
+++ b/packages/mama-core/src/mama-api.ts
@@ -1615,6 +1615,44 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
       }
     };
 
+    const summarizeGraphExpansion = <
+      T extends {
+        graph_source?: string | null;
+      },
+    >(
+      rows: T[]
+    ) => {
+      const sources = {
+        primary: 0,
+        supersedes_chain: 0,
+        refines: 0,
+        refined_by: 0,
+        contradicts: 0,
+      };
+
+      let expandedCount = 0;
+      for (const row of rows) {
+        const graphSource = row.graph_source ?? 'primary';
+        if (graphSource === 'primary') {
+          sources.primary += 1;
+          continue;
+        }
+
+        expandedCount += 1;
+        if (graphSource in sources) {
+          const key = graphSource as keyof typeof sources;
+          sources[key] += 1;
+        }
+      }
+
+      return {
+        total_results: rows.length,
+        primary_count: sources.primary,
+        expanded_count: expandedCount,
+        sources,
+      };
+    };
+
     if (rolledUp.length > 0) {
       const filteredResults = rolledUp.slice(0, rerankPoolLimit);
       const { results: mappedResults, meta: rankerMeta } = applyLearnedRanker(
@@ -1646,18 +1684,7 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
                 scale: recencyScale,
                 decay: recencyDecay,
               },
-          graph_expansion: {
-            total_results: limitedResults.length,
-            primary_count: bundle.graph_context.primary.length,
-            expanded_count: bundle.graph_context.expanded.length,
-            sources: {
-              primary: bundle.graph_context.primary.length,
-              supersedes_chain: 0,
-              refines: 0,
-              refined_by: 0,
-              contradicts: 0,
-            },
-          },
+          graph_expansion: summarizeGraphExpansion(limitedResults),
           ranker: rankerMeta,
         },
       };
@@ -1690,7 +1717,11 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
         related_to: null,
         edge_reason: null,
         case_id: null as string | null,
-        source_type: 'decision',
+        source_type:
+          memory.source?.source_type ??
+          (memory as { source_type?: string; type?: string }).source_type ??
+          (memory as { type?: string }).type ??
+          'decision',
       }));
       const { results: rankedRows, meta: rankerMeta } = applyLearnedRanker(baseRows);
       const limitedRows = rankedRows.slice(0, limit);
@@ -1716,18 +1747,7 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
                 scale: recencyScale,
                 decay: recencyDecay,
               },
-          graph_expansion: {
-            total_results: limitedRows.length,
-            primary_count: bundle.graph_context.primary.length,
-            expanded_count: bundle.graph_context.expanded.length,
-            sources: {
-              primary: bundle.graph_context.primary.length,
-              supersedes_chain: 0,
-              refines: 0,
-              refined_by: 0,
-              contradicts: 0,
-            },
-          },
+          graph_expansion: summarizeGraphExpansion(limitedRows),
           ranker: rankerMeta,
         },
       };

--- a/packages/mama-core/src/mama-api.ts
+++ b/packages/mama-core/src/mama-api.ts
@@ -132,6 +132,7 @@ interface SearchResult {
       expanded_count: number;
       sources: Record<string, number>;
     } | null;
+    ranker: Record<string, unknown> | null;
   };
 }
 
@@ -142,6 +143,7 @@ export interface SuggestOptions {
   limit?: number;
   threshold?: number;
   format?: 'full' | 'teaser' | 'brief' | 'markdown';
+  rerankWithLearned?: boolean;
   recency_boost?:
     | boolean
     | {
@@ -1718,6 +1720,7 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
         edge_reason: null,
         case_id: null as string | null,
         source_type:
+          memory.kind ??
           memory.source?.source_type ??
           (memory as { source_type?: string; type?: string }).source_type ??
           (memory as { type?: string }).type ??

--- a/packages/mama-core/src/mama-api.ts
+++ b/packages/mama-core/src/mama-api.ts
@@ -1504,7 +1504,11 @@ function mapRolledUpResult(result: SearchRollupResult) {
     decision,
     reasoning,
     confidence: confidenceValue(record, result.score),
-    similarity: null,
+    // Back-compat with pre-rollup consumers (swarm-mama-adapter tests,
+    // older callers): similarity mirrors the retrieval score when we don't
+    // have a separate similarity measure. retrieval_score remains the
+    // authoritative field for Phase 3 code paths.
+    similarity: result.score,
     retrieval_score: result.score,
     created_at: record.created_at ?? null,
     event_date: record.event_date ?? null,

--- a/packages/mama-core/src/mama-api.ts
+++ b/packages/mama-core/src/mama-api.ts
@@ -1543,12 +1543,13 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
     recencyDecay = 0.5, // Score at scale point (0.5 = 50%)
     disableRecency = false, // Set true to disable recency boosting entirely
   } = options;
+  const rerankPoolLimit = rerankWithLearned ? Math.max(limit * 4, limit + 5) : limit;
 
   try {
     const bundle = await recallMemory(userQuestion, {
       includeProfile: false,
       topicPrefix: options.topicPrefix,
-      limit,
+      limit: rerankPoolLimit,
       ...(options.scopes && { scopes: options.scopes }),
     });
     const fusedHits = (bundle as { fused_hits?: SearchRollupLeafHit[] }).fused_hits ?? [];
@@ -1612,13 +1613,14 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
     };
 
     if (rolledUp.length > 0) {
-      const filteredResults = rolledUp.slice(0, limit);
+      const filteredResults = rolledUp.slice(0, rerankPoolLimit);
       const { results: mappedResults, meta: rankerMeta } = applyLearnedRanker(
         filteredResults.map(mapRolledUpResult)
       );
+      const limitedResults = mappedResults.slice(0, limit);
 
       if (format === 'markdown') {
-        const context = mappedResults
+        const context = limitedResults
           .map(
             (result, index) =>
               `${index + 1}. [${result.topic}] ${result.decision}\n   ${result.reasoning}`
@@ -1629,9 +1631,9 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
 
       return {
         query: userQuestion,
-        results: mappedResults,
+        results: limitedResults,
         meta: {
-          count: mappedResults.length,
+          count: limitedResults.length,
           search_method: 'memory_v2',
           threshold: threshold || 'adaptive',
           recency_boost: disableRecency
@@ -1642,7 +1644,7 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
                 decay: recencyDecay,
               },
           graph_expansion: {
-            total_results: mappedResults.length,
+            total_results: limitedResults.length,
             primary_count: bundle.graph_context.primary.length,
             expanded_count: bundle.graph_context.expanded.length,
             sources: {
@@ -1664,7 +1666,7 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
       // The original stored confidence is lost after RRF normalization.
       // We capture the retrieval score separately so `similarity` reflects search
       // relevance while `confidence` is passed through as-is from the bundle.
-      const filteredMemories = bundle.memories.slice(0, limit);
+      const filteredMemories = bundle.memories.slice(0, rerankPoolLimit);
       const baseRows = filteredMemories.map((memory) => ({
         id: memory.id,
         topic: memory.topic,
@@ -1688,9 +1690,10 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
         source_type: 'decision',
       }));
       const { results: rankedRows, meta: rankerMeta } = applyLearnedRanker(baseRows);
+      const limitedRows = rankedRows.slice(0, limit);
 
       if (format === 'markdown') {
-        const context = rankedRows
+        const context = limitedRows
           .map((row, index) => `${index + 1}. [${row.topic}] ${row.decision}\n   ${row.reasoning}`)
           .join('\n');
         return `🔍 Search method: memory_v2\n${context}`;
@@ -1698,9 +1701,9 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
 
       return {
         query: userQuestion,
-        results: rankedRows,
+        results: limitedRows,
         meta: {
-          count: rankedRows.length,
+          count: limitedRows.length,
           search_method: 'memory_v2',
           threshold: threshold || 'adaptive',
           recency_boost: disableRecency
@@ -1711,7 +1714,7 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
                 decay: recencyDecay,
               },
           graph_expansion: {
-            total_results: rankedRows.length,
+            total_results: limitedRows.length,
             primary_count: bundle.graph_context.primary.length,
             expanded_count: bundle.graph_context.expanded.length,
             sources: {
@@ -1746,7 +1749,7 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
       const adaptiveThreshold = threshold !== undefined ? threshold : wordCount < 3 ? 0.7 : 0.6;
 
       // Vector search
-      results = await vectorSearch(queryEmbedding, limit * 2, 0.5); // Get more candidates
+      results = await vectorSearch(queryEmbedding, rerankPoolLimit * 2, 0.5); // Get more candidates
 
       // Filter by adaptive threshold
       results = results.filter((r) => r.similarity >= adaptiveThreshold);
@@ -1803,7 +1806,7 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
       // Stage 1.7: FTS5 hybrid merge (Haiku Memory Layer)
       {
         try {
-          const ftsResults = await fts5Search(userQuestion, limit * 2);
+          const ftsResults = await fts5Search(userQuestion, rerankPoolLimit * 2);
           if (ftsResults.length > 0) {
             // Normalize FTS5 ranks (BM25 returns negative values, closer to 0 = better)
             const maxRank = Math.max(...ftsResults.map((r) => Math.abs(r.rank)));
@@ -1908,7 +1911,7 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
         LIMIT ?
       `);
 
-      const rows = (await stmt.all(...likeParams, limit)) as DecisionRecord[];
+      const rows = (await stmt.all(...likeParams, rerankPoolLimit)) as DecisionRecord[];
       results = rows.map((row: DecisionRecord) => ({
         ...row,
         similarity: 0.75, // Assign moderate similarity for keyword matches
@@ -1937,18 +1940,21 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
       results = await rerankWithLLM(userQuestion, results);
     }
 
-    // Slice to limit
-    const finalResults = results.slice(0, limit);
+    const rerankCandidateResults = results.slice(0, rerankPoolLimit);
 
     // Markdown format (for human display)
     if (format === 'markdown') {
-      const context = formatContext(finalResults, { maxTokens: 500 });
+      const context = formatContext(rerankCandidateResults.slice(0, limit), { maxTokens: 500 });
 
       // Add graph expansion summary if applicable
       let graphSummary = '';
       if (searchMethod.includes('graph')) {
-        const primaryCount = finalResults.filter((r) => r.graph_source === 'primary').length;
-        const expandedCount = finalResults.filter((r) => r.graph_source !== 'primary').length;
+        const primaryCount = rerankCandidateResults
+          .slice(0, limit)
+          .filter((r) => r.graph_source === 'primary').length;
+        const expandedCount = rerankCandidateResults
+          .slice(0, limit)
+          .filter((r) => r.graph_source !== 'primary').length;
 
         graphSummary = `\n📊 Graph expansion: ${primaryCount} primary + ${expandedCount} related (supersedes/refines/contradicts)\n`;
       }
@@ -1956,22 +1962,8 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
       return `🔍 Search method: ${searchMethod}${graphSummary}\n${context}`;
     }
 
-    // Calculate graph expansion stats
-    const graphStats = {
-      total_results: finalResults.length,
-      primary_count: finalResults.filter((r) => r.graph_source === 'primary').length,
-      expanded_count: finalResults.filter((r) => r.graph_source !== 'primary').length,
-      sources: {
-        primary: finalResults.filter((r) => r.graph_source === 'primary').length,
-        supersedes_chain: finalResults.filter((r) => r.graph_source === 'supersedes_chain').length,
-        refines: finalResults.filter((r) => r.graph_source === 'refines').length,
-        refined_by: finalResults.filter((r) => r.graph_source === 'refined_by').length,
-        contradicts: finalResults.filter((r) => r.graph_source === 'contradicts').length,
-      },
-    };
-
     // JSON format (default - LLM-first)
-    const vectorRows = finalResults.map((r) => ({
+    const vectorRows = rerankCandidateResults.map((r) => ({
       id: r.id,
       topic: r.topic,
       decision: r.decision,
@@ -1993,12 +1985,27 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
       source_type: 'decision',
     }));
     const { results: rankedVectorRows, meta: rankerMeta } = applyLearnedRanker(vectorRows);
+    const finalResults = rankedVectorRows.slice(0, limit);
+
+    // Calculate graph expansion stats
+    const graphStats = {
+      total_results: finalResults.length,
+      primary_count: finalResults.filter((r) => r.graph_source === 'primary').length,
+      expanded_count: finalResults.filter((r) => r.graph_source !== 'primary').length,
+      sources: {
+        primary: finalResults.filter((r) => r.graph_source === 'primary').length,
+        supersedes_chain: finalResults.filter((r) => r.graph_source === 'supersedes_chain').length,
+        refines: finalResults.filter((r) => r.graph_source === 'refines').length,
+        refined_by: finalResults.filter((r) => r.graph_source === 'refined_by').length,
+        contradicts: finalResults.filter((r) => r.graph_source === 'contradicts').length,
+      },
+    };
 
     return {
       query: userQuestion,
-      results: rankedVectorRows,
+      results: finalResults,
       meta: {
-        count: rankedVectorRows.length,
+        count: finalResults.length,
         search_method: searchMethod,
         threshold: threshold || 'adaptive',
         // Recency boosting config (NEW - Gaussian Decay)

--- a/packages/mama-core/src/memory/api.ts
+++ b/packages/mama-core/src/memory/api.ts
@@ -1460,6 +1460,7 @@ export async function ingestMemory(
     scopes: input.scopes ?? [],
     source: input.source,
     eventDate: input.eventDate,
+    eventDateTime: input.eventDateTime,
   });
 }
 

--- a/packages/mama-core/src/memory/api.ts
+++ b/packages/mama-core/src/memory/api.ts
@@ -8,6 +8,11 @@ import {
   fts5Search,
 } from '../db-manager.js';
 import { generateEmbedding } from '../embeddings.js';
+import {
+  ftsSearchWikiPages,
+  vectorSearchWikiPages,
+  type WikiPageIndexRecord,
+} from '../cases/wiki-page-index.js';
 import { classifyProfileEntries } from './profile-builder.js';
 import { buildMemoryAgentBootstrap } from './bootstrap-builder.js';
 import { resolveMemoryEvolution } from './evolution-engine.js';
@@ -18,6 +23,7 @@ import { buildExtractionPrompt, parseExtractionResponse } from './extraction-pro
 import { createEmptyRecallBundle, createMemoryAuditAck } from './types.js';
 import { getChannelSummary, upsertChannelSummary } from './channel-summary-store.js';
 import { queryCanonicalEntities } from '../entities/recall-bridge.js';
+import { loadDecisionReadIdentityIndex, resolveReadIdentity } from '../entities/read-identity.js';
 import type {
   MemoryKind,
   MemoryAgentBootstrap,
@@ -57,6 +63,21 @@ interface SaveMemoryInput {
    * Stored in the event_date column. Defaults to created_at if omitted.
    */
   eventDate?: string;
+  /** Source event timestamp in milliseconds when known. */
+  eventDateTime?: number;
+  entityObservationIds?: string[];
+  timelineEvent?: {
+    id?: string;
+    entity_id?: string;
+    event_type: string;
+    role?: string | null;
+    valid_from?: number | null;
+    valid_to?: number | null;
+    observed_at?: number | null;
+    source_ref?: string | null;
+    summary: string;
+    details?: string | null;
+  };
 }
 
 interface RecallMemoryOptions {
@@ -65,6 +86,7 @@ interface RecallMemoryOptions {
   includeHistory?: boolean;
   skipGraphExpansion?: boolean;
   topicPrefix?: string;
+  limit?: number;
 }
 
 interface IngestMemoryInput {
@@ -72,6 +94,18 @@ interface IngestMemoryInput {
   scopes?: MemoryScopeRef[];
   source: SaveMemoryInput['source'];
   eventDate?: string;
+  eventDateTime?: number;
+}
+
+export interface FusedHit {
+  source_type: 'decision' | 'wiki_page';
+  source_id: string;
+  record: MemoryRecord | WikiPageIndexRecord;
+  fused_rank_score: number;
+}
+
+interface SaveMemoryRollbackError extends Error {
+  memoryId?: string;
 }
 
 function buildDecisionId(topic: string): string {
@@ -107,7 +141,221 @@ function toMemoryRecord(
     created_at: row.created_at as number | string,
     updated_at: (row.updated_at as number | string) ?? (row.created_at as number | string),
     event_date: (row.event_date as string) ?? null,
+    event_datetime:
+      typeof row.event_datetime === 'number' && Number.isFinite(row.event_datetime)
+        ? row.event_datetime
+        : null,
   };
+}
+
+function loadEventDateTimeForObservations(
+  adapter: ReturnType<typeof getAdapter>,
+  observationIds: string[]
+): number | null {
+  const uniqueIds = Array.from(new Set(observationIds.filter(Boolean)));
+  if (uniqueIds.length === 0) {
+    return null;
+  }
+
+  const placeholders = uniqueIds.map(() => '?').join(', ');
+  const row = adapter
+    .prepare(
+      `
+        SELECT MAX(COALESCE(timestamp_observed, created_at)) AS event_datetime
+        FROM entity_observations
+        WHERE id IN (${placeholders})
+      `
+    )
+    .get(...uniqueIds) as { event_datetime?: number | null } | undefined;
+
+  return typeof row?.event_datetime === 'number' && Number.isFinite(row.event_datetime)
+    ? row.event_datetime
+    : null;
+}
+
+function getTimelineEntityKindPriority(kind: string): number {
+  switch (kind) {
+    case 'work_item':
+      return 0;
+    case 'project':
+      return 1;
+    case 'organization':
+      return 2;
+    case 'person':
+      return 3;
+    default:
+      return 99;
+  }
+}
+
+function resolveTimelineTargetEntityIdFromObservations(
+  adapter: ReturnType<typeof getAdapter>,
+  observationIds: string[]
+): string | null {
+  const uniqueIds = Array.from(new Set(observationIds.filter(Boolean)));
+  if (uniqueIds.length === 0) {
+    return null;
+  }
+
+  const placeholders = uniqueIds.map(() => '?').join(', ');
+  const rows = adapter
+    .prepare(
+      `
+        SELECT
+          n.id AS entity_id,
+          n.kind AS entity_kind,
+          COUNT(*) AS matched_observations
+        FROM entity_lineage_links l
+        JOIN entity_nodes n
+          ON n.id = l.canonical_entity_id
+        WHERE l.entity_observation_id IN (${placeholders})
+          AND l.status = 'active'
+          AND n.status = 'active'
+          AND n.merged_into IS NULL
+        GROUP BY n.id, n.kind
+      `
+    )
+    .all(...uniqueIds) as Array<{
+    entity_id: string;
+    entity_kind: string;
+    matched_observations: number;
+  }>;
+
+  rows.sort((left, right) => {
+    const kindDelta =
+      getTimelineEntityKindPriority(left.entity_kind) -
+      getTimelineEntityKindPriority(right.entity_kind);
+    if (kindDelta !== 0) {
+      return kindDelta;
+    }
+    if (right.matched_observations !== left.matched_observations) {
+      return right.matched_observations - left.matched_observations;
+    }
+    return left.entity_id.localeCompare(right.entity_id);
+  });
+
+  return rows[0]?.entity_id ?? null;
+}
+
+function buildTimelineEventForSave(
+  adapter: ReturnType<typeof getAdapter>,
+  memoryId: string,
+  topic: string,
+  entityObservationIds: string[],
+  timelineEvent:
+    | {
+        id?: string;
+        entity_id?: string;
+        event_type: string;
+        role?: string | null;
+        valid_from?: number | null;
+        valid_to?: number | null;
+        observed_at?: number | null;
+        source_ref?: string | null;
+        summary: string;
+        details?: string | null;
+      }
+    | undefined
+): {
+  id: string;
+  entity_id: string;
+  event_type: string;
+  role: string | null;
+  valid_from: number | null;
+  valid_to: number | null;
+  observed_at: number | null;
+  source_ref: string | null;
+  summary: string;
+  details: string | null;
+} | null {
+  if (!timelineEvent) {
+    return null;
+  }
+
+  const resolvedEntityId =
+    timelineEvent.entity_id ??
+    resolveTimelineTargetEntityIdFromObservations(adapter, entityObservationIds);
+  if (!resolvedEntityId) {
+    return null;
+  }
+
+  return {
+    id: timelineEvent.id ?? `et_${crypto.randomUUID()}`,
+    entity_id: resolvedEntityId,
+    event_type: timelineEvent.event_type,
+    role: timelineEvent.role ?? null,
+    valid_from: timelineEvent.valid_from ?? null,
+    valid_to: timelineEvent.valid_to ?? null,
+    observed_at: timelineEvent.observed_at ?? null,
+    source_ref: timelineEvent.source_ref ?? `decision:${memoryId}`,
+    summary: timelineEvent.summary,
+    details:
+      timelineEvent.details ??
+      JSON.stringify({
+        memory_id: memoryId,
+        topic,
+      }),
+  };
+}
+
+function insertTimelineEventForSave(
+  adapter: ReturnType<typeof getAdapter>,
+  event: {
+    id: string;
+    entity_id: string;
+    event_type: string;
+    role: string | null;
+    valid_from: number | null;
+    valid_to: number | null;
+    observed_at: number | null;
+    source_ref: string | null;
+    summary: string;
+    details: string | null;
+  },
+  createdAt: number
+): void {
+  adapter
+    .prepare(
+      `
+        INSERT INTO entity_timeline_events (
+          id, entity_id, event_type, role, valid_from, valid_to, observed_at,
+          source_ref, summary, details, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      event.id,
+      event.entity_id,
+      event.event_type,
+      event.role,
+      event.valid_from,
+      event.valid_to,
+      event.observed_at,
+      event.source_ref,
+      event.summary,
+      event.details,
+      createdAt
+    );
+}
+
+function cleanupFailedMemorySave(adapter: ReturnType<typeof getAdapter>, memoryId: string): void {
+  const row = adapter.prepare(`SELECT rowid FROM decisions WHERE id = ?`).get(memoryId) as
+    | { rowid: number }
+    | undefined;
+  if (!row) {
+    return;
+  }
+
+  const cleanup = () => {
+    adapter.prepare(`DELETE FROM embeddings WHERE rowid = ?`).run(row.rowid);
+    adapter.prepare(`DELETE FROM decisions WHERE id = ?`).run(memoryId);
+  };
+
+  const txResult = adapter.transaction(cleanup) as unknown;
+  if (typeof txResult === 'function') {
+    txResult();
+  }
 }
 
 function batchLoadScopes(
@@ -150,9 +398,9 @@ async function loadScopedMemories(scopes: MemoryScopeRef[]): Promise<MemoryRecor
       .prepare(
         `
           SELECT id, topic, decision, reasoning, confidence, created_at, updated_at, trust_context,
-                 kind, status, summary, event_date
+                 kind, status, summary, event_date, event_datetime
           FROM decisions
-          ORDER BY created_at DESC
+          ORDER BY COALESCE(event_datetime, created_at) DESC, created_at DESC
         `
       )
       .all() as Record<string, unknown>[];
@@ -165,11 +413,11 @@ async function loadScopedMemories(scopes: MemoryScopeRef[]): Promise<MemoryRecor
       .prepare(
         `
           SELECT DISTINCT d.id, d.topic, d.decision, d.reasoning, d.confidence, d.created_at,
-                 d.updated_at, d.trust_context, d.kind, d.status, d.summary, d.event_date
+                 d.updated_at, d.trust_context, d.kind, d.status, d.summary, d.event_date, d.event_datetime
           FROM decisions d
           JOIN memory_scope_bindings msb ON msb.memory_id = d.id
           WHERE msb.scope_id IN (${placeholders})
-          ORDER BY d.created_at DESC
+          ORDER BY COALESCE(d.event_datetime, d.created_at) DESC, d.created_at DESC
         `
       )
       .all(...scopeIds) as Record<string, unknown>[];
@@ -375,9 +623,13 @@ export async function loadEdgesForIds(ids: string[]): Promise<MemoryEdge[]> {
   }));
 }
 
-export async function saveMemory(
-  input: SaveMemoryInput
-): Promise<{ success: boolean; id: string }> {
+export async function saveMemory(input: SaveMemoryInput): Promise<{
+  success: boolean;
+  id: string;
+  saved_decision_id?: string;
+  timeline_event_id?: string | null;
+  timeline_event_ids?: string[];
+}> {
   await initDB();
   const adapter = getAdapter();
 
@@ -475,6 +727,19 @@ export async function saveMemory(
   const supersedesTarget =
     evolution.edges.find((edge) => edge.type === 'supersedes')?.to_id ?? null;
 
+  const entityObservationIds = Array.from(new Set(input.entityObservationIds ?? []));
+  const eventDateTime =
+    typeof input.eventDateTime === 'number'
+      ? input.eventDateTime
+      : loadEventDateTimeForObservations(adapter, entityObservationIds);
+  const timelineEvent = buildTimelineEventForSave(
+    adapter,
+    id,
+    input.topic,
+    entityObservationIds,
+    input.timelineEvent
+  );
+
   await insertDecisionWithEmbedding({
     id,
     topic: input.topic,
@@ -486,6 +751,7 @@ export async function saveMemory(
     updated_at: now,
     trust_context: JSON.stringify({ source: input.source }),
     event_date: input.eventDate ?? null,
+    event_datetime: eventDateTime,
   });
 
   // Pre-resolve scope IDs before the synchronous transaction
@@ -494,57 +760,81 @@ export async function saveMemory(
     const scopeId = await ensureMemoryScope(scope.kind, scope.id);
     resolvedScopeIds.push({ scopeId, isPrimary: index === 0 });
   }
-
   // Wrap all post-insert mutations in a transaction for atomicity
-  adapter.transaction(() => {
-    adapter
-      .prepare(
-        `
-          UPDATE decisions
-          SET kind = ?, status = ?, summary = ?, is_static = ?, trust_context = ?, updated_at = ?
-          WHERE id = ?
-        `
-      )
-      .run(
-        input.kind,
-        input.status ?? 'active',
-        input.summary,
-        input.kind === 'preference' || input.kind === 'constraint' ? 1 : 0,
-        JSON.stringify({ source: input.source }),
-        now,
-        id
-      );
-
-    for (const { scopeId, isPrimary } of resolvedScopeIds) {
+  try {
+    adapter.transaction(() => {
       adapter
         .prepare(
           `
-            INSERT OR REPLACE INTO memory_scope_bindings (memory_id, scope_id, is_primary)
-            VALUES (?, ?, ?)
+            UPDATE decisions
+            SET kind = ?, status = ?, summary = ?, is_static = ?, trust_context = ?, updated_at = ?
+            WHERE id = ?
           `
         )
-        .run(id, scopeId, isPrimary ? 1 : 0);
-    }
+        .run(
+          input.kind,
+          input.status ?? 'active',
+          input.summary,
+          input.kind === 'preference' || input.kind === 'constraint' ? 1 : 0,
+          JSON.stringify({ source: input.source }),
+          now,
+          id
+        );
 
-    for (const edge of evolution.edges) {
-      if (edge.type === 'supersedes') {
+      for (const { scopeId, isPrimary } of resolvedScopeIds) {
         adapter
           .prepare(
-            `UPDATE decisions SET superseded_by = ?, status = 'superseded', updated_at = ? WHERE id = ?`
+            `
+              INSERT OR REPLACE INTO memory_scope_bindings (memory_id, scope_id, is_primary)
+              VALUES (?, ?, ?)
+            `
           )
-          .run(id, now, edge.to_id);
+          .run(id, scopeId, isPrimary ? 1 : 0);
       }
 
-      adapter
-        .prepare(
-          `
-            INSERT OR REPLACE INTO decision_edges (from_id, to_id, relationship, reason, weight, created_at)
-            VALUES (?, ?, ?, ?, ?, ?)
-          `
-        )
-        .run(id, edge.to_id, edge.type, edge.reason ?? null, 1.0, now);
-    }
-  });
+      for (const entityObservationId of entityObservationIds) {
+        adapter
+          .prepare(
+            `
+              INSERT OR IGNORE INTO decision_entity_sources (
+                decision_id, entity_observation_id, relation_type, created_at
+              ) VALUES (?, ?, ?, ?)
+            `
+          )
+          .run(id, entityObservationId, 'support', now);
+      }
+
+      if (timelineEvent) {
+        insertTimelineEventForSave(adapter, timelineEvent, now);
+      }
+
+      for (const edge of evolution.edges) {
+        if (edge.type === 'supersedes') {
+          adapter
+            .prepare(
+              `UPDATE decisions SET superseded_by = ?, status = 'superseded', updated_at = ? WHERE id = ?`
+            )
+            .run(id, now, edge.to_id);
+        }
+
+        adapter
+          .prepare(
+            `
+              INSERT OR REPLACE INTO decision_edges (from_id, to_id, relationship, reason, weight, created_at)
+              VALUES (?, ?, ?, ?, ?, ?)
+            `
+          )
+          .run(id, edge.to_id, edge.type, edge.reason ?? null, 1.0, now);
+      }
+    });
+  } catch (error) {
+    cleanupFailedMemorySave(adapter, id);
+    const rollbackError = (
+      error instanceof Error ? error : new Error(String(error))
+    ) as SaveMemoryRollbackError;
+    rollbackError.memoryId = id;
+    throw rollbackError;
+  }
 
   // Project to memory_truth table (best-effort; failure should not break save)
   try {
@@ -563,7 +853,13 @@ export async function saveMemory(
     // Truth projection is best-effort; do not fail the save
   }
 
-  return { success: true, id };
+  return {
+    success: true,
+    id,
+    saved_decision_id: id,
+    timeline_event_id: timelineEvent?.id ?? null,
+    timeline_event_ids: timelineEvent ? [timelineEvent.id] : [],
+  };
 }
 
 export async function buildProfile(scopes: MemoryScopeRef[]): Promise<ProfileSnapshot> {
@@ -585,6 +881,7 @@ export async function recallMemory(
   const bundle = createEmptyRecallBundle(query);
 
   let matched: MemoryRecord[] = [];
+  let fusedHits: FusedHit[] = [];
   let retrievalSource = 'none';
   const projectionMode = process.env.MAMA_ENTITY_PROJECTION_MODE ?? 'shadow';
   let _lexicalRecords: MemoryRecord[] | null = null;
@@ -602,6 +899,7 @@ export async function recallMemory(
   );
   const hasMultipleEntities = /\b(and|or|vs|versus|compared|between)\b/.test(lowerQuery);
   const vectorLimit = isAggregation ? 50 : 20;
+  const requestedLimit = Math.max(1, Math.floor(options.limit ?? 10));
 
   // Multi-query decomposition: extract sub-queries for complex questions
   const subQueries: string[] = [query];
@@ -621,9 +919,13 @@ export async function recallMemory(
 
   // Channel 1: Vector search (semantic similarity) — run all sub-queries
   const vectorMatched: MemoryRecord[] = [];
+  let primaryQueryEmbedding: Float32Array | null = null;
   try {
     for (const sq of subQueries) {
       const queryEmbedding = await generateEmbedding(sq);
+      if (sq === query && primaryQueryEmbedding === null) {
+        primaryQueryEmbedding = queryEmbedding;
+      }
       const vectorResults = await vectorSearch(
         queryEmbedding,
         vectorLimit,
@@ -663,6 +965,8 @@ export async function recallMemory(
           source: { package: 'mama-core', source_type: 'vector_search' },
           created_at: result.created_at ?? Date.now(),
           updated_at: result.created_at ?? Date.now(),
+          event_date: result.event_date ?? null,
+          event_datetime: result.event_datetime ?? null,
         });
       }
     } // end sub-query loop
@@ -749,7 +1053,7 @@ export async function recallMemory(
           const row = adapter
             .prepare(
               `SELECT id, topic, decision, reasoning, confidence, created_at, updated_at,
-                    trust_context, kind, status, summary, event_date
+                    trust_context, kind, status, summary, event_date, event_datetime
              FROM decisions WHERE id = ?`
             )
             .get(ftsRow.id) as Record<string, unknown> | undefined;
@@ -859,6 +1163,79 @@ export async function recallMemory(
   }
 
   const sortedRrf = Array.from(rrfScores.values()).sort((a, b) => b.score - a.score);
+  const decisionFusedHits: FusedHit[] = sortedRrf.map((entry) => ({
+    source_type: 'decision',
+    source_id: entry.record.id,
+    record: entry.record,
+    fused_rank_score: entry.score,
+  }));
+
+  let hasWikiHits = false;
+  const wikiScores = new Map<number, { record: WikiPageIndexRecord; score: number }>();
+  const wikiVectorRankMap = new Map<number, number>();
+
+  try {
+    const adapter = getAdapter();
+    const wikiFtsHits = ftsSearchWikiPages(adapter, query, requestedLimit * 2);
+    let wikiVectorHits: ReturnType<typeof vectorSearchWikiPages> = [];
+
+    if (primaryQueryEmbedding) {
+      try {
+        wikiVectorHits = vectorSearchWikiPages(adapter, primaryQueryEmbedding, requestedLimit * 2);
+      } catch (wikiVectorErr) {
+        warn(
+          `[recallMemory] Wiki vector search failed: ${wikiVectorErr instanceof Error ? wikiVectorErr.message : String(wikiVectorErr)}`
+        );
+      }
+    }
+
+    for (let i = 0; i < wikiVectorHits.length; i++) {
+      wikiVectorRankMap.set(wikiVectorHits[i].record.id, i);
+    }
+
+    for (let i = 0; i < wikiFtsHits.length; i++) {
+      const hit = wikiFtsHits[i];
+      const lexScore = 1 / (RRF_K + i + 1);
+      const vecRank = wikiVectorRankMap.get(hit.record.id);
+      const vecBoost = vecRank !== undefined ? 0.2 * (1 / (RRF_K + vecRank + 1)) : 0;
+      wikiScores.set(hit.record.id, {
+        record: hit.record,
+        score: lexScore + vecBoost,
+      });
+    }
+
+    for (let i = 0; i < wikiVectorHits.length; i++) {
+      const hit = wikiVectorHits[i];
+      if (wikiScores.has(hit.record.id)) {
+        continue;
+      }
+      wikiScores.set(hit.record.id, {
+        record: hit.record,
+        score: 0.15 * (1 / (RRF_K + i + 1)),
+      });
+    }
+
+    hasWikiHits = wikiScores.size > 0;
+  } catch (wikiFtsErr) {
+    warn(
+      `[recallMemory] Wiki FTS search failed: ${wikiFtsErr instanceof Error ? wikiFtsErr.message : String(wikiFtsErr)}`
+    );
+  }
+
+  const wikiFusedHits: FusedHit[] = Array.from(wikiScores.values())
+    .sort((a, b) => b.score - a.score)
+    .map((entry) => ({
+      source_type: 'wiki_page',
+      source_id: entry.record.source_locator,
+      record: entry.record,
+      fused_rank_score: entry.score,
+      ...(entry.record.page_type === 'case' ? { page_type: 'case' as const } : {}),
+      ...(entry.record.case_id ? { case_id: entry.record.case_id } : {}),
+    }));
+
+  fusedHits = [...decisionFusedHits, ...wikiFusedHits].sort(
+    (left, right) => right.fused_rank_score - left.fused_rank_score
+  );
 
   // Normalize RRF scores to 0-1 range so downstream consumers (threshold filters,
   // similarity displays) get meaningful values.  The raw RRF score for K=60 tops out
@@ -875,6 +1252,10 @@ export async function recallMemory(
     retrievalSource = 'vector_search';
   } else if (lexicalCandidates.length > 0) {
     retrievalSource = 'lexical_search';
+  }
+
+  if (hasWikiHits) {
+    retrievalSource = retrievalSource === 'none' ? 'wiki_page' : `${retrievalSource}+wiki_page`;
   }
 
   let canonicalMatched: MemoryRecord[] = [];
@@ -899,6 +1280,18 @@ export async function recallMemory(
       warn(
         `[recallMemory] Canonical entity recall failed: ${canonicalErr instanceof Error ? canonicalErr.message : String(canonicalErr)}`
       );
+    }
+  }
+
+  if (matched.length > 0) {
+    const readIdentityIndex = await loadDecisionReadIdentityIndex(
+      matched.filter((record) => !record.read_identity).map((record) => record.id)
+    );
+    for (const record of matched) {
+      if (record.read_identity) {
+        continue;
+      }
+      record.read_identity = resolveReadIdentity(record, readIdentityIndex.get(record.id) ?? []);
     }
   }
 
@@ -1039,6 +1432,7 @@ export async function recallMemory(
     }
   }
 
+  (bundle as RecallBundle & { fused_hits?: FusedHit[] }).fused_hits = fusedHits;
   bundle.search_meta.scope_order = (options.scopes ?? []).map((scope) => scope.kind);
   bundle.search_meta.retrieval_sources = [retrievalSource];
 

--- a/packages/mama-core/src/memory/types.ts
+++ b/packages/mama-core/src/memory/types.ts
@@ -1,3 +1,6 @@
+import type { ConnectorEventSearchHit } from '../connectors/types.js';
+import type { ReadIdentity } from '../entities/read-identity.js';
+
 export const MEMORY_SCOPE_KINDS = ['global', 'user', 'channel', 'project'] as const;
 export type MemoryScopeKind = (typeof MEMORY_SCOPE_KINDS)[number];
 
@@ -75,6 +78,9 @@ export interface MemoryRecord {
   updated_at: number | string;
   /** ISO 8601 date when the event actually occurred (e.g. "2023-01-15"). Null if not set. */
   event_date?: string | null;
+  /** Source event timestamp in milliseconds when known. Null if not set. */
+  event_datetime?: number | null;
+  read_identity?: ReadIdentity;
 }
 
 export interface MemoryEdge {
@@ -97,6 +103,8 @@ export interface ProfileSnapshot {
 export interface RecallBundle {
   profile: ProfileSnapshot;
   memories: MemoryRecord[];
+  /** Phase 3: cross-connector event hits, populated when searchWithConnectorEvents=true */
+  connector_event_hits?: ConnectorEventSearchHit[];
   graph_context: {
     primary: MemoryRecord[];
     expanded: MemoryRecord[];
@@ -109,6 +117,9 @@ export interface RecallBundle {
   };
 }
 
+/** Phase 3: unified search result type — memory-authored or connector-enriched. */
+export type MemorySearchResultHit = MemoryRecord | ConnectorEventSearchHit;
+
 export interface MemoryEventRecord {
   event_id: string;
   event_type:
@@ -120,8 +131,50 @@ export interface MemoryEventRecord {
     | 'quarantine'
     | 'no_op'
     | 'audit_failed'
-    | 'notice_sent';
-  actor: 'memory_agent' | 'main_agent' | 'user' | 'system';
+    | 'notice_sent'
+    | 'provenance.empty_batch'
+    | 'provenance.link_write_failed'
+    | 'connector_event_index.retention_swept'
+    | 'case.link_created'
+    | 'case.link_revoked'
+    | 'case.membership_pinned'
+    | 'case.membership_unpinned'
+    | 'case.source_promoted'
+    | 'case.freshness_drifted'
+    | 'automation.job.started'
+    | 'automation.job.succeeded'
+    | 'automation.job.failed'
+    | 'automation.job.skipped_concurrent'
+    | 'review.bulk.approved'
+    | 'review.bulk.rejected'
+    | 'review.bulk.deferred'
+    | 'canary.drift.false_merge_rate'
+    | 'canary.drift.projection_fragmentation_rate'
+    | 'canary.drift.replay_stale'
+    | 'auth.role_denied'
+    | 'ontology.proposal'
+    | 'ontology.approval'
+    | 'repair.approval'
+    | 'case.fast_write_applied'
+    | 'case.fast_write_lock_skipped'
+    | 'case.correction_applied'
+    | 'case.correction_reverted'
+    | 'case.correction_superseded'
+    | 'case.membership_tombstoned'
+    | 'case.merged'
+    | 'case.split'
+    | 'case.membership_matched'
+    | 'case.membership_candidate';
+  actor:
+    | 'memory_agent'
+    | 'main_agent'
+    | 'user'
+    | 'system'
+    | `user:${string}`
+    | `user_uuid:${string}`
+    | `local:${string}`
+    | `actor:${string}`
+    | 'token:bearer';
   source_turn_id?: string;
   memory_id?: string;
   topic?: string;

--- a/packages/mama-core/src/search/feedback-store.ts
+++ b/packages/mama-core/src/search/feedback-store.ts
@@ -232,7 +232,7 @@ export function recordSearchFeedback(
   const questionType = questionTypeForInput(input);
   const rankPosition = rankPositionForInput(input);
   const createdAt = input.created_at ?? nowIso();
-  const feedbackId = input.result_id || `search_feedback_${randomUUID()}`;
+  const feedbackId = `search_feedback_${randomUUID()}`;
   const metadataJson = canonicalJson({
     clicked_result_rank: input.clicked_result_rank ?? null,
     input_result_id: input.result_id,

--- a/packages/mama-core/src/search/feedback-store.ts
+++ b/packages/mama-core/src/search/feedback-store.ts
@@ -19,7 +19,7 @@ export interface SearchFeedbackInput {
   result_source_type: SearchFeedbackSourceType;
   result_source_id: string;
   feedback_kind: SearchFeedbackKind;
-  question_type: QuestionType;
+  question_type?: QuestionType | null;
   shown_index: number;
   result_case_id?: string | null;
   clicked_result_rank?: number | null;
@@ -131,7 +131,7 @@ function canonicalJson(value: Record<string, unknown>): string {
 
 function runTransaction<T>(adapter: FeedbackStoreAdapter, fn: () => T): T {
   if (!adapter.transaction) {
-    return fn();
+    throw new Error('recordSearchFeedback requires adapter.transaction for atomic writes.');
   }
 
   const result = adapter.transaction(fn);

--- a/packages/mama-core/src/search/feedback-store.ts
+++ b/packages/mama-core/src/search/feedback-store.ts
@@ -1,0 +1,340 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+import type { RunResult } from '../db-adapter/statement.js';
+import { classifyQuestionType, isQuestionType, type QuestionType } from './question-type.js';
+
+export type SearchFeedbackKind = 'shown' | 'accept' | 'reject' | 'hide' | 'click';
+
+export type SearchFeedbackSourceType =
+  | 'decision'
+  | 'checkpoint'
+  | 'wiki_page'
+  | 'case'
+  | 'connector_event';
+
+export interface SearchFeedbackInput {
+  result_id: string;
+  session_id?: string | null;
+  query: string;
+  result_source_type: SearchFeedbackSourceType;
+  result_source_id: string;
+  feedback_kind: SearchFeedbackKind;
+  question_type: QuestionType;
+  shown_index: number;
+  result_case_id?: string | null;
+  clicked_result_rank?: number | null;
+  created_at?: string;
+}
+
+export interface ListSearchFeedbackOptions {
+  since?: string;
+  until?: string;
+  limit?: number;
+}
+
+export interface SearchFeedbackRow {
+  feedback_id: string;
+  query: string;
+  query_hash_hex: string;
+  question_type: QuestionType;
+  result_source_type: SearchFeedbackSourceType;
+  result_source_id: string;
+  case_id: string | null;
+  feedback_kind: SearchFeedbackKind;
+  rank_position: number;
+  score_before: number | null;
+  score_after: number | null;
+  session_id: string | null;
+  actor: string;
+  metadata_json: string | null;
+  created_at: string;
+  updated_at: string | null;
+}
+
+export interface RecordSearchFeedbackResult {
+  feedback_id: string;
+  query_hash: string;
+  deduped: boolean;
+}
+
+export interface FeedbackStoreAdapter {
+  prepare(sql: string): {
+    run(...params: unknown[]): RunResult;
+    get(...params: unknown[]): unknown;
+    all(...params: unknown[]): unknown[];
+  };
+  transaction?<T>(fn: () => T): T | (() => T);
+}
+
+const DEFAULT_RETENTION_DAYS = 180;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function normalizedQuery(query: string): string {
+  return query.trim().toLowerCase();
+}
+
+function fullQueryHashHex(query: string): string {
+  return createHash('sha256').update(normalizedQuery(query)).digest('hex');
+}
+
+function fullQueryHashBuffer(query: string): Buffer {
+  return Buffer.from(fullQueryHashHex(query), 'hex');
+}
+
+export function hashQuery(query: string): string {
+  return fullQueryHashHex(query).slice(0, 16);
+}
+
+function assertNonEmpty(value: string, field: string): void {
+  if (!value || value.trim().length === 0) {
+    throw new Error(`${field} is required`);
+  }
+}
+
+function assertRank(value: number, field: string): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${field} must be a non-negative integer`);
+  }
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function cutoffIso(retentionDays: number, now = new Date()): string {
+  return new Date(now.getTime() - retentionDays * MS_PER_DAY).toISOString();
+}
+
+function stableObject(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => stableObject(item));
+  }
+
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+
+  const input = value as Record<string, unknown>;
+  const output: Record<string, unknown> = {};
+  for (const key of Object.keys(input).sort((left, right) => left.localeCompare(right))) {
+    const item = input[key];
+    if (item !== undefined) {
+      output[key] = stableObject(item);
+    }
+  }
+  return output;
+}
+
+function canonicalJson(value: Record<string, unknown>): string {
+  return JSON.stringify(stableObject(value));
+}
+
+function runTransaction<T>(adapter: FeedbackStoreAdapter, fn: () => T): T {
+  if (!adapter.transaction) {
+    return fn();
+  }
+
+  const result = adapter.transaction(fn);
+  if (typeof result === 'function') {
+    return (result as () => T)();
+  }
+  return result;
+}
+
+function parseRetentionValue(value: string): number {
+  const parsed = JSON.parse(value) as unknown;
+  const numeric = typeof parsed === 'number' ? parsed : Number(parsed);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    throw new Error(`Invalid search_feedback_retention_days value: ${value}`);
+  }
+  return Math.floor(numeric);
+}
+
+export function getFeedbackRetentionDays(adapter: FeedbackStoreAdapter): number {
+  const row = adapter
+    .prepare(
+      `
+        SELECT value_json
+        FROM search_ranker_settings
+        WHERE key = 'search_feedback_retention_days'
+      `
+    )
+    .get() as { value_json?: string } | undefined;
+
+  if (!row?.value_json) {
+    return DEFAULT_RETENTION_DAYS;
+  }
+
+  return parseRetentionValue(row.value_json);
+}
+
+export function compactShownSearchFeedback(
+  adapter: FeedbackStoreAdapter,
+  retentionDays = getFeedbackRetentionDays(adapter)
+): number {
+  const result = adapter
+    .prepare(
+      `
+        DELETE FROM search_feedback
+        WHERE feedback_kind = 'shown'
+          AND created_at < ?
+      `
+    )
+    .run(cutoffIso(retentionDays));
+
+  return result.changes;
+}
+
+function sessionForInput(input: SearchFeedbackInput, queryHash: string): string | null {
+  if (input.session_id && input.session_id.trim().length > 0) {
+    return input.session_id;
+  }
+
+  if (input.feedback_kind === 'shown') {
+    return `anonymous:${queryHash}`;
+  }
+
+  return input.session_id ?? null;
+}
+
+function rankPositionForInput(input: SearchFeedbackInput): number {
+  if (input.feedback_kind === 'click' && input.clicked_result_rank !== undefined) {
+    const rank = input.clicked_result_rank ?? input.shown_index;
+    assertRank(rank, 'clicked_result_rank');
+    return rank;
+  }
+
+  assertRank(input.shown_index, 'shown_index');
+  return input.shown_index;
+}
+
+function questionTypeForInput(input: SearchFeedbackInput): QuestionType {
+  if (input.question_type && isQuestionType(input.question_type)) {
+    return input.question_type;
+  }
+
+  return classifyQuestionType(input.query);
+}
+
+export function recordSearchFeedback(
+  adapter: FeedbackStoreAdapter,
+  input: SearchFeedbackInput
+): RecordSearchFeedbackResult {
+  assertNonEmpty(input.result_id, 'result_id');
+  assertNonEmpty(input.query, 'query');
+  assertNonEmpty(input.result_source_type, 'result_source_type');
+  assertNonEmpty(input.result_source_id, 'result_source_id');
+
+  const queryHashHex = fullQueryHashHex(input.query);
+  const queryHash = fullQueryHashBuffer(input.query);
+  const queryHashShort = queryHashHex.slice(0, 16);
+  const sessionId = sessionForInput(input, queryHashShort);
+  const questionType = questionTypeForInput(input);
+  const rankPosition = rankPositionForInput(input);
+  const createdAt = input.created_at ?? nowIso();
+  const feedbackId = input.result_id || `search_feedback_${randomUUID()}`;
+  const metadataJson = canonicalJson({
+    clicked_result_rank: input.clicked_result_rank ?? null,
+    input_result_id: input.result_id,
+  });
+
+  return runTransaction(adapter, () => {
+    let deduped = false;
+
+    if (input.feedback_kind === 'shown') {
+      compactShownSearchFeedback(adapter);
+
+      if (sessionId) {
+        const deleted = adapter
+          .prepare(
+            `
+              DELETE FROM search_feedback
+              WHERE feedback_kind = 'shown'
+                AND session_id = ?
+                AND query_hash = ?
+                AND result_source_type = ?
+                AND result_source_id = ?
+            `
+          )
+          .run(sessionId, queryHash, input.result_source_type, input.result_source_id);
+
+        deduped = deleted.changes > 0;
+      }
+    }
+
+    adapter
+      .prepare(
+        `
+          INSERT INTO search_feedback (
+            feedback_id, query, query_hash, question_type, result_source_type, result_source_id,
+            case_id, feedback_kind, rank_position, score_before, score_after, session_id,
+            actor, metadata_json, created_at, updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, 'system:search-feedback', ?, ?, NULL)
+        `
+      )
+      .run(
+        feedbackId,
+        input.query,
+        queryHash,
+        questionType,
+        input.result_source_type,
+        input.result_source_id,
+        input.result_case_id ?? null,
+        input.feedback_kind,
+        rankPosition,
+        sessionId,
+        metadataJson,
+        createdAt
+      );
+
+    return {
+      feedback_id: feedbackId,
+      query_hash: queryHashShort,
+      deduped,
+    };
+  });
+}
+
+export function listSearchFeedback(
+  adapter: FeedbackStoreAdapter,
+  options: ListSearchFeedbackOptions = {}
+): SearchFeedbackRow[] {
+  const retentionDays = getFeedbackRetentionDays(adapter);
+  const until = options.until ?? nowIso();
+  const since = options.since ?? cutoffIso(retentionDays, new Date(until));
+  const limit = options.limit ?? 10_000;
+
+  assertRank(limit, 'limit');
+
+  const rows = adapter
+    .prepare(
+      `
+        SELECT
+          feedback_id,
+          query,
+          lower(hex(query_hash)) AS query_hash_hex,
+          question_type,
+          result_source_type,
+          result_source_id,
+          case_id,
+          feedback_kind,
+          rank_position,
+          score_before,
+          score_after,
+          session_id,
+          actor,
+          metadata_json,
+          created_at,
+          updated_at
+        FROM search_feedback
+        WHERE created_at >= ?
+          AND created_at <= ?
+        ORDER BY created_at ASC, feedback_id ASC
+        LIMIT ?
+      `
+    )
+    .all(since, until, limit) as SearchFeedbackRow[];
+
+  return rows;
+}

--- a/packages/mama-core/src/search/question-type.ts
+++ b/packages/mama-core/src/search/question-type.ts
@@ -1,0 +1,46 @@
+export type QuestionType =
+  | 'correction'
+  | 'artifact'
+  | 'timeline'
+  | 'status'
+  | 'decision_reason'
+  | 'how_to'
+  | 'unknown';
+
+export const QUESTION_TYPES: readonly QuestionType[] = [
+  'correction',
+  'artifact',
+  'timeline',
+  'status',
+  'decision_reason',
+  'how_to',
+  'unknown',
+];
+
+// Korean: patterns for classifyQuestionType() multilingual query routing.
+const CORRECTION_PATTERN =
+  /\b(fix|revert|correct|correction|supersede|superseded|revise|revision|수정|되돌|정정|교정)\b/i; // Korean: keywords
+const ARTIFACT_PATTERN =
+  /\b(file|doc|docs|document|image|video|pdf|drive|obsidian|attachment|artifact|파일|문서|이미지|영상|첨부|드라이브|옵시디언)\b/i; // Korean: keywords
+const TIMELINE_PATTERN =
+  /\b(when|history|before|after|around|timeline|chronology|언제|이력|히스토리|전|후|즈음)\b|\bon\s+\d{4}(?:-\d{1,2})?(?:-\d{1,2})?\b|\b\d{4}-\d{1,2}-\d{1,2}\b/i; // Korean: keywords
+const STATUS_PATTERN =
+  /\b(status|state|current|currently|now|latest|progress|blocked|done|상태|현재|최신|진행|진척)\b/i; // Korean: keywords
+const DECISION_REASON_PATTERN = /\b(why|reason|because|rationale|근거|이유|왜|때문)\b/i; // Korean: keywords
+const HOW_TO_PATTERN =
+  /\b(how\s+to|how\s+do|setup|set\s+up|configure|configuration|install|설정|구성|어떻게)\b/i; // Korean: keywords
+
+export function classifyQuestionType(query: string): QuestionType {
+  const normalized = query.trim();
+  if (CORRECTION_PATTERN.test(normalized)) return 'correction';
+  if (ARTIFACT_PATTERN.test(normalized)) return 'artifact';
+  if (TIMELINE_PATTERN.test(normalized)) return 'timeline';
+  if (STATUS_PATTERN.test(normalized)) return 'status';
+  if (DECISION_REASON_PATTERN.test(normalized)) return 'decision_reason';
+  if (HOW_TO_PATTERN.test(normalized)) return 'how_to';
+  return 'unknown';
+}
+
+export function isQuestionType(value: string): value is QuestionType {
+  return (QUESTION_TYPES as readonly string[]).includes(value);
+}

--- a/packages/mama-core/src/search/ranker-features.ts
+++ b/packages/mama-core/src/search/ranker-features.ts
@@ -1,0 +1,143 @@
+import { classifyQuestionType, QUESTION_TYPES, type QuestionType } from './question-type.js';
+
+export const SEARCH_RANKER_FEATURE_SET_VERSION = 'v1.0.0';
+
+export type RankerSourceType =
+  | 'decision'
+  | 'event'
+  | 'observation'
+  | 'artifact'
+  | 'connector_event';
+
+export const RANKER_SOURCE_TYPES: readonly RankerSourceType[] = [
+  'decision',
+  'event',
+  'observation',
+  'artifact',
+  'connector_event',
+];
+
+export interface RankerFeatureVector {
+  bm25_score: number;
+  vector_score: number;
+  case_rollup_score: number;
+  recency_score: number;
+  same_case_boost: number;
+  source_type_onehot: Record<RankerSourceType, number>;
+  question_type_onehot: Record<QuestionType, number>;
+}
+
+export interface RankerQueryMeta {
+  question_type?: QuestionType;
+  case_id?: string | null;
+}
+
+type FeatureRow = Record<string, unknown>;
+
+function numberValue(value: unknown, fallback = 0): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return value;
+}
+
+function stringValue(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return String(value);
+}
+
+function sourceTypeKey(row: FeatureRow): RankerSourceType | null {
+  const sourceType = stringValue(
+    row.source_type ?? row.result_source_type ?? row.kind ?? row.page_type
+  );
+
+  switch (sourceType) {
+    case 'decision':
+      return 'decision';
+    case 'event':
+    case 'checkpoint':
+      return 'event';
+    case 'observation':
+    case 'case':
+      return 'observation';
+    case 'artifact':
+    case 'wiki_page':
+      return 'artifact';
+    case 'connector_event':
+    case 'standalone_connector_hit':
+      return 'connector_event';
+    default:
+      return null;
+  }
+}
+
+function zeroSourceOnehot(): Record<RankerSourceType, number> {
+  return {
+    decision: 0,
+    event: 0,
+    observation: 0,
+    artifact: 0,
+    connector_event: 0,
+  };
+}
+
+function zeroQuestionOnehot(): Record<QuestionType, number> {
+  return {
+    correction: 0,
+    artifact: 0,
+    timeline: 0,
+    status: 0,
+    decision_reason: 0,
+    how_to: 0,
+    unknown: 0,
+  };
+}
+
+export function extractFeatures(
+  row: FeatureRow,
+  query: string,
+  queryMeta: RankerQueryMeta = {}
+): RankerFeatureVector {
+  const sourceOnehot = zeroSourceOnehot();
+  const sourceType = sourceTypeKey(row);
+  if (sourceType) {
+    sourceOnehot[sourceType] = 1;
+  }
+
+  const questionType = queryMeta.question_type ?? classifyQuestionType(query);
+  const questionOnehot = zeroQuestionOnehot();
+  questionOnehot[questionType] = 1;
+
+  const rowCaseId = stringValue(row.case_id ?? row.result_case_id);
+  const queryCaseId = queryMeta.case_id ?? null;
+
+  return {
+    bm25_score: numberValue(row.bm25_score ?? row.bm25 ?? row.fts_score),
+    vector_score: numberValue(row.vector_score ?? row.similarity),
+    case_rollup_score: numberValue(
+      row.case_rollup_score ?? row.retrieval_score ?? row.final_score ?? row.score
+    ),
+    recency_score: numberValue(row.recency_score),
+    same_case_boost: queryCaseId && rowCaseId && queryCaseId === rowCaseId ? 1 : 0,
+    source_type_onehot: sourceOnehot,
+    question_type_onehot: questionOnehot,
+  };
+}
+
+export function serializeFeatures(vec: RankerFeatureVector): number[] {
+  return [
+    vec.bm25_score,
+    vec.vector_score,
+    vec.case_rollup_score,
+    vec.recency_score,
+    vec.same_case_boost,
+    ...RANKER_SOURCE_TYPES.map((sourceType) => vec.source_type_onehot[sourceType]),
+    ...QUESTION_TYPES.map((questionType) => vec.question_type_onehot[questionType]),
+  ];
+}
+
+export function featureSetVersion(): string {
+  return SEARCH_RANKER_FEATURE_SET_VERSION;
+}

--- a/packages/mama-core/src/search/ranker-rescore.ts
+++ b/packages/mama-core/src/search/ranker-rescore.ts
@@ -1,0 +1,320 @@
+import type { RunResult } from '../db-adapter/statement.js';
+import {
+  SEARCH_RANKER_FEATURE_SET_VERSION,
+  serializeFeatures,
+  extractFeatures,
+} from './ranker-features.js';
+import { scoreWithRankerModel, type SearchRankerModel } from './ranker-trainer.js';
+import { classifyQuestionType } from './question-type.js';
+
+export type SearchRankerSkippedReason =
+  | 'feature_disabled'
+  | 'no_active_model'
+  | 'feature_set_mismatch'
+  | 'quality_gate_failed'
+  | 'insufficient_result_count'
+  | 'llm_reranking_requested';
+
+export interface RankerRescoreAdapter {
+  prepare(sql: string): {
+    run(...params: unknown[]): RunResult;
+    get(...params: unknown[]): unknown;
+    all(...params: unknown[]): unknown[];
+  };
+}
+
+export interface RankerScoredFields {
+  ranker_score?: number;
+  score_before_ranker?: number;
+  final_score?: number;
+}
+
+export interface RescoreSearchResultsOptions<T> {
+  query: string;
+  results: T[];
+  featureEnabled?: boolean;
+  useReranking?: boolean;
+}
+
+export interface RescoreSearchResultsResult<T> {
+  results: Array<T & RankerScoredFields>;
+  model_id: string | null;
+  skipped_reason?: SearchRankerSkippedReason;
+}
+
+interface RankerModelRow {
+  model_id: string;
+  feature_set_version: string;
+  coefficients_json: string;
+  quality_gate_status: 'passed' | 'failed' | 'not_run';
+  trained_at: string;
+}
+
+function parseJsonObject(value: string): Record<string, unknown> {
+  const parsed = JSON.parse(value) as unknown;
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('Expected JSON object');
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function parseNumberArray(value: unknown): number[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => (typeof item === 'number' && Number.isFinite(item) ? item : 0));
+}
+
+function parseQuestionWeights(
+  value: unknown,
+  fallback: number[]
+): SearchRankerModel['question_type_weights'] {
+  const object =
+    typeof value === 'object' && value !== null && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  return {
+    correction:
+      parseNumberArray(object.correction).length > 0
+        ? parseNumberArray(object.correction)
+        : [...fallback],
+    artifact:
+      parseNumberArray(object.artifact).length > 0
+        ? parseNumberArray(object.artifact)
+        : [...fallback],
+    timeline:
+      parseNumberArray(object.timeline).length > 0
+        ? parseNumberArray(object.timeline)
+        : [...fallback],
+    status:
+      parseNumberArray(object.status).length > 0 ? parseNumberArray(object.status) : [...fallback],
+    decision_reason:
+      parseNumberArray(object.decision_reason).length > 0
+        ? parseNumberArray(object.decision_reason)
+        : [...fallback],
+    how_to:
+      parseNumberArray(object.how_to).length > 0 ? parseNumberArray(object.how_to) : [...fallback],
+    unknown:
+      parseNumberArray(object.unknown).length > 0
+        ? parseNumberArray(object.unknown)
+        : [...fallback],
+  };
+}
+
+function modelFromRow(row: RankerModelRow): SearchRankerModel {
+  const payload = parseJsonObject(row.coefficients_json);
+  const coefficients = parseNumberArray(payload.coefficients);
+  const intercept = typeof payload.intercept === 'number' ? payload.intercept : 0;
+  const trainingRowsCount =
+    typeof payload.training_rows_count === 'number' ? payload.training_rows_count : 0;
+
+  return {
+    model_id: row.model_id,
+    feature_set_version: row.feature_set_version,
+    trained_at: row.trained_at,
+    training_rows_count: trainingRowsCount,
+    coefficients,
+    intercept,
+    question_type_weights: parseQuestionWeights(payload.question_type_weights, coefficients),
+  };
+}
+
+function loadActiveRow(adapter: RankerRescoreAdapter): RankerModelRow | null {
+  const row = adapter
+    .prepare(
+      `
+        SELECT model_id, feature_set_version, coefficients_json, quality_gate_status, trained_at
+        FROM ranker_model_versions
+        WHERE active = 1
+        ORDER BY trained_at DESC
+        LIMIT 1
+      `
+    )
+    .get() as RankerModelRow | undefined;
+
+  return row ?? null;
+}
+
+function logSkipped(reason: SearchRankerSkippedReason, modelId: string | null): void {
+  console.warn(
+    JSON.stringify({
+      event: 'search_ranker_skipped',
+      skipped_reason: reason,
+      model_id: modelId,
+      feature_set_version: SEARCH_RANKER_FEATURE_SET_VERSION,
+    })
+  );
+}
+
+export function loadActiveSearchRankerModel(
+  adapter: RankerRescoreAdapter
+): SearchRankerModel | null {
+  const row = loadActiveRow(adapter);
+  if (!row) {
+    return null;
+  }
+
+  if (row.feature_set_version !== SEARCH_RANKER_FEATURE_SET_VERSION) {
+    logSkipped('feature_set_mismatch', row.model_id);
+    return null;
+  }
+
+  return modelFromRow(row);
+}
+
+export function isSearchRankerEnabled(adapter: RankerRescoreAdapter): boolean {
+  const row = adapter
+    .prepare(
+      `
+        SELECT value_json
+        FROM search_ranker_settings
+        WHERE key = 'search_ranker_enabled'
+      `
+    )
+    .get() as { value_json?: string } | undefined;
+
+  if (!row?.value_json) {
+    return true;
+  }
+
+  const parsed = JSON.parse(row.value_json) as unknown;
+  return parsed !== false;
+}
+
+function baseScore(row: Record<string, unknown>): number {
+  const candidates = [
+    row.final_score,
+    row.retrieval_score,
+    row.score,
+    row.similarity,
+    row.confidence,
+    row.case_rollup_score,
+    row.vector_score,
+    row.bm25_score,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+      return candidate;
+    }
+  }
+
+  return 0;
+}
+
+function resultId(row: Record<string, unknown>, fallback: number): string {
+  const id = row.id ?? row.source_id ?? row.result_source_id;
+  return id === undefined || id === null ? String(fallback) : String(id);
+}
+
+export function rescoreSearchResults<T extends Record<string, unknown>>(
+  adapter: RankerRescoreAdapter,
+  options: RescoreSearchResultsOptions<T>
+): RescoreSearchResultsResult<T> {
+  const passthrough = options.results as Array<T & RankerScoredFields>;
+
+  if (options.useReranking) {
+    return {
+      results: passthrough,
+      model_id: null,
+      skipped_reason: 'llm_reranking_requested',
+    };
+  }
+
+  if (options.featureEnabled === false) {
+    return {
+      results: passthrough,
+      model_id: null,
+      skipped_reason: 'feature_disabled',
+    };
+  }
+
+  if (options.results.length < 2) {
+    return {
+      results: passthrough,
+      model_id: null,
+      skipped_reason: 'insufficient_result_count',
+    };
+  }
+
+  const row = loadActiveRow(adapter);
+  if (!row) {
+    return {
+      results: passthrough,
+      model_id: null,
+      skipped_reason: 'no_active_model',
+    };
+  }
+
+  if (row.feature_set_version !== SEARCH_RANKER_FEATURE_SET_VERSION) {
+    logSkipped('feature_set_mismatch', row.model_id);
+    return {
+      results: passthrough,
+      model_id: row.model_id,
+      skipped_reason: 'feature_set_mismatch',
+    };
+  }
+
+  if (row.quality_gate_status === 'failed') {
+    return {
+      results: passthrough,
+      model_id: row.model_id,
+      skipped_reason: 'quality_gate_failed',
+    };
+  }
+
+  if (row.quality_gate_status !== 'passed') {
+    return {
+      results: passthrough,
+      model_id: row.model_id,
+      skipped_reason: 'quality_gate_failed',
+    };
+  }
+
+  const model = modelFromRow(row);
+  const questionType = classifyQuestionType(options.query);
+  const scored = options.results.map((result, index) => {
+    const scoreBeforeRanker = baseScore(result);
+    const rankerScore = scoreWithRankerModel(model, result, options.query, questionType);
+    const finalScore = 0.8 * scoreBeforeRanker + 0.2 * rankerScore;
+
+    return {
+      result: {
+        ...result,
+        ranker_score: rankerScore,
+        score_before_ranker: scoreBeforeRanker,
+        final_score: finalScore,
+      } as T & RankerScoredFields,
+      index,
+      id: resultId(result, index),
+      finalScore,
+    };
+  });
+
+  scored.sort((left, right) => {
+    const diff = right.finalScore - left.finalScore;
+    if (Math.abs(diff) > 1e-12) return diff;
+    if (left.index !== right.index) return left.index - right.index;
+    return left.id.localeCompare(right.id);
+  });
+
+  return {
+    results: scored.map((entry) => entry.result),
+    model_id: model.model_id,
+  };
+}
+
+export function logisticScoreForRow(
+  model: SearchRankerModel,
+  row: Record<string, unknown>,
+  query: string
+): number {
+  const questionType = classifyQuestionType(query);
+  const features = serializeFeatures(extractFeatures(row, query, { question_type: questionType }));
+  const coefficients = model.question_type_weights[questionType] ?? model.coefficients;
+  let score = model.intercept;
+  for (let index = 0; index < Math.min(coefficients.length, features.length); index += 1) {
+    score += coefficients[index] * features[index];
+  }
+  if (score >= 35) return 1;
+  if (score <= -35) return 0;
+  return 1 / (1 + Math.exp(-score));
+}

--- a/packages/mama-core/src/search/ranker-trainer.ts
+++ b/packages/mama-core/src/search/ranker-trainer.ts
@@ -1,0 +1,1059 @@
+import type { RunResult } from '../db-adapter/statement.js';
+import {
+  getFeedbackRetentionDays,
+  listSearchFeedback,
+  type SearchFeedbackRow,
+} from './feedback-store.js';
+import {
+  extractFeatures,
+  featureSetVersion as currentFeatureSetVersion,
+  SEARCH_RANKER_FEATURE_SET_VERSION,
+  serializeFeatures,
+} from './ranker-features.js';
+import { QUESTION_TYPES, type QuestionType } from './question-type.js';
+
+export interface SearchRankerModel {
+  model_id: string;
+  feature_set_version: string;
+  trained_at: string;
+  training_rows_count: number;
+  coefficients: number[];
+  intercept: number;
+  question_type_weights: Record<QuestionType, number[]>;
+  training_window?: EffectiveTrainingWindow;
+}
+
+export interface RankerTrainerInput {
+  adapter: RankerTrainerAdapter;
+  since?: string;
+  until?: string;
+  minFeedbackRows?: number;
+  minDistinctQueries?: number;
+  featureSetVersion?: string;
+  now?: Date;
+}
+
+export interface EffectiveTrainingWindow {
+  since: string;
+  until: string;
+  retention_cutoff_at: string;
+  retention_days_at_train_time: number;
+  retention_warning: boolean;
+}
+
+export interface TrainOfflineRankerResult {
+  status: 'trained' | 'insufficient_data';
+  model?: SearchRankerModel;
+  effectiveWindow: EffectiveTrainingWindow;
+  counts: {
+    feedbackRows: number;
+    distinctQueries: number;
+  };
+}
+
+export interface BaselineMetrics {
+  ndcg: number;
+  mrr: number;
+  per_query: Record<string, { ndcg: number; mrr: number }>;
+}
+
+export interface RankerEvaluation {
+  bm25: BaselineMetrics;
+  vector: BaselineMetrics;
+  rrf: BaselineMetrics;
+  logistic: BaselineMetrics;
+  learned: BaselineMetrics;
+  passes: boolean;
+}
+
+export interface RankerTrainerAdapter {
+  prepare(sql: string): {
+    run(...params: unknown[]): RunResult;
+    get(...params: unknown[]): unknown;
+    all(...params: unknown[]): unknown[];
+  };
+  transaction?<T>(fn: () => T): T | (() => T);
+}
+
+interface TrainingExample {
+  query: string;
+  question_type: QuestionType;
+  features: number[];
+  label: number;
+  feedback_kind: SearchFeedbackRow['feedback_kind'];
+  created_at: string;
+  feedback_id: string;
+}
+
+interface QualityCandidate {
+  id: string;
+  source_type: string;
+  bm25_score: number;
+  vector_score: number;
+  case_rollup_score: number;
+  recency_score: number;
+  relevance: number;
+}
+
+interface QualityFixture {
+  query: string;
+  question_type: QuestionType;
+  candidates: QualityCandidate[];
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const LEARNING_RATE = 0.05;
+const MAX_EPOCHS = 500;
+const EARLY_STOP_DELTA = 1e-5;
+
+export const RANKER_QUALITY_FIXTURES: readonly QualityFixture[] = [
+  {
+    query: 'fix the stale case status correction',
+    question_type: 'correction',
+    candidates: [
+      {
+        id: 'correction-good-1',
+        source_type: 'decision',
+        bm25_score: 0.18,
+        vector_score: 0.25,
+        case_rollup_score: 0.3,
+        recency_score: 0.4,
+        relevance: 3,
+      },
+      {
+        id: 'correction-bad-1',
+        source_type: 'wiki_page',
+        bm25_score: 0.95,
+        vector_score: 0.86,
+        case_rollup_score: 0.2,
+        recency_score: 0.2,
+        relevance: 0,
+      },
+      {
+        id: 'correction-mid-1',
+        source_type: 'case',
+        bm25_score: 0.45,
+        vector_score: 0.42,
+        case_rollup_score: 0.35,
+        recency_score: 0.1,
+        relevance: 1,
+      },
+      {
+        id: 'correction-bad-2',
+        source_type: 'connector_event',
+        bm25_score: 0.74,
+        vector_score: 0.71,
+        case_rollup_score: 0.25,
+        recency_score: 0.3,
+        relevance: 0,
+      },
+      {
+        id: 'correction-bad-3',
+        source_type: 'checkpoint',
+        bm25_score: 0.61,
+        vector_score: 0.67,
+        case_rollup_score: 0.15,
+        recency_score: 0.2,
+        relevance: 0,
+      },
+    ],
+  },
+  {
+    query: 'revert the mistaken merge decision',
+    question_type: 'correction',
+    candidates: [
+      {
+        id: 'correction-good-2',
+        source_type: 'decision',
+        bm25_score: 0.22,
+        vector_score: 0.2,
+        case_rollup_score: 0.33,
+        recency_score: 0.2,
+        relevance: 3,
+      },
+      {
+        id: 'correction-bad-4',
+        source_type: 'connector_event',
+        bm25_score: 0.92,
+        vector_score: 0.88,
+        case_rollup_score: 0.2,
+        recency_score: 0.3,
+        relevance: 0,
+      },
+      {
+        id: 'correction-mid-2',
+        source_type: 'case',
+        bm25_score: 0.5,
+        vector_score: 0.49,
+        case_rollup_score: 0.38,
+        recency_score: 0.1,
+        relevance: 1,
+      },
+      {
+        id: 'correction-bad-5',
+        source_type: 'wiki_page',
+        bm25_score: 0.7,
+        vector_score: 0.76,
+        case_rollup_score: 0.2,
+        recency_score: 0.2,
+        relevance: 0,
+      },
+      {
+        id: 'correction-bad-6',
+        source_type: 'checkpoint',
+        bm25_score: 0.6,
+        vector_score: 0.57,
+        case_rollup_score: 0.19,
+        recency_score: 0.2,
+        relevance: 0,
+      },
+    ],
+  },
+  {
+    query: 'find the Obsidian doc for the case',
+    question_type: 'artifact',
+    candidates: [
+      {
+        id: 'artifact-good-1',
+        source_type: 'wiki_page',
+        bm25_score: 0.21,
+        vector_score: 0.28,
+        case_rollup_score: 0.3,
+        recency_score: 0.2,
+        relevance: 3,
+      },
+      {
+        id: 'artifact-bad-1',
+        source_type: 'decision',
+        bm25_score: 0.96,
+        vector_score: 0.87,
+        case_rollup_score: 0.21,
+        recency_score: 0.4,
+        relevance: 0,
+      },
+      {
+        id: 'artifact-mid-1',
+        source_type: 'case',
+        bm25_score: 0.44,
+        vector_score: 0.47,
+        case_rollup_score: 0.36,
+        recency_score: 0.2,
+        relevance: 1,
+      },
+      {
+        id: 'artifact-bad-2',
+        source_type: 'connector_event',
+        bm25_score: 0.73,
+        vector_score: 0.74,
+        case_rollup_score: 0.18,
+        recency_score: 0.3,
+        relevance: 0,
+      },
+      {
+        id: 'artifact-bad-3',
+        source_type: 'checkpoint',
+        bm25_score: 0.68,
+        vector_score: 0.62,
+        case_rollup_score: 0.19,
+        recency_score: 0.2,
+        relevance: 0,
+      },
+    ],
+  },
+  {
+    query: 'which pdf described the rollout',
+    question_type: 'artifact',
+    candidates: [
+      {
+        id: 'artifact-good-2',
+        source_type: 'wiki_page',
+        bm25_score: 0.19,
+        vector_score: 0.26,
+        case_rollup_score: 0.31,
+        recency_score: 0.2,
+        relevance: 3,
+      },
+      {
+        id: 'artifact-bad-4',
+        source_type: 'decision',
+        bm25_score: 0.91,
+        vector_score: 0.89,
+        case_rollup_score: 0.21,
+        recency_score: 0.3,
+        relevance: 0,
+      },
+      {
+        id: 'artifact-mid-2',
+        source_type: 'case',
+        bm25_score: 0.49,
+        vector_score: 0.43,
+        case_rollup_score: 0.35,
+        recency_score: 0.3,
+        relevance: 1,
+      },
+      {
+        id: 'artifact-bad-5',
+        source_type: 'connector_event',
+        bm25_score: 0.76,
+        vector_score: 0.72,
+        case_rollup_score: 0.2,
+        recency_score: 0.2,
+        relevance: 0,
+      },
+      {
+        id: 'artifact-bad-6',
+        source_type: 'checkpoint',
+        bm25_score: 0.63,
+        vector_score: 0.61,
+        case_rollup_score: 0.19,
+        recency_score: 0.2,
+        relevance: 0,
+      },
+    ],
+  },
+  {
+    query: 'when did the blocker first happen',
+    question_type: 'timeline',
+    candidates: [
+      {
+        id: 'timeline-good-1',
+        source_type: 'connector_event',
+        bm25_score: 0.2,
+        vector_score: 0.29,
+        case_rollup_score: 0.3,
+        recency_score: 0.2,
+        relevance: 3,
+      },
+      {
+        id: 'timeline-bad-1',
+        source_type: 'decision',
+        bm25_score: 0.93,
+        vector_score: 0.91,
+        case_rollup_score: 0.18,
+        recency_score: 0.3,
+        relevance: 0,
+      },
+      {
+        id: 'timeline-mid-1',
+        source_type: 'checkpoint',
+        bm25_score: 0.48,
+        vector_score: 0.46,
+        case_rollup_score: 0.34,
+        recency_score: 0.2,
+        relevance: 1,
+      },
+      {
+        id: 'timeline-bad-2',
+        source_type: 'case',
+        bm25_score: 0.78,
+        vector_score: 0.74,
+        case_rollup_score: 0.18,
+        recency_score: 0.2,
+        relevance: 0,
+      },
+      {
+        id: 'timeline-bad-3',
+        source_type: 'wiki_page',
+        bm25_score: 0.64,
+        vector_score: 0.63,
+        case_rollup_score: 0.19,
+        recency_score: 0.2,
+        relevance: 0,
+      },
+    ],
+  },
+  {
+    query: 'history before the regression',
+    question_type: 'timeline',
+    candidates: [
+      {
+        id: 'timeline-good-2',
+        source_type: 'connector_event',
+        bm25_score: 0.23,
+        vector_score: 0.27,
+        case_rollup_score: 0.31,
+        recency_score: 0.2,
+        relevance: 3,
+      },
+      {
+        id: 'timeline-bad-4',
+        source_type: 'decision',
+        bm25_score: 0.94,
+        vector_score: 0.9,
+        case_rollup_score: 0.18,
+        recency_score: 0.3,
+        relevance: 0,
+      },
+      {
+        id: 'timeline-mid-2',
+        source_type: 'checkpoint',
+        bm25_score: 0.47,
+        vector_score: 0.45,
+        case_rollup_score: 0.36,
+        recency_score: 0.2,
+        relevance: 1,
+      },
+      {
+        id: 'timeline-bad-5',
+        source_type: 'case',
+        bm25_score: 0.75,
+        vector_score: 0.77,
+        case_rollup_score: 0.19,
+        recency_score: 0.2,
+        relevance: 0,
+      },
+      {
+        id: 'timeline-bad-6',
+        source_type: 'wiki_page',
+        bm25_score: 0.62,
+        vector_score: 0.64,
+        case_rollup_score: 0.18,
+        recency_score: 0.2,
+        relevance: 0,
+      },
+    ],
+  },
+  {
+    query: 'current status of the rollout',
+    question_type: 'status',
+    candidates: [
+      {
+        id: 'status-good-1',
+        source_type: 'case',
+        bm25_score: 0.2,
+        vector_score: 0.24,
+        case_rollup_score: 0.36,
+        recency_score: 0.2,
+        relevance: 3,
+      },
+      {
+        id: 'status-bad-1',
+        source_type: 'decision',
+        bm25_score: 0.97,
+        vector_score: 0.9,
+        case_rollup_score: 0.2,
+        recency_score: 0.3,
+        relevance: 0,
+      },
+      {
+        id: 'status-mid-1',
+        source_type: 'checkpoint',
+        bm25_score: 0.46,
+        vector_score: 0.47,
+        case_rollup_score: 0.34,
+        recency_score: 0.2,
+        relevance: 1,
+      },
+      {
+        id: 'status-bad-2',
+        source_type: 'connector_event',
+        bm25_score: 0.74,
+        vector_score: 0.73,
+        case_rollup_score: 0.19,
+        recency_score: 0.2,
+        relevance: 0,
+      },
+      {
+        id: 'status-bad-3',
+        source_type: 'wiki_page',
+        bm25_score: 0.65,
+        vector_score: 0.62,
+        case_rollup_score: 0.18,
+        recency_score: 0.2,
+        relevance: 0,
+      },
+    ],
+  },
+  {
+    query: 'latest progress on case assembly',
+    question_type: 'status',
+    candidates: [
+      {
+        id: 'status-good-2',
+        source_type: 'case',
+        bm25_score: 0.22,
+        vector_score: 0.23,
+        case_rollup_score: 0.37,
+        recency_score: 0.2,
+        relevance: 3,
+      },
+      {
+        id: 'status-bad-4',
+        source_type: 'decision',
+        bm25_score: 0.92,
+        vector_score: 0.91,
+        case_rollup_score: 0.2,
+        recency_score: 0.3,
+        relevance: 0,
+      },
+      {
+        id: 'status-mid-2',
+        source_type: 'checkpoint',
+        bm25_score: 0.48,
+        vector_score: 0.45,
+        case_rollup_score: 0.34,
+        recency_score: 0.2,
+        relevance: 1,
+      },
+      {
+        id: 'status-bad-5',
+        source_type: 'connector_event',
+        bm25_score: 0.77,
+        vector_score: 0.75,
+        case_rollup_score: 0.2,
+        recency_score: 0.2,
+        relevance: 0,
+      },
+      {
+        id: 'status-bad-6',
+        source_type: 'wiki_page',
+        bm25_score: 0.66,
+        vector_score: 0.63,
+        case_rollup_score: 0.18,
+        recency_score: 0.2,
+        relevance: 0,
+      },
+    ],
+  },
+];
+
+function asSourceForFeedback(
+  sourceType: string
+): 'decision' | 'checkpoint' | 'wiki_page' | 'case' | 'connector_event' {
+  switch (sourceType) {
+    case 'wiki_page':
+      return 'wiki_page';
+    case 'case':
+      return 'case';
+    case 'connector_event':
+      return 'connector_event';
+    case 'checkpoint':
+      return 'checkpoint';
+    default:
+      return 'decision';
+  }
+}
+
+function parseDate(input: string, field: string): Date {
+  const date = new Date(input);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`${field} must be a valid ISO timestamp`);
+  }
+  return date;
+}
+
+function iso(date: Date): string {
+  return date.toISOString();
+}
+
+function effectiveWindow(input: RankerTrainerInput): EffectiveTrainingWindow {
+  const retentionDays = getFeedbackRetentionDays(input.adapter);
+  const now = input.now ?? new Date();
+  const retentionCutoff = new Date(now.getTime() - retentionDays * MS_PER_DAY);
+  const until = input.until ? parseDate(input.until, 'until') : now;
+  const since = input.since ? parseDate(input.since, 'since') : retentionCutoff;
+
+  if (since.getTime() > until.getTime()) {
+    throw new Error('since must be before until');
+  }
+
+  const retentionWarning = Boolean(input.since && since.getTime() < retentionCutoff.getTime());
+  if (retentionWarning) {
+    console.warn(
+      JSON.stringify({
+        event: 'training_window_exceeds_retention',
+        since: iso(since),
+        retention_cutoff_at: iso(retentionCutoff),
+      })
+    );
+  }
+
+  return {
+    since: iso(since),
+    until: iso(until),
+    retention_cutoff_at: iso(retentionCutoff),
+    retention_days_at_train_time: retentionDays,
+    retention_warning: retentionWarning,
+  };
+}
+
+function labelForKind(kind: SearchFeedbackRow['feedback_kind']): number | null {
+  if (kind === 'accept' || kind === 'click') return 1;
+  if (kind === 'reject' || kind === 'hide' || kind === 'shown') return 0;
+  return null;
+}
+
+function rowToExample(row: SearchFeedbackRow): TrainingExample | null {
+  const label = labelForKind(row.feedback_kind);
+  if (label === null) return null;
+
+  const features = serializeFeatures(
+    extractFeatures(
+      {
+        ...row,
+        source_type: row.result_source_type,
+        rank_position: row.rank_position,
+      },
+      row.query,
+      { question_type: row.question_type }
+    )
+  );
+
+  return {
+    query: row.query,
+    question_type: row.question_type,
+    features,
+    label,
+    feedback_kind: row.feedback_kind,
+    created_at: row.created_at,
+    feedback_id: row.feedback_id,
+  };
+}
+
+function capNeutralRows(rows: SearchFeedbackRow[]): SearchFeedbackRow[] {
+  const byQuery = new Map<string, SearchFeedbackRow[]>();
+  for (const row of rows) {
+    const key = row.query_hash_hex || row.query;
+    const current = byQuery.get(key) ?? [];
+    current.push(row);
+    byQuery.set(key, current);
+  }
+
+  const capped: SearchFeedbackRow[] = [];
+  for (const groupRows of byQuery.values()) {
+    const explicit = groupRows.filter((row) => row.feedback_kind !== 'shown');
+    const shown = groupRows.filter((row) => row.feedback_kind === 'shown');
+    const neutralLimit = explicit.length * 3;
+    capped.push(...explicit, ...shown.slice(0, neutralLimit));
+  }
+
+  capped.sort((left, right) => {
+    const byCreatedAt = left.created_at.localeCompare(right.created_at);
+    return byCreatedAt !== 0 ? byCreatedAt : left.feedback_id.localeCompare(right.feedback_id);
+  });
+
+  return capped;
+}
+
+function sigmoid(value: number): number {
+  if (value >= 35) return 1;
+  if (value <= -35) return 0;
+  return 1 / (1 + Math.exp(-value));
+}
+
+function dot(left: number[], right: number[]): number {
+  const length = Math.min(left.length, right.length);
+  let total = 0;
+  for (let index = 0; index < length; index += 1) {
+    total += left[index] * right[index];
+  }
+  return total;
+}
+
+function hasBothLabels(examples: TrainingExample[]): boolean {
+  const labels = new Set(examples.map((example) => example.label));
+  return labels.has(0) && labels.has(1);
+}
+
+function trainWeights(
+  examples: TrainingExample[],
+  featureCount: number
+): { coefficients: number[]; intercept: number } {
+  const coefficients = new Array(featureCount).fill(0);
+  let intercept = 0;
+
+  if (examples.length === 0 || !hasBothLabels(examples)) {
+    return { coefficients, intercept };
+  }
+
+  for (let epoch = 0; epoch < MAX_EPOCHS; epoch += 1) {
+    const gradients = new Array(featureCount).fill(0);
+    let interceptGradient = 0;
+
+    for (const example of examples) {
+      const prediction = sigmoid(dot(coefficients, example.features) + intercept);
+      const error = prediction - example.label;
+      for (let index = 0; index < featureCount; index += 1) {
+        gradients[index] += error * example.features[index];
+      }
+      interceptGradient += error;
+    }
+
+    let delta = 0;
+    for (let index = 0; index < featureCount; index += 1) {
+      const update = (LEARNING_RATE * gradients[index]) / examples.length;
+      coefficients[index] -= update;
+      delta += Math.abs(update);
+    }
+
+    const interceptUpdate = (LEARNING_RATE * interceptGradient) / examples.length;
+    intercept -= interceptUpdate;
+    delta += Math.abs(interceptUpdate);
+
+    if (delta < EARLY_STOP_DELTA) {
+      break;
+    }
+  }
+
+  return { coefficients, intercept };
+}
+
+function questionWeights(
+  examples: TrainingExample[],
+  featureCount: number,
+  fallback: number[]
+): Record<QuestionType, number[]> {
+  const output = {} as Record<QuestionType, number[]>;
+
+  for (const questionType of QUESTION_TYPES) {
+    const subset = examples.filter((example) => example.question_type === questionType);
+    output[questionType] = hasBothLabels(subset)
+      ? trainWeights(subset, featureCount).coefficients
+      : [...fallback];
+  }
+
+  return output;
+}
+
+function modelIdFor(input: { trainedAt: string; rows: number; distinctQueries: number }): string {
+  const compactTime = input.trainedAt.replace(/[^0-9]/g, '').slice(0, 17);
+  return `ranker_${compactTime}_${input.rows}_${input.distinctQueries}`;
+}
+
+export async function trainOfflineRanker(
+  input: RankerTrainerInput
+): Promise<TrainOfflineRankerResult> {
+  const minFeedbackRows = input.minFeedbackRows ?? 1000;
+  const minDistinctQueries = input.minDistinctQueries ?? 10;
+  const window = effectiveWindow(input);
+  const rows = listSearchFeedback(input.adapter, {
+    since: window.since,
+    until: window.until,
+  });
+  const cappedRows = capNeutralRows(rows);
+  const examples = cappedRows
+    .map(rowToExample)
+    .filter((example): example is TrainingExample => Boolean(example));
+  const distinctQueries = new Set(examples.map((example) => example.query.trim().toLowerCase()))
+    .size;
+  const counts = {
+    feedbackRows: examples.length,
+    distinctQueries,
+  };
+
+  if (counts.feedbackRows < minFeedbackRows || counts.distinctQueries < minDistinctQueries) {
+    return {
+      status: 'insufficient_data',
+      effectiveWindow: window,
+      counts,
+    };
+  }
+
+  const featureCount =
+    examples[0]?.features.length ?? serializeFeatures(extractFeatures({}, '')).length;
+  const trained = trainWeights(examples, featureCount);
+  const trainedAt = input.now ? input.now.toISOString() : new Date().toISOString();
+  const model: SearchRankerModel = {
+    model_id: modelIdFor({
+      trainedAt,
+      rows: counts.feedbackRows,
+      distinctQueries: counts.distinctQueries,
+    }),
+    feature_set_version: input.featureSetVersion ?? currentFeatureSetVersion(),
+    trained_at: trainedAt,
+    training_rows_count: examples.length,
+    coefficients: trained.coefficients,
+    intercept: trained.intercept,
+    question_type_weights: questionWeights(examples, featureCount, trained.coefficients),
+    training_window: window,
+  };
+
+  return {
+    status: 'trained',
+    model,
+    effectiveWindow: window,
+    counts,
+  };
+}
+
+function rankByScore<T extends { id: string }>(items: T[], score: (item: T) => number): T[] {
+  return items
+    .map((item, index) => ({ item, index, score: score(item) }))
+    .sort((left, right) => {
+      const diff = right.score - left.score;
+      if (Math.abs(diff) > 1e-12) return diff;
+      return left.index - right.index;
+    })
+    .map((entry) => entry.item);
+}
+
+function reciprocalRankRanks<T extends { id: string }>(
+  items: T[],
+  leftScore: (item: T) => number,
+  rightScore: (item: T) => number
+): T[] {
+  const left = rankByScore(items, leftScore);
+  const right = rankByScore(items, rightScore);
+  const leftRanks = new Map(left.map((item, index) => [item.id, index + 1]));
+  const rightRanks = new Map(right.map((item, index) => [item.id, index + 1]));
+
+  return rankByScore(items, (item) => {
+    const leftRank = leftRanks.get(item.id) ?? items.length;
+    const rightRank = rightRanks.get(item.id) ?? items.length;
+    return 1 / (60 + leftRank) + 1 / (60 + rightRank);
+  });
+}
+
+export function scoreWithRankerModel(
+  model: SearchRankerModel,
+  row: Record<string, unknown>,
+  query: string,
+  questionType: QuestionType
+): number {
+  const features = serializeFeatures(extractFeatures(row, query, { question_type: questionType }));
+  const coefficients = model.question_type_weights[questionType] ?? model.coefficients;
+  return sigmoid(dot(coefficients, features) + model.intercept);
+}
+
+function baselineMetrics(
+  fixtures: readonly QualityFixture[],
+  ranker: (fixture: QualityFixture) => QualityCandidate[]
+): BaselineMetrics {
+  const perQuery: Record<string, { ndcg: number; mrr: number }> = {};
+  let ndcgTotal = 0;
+  let mrrTotal = 0;
+
+  for (const fixture of fixtures) {
+    const ranked = ranker(fixture);
+    const relevance = new Map(
+      fixture.candidates.map((candidate) => [candidate.id, candidate.relevance])
+    );
+    const relevantSet = new Set(
+      fixture.candidates
+        .filter((candidate) => candidate.relevance > 0)
+        .map((candidate) => candidate.id)
+    );
+    const ndcg = ndcgAtK(ranked, relevance, 5);
+    const mrrScore = mrr(ranked, relevantSet);
+    perQuery[fixture.query] = { ndcg, mrr: mrrScore };
+    ndcgTotal += ndcg;
+    mrrTotal += mrrScore;
+  }
+
+  return {
+    ndcg: ndcgTotal / fixtures.length,
+    mrr: mrrTotal / fixtures.length,
+    per_query: perQuery,
+  };
+}
+
+export async function evaluateAgainstBaselines(
+  _input: RankerTrainerInput,
+  model: SearchRankerModel
+): Promise<RankerEvaluation> {
+  const bm25 = baselineMetrics(RANKER_QUALITY_FIXTURES, (fixture) =>
+    rankByScore(fixture.candidates, (candidate) => candidate.bm25_score)
+  );
+  const vector = baselineMetrics(RANKER_QUALITY_FIXTURES, (fixture) =>
+    rankByScore(fixture.candidates, (candidate) => candidate.vector_score)
+  );
+  const rrf = baselineMetrics(RANKER_QUALITY_FIXTURES, (fixture) =>
+    reciprocalRankRanks(
+      fixture.candidates,
+      (candidate) => candidate.bm25_score,
+      (candidate) => candidate.vector_score
+    )
+  );
+  const logistic = baselineMetrics(RANKER_QUALITY_FIXTURES, (fixture) =>
+    rankByScore(
+      fixture.candidates,
+      (candidate) => 0.5 * candidate.bm25_score + 0.5 * candidate.vector_score
+    )
+  );
+  const learned = baselineMetrics(RANKER_QUALITY_FIXTURES, (fixture) =>
+    rankByScore(fixture.candidates, (candidate) =>
+      scoreWithRankerModel(
+        model,
+        candidate as unknown as Record<string, unknown>,
+        fixture.query,
+        fixture.question_type
+      )
+    )
+  );
+
+  const bestBaselineNdcg = Math.max(bm25.ndcg, vector.ndcg, rrf.ndcg, logistic.ndcg);
+  const bestBaselineMrr = Math.max(bm25.mrr, vector.mrr, rrf.mrr, logistic.mrr);
+
+  return {
+    bm25,
+    vector,
+    rrf,
+    logistic,
+    learned,
+    passes: learned.ndcg >= bestBaselineNdcg + 0.01 && learned.mrr >= bestBaselineMrr + 0.01,
+  };
+}
+
+function runTransaction<T>(adapter: RankerTrainerAdapter, fn: () => T): T {
+  if (!adapter.transaction) {
+    return fn();
+  }
+
+  const result = adapter.transaction(fn);
+  if (typeof result === 'function') {
+    return (result as () => T)();
+  }
+  return result;
+}
+
+export async function insertRankerModelVersion(
+  adapter: RankerTrainerAdapter,
+  model: SearchRankerModel,
+  evaluation: RankerEvaluation
+): Promise<{ model_id: string; active: boolean }> {
+  const coefficientsPayload = JSON.stringify({
+    coefficients: model.coefficients,
+    intercept: model.intercept,
+    question_type_weights: model.question_type_weights,
+    training_rows_count: model.training_rows_count,
+  });
+  const metricsPayload = JSON.stringify({
+    learned: evaluation.learned,
+    passes: evaluation.passes,
+  });
+  const baselinePayload = JSON.stringify({
+    bm25: evaluation.bm25,
+    vector: evaluation.vector,
+    rrf: evaluation.rrf,
+    logistic: evaluation.logistic,
+  });
+  const trainingWindowPayload = JSON.stringify(
+    model.training_window ?? {
+      since: null,
+      until: null,
+      retention_cutoff_at: null,
+      retention_days_at_train_time: null,
+      retention_warning: false,
+    }
+  );
+
+  adapter
+    .prepare(
+      `
+        INSERT INTO ranker_model_versions (
+          model_id, model_version, feature_set_version, coefficients_json, metrics_json,
+          training_window_json, baseline_metrics_json, quality_gate_status, trained_at,
+          trained_by, active
+        )
+        VALUES (?, 'offline-logistic-v1', ?, ?, ?, ?, ?, ?, ?, 'mama train-ranker', 0)
+      `
+    )
+    .run(
+      model.model_id,
+      model.feature_set_version,
+      coefficientsPayload,
+      metricsPayload,
+      trainingWindowPayload,
+      baselinePayload,
+      evaluation.passes ? 'passed' : 'failed',
+      model.trained_at
+    );
+
+  return { model_id: model.model_id, active: false };
+}
+
+export async function activateRankerModel(
+  adapter: RankerTrainerAdapter,
+  model_id: string
+): Promise<'activated' | 'quality_gate_failed' | 'feature_set_mismatch' | 'not_found'> {
+  const row = adapter
+    .prepare(
+      `
+        SELECT model_id, feature_set_version, quality_gate_status
+        FROM ranker_model_versions
+        WHERE model_id = ?
+      `
+    )
+    .get(model_id) as
+    | {
+        model_id: string;
+        feature_set_version: string;
+        quality_gate_status: string;
+      }
+    | undefined;
+
+  if (!row) return 'not_found';
+  if (row.feature_set_version !== SEARCH_RANKER_FEATURE_SET_VERSION) return 'feature_set_mismatch';
+  if (row.quality_gate_status !== 'passed') return 'quality_gate_failed';
+
+  runTransaction(adapter, () => {
+    adapter.prepare('UPDATE ranker_model_versions SET active = 0 WHERE active = 1').run();
+    adapter.prepare('UPDATE ranker_model_versions SET active = 1 WHERE model_id = ?').run(model_id);
+  });
+
+  return 'activated';
+}
+
+export function ndcgAtK<T extends { id: string }>(
+  results: readonly T[],
+  relevanceMap: Map<string, number>,
+  k: number
+): number {
+  const gains = results.slice(0, k).map((result, index) => {
+    const relevance = relevanceMap.get(result.id) ?? 0;
+    return (2 ** relevance - 1) / Math.log2(index + 2);
+  });
+  const dcg = gains.reduce((sum, gain) => sum + gain, 0);
+  const ideal = Array.from(relevanceMap.values())
+    .sort((left, right) => right - left)
+    .slice(0, k)
+    .map((relevance, index) => (2 ** relevance - 1) / Math.log2(index + 2))
+    .reduce((sum, gain) => sum + gain, 0);
+
+  return ideal === 0 ? 0 : dcg / ideal;
+}
+
+export function mrr<T extends { id: string }>(
+  results: readonly T[],
+  relevantSet: Set<string>
+): number {
+  const index = results.findIndex((result) => relevantSet.has(result.id));
+  return index === -1 ? 0 : 1 / (index + 1);
+}
+
+export function seedQualityFixtureFeedback(
+  adapter: RankerTrainerAdapter,
+  createdAt = '2026-04-18T00:00:00.000Z'
+): void {
+  let counter = 0;
+  for (const fixture of RANKER_QUALITY_FIXTURES) {
+    for (const candidate of fixture.candidates) {
+      counter += 1;
+      const kind = candidate.relevance >= 3 ? 'accept' : 'reject';
+      adapter
+        .prepare(
+          `
+            INSERT INTO search_feedback (
+              feedback_id, query, query_hash, question_type, result_source_type, result_source_id,
+              case_id, feedback_kind, rank_position, score_before, score_after, session_id,
+              actor, metadata_json, created_at, updated_at
+            )
+            VALUES (?, ?, zeroblob(32), ?, ?, ?, NULL, ?, ?, NULL, NULL, ?, 'test:ranker-fixture', '{}', ?, NULL)
+          `
+        )
+        .run(
+          `quality-${counter}`,
+          fixture.query,
+          fixture.question_type,
+          asSourceForFeedback(candidate.source_type),
+          candidate.id,
+          kind,
+          counter % 5,
+          `fixture:${fixture.question_type}`,
+          createdAt
+        );
+    }
+  }
+}
+
+export { SEARCH_RANKER_FEATURE_SET_VERSION, currentFeatureSetVersion as featureSetVersion };

--- a/packages/mama-core/src/search/ranker-trainer.ts
+++ b/packages/mama-core/src/search/ranker-trainer.ts
@@ -103,6 +103,7 @@ interface QualityFixture {
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const LEARNING_RATE = 0.05;
+const MINI_BATCH_SIZE = 32;
 const MAX_EPOCHS = 500;
 const EARLY_STOP_DELTA = 1e-5;
 
@@ -667,30 +668,39 @@ function trainWeights(
   }
 
   for (let epoch = 0; epoch < MAX_EPOCHS; epoch += 1) {
-    const gradients = new Array(featureCount).fill(0);
-    let interceptGradient = 0;
+    let epochDelta = 0;
+    let batchCount = 0;
 
-    for (const example of examples) {
-      const prediction = sigmoid(dot(coefficients, example.features) + intercept);
-      const error = prediction - example.label;
-      for (let index = 0; index < featureCount; index += 1) {
-        gradients[index] += error * example.features[index];
+    for (let batchStart = 0; batchStart < examples.length; batchStart += MINI_BATCH_SIZE) {
+      const batch = examples.slice(batchStart, batchStart + MINI_BATCH_SIZE);
+      const gradients = new Array(featureCount).fill(0);
+      let interceptGradient = 0;
+
+      for (const example of batch) {
+        const prediction = sigmoid(dot(coefficients, example.features) + intercept);
+        const error = prediction - example.label;
+        for (let index = 0; index < featureCount; index += 1) {
+          gradients[index] += error * example.features[index];
+        }
+        interceptGradient += error;
       }
-      interceptGradient += error;
+
+      let delta = 0;
+      for (let index = 0; index < featureCount; index += 1) {
+        const update = (LEARNING_RATE * gradients[index]) / batch.length;
+        coefficients[index] -= update;
+        delta += Math.abs(update);
+      }
+
+      const interceptUpdate = (LEARNING_RATE * interceptGradient) / batch.length;
+      intercept -= interceptUpdate;
+      delta += Math.abs(interceptUpdate);
+
+      epochDelta += delta;
+      batchCount += 1;
     }
 
-    let delta = 0;
-    for (let index = 0; index < featureCount; index += 1) {
-      const update = (LEARNING_RATE * gradients[index]) / examples.length;
-      coefficients[index] -= update;
-      delta += Math.abs(update);
-    }
-
-    const interceptUpdate = (LEARNING_RATE * interceptGradient) / examples.length;
-    intercept -= interceptUpdate;
-    delta += Math.abs(interceptUpdate);
-
-    if (delta < EARLY_STOP_DELTA) {
+    if (batchCount > 0 && epochDelta / batchCount < EARLY_STOP_DELTA) {
       break;
     }
   }

--- a/packages/mama-core/src/search/ranker-trainer.ts
+++ b/packages/mama-core/src/search/ranker-trainer.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import type { RunResult } from '../db-adapter/statement.js';
 import {
   getFeedbackRetentionDays,
@@ -107,7 +108,20 @@ const MINI_BATCH_SIZE = 32;
 const MAX_EPOCHS = 500;
 const EARLY_STOP_DELTA = 1e-5;
 
-export const RANKER_QUALITY_FIXTURES: readonly QualityFixture[] = [
+function reorderFixtureCandidates(
+  query: string,
+  candidates: readonly QualityCandidate[]
+): QualityCandidate[] {
+  if (candidates.length <= 1) {
+    return [...candidates];
+  }
+
+  const offset =
+    Array.from(query).reduce((total, char) => total + char.charCodeAt(0), 0) % candidates.length;
+  return candidates.map((_, index) => candidates[(index + offset) % candidates.length]!);
+}
+
+const RAW_RANKER_QUALITY_FIXTURES: readonly QualityFixture[] = [
   {
     query: 'fix the stale case status correction',
     question_type: 'correction',
@@ -518,6 +532,13 @@ export const RANKER_QUALITY_FIXTURES: readonly QualityFixture[] = [
   },
 ];
 
+export const RANKER_QUALITY_FIXTURES: readonly QualityFixture[] = RAW_RANKER_QUALITY_FIXTURES.map(
+  (fixture) => ({
+    ...fixture,
+    candidates: reorderFixtureCandidates(fixture.query, fixture.candidates),
+  })
+);
+
 function asSourceForFeedback(
   sourceType: string
 ): 'decision' | 'checkpoint' | 'wiki_page' | 'case' | 'connector_event' {
@@ -579,14 +600,20 @@ function effectiveWindow(input: RankerTrainerInput): EffectiveTrainingWindow {
 }
 
 function labelForKind(kind: SearchFeedbackRow['feedback_kind']): number | null {
-  if (kind === 'accept' || kind === 'click') return 1;
-  if (kind === 'reject' || kind === 'hide' || kind === 'shown') return 0;
+  if (kind === 'accept' || kind === 'click') {
+    return 1;
+  }
+  if (kind === 'reject' || kind === 'hide' || kind === 'shown') {
+    return 0;
+  }
   return null;
 }
 
 function rowToExample(row: SearchFeedbackRow): TrainingExample | null {
   const label = labelForKind(row.feedback_kind);
-  if (label === null) return null;
+  if (label === null) {
+    return null;
+  }
 
   const features = serializeFeatures(
     extractFeatures(
@@ -637,8 +664,12 @@ function capNeutralRows(rows: SearchFeedbackRow[]): SearchFeedbackRow[] {
 }
 
 function sigmoid(value: number): number {
-  if (value >= 35) return 1;
-  if (value <= -35) return 0;
+  if (value >= 35) {
+    return 1;
+  }
+  if (value <= -35) {
+    return 0;
+  }
   return 1 / (1 + Math.exp(-value));
 }
 
@@ -727,7 +758,8 @@ function questionWeights(
 
 function modelIdFor(input: { trainedAt: string; rows: number; distinctQueries: number }): string {
   const compactTime = input.trainedAt.replace(/[^0-9]/g, '').slice(0, 17);
-  return `ranker_${compactTime}_${input.rows}_${input.distinctQueries}`;
+  const uniqueSuffix = randomBytes(4).toString('hex');
+  return `ranker_${compactTime}_${input.rows}_${input.distinctQueries}_${uniqueSuffix}`;
 }
 
 export async function trainOfflineRanker(
@@ -750,8 +782,13 @@ export async function trainOfflineRanker(
     feedbackRows: examples.length,
     distinctQueries,
   };
+  const examplesHaveBothLabels = hasBothLabels(examples);
 
-  if (counts.feedbackRows < minFeedbackRows || counts.distinctQueries < minDistinctQueries) {
+  if (
+    counts.feedbackRows < minFeedbackRows ||
+    counts.distinctQueries < minDistinctQueries ||
+    !examplesHaveBothLabels
+  ) {
     return {
       status: 'insufficient_data',
       effectiveWindow: window,
@@ -791,7 +828,9 @@ function rankByScore<T extends { id: string }>(items: T[], score: (item: T) => n
     .map((item, index) => ({ item, index, score: score(item) }))
     .sort((left, right) => {
       const diff = right.score - left.score;
-      if (Math.abs(diff) > 1e-12) return diff;
+      if (Math.abs(diff) > 1e-12) {
+        return diff;
+      }
       return left.index - right.index;
     })
     .map((entry) => entry.item);
@@ -992,9 +1031,15 @@ export async function activateRankerModel(
       }
     | undefined;
 
-  if (!row) return 'not_found';
-  if (row.feature_set_version !== SEARCH_RANKER_FEATURE_SET_VERSION) return 'feature_set_mismatch';
-  if (row.quality_gate_status !== 'passed') return 'quality_gate_failed';
+  if (!row) {
+    return 'not_found';
+  }
+  if (row.feature_set_version !== SEARCH_RANKER_FEATURE_SET_VERSION) {
+    return 'feature_set_mismatch';
+  }
+  if (row.quality_gate_status !== 'passed') {
+    return 'quality_gate_failed';
+  }
 
   runTransaction(adapter, () => {
     adapter.prepare('UPDATE ranker_model_versions SET active = 0 WHERE active = 1').run();

--- a/packages/mama-core/src/search/ranker-trainer.ts
+++ b/packages/mama-core/src/search/ranker-trainer.ts
@@ -107,6 +107,23 @@ const LEARNING_RATE = 0.05;
 const MINI_BATCH_SIZE = 32;
 const MAX_EPOCHS = 500;
 const EARLY_STOP_DELTA = 1e-5;
+const MIN_NEUTRAL_PER_QUERY = 3;
+// 0.01 is a small but meaningful margin across 8 fixture queries: it blocks
+// tie/noise wins without demanding a large jump on a tiny evaluation set.
+const RANKER_QUALITY_MARGIN = 0.01;
+
+function seededShuffle<T>(items: readonly T[], seed: number): T[] {
+  const shuffled = [...items];
+  let state = seed >>> 0;
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    const swapIndex = state % (index + 1);
+    const current = shuffled[index]!;
+    shuffled[index] = shuffled[swapIndex]!;
+    shuffled[swapIndex] = current;
+  }
+  return shuffled;
+}
 
 function reorderFixtureCandidates(
   query: string,
@@ -116,9 +133,8 @@ function reorderFixtureCandidates(
     return [...candidates];
   }
 
-  const offset =
-    Array.from(query).reduce((total, char) => total + char.charCodeAt(0), 0) % candidates.length;
-  return candidates.map((_, index) => candidates[(index + offset) % candidates.length]!);
+  const seed = Array.from(query).reduce((total, char) => total + char.charCodeAt(0), 0);
+  return seededShuffle(candidates, seed);
 }
 
 const RAW_RANKER_QUALITY_FIXTURES: readonly QualityFixture[] = [
@@ -651,7 +667,7 @@ function capNeutralRows(rows: SearchFeedbackRow[]): SearchFeedbackRow[] {
   for (const groupRows of byQuery.values()) {
     const explicit = groupRows.filter((row) => row.feedback_kind !== 'shown');
     const shown = groupRows.filter((row) => row.feedback_kind === 'shown');
-    const neutralLimit = explicit.length * 3;
+    const neutralLimit = Math.max(explicit.length * 3, MIN_NEUTRAL_PER_QUERY);
     capped.push(...explicit, ...shown.slice(0, neutralLimit));
   }
 
@@ -699,11 +715,12 @@ function trainWeights(
   }
 
   for (let epoch = 0; epoch < MAX_EPOCHS; epoch += 1) {
+    const shuffledExamples = seededShuffle(examples, epoch + 1);
     let epochDelta = 0;
     let batchCount = 0;
 
-    for (let batchStart = 0; batchStart < examples.length; batchStart += MINI_BATCH_SIZE) {
-      const batch = examples.slice(batchStart, batchStart + MINI_BATCH_SIZE);
+    for (let batchStart = 0; batchStart < shuffledExamples.length; batchStart += MINI_BATCH_SIZE) {
+      const batch = shuffledExamples.slice(batchStart, batchStart + MINI_BATCH_SIZE);
       const gradients = new Array(featureCount).fill(0);
       let interceptGradient = 0;
 
@@ -796,8 +813,7 @@ export async function trainOfflineRanker(
     };
   }
 
-  const featureCount =
-    examples[0]?.features.length ?? serializeFeatures(extractFeatures({}, '')).length;
+  const featureCount = examples[0]!.features.length;
   const trained = trainWeights(examples, featureCount);
   const trainedAt = input.now ? input.now.toISOString() : new Date().toISOString();
   const model: SearchRankerModel = {
@@ -825,13 +841,13 @@ export async function trainOfflineRanker(
 
 function rankByScore<T extends { id: string }>(items: T[], score: (item: T) => number): T[] {
   return items
-    .map((item, index) => ({ item, index, score: score(item) }))
+    .map((item) => ({ item, score: score(item) }))
     .sort((left, right) => {
       const diff = right.score - left.score;
       if (Math.abs(diff) > 1e-12) {
         return diff;
       }
-      return left.index - right.index;
+      return left.item.id.localeCompare(right.item.id);
     })
     .map((entry) => entry.item);
 }
@@ -939,7 +955,9 @@ export async function evaluateAgainstBaselines(
     rrf,
     logistic,
     learned,
-    passes: learned.ndcg >= bestBaselineNdcg + 0.01 && learned.mrr >= bestBaselineMrr + 0.01,
+    passes:
+      learned.ndcg >= bestBaselineNdcg + RANKER_QUALITY_MARGIN &&
+      learned.mrr >= bestBaselineMrr + RANKER_QUALITY_MARGIN,
   };
 }
 

--- a/packages/mama-core/src/test-utils.ts
+++ b/packages/mama-core/src/test-utils.ts
@@ -11,8 +11,60 @@
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import type Database from 'better-sqlite3';
 import { resetDBState, initDB, closeDB } from './db-manager.js';
 import { warn } from './debug-logger.js';
+
+const MIGRATIONS_DIR = join(__dirname, '..', 'db', 'migrations');
+
+/**
+ * Returns migration SQL filenames sorted by their leading three-digit version.
+ */
+export function migrationFiles(): string[] {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((file) => /^\d{3}-.+\.sql$/.test(file))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+export function migrationVersion(file: string): number {
+  return Number.parseInt(file.slice(0, 3), 10);
+}
+
+/**
+ * Apply migrations in order up to `maxVersion` (inclusive), starting from
+ * `fromVersion`. Mirrors the production runner's two-part contract:
+ *   - skip files whose version is already recorded in `schema_version`
+ *   - tolerate `duplicate column` errors (legacy migrations that add
+ *     columns idempotently without recording into schema_version)
+ */
+export function applyMigrationsThrough(
+  db: Database.Database,
+  maxVersion: number,
+  fromVersion = 1
+): void {
+  for (const file of migrationFiles()) {
+    const version = migrationVersion(file);
+    if (version < fromVersion) continue;
+    if (version > maxVersion) break;
+    let alreadyApplied = false;
+    try {
+      alreadyApplied = !!db
+        .prepare('SELECT 1 FROM schema_version WHERE version = ?')
+        .get(version);
+    } catch {
+      alreadyApplied = false;
+    }
+    if (alreadyApplied) continue;
+    try {
+      db.exec(readFileSync(join(MIGRATIONS_DIR, file), 'utf8'));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!/duplicate column/i.test(msg)) throw err;
+    }
+  }
+}
 
 // Track test databases for cleanup
 const testDatabases: string[] = [];

--- a/packages/mama-core/tests/canonicalize.test.ts
+++ b/packages/mama-core/tests/canonicalize.test.ts
@@ -93,6 +93,12 @@ describe('targetRefHash', () => {
     expect(direct.equals(composed)).toBe(true);
   });
 
+  it('canonicalizes raw string values before hashing', () => {
+    const direct = targetRefHash('x');
+    const composed = targetRefHash(canonicalizeJSON('x'));
+    expect(direct.equals(composed)).toBe(true);
+  });
+
   it('hashes semantically distinct input to distinct digests', () => {
     const h1 = targetRefHash({ x: 1 });
     const h2 = targetRefHash({ x: '1' });

--- a/packages/mama-core/tests/canonicalize.test.ts
+++ b/packages/mama-core/tests/canonicalize.test.ts
@@ -5,7 +5,8 @@ import { CanonicalizeError, canonicalizeJSON, targetRefHash } from '../src/canon
 
 const cjsRequire = createRequire(import.meta.url);
 
-describe('canonicalizeJSON', () => {
+describe('Story C1.1: Canonical JSON and hashing helpers', () => {
+  describe('AC #1: canonicalizeJSON stays deterministic and rejects invalid inputs', () => {
   it('is stable across differently ordered sibling keys', () => {
     const a = canonicalizeJSON({ b: 2, a: 1 });
     const b = canonicalizeJSON({ a: 1, b: 2 });
@@ -71,9 +72,9 @@ describe('canonicalizeJSON', () => {
     });
     expect(s).toBe('{"list":[{"a":1,"b":2},{"c":3,"d":4}]}');
   });
-});
+  });
 
-describe('targetRefHash', () => {
+  describe('AC #2: targetRefHash preserves canonical hashing properties', () => {
   it('returns a 32-byte Buffer (SHA-256 digest)', () => {
     const h = targetRefHash({ a: 1 });
     expect(Buffer.isBuffer(h)).toBe(true);
@@ -104,9 +105,9 @@ describe('targetRefHash', () => {
     const h2 = targetRefHash({ x: '1' });
     expect(h1.equals(h2)).toBe(false);
   });
-});
+  });
 
-describe('CJS require interop via createRequire', () => {
+  describe('AC #3: CJS export interop stays intact', () => {
   // Resolves against dist/ — requires `pnpm --filter @jungjaehoon/mama-core build`
   // to have run before this test. Without dist, the require throws and this
   // test surfaces the export-map break that ESM-only tests would miss.
@@ -121,5 +122,6 @@ describe('CJS require interop via createRequire', () => {
     const obj = { b: 2, a: 1 };
     expect(cjs.canonicalizeJSON(obj)).toBe(canonicalizeJSON(obj));
     expect(cjs.targetRefHash(obj).equals(targetRefHash(obj))).toBe(true);
+  });
   });
 });

--- a/packages/mama-core/tests/canonicalize.test.ts
+++ b/packages/mama-core/tests/canonicalize.test.ts
@@ -1,0 +1,119 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+import { CanonicalizeError, canonicalizeJSON, targetRefHash } from '../src/canonicalize.js';
+
+const cjsRequire = createRequire(import.meta.url);
+
+describe('canonicalizeJSON', () => {
+  it('is stable across differently ordered sibling keys', () => {
+    const a = canonicalizeJSON({ b: 2, a: 1 });
+    const b = canonicalizeJSON({ a: 1, b: 2 });
+    expect(a).toBe(b);
+    expect(a).toBe('{"a":1,"b":2}');
+  });
+
+  it('sorts nested object keys recursively', () => {
+    const a = canonicalizeJSON({ outer: { z: 1, a: 2 }, alpha: { y: 3, x: 4 } });
+    const b = canonicalizeJSON({ alpha: { x: 4, y: 3 }, outer: { a: 2, z: 1 } });
+    expect(a).toBe(b);
+    expect(a).toBe('{"alpha":{"x":4,"y":3},"outer":{"a":2,"z":1}}');
+  });
+
+  it('preserves array order (arrays are semantic)', () => {
+    expect(canonicalizeJSON(['a', 'b', 'c'])).toBe('["a","b","c"]');
+    expect(canonicalizeJSON(['c', 'b', 'a'])).toBe('["c","b","a"]');
+    expect(canonicalizeJSON(['a', 'b', 'c'])).not.toBe(canonicalizeJSON(['c', 'b', 'a']));
+  });
+
+  it('distinguishes numeric 1 from string "1"', () => {
+    expect(canonicalizeJSON({ x: 1 })).toBe('{"x":1}');
+    expect(canonicalizeJSON({ x: '1' })).toBe('{"x":"1"}');
+    expect(canonicalizeJSON({ x: 1 })).not.toBe(canonicalizeJSON({ x: '1' }));
+  });
+
+  it('rejects undefined values with canonicalize.undefined_value', () => {
+    expect(() => canonicalizeJSON({ x: undefined })).toThrow(CanonicalizeError);
+    try {
+      canonicalizeJSON({ x: undefined });
+    } catch (err) {
+      expect((err as CanonicalizeError).code).toBe('canonicalize.undefined_value');
+    }
+  });
+
+  it('rejects function values with canonicalize.function_value', () => {
+    const fn = (): number => 42;
+    expect(() => canonicalizeJSON({ x: fn })).toThrow(CanonicalizeError);
+    try {
+      canonicalizeJSON({ x: fn });
+    } catch (err) {
+      expect((err as CanonicalizeError).code).toBe('canonicalize.function_value');
+    }
+  });
+
+  it('rejects non-finite numbers with canonicalize.non_finite_number', () => {
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      expect(() => canonicalizeJSON({ x: bad })).toThrow(CanonicalizeError);
+      try {
+        canonicalizeJSON({ x: bad });
+      } catch (err) {
+        expect((err as CanonicalizeError).code).toBe('canonicalize.non_finite_number');
+      }
+    }
+  });
+
+  it('handles nested arrays of objects', () => {
+    const s = canonicalizeJSON({
+      list: [
+        { b: 2, a: 1 },
+        { d: 4, c: 3 },
+      ],
+    });
+    expect(s).toBe('{"list":[{"a":1,"b":2},{"c":3,"d":4}]}');
+  });
+});
+
+describe('targetRefHash', () => {
+  it('returns a 32-byte Buffer (SHA-256 digest)', () => {
+    const h = targetRefHash({ a: 1 });
+    expect(Buffer.isBuffer(h)).toBe(true);
+    expect(h.length).toBe(32);
+  });
+
+  it('produces identical hashes for semantically equivalent input (different key order)', () => {
+    const h1 = targetRefHash({ b: 2, a: 1 });
+    const h2 = targetRefHash({ a: 1, b: 2 });
+    expect(h1.equals(h2)).toBe(true);
+  });
+
+  it('composition: targetRefHash(obj) === targetRefHash(canonicalizeJSON(obj))', () => {
+    const x = { z: [1, 2, 3], alpha: { inner: true }, beta: 'text' };
+    const direct = targetRefHash(x);
+    const composed = targetRefHash(canonicalizeJSON(x));
+    expect(direct.equals(composed)).toBe(true);
+  });
+
+  it('hashes semantically distinct input to distinct digests', () => {
+    const h1 = targetRefHash({ x: 1 });
+    const h2 = targetRefHash({ x: '1' });
+    expect(h1.equals(h2)).toBe(false);
+  });
+});
+
+describe('CJS require interop via createRequire', () => {
+  // Resolves against dist/ — requires `pnpm --filter @jungjaehoon/mama-core build`
+  // to have run before this test. Without dist, the require throws and this
+  // test surfaces the export-map break that ESM-only tests would miss.
+  it('imports canonicalizeJSON and targetRefHash through the CJS subpath export', () => {
+    const cjs = cjsRequire('@jungjaehoon/mama-core/canonicalize') as {
+      canonicalizeJSON: typeof canonicalizeJSON;
+      targetRefHash: typeof targetRefHash;
+    };
+    expect(typeof cjs.canonicalizeJSON).toBe('function');
+    expect(typeof cjs.targetRefHash).toBe('function');
+
+    const obj = { b: 2, a: 1 };
+    expect(cjs.canonicalizeJSON(obj)).toBe(canonicalizeJSON(obj));
+    expect(cjs.targetRefHash(obj).equals(targetRefHash(obj))).toBe(true);
+  });
+});

--- a/packages/mama-core/tests/cases/case-composition-overrides.test.ts
+++ b/packages/mama-core/tests/cases/case-composition-overrides.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
+import { canonicalizeJSON } from '../../src/canonicalize.js';
 import { getAdapter } from '../../src/db-manager.js';
 import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
 import {
@@ -259,6 +260,58 @@ describe('Task 14: Membership pin and source promotion core helpers', () => {
       canonical_event_id: 'evt-promoted',
     });
     expect(membershipRow('case-promote-event', 'evt-promoted').user_locked).toBe(1);
+  });
+
+  it('reconfirm tokens remain valid even when the confirmation call uses a later timestamp', () => {
+    insertCase({ case_id: 'case-promote-reconfirm' });
+    insertMembership({ case_id: 'case-promote-reconfirm', source_id: 'dec-reconfirm' });
+    const previousSecret = process.env.MAMA_RECONFIRM_TOKEN_SECRET;
+    process.env.MAMA_RECONFIRM_TOKEN_SECRET = Buffer.alloc(32, 9).toString('hex');
+
+    try {
+      const first = promoteCaseSource(getAdapter(), {
+        case_id: 'case-promote-reconfirm',
+        source_type: 'decision',
+        source_id: 'dec-reconfirm',
+        promoted_by: 'user:test',
+        reason: 'needs reconfirm',
+        expected_current_value_json: canonicalizeJSON({
+          promotion: { canonical_decision_id: 'dec-old', canonical_event_id: null },
+        }),
+        session_id: 'turn-promote',
+        now: '2026-04-18T01:00:00.000Z',
+      });
+
+      expect(first.kind).toBe('requires_reconfirm');
+      if (first.kind !== 'requires_reconfirm') {
+        throw new Error('Expected reconfirm result');
+      }
+
+      const confirmed = promoteCaseSource(getAdapter(), {
+        case_id: 'case-promote-reconfirm',
+        source_type: 'decision',
+        source_id: 'dec-reconfirm',
+        promoted_by: 'user:test',
+        reason: 'needs reconfirm',
+        expected_current_value_json: canonicalizeJSON({
+          promotion: { canonical_decision_id: 'dec-old', canonical_event_id: null },
+        }),
+        reconfirm_token: first.reconfirm_token,
+        session_id: 'turn-promote',
+        now: '2026-04-18T01:05:00.000Z',
+      });
+
+      expect(confirmed).toMatchObject({
+        kind: 'promoted',
+        canonical_decision_id: 'dec-reconfirm',
+      });
+    } finally {
+      if (previousSecret === undefined) {
+        delete process.env.MAMA_RECONFIRM_TOKEN_SECRET;
+      } else {
+        process.env.MAMA_RECONFIRM_TOKEN_SECRET = previousSecret;
+      }
+    }
   });
 
   it('promote rejects observation with case.promote_invalid_source_type', () => {

--- a/packages/mama-core/tests/cases/case-composition-overrides.test.ts
+++ b/packages/mama-core/tests/cases/case-composition-overrides.test.ts
@@ -144,6 +144,31 @@ describe('Task 14: Membership pin and source promotion core helpers', () => {
     expect(membershipRow('case-pin', 'dec-pin').reason).toContain('keep this source');
   });
 
+  it('replaces an existing trailing manual-pin line instead of appending duplicates', () => {
+    insertCase({ case_id: 'case-pin-reason' });
+    insertMembership({
+      case_id: 'case-pin-reason',
+      source_id: 'dec-pin-reason',
+      reason: 'initial reason\nmanual-pin: old choice',
+      user_locked: 1,
+      assignment_strategy: 'manual-pin',
+    });
+
+    const result = pinCaseMembership(getAdapter(), {
+      case_id: 'case-pin-reason',
+      source_type: 'decision',
+      source_id: 'dec-pin-reason',
+      pinned_by: 'user:test',
+      reason: 'new choice',
+      now: '2026-04-18T01:00:00.000Z',
+    });
+
+    expect(result.kind).toBe('pinned');
+    expect(membershipRow('case-pin-reason', 'dec-pin-reason').reason).toBe(
+      'initial reason\nmanual-pin: new choice'
+    );
+  });
+
   it('unpin clears user_locked', () => {
     insertCase({ case_id: 'case-unpin' });
     insertMembership({

--- a/packages/mama-core/tests/cases/case-composition-overrides.test.ts
+++ b/packages/mama-core/tests/cases/case-composition-overrides.test.ts
@@ -1,0 +1,354 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { getAdapter } from '../../src/db-manager.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import {
+  pinCaseMembership,
+  promoteCaseSource,
+  unpinCaseMembership,
+} from '../../src/cases/composition-overrides.js';
+
+function resetCaseTables(): void {
+  const adapter = getAdapter();
+  adapter.prepare('DELETE FROM memory_events').run();
+  adapter.prepare('DELETE FROM case_links').run();
+  adapter.prepare('DELETE FROM case_corrections').run();
+  adapter.prepare('DELETE FROM case_memberships').run();
+  adapter.prepare('DELETE FROM case_truth').run();
+}
+
+function insertCase(
+  overrides: Partial<{
+    case_id: string;
+    title: string;
+    status: string;
+    canonical_case_id: string | null;
+    created_at: string;
+    updated_at: string;
+  }>
+): void {
+  const now = '2026-04-18T00:00:00.000Z';
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO case_truth (
+          case_id, title, status, canonical_case_id, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      overrides.case_id,
+      overrides.title ?? overrides.case_id,
+      overrides.status ?? 'active',
+      overrides.canonical_case_id ?? null,
+      overrides.created_at ?? now,
+      overrides.updated_at ?? now
+    );
+}
+
+function insertMembership(input: {
+  case_id: string;
+  source_type?: 'decision' | 'event' | 'observation' | 'artifact';
+  source_id: string;
+  status?: string;
+  reason?: string | null;
+  user_locked?: 0 | 1;
+  assignment_strategy?: string | null;
+}): void {
+  const now = '2026-04-18T00:00:00.000Z';
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO case_memberships (
+          case_id, source_type, source_id, role, confidence, reason, status,
+          added_by, added_at, updated_at, user_locked, assignment_strategy
+        )
+        VALUES (?, ?, ?, NULL, 0.9, ?, ?, 'wiki-compiler', ?, ?, ?, ?)
+      `
+    )
+    .run(
+      input.case_id,
+      input.source_type ?? 'decision',
+      input.source_id,
+      input.reason ?? null,
+      input.status ?? 'active',
+      now,
+      now,
+      input.user_locked ?? 0,
+      input.assignment_strategy ?? null
+    );
+}
+
+function membershipRow(
+  caseId: string,
+  sourceId: string
+): {
+  user_locked: number;
+  assignment_strategy: string | null;
+  reason: string | null;
+  status: string;
+} {
+  return getAdapter()
+    .prepare(
+      `
+        SELECT user_locked, assignment_strategy, reason, status
+        FROM case_memberships
+        WHERE case_id = ? AND source_id = ?
+      `
+    )
+    .get(caseId, sourceId) as {
+    user_locked: number;
+    assignment_strategy: string | null;
+    reason: string | null;
+    status: string;
+  };
+}
+
+describe('Task 14: Membership pin and source promotion core helpers', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    process.env.MAMA_FORCE_TIER_3 = 'true';
+    testDbPath = await initTestDB('case-composition-overrides');
+  });
+
+  beforeEach(() => {
+    resetCaseTables();
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  it('pin sets user_locked=1 and assignment_strategy=manual-pin', () => {
+    insertCase({ case_id: 'case-pin' });
+    insertMembership({ case_id: 'case-pin', source_id: 'dec-pin', reason: 'initial reason' });
+
+    const result = pinCaseMembership(getAdapter(), {
+      case_id: 'case-pin',
+      source_type: 'decision',
+      source_id: 'dec-pin',
+      pinned_by: 'user:test',
+      reason: 'keep this source',
+      now: '2026-04-18T01:00:00.000Z',
+    });
+
+    expect(result.kind).toBe('pinned');
+    expect(membershipRow('case-pin', 'dec-pin')).toMatchObject({
+      user_locked: 1,
+      assignment_strategy: 'manual-pin',
+      status: 'active',
+    });
+    expect(membershipRow('case-pin', 'dec-pin').reason).toContain('keep this source');
+  });
+
+  it('unpin clears user_locked', () => {
+    insertCase({ case_id: 'case-unpin' });
+    insertMembership({
+      case_id: 'case-unpin',
+      source_id: 'dec-unpin',
+      user_locked: 1,
+      assignment_strategy: 'manual-pin',
+    });
+
+    const result = unpinCaseMembership(getAdapter(), {
+      case_id: 'case-unpin',
+      source_type: 'decision',
+      source_id: 'dec-unpin',
+      unpinned_by: 'user:test',
+      reason: 'release lock',
+    });
+
+    expect(result.kind).toBe('unpinned');
+    expect(membershipRow('case-unpin', 'dec-unpin').user_locked).toBe(0);
+  });
+
+  it('pin rejects stale membership', () => {
+    insertCase({ case_id: 'case-stale' });
+    insertMembership({ case_id: 'case-stale', source_id: 'dec-stale', status: 'stale' });
+
+    const result = pinCaseMembership(getAdapter(), {
+      case_id: 'case-stale',
+      source_type: 'decision',
+      source_id: 'dec-stale',
+      pinned_by: 'user:test',
+      reason: 'cannot pin stale',
+    });
+
+    expect(result).toMatchObject({ kind: 'rejected', code: 'case.membership_stale' });
+  });
+
+  it('pin rejects terminal case', () => {
+    insertCase({ case_id: 'case-archived', status: 'archived' });
+    insertMembership({ case_id: 'case-archived', source_id: 'dec-archived' });
+
+    const result = pinCaseMembership(getAdapter(), {
+      case_id: 'case-archived',
+      source_type: 'decision',
+      source_id: 'dec-archived',
+      pinned_by: 'user:test',
+      reason: 'terminal',
+    });
+
+    expect(result).toMatchObject({ kind: 'rejected', code: 'case.terminal_status' });
+  });
+
+  it('promote decision sets canonical_decision_id and pins membership', () => {
+    insertCase({ case_id: 'case-promote-decision' });
+    insertMembership({ case_id: 'case-promote-decision', source_id: 'dec-promoted' });
+
+    const result = promoteCaseSource(getAdapter(), {
+      case_id: 'case-promote-decision',
+      source_type: 'decision',
+      source_id: 'dec-promoted',
+      promoted_by: 'user:test',
+      reason: 'canonical decision',
+      now: '2026-04-18T01:00:00.000Z',
+    });
+
+    expect(result).toMatchObject({
+      kind: 'promoted',
+      canonical_decision_id: 'dec-promoted',
+      canonical_event_id: null,
+    });
+
+    const row = getAdapter()
+      .prepare(
+        `
+          SELECT canonical_decision_id, canonical_event_id, promoted_by, promotion_reason
+          FROM case_truth
+          WHERE case_id = 'case-promote-decision'
+        `
+      )
+      .get() as {
+      canonical_decision_id: string | null;
+      canonical_event_id: string | null;
+      promoted_by: string;
+      promotion_reason: string;
+    };
+
+    expect(row).toEqual({
+      canonical_decision_id: 'dec-promoted',
+      canonical_event_id: null,
+      promoted_by: 'user:test',
+      promotion_reason: 'canonical decision',
+    });
+    expect(membershipRow('case-promote-decision', 'dec-promoted').user_locked).toBe(1);
+  });
+
+  it('promote event sets canonical_event_id and pins membership', () => {
+    insertCase({ case_id: 'case-promote-event' });
+    insertMembership({
+      case_id: 'case-promote-event',
+      source_type: 'event',
+      source_id: 'evt-promoted',
+    });
+
+    const result = promoteCaseSource(getAdapter(), {
+      case_id: 'case-promote-event',
+      source_type: 'event',
+      source_id: 'evt-promoted',
+      promoted_by: 'user:test',
+      reason: 'canonical event',
+    });
+
+    expect(result).toMatchObject({
+      kind: 'promoted',
+      canonical_decision_id: null,
+      canonical_event_id: 'evt-promoted',
+    });
+    expect(membershipRow('case-promote-event', 'evt-promoted').user_locked).toBe(1);
+  });
+
+  it('promote rejects observation with case.promote_invalid_source_type', () => {
+    insertCase({ case_id: 'case-observation' });
+    insertMembership({
+      case_id: 'case-observation',
+      source_type: 'observation',
+      source_id: 'obs-1',
+    });
+
+    const result = promoteCaseSource(getAdapter(), {
+      case_id: 'case-observation',
+      source_type: 'observation',
+      source_id: 'obs-1',
+      promoted_by: 'user:test',
+      reason: 'invalid',
+    });
+
+    expect(result).toMatchObject({
+      kind: 'rejected',
+      code: 'case.promote_invalid_source_type',
+    });
+  });
+
+  it('promote rejects non-active source with case.promote_source_not_active', () => {
+    insertCase({ case_id: 'case-candidate' });
+    insertMembership({
+      case_id: 'case-candidate',
+      source_type: 'decision',
+      source_id: 'dec-candidate',
+      status: 'candidate',
+    });
+
+    const result = promoteCaseSource(getAdapter(), {
+      case_id: 'case-candidate',
+      source_type: 'decision',
+      source_id: 'dec-candidate',
+      promoted_by: 'user:test',
+      reason: 'not active',
+    });
+
+    expect(result).toMatchObject({
+      kind: 'rejected',
+      code: 'case.promote_source_not_active',
+    });
+  });
+
+  it('promote rejects terminal case', () => {
+    insertCase({ case_id: 'case-split', status: 'split' });
+    insertMembership({ case_id: 'case-split', source_id: 'dec-split' });
+
+    const result = promoteCaseSource(getAdapter(), {
+      case_id: 'case-split',
+      source_type: 'decision',
+      source_id: 'dec-split',
+      promoted_by: 'user:test',
+      reason: 'terminal',
+    });
+
+    expect(result).toMatchObject({ kind: 'rejected', code: 'case.terminal_status' });
+  });
+
+  it('merge chain lookup allows promoting a source on loser row to survivor', () => {
+    insertCase({ case_id: 'case-survivor' });
+    insertCase({
+      case_id: 'case-loser',
+      status: 'merged',
+      canonical_case_id: 'case-survivor',
+    });
+    insertMembership({ case_id: 'case-loser', source_id: 'dec-on-loser' });
+
+    const result = promoteCaseSource(getAdapter(), {
+      case_id: 'case-survivor',
+      source_type: 'decision',
+      source_id: 'dec-on-loser',
+      promoted_by: 'user:test',
+      reason: 'canonical source survived merge',
+    });
+
+    expect(result).toMatchObject({
+      kind: 'promoted',
+      terminal_case_id: 'case-survivor',
+      membership_case_id: 'case-loser',
+      canonical_decision_id: 'dec-on-loser',
+    });
+
+    const survivor = getAdapter()
+      .prepare('SELECT canonical_decision_id FROM case_truth WHERE case_id = ?')
+      .get('case-survivor') as { canonical_decision_id: string | null };
+    expect(survivor.canonical_decision_id).toBe('dec-on-loser');
+    expect(membershipRow('case-loser', 'dec-on-loser').user_locked).toBe(1);
+  });
+});

--- a/packages/mama-core/tests/cases/case-composition-overrides.test.ts
+++ b/packages/mama-core/tests/cases/case-composition-overrides.test.ts
@@ -118,7 +118,11 @@ function membershipRow(
   };
 }
 
-describe('Task 14: Membership pin and source promotion core helpers', () => {
+describe('Story CF2.7: Membership pin and source promotion core helpers', () => {
+  // Acceptance Criteria:
+  // - pinCaseMembership marks the row as manually pinned and keeps the reason trail stable.
+  // - unpinCaseMembership clears the manual-pin lock metadata that explain/assembly surfaces.
+  // - promoteCaseSource enforces CAS/reconfirm rules and only promotes valid decision sources.
   let testDbPath = '';
 
   beforeAll(async () => {
@@ -181,7 +185,7 @@ describe('Task 14: Membership pin and source promotion core helpers', () => {
     );
   });
 
-  it('unpin clears user_locked', () => {
+  it('unpin clears user_locked and manual-pin metadata', () => {
     insertCase({ case_id: 'case-unpin' });
     insertMembership({
       case_id: 'case-unpin',
@@ -199,7 +203,10 @@ describe('Task 14: Membership pin and source promotion core helpers', () => {
     });
 
     expect(result.kind).toBe('unpinned');
-    expect(membershipRow('case-unpin', 'dec-unpin').user_locked).toBe(0);
+    expect(membershipRow('case-unpin', 'dec-unpin')).toMatchObject({
+      user_locked: 0,
+      assignment_strategy: null,
+    });
   });
 
   it('pin rejects stale membership', () => {

--- a/packages/mama-core/tests/cases/case-composition-overrides.test.ts
+++ b/packages/mama-core/tests/cases/case-composition-overrides.test.ts
@@ -12,22 +12,25 @@ import {
 function resetCaseTables(): void {
   const adapter = getAdapter();
   adapter.prepare('PRAGMA foreign_keys = OFF').run();
-  adapter.prepare('DELETE FROM memory_events').run();
-  const tables = adapter
-    .prepare(
-      `
-        SELECT name
-        FROM sqlite_master
-        WHERE type = 'table'
-          AND name LIKE 'case_%'
-        ORDER BY name DESC
-      `
-    )
-    .all() as Array<{ name: string }>;
-  for (const table of tables) {
-    adapter.prepare(`DELETE FROM "${table.name}"`).run();
+  try {
+    adapter.prepare('DELETE FROM memory_events').run();
+    const tables = adapter
+      .prepare(
+        `
+          SELECT name
+          FROM sqlite_master
+          WHERE type = 'table'
+            AND name LIKE 'case_%'
+          ORDER BY name DESC
+        `
+      )
+      .all() as Array<{ name: string }>;
+    for (const table of tables) {
+      adapter.prepare(`DELETE FROM "${table.name}"`).run();
+    }
+  } finally {
+    adapter.prepare('PRAGMA foreign_keys = ON').run();
   }
-  adapter.prepare('PRAGMA foreign_keys = ON').run();
 }
 
 function insertCase(
@@ -124,6 +127,7 @@ describe('Story CF2.7: Membership pin and source promotion core helpers', () => 
   // - unpinCaseMembership clears the manual-pin lock metadata that explain/assembly surfaces.
   // - promoteCaseSource enforces CAS/reconfirm rules and only promotes valid decision sources.
   let testDbPath = '';
+  const previousForceTier = process.env.MAMA_FORCE_TIER_3;
 
   beforeAll(async () => {
     process.env.MAMA_FORCE_TIER_3 = 'true';
@@ -136,6 +140,11 @@ describe('Story CF2.7: Membership pin and source promotion core helpers', () => 
 
   afterAll(async () => {
     await cleanupTestDB(testDbPath);
+    if (previousForceTier === undefined) {
+      delete process.env.MAMA_FORCE_TIER_3;
+    } else {
+      process.env.MAMA_FORCE_TIER_3 = previousForceTier;
+    }
   });
 
   it('pin sets user_locked=1 and assignment_strategy=manual-pin', () => {

--- a/packages/mama-core/tests/cases/case-composition-overrides.test.ts
+++ b/packages/mama-core/tests/cases/case-composition-overrides.test.ts
@@ -11,11 +11,23 @@ import {
 
 function resetCaseTables(): void {
   const adapter = getAdapter();
+  adapter.prepare('PRAGMA foreign_keys = OFF').run();
   adapter.prepare('DELETE FROM memory_events').run();
-  adapter.prepare('DELETE FROM case_links').run();
-  adapter.prepare('DELETE FROM case_corrections').run();
-  adapter.prepare('DELETE FROM case_memberships').run();
-  adapter.prepare('DELETE FROM case_truth').run();
+  const tables = adapter
+    .prepare(
+      `
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table'
+          AND name LIKE 'case_%'
+        ORDER BY name DESC
+      `
+    )
+    .all() as Array<{ name: string }>;
+  for (const table of tables) {
+    adapter.prepare(`DELETE FROM "${table.name}"`).run();
+  }
+  adapter.prepare('PRAGMA foreign_keys = ON').run();
 }
 
 function insertCase(
@@ -330,6 +342,166 @@ describe('Task 14: Membership pin and source promotion core helpers', () => {
         kind: 'promoted',
         canonical_decision_id: 'dec-reconfirm',
       });
+    } finally {
+      if (previousSecret === undefined) {
+        delete process.env.MAMA_RECONFIRM_TOKEN_SECRET;
+      } else {
+        process.env.MAMA_RECONFIRM_TOKEN_SECRET = previousSecret;
+      }
+    }
+  });
+
+  it('falls back to a fresh reconfirm flow when replay uses a stale consumed token', () => {
+    insertCase({ case_id: 'case-promote-replay' });
+    insertMembership({ case_id: 'case-promote-replay', source_id: 'dec-replay' });
+    const previousSecret = process.env.MAMA_RECONFIRM_TOKEN_SECRET;
+    process.env.MAMA_RECONFIRM_TOKEN_SECRET = Buffer.alloc(32, 9).toString('hex');
+
+    try {
+      const first = promoteCaseSource(getAdapter(), {
+        case_id: 'case-promote-replay',
+        source_type: 'decision',
+        source_id: 'dec-replay',
+        promoted_by: 'user:test',
+        reason: 'needs reconfirm',
+        expected_current_value_json: canonicalizeJSON({
+          promotion: { canonical_decision_id: 'dec-old', canonical_event_id: null },
+        }),
+        session_id: 'turn-promote',
+        now: '2026-04-18T01:00:00.000Z',
+      });
+      expect(first.kind).toBe('requires_reconfirm');
+      if (first.kind !== 'requires_reconfirm') {
+        throw new Error('Expected reconfirm result');
+      }
+
+      const confirmed = promoteCaseSource(getAdapter(), {
+        case_id: 'case-promote-replay',
+        source_type: 'decision',
+        source_id: 'dec-replay',
+        promoted_by: 'user:test',
+        reason: 'needs reconfirm',
+        expected_current_value_json: canonicalizeJSON({
+          promotion: { canonical_decision_id: 'dec-old', canonical_event_id: null },
+        }),
+        reconfirm_token: first.reconfirm_token,
+        session_id: 'turn-promote',
+        now: '2026-04-18T01:05:00.000Z',
+      });
+      expect(confirmed.kind).toBe('promoted');
+
+      const replay = promoteCaseSource(getAdapter(), {
+        case_id: 'case-promote-replay',
+        source_type: 'decision',
+        source_id: 'dec-replay',
+        promoted_by: 'user:test',
+        reason: 'needs reconfirm',
+        expected_current_value_json: canonicalizeJSON({
+          promotion: { canonical_decision_id: 'dec-old', canonical_event_id: null },
+        }),
+        reconfirm_token: first.reconfirm_token,
+        session_id: 'turn-promote',
+        now: '2026-04-18T01:06:00.000Z',
+      });
+
+      expect(replay.kind).toBe('requires_reconfirm');
+    } finally {
+      if (previousSecret === undefined) {
+        delete process.env.MAMA_RECONFIRM_TOKEN_SECRET;
+      } else {
+        process.env.MAMA_RECONFIRM_TOKEN_SECRET = previousSecret;
+      }
+    }
+  });
+
+  it('falls back to a new reconfirm flow when the token is expired', () => {
+    insertCase({ case_id: 'case-promote-expired' });
+    insertMembership({ case_id: 'case-promote-expired', source_id: 'dec-expired' });
+    const previousSecret = process.env.MAMA_RECONFIRM_TOKEN_SECRET;
+    process.env.MAMA_RECONFIRM_TOKEN_SECRET = Buffer.alloc(32, 9).toString('hex');
+
+    try {
+      const first = promoteCaseSource(getAdapter(), {
+        case_id: 'case-promote-expired',
+        source_type: 'decision',
+        source_id: 'dec-expired',
+        promoted_by: 'user:test',
+        reason: 'needs reconfirm',
+        expected_current_value_json: canonicalizeJSON({
+          promotion: { canonical_decision_id: 'dec-old', canonical_event_id: null },
+        }),
+        session_id: 'turn-promote',
+        now: '2026-04-18T01:00:00.000Z',
+      });
+      expect(first.kind).toBe('requires_reconfirm');
+      if (first.kind !== 'requires_reconfirm') {
+        throw new Error('Expected reconfirm result');
+      }
+
+      const expired = promoteCaseSource(getAdapter(), {
+        case_id: 'case-promote-expired',
+        source_type: 'decision',
+        source_id: 'dec-expired',
+        promoted_by: 'user:test',
+        reason: 'needs reconfirm',
+        expected_current_value_json: canonicalizeJSON({
+          promotion: { canonical_decision_id: 'dec-old', canonical_event_id: null },
+        }),
+        reconfirm_token: first.reconfirm_token,
+        session_id: 'turn-promote',
+        now: '2026-04-18T02:00:00.000Z',
+      });
+
+      expect(expired.kind).toBe('requires_reconfirm');
+    } finally {
+      if (previousSecret === undefined) {
+        delete process.env.MAMA_RECONFIRM_TOKEN_SECRET;
+      } else {
+        process.env.MAMA_RECONFIRM_TOKEN_SECRET = previousSecret;
+      }
+    }
+  });
+
+  it('falls back to a new reconfirm flow when the token signature is tampered', () => {
+    insertCase({ case_id: 'case-promote-tampered' });
+    insertMembership({ case_id: 'case-promote-tampered', source_id: 'dec-tampered' });
+    const previousSecret = process.env.MAMA_RECONFIRM_TOKEN_SECRET;
+    process.env.MAMA_RECONFIRM_TOKEN_SECRET = Buffer.alloc(32, 9).toString('hex');
+
+    try {
+      const first = promoteCaseSource(getAdapter(), {
+        case_id: 'case-promote-tampered',
+        source_type: 'decision',
+        source_id: 'dec-tampered',
+        promoted_by: 'user:test',
+        reason: 'needs reconfirm',
+        expected_current_value_json: canonicalizeJSON({
+          promotion: { canonical_decision_id: 'dec-old', canonical_event_id: null },
+        }),
+        session_id: 'turn-promote',
+        now: '2026-04-18T01:00:00.000Z',
+      });
+      expect(first.kind).toBe('requires_reconfirm');
+      if (first.kind !== 'requires_reconfirm') {
+        throw new Error('Expected reconfirm result');
+      }
+
+      const token = first.reconfirm_token.slice(0, -1) + (first.reconfirm_token.endsWith('A') ? 'B' : 'A');
+      const tampered = promoteCaseSource(getAdapter(), {
+        case_id: 'case-promote-tampered',
+        source_type: 'decision',
+        source_id: 'dec-tampered',
+        promoted_by: 'user:test',
+        reason: 'needs reconfirm',
+        expected_current_value_json: canonicalizeJSON({
+          promotion: { canonical_decision_id: 'dec-old', canonical_event_id: null },
+        }),
+        reconfirm_token: token,
+        session_id: 'turn-promote',
+        now: '2026-04-18T01:05:00.000Z',
+      });
+
+      expect(tampered.kind).toBe('requires_reconfirm');
     } finally {
       if (previousSecret === undefined) {
         delete process.env.MAMA_RECONFIRM_TOKEN_SECRET;

--- a/packages/mama-core/tests/cases/case-correction-supersede.test.ts
+++ b/packages/mama-core/tests/cases/case-correction-supersede.test.ts
@@ -1,0 +1,644 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { getAdapter } from '../../src/db-manager.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import { applyCorrection, supersedeCorrection } from '../../src/cases/corrections.js';
+
+const CASE_ID = '11111111-1111-4111-8111-111111111111';
+const ENTITY_ID = 'entity_supersede';
+const NOW = '2026-04-18T04:00:00.000Z';
+
+function insertCase(status: string = 'active'): void {
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO case_truth (
+          case_id, current_wiki_path, title, status, primary_actors,
+          compiled_at, created_at, updated_at
+        )
+        VALUES (?, 'cases/s.md', 'Supersede Case', ?, ?, ?, ?, ?)
+      `
+    )
+    .run(CASE_ID, status, JSON.stringify([{ entity_id: ENTITY_ID, role: 'owner' }]), NOW, NOW, NOW);
+}
+
+function resetTables(): void {
+  const adapter = getAdapter();
+  adapter.prepare('DELETE FROM memory_events').run();
+  adapter.prepare('DELETE FROM case_corrections').run();
+  adapter.prepare('DELETE FROM case_memberships').run();
+  adapter.prepare('DELETE FROM case_truth').run();
+}
+
+function applyInitialCorrection(): string {
+  const result = applyCorrection(getAdapter(), {
+    case_id: CASE_ID,
+    target_kind: 'case_field',
+    target_ref: { kind: 'case_field', field: 'status_reason' },
+    field_name: 'status_reason',
+    old_value_json: null,
+    new_value_json: JSON.stringify('blocked on CI'),
+    reason: 'Initial user correction',
+    confirmed: true,
+    confirmed_by: 'user-1',
+    confirmation_summary: 'Confirmed status_reason correction',
+    now: NOW,
+  });
+  if (result.kind !== 'applied') {
+    throw new Error(`expected applied, got ${result.kind}`);
+  }
+  return result.correction_id;
+}
+
+const RECONFIRM_SECRET = 'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+
+describe('Phase 2b Task — supersedeCorrection (spec amendment-8 unblocked)', () => {
+  let testDbPath = '';
+  const originalSecret = process.env.MAMA_RECONFIRM_TOKEN_SECRET;
+
+  beforeAll(async () => {
+    process.env.MAMA_FORCE_TIER_3 = 'true';
+    process.env.MAMA_RECONFIRM_TOKEN_SECRET = RECONFIRM_SECRET;
+    testDbPath = await initTestDB('case-correction-supersede');
+  });
+
+  beforeEach(() => {
+    resetTables();
+    insertCase();
+  });
+
+  afterAll(async () => {
+    if (originalSecret === undefined) {
+      delete process.env.MAMA_RECONFIRM_TOKEN_SECRET;
+    } else {
+      process.env.MAMA_RECONFIRM_TOKEN_SECRET = originalSecret;
+    }
+    await cleanupTestDB(testDbPath);
+  });
+
+  it('INSERTs new row, sets OLD.superseded_by + is_lock_active=0 atomically', () => {
+    const oldId = applyInitialCorrection();
+
+    const result = supersedeCorrection(getAdapter(), {
+      old_correction_id: oldId,
+      new_value_json: JSON.stringify('still blocked on legal'),
+      reason: 'User revised blocker',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 'User changed their mind on blocker reason',
+      now: NOW,
+    });
+
+    expect(result.kind).toBe('superseded');
+    if (result.kind !== 'superseded') return;
+
+    const rows = getAdapter()
+      .prepare(
+        'SELECT correction_id, is_lock_active, reverted_at, superseded_by FROM case_corrections ORDER BY applied_at'
+      )
+      .all() as Array<{
+      correction_id: string;
+      is_lock_active: number;
+      reverted_at: string | null;
+      superseded_by: string | null;
+    }>;
+
+    expect(rows).toHaveLength(2);
+    const old = rows.find((r) => r.correction_id === oldId);
+    const fresh = rows.find((r) => r.correction_id === result.new_correction_id);
+    expect(old).toMatchObject({
+      is_lock_active: 0,
+      reverted_at: null,
+      superseded_by: result.new_correction_id,
+    });
+    expect(fresh).toMatchObject({
+      is_lock_active: 1,
+      reverted_at: null,
+      superseded_by: null,
+    });
+  });
+
+  it('emits case.correction_superseded memory_event with predecessor linkage', () => {
+    const oldId = applyInitialCorrection();
+    const result = supersedeCorrection(getAdapter(), {
+      old_correction_id: oldId,
+      new_value_json: JSON.stringify('now resolved'),
+      reason: 'User resolved the blocker',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 'Resolved',
+      now: NOW,
+    });
+
+    if (result.kind !== 'superseded') throw new Error('expected superseded');
+
+    const events = getAdapter()
+      .prepare(
+        "SELECT event_type, reason, evidence_refs FROM memory_events WHERE event_type = 'case.correction_superseded'"
+      )
+      .all() as Array<{ event_type: string; reason: string; evidence_refs: string }>;
+
+    expect(events).toHaveLength(1);
+    const refs = JSON.parse(events[0].evidence_refs);
+    expect(refs).toContain(result.new_correction_id);
+    expect(refs).toContain(oldId);
+  });
+
+  it('rejects supersede on already-superseded correction', () => {
+    const oldId = applyInitialCorrection();
+    supersedeCorrection(getAdapter(), {
+      old_correction_id: oldId,
+      new_value_json: JSON.stringify('revision 1'),
+      reason: 'first revision',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 'rev1',
+      now: NOW,
+    });
+
+    const second = supersedeCorrection(getAdapter(), {
+      old_correction_id: oldId,
+      new_value_json: JSON.stringify('revision 2'),
+      reason: 'second revision',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 'rev2',
+      now: NOW,
+    });
+
+    expect(second).toMatchObject({
+      kind: 'rejected',
+      code: 'case.correction_already_superseded',
+    });
+  });
+
+  it('rejects supersede on reverted correction', () => {
+    const oldId = applyInitialCorrection();
+    getAdapter()
+      .prepare(
+        'UPDATE case_corrections SET reverted_at = ?, is_lock_active = 0 WHERE correction_id = ?'
+      )
+      .run(NOW, oldId);
+
+    const result = supersedeCorrection(getAdapter(), {
+      old_correction_id: oldId,
+      new_value_json: JSON.stringify('too late'),
+      reason: 'late attempt',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 'late',
+      now: NOW,
+    });
+
+    expect(result).toMatchObject({
+      kind: 'rejected',
+      code: 'case.correction_reverted',
+    });
+  });
+
+  it('rejects supersede on missing correction_id', () => {
+    const result = supersedeCorrection(getAdapter(), {
+      old_correction_id: '00000000-0000-0000-0000-000000000000',
+      new_value_json: JSON.stringify('x'),
+      reason: 'r',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 's',
+      now: NOW,
+    });
+
+    expect(result).toMatchObject({
+      kind: 'rejected',
+      code: 'case.correction_not_found',
+    });
+  });
+
+  it('mutates live case_truth.status_reason to the new value (P1-1 fix)', () => {
+    const oldId = applyInitialCorrection();
+
+    // Sanity: applyCorrection already wrote 'blocked on CI' to case_truth.status_reason
+    const before = getAdapter()
+      .prepare('SELECT status_reason FROM case_truth WHERE case_id = ?')
+      .get(CASE_ID) as { status_reason: string | null };
+    expect(before.status_reason).toBe('blocked on CI');
+
+    const result = supersedeCorrection(getAdapter(), {
+      old_correction_id: oldId,
+      new_value_json: JSON.stringify('still blocked on legal'),
+      reason: 'User revised blocker',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 'User changed their mind on blocker reason',
+      now: NOW,
+    });
+    expect(result.kind).toBe('superseded');
+
+    // After supersede, the live target must reflect the revised value.
+    const after = getAdapter()
+      .prepare('SELECT status_reason FROM case_truth WHERE case_id = ?')
+      .get(CASE_ID) as { status_reason: string | null };
+    expect(after.status_reason).toBe('still blocked on legal');
+  });
+
+  it('new superseded row preserves the pre-mutation current value as old_value_json (P1-1 fix)', () => {
+    const oldId = applyInitialCorrection();
+    const result = supersedeCorrection(getAdapter(), {
+      old_correction_id: oldId,
+      new_value_json: JSON.stringify('replan'),
+      reason: 'Revised',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 'revised',
+      now: NOW,
+    });
+    if (result.kind !== 'superseded') throw new Error('expected superseded');
+
+    const newRow = getAdapter()
+      .prepare(
+        'SELECT old_value_json, new_value_json FROM case_corrections WHERE correction_id = ?'
+      )
+      .get(result.new_correction_id) as { old_value_json: string | null; new_value_json: string };
+
+    // old_value_json must snapshot the value that was live BEFORE supersede
+    // (i.e., what applyCorrection had written: 'blocked on CI'). NULL loses
+    // the snapshot and breaks audit / rollback reasoning.
+    expect(newRow.old_value_json).toBe(JSON.stringify('blocked on CI'));
+    expect(newRow.new_value_json).toBe(JSON.stringify('replan'));
+  });
+
+  it('returns requires_reconfirm when expected_current_value_json disagrees with live value (P2-1 fix)', () => {
+    const oldId = applyInitialCorrection();
+
+    // Simulate drift: someone (e.g. another sub-agent) wrote the live
+    // case_truth.status_reason after the user opened the drawer.
+    getAdapter()
+      .prepare('UPDATE case_truth SET status_reason = ? WHERE case_id = ?')
+      .run('drifted by another writer', CASE_ID);
+
+    const result = supersedeCorrection(getAdapter(), {
+      old_correction_id: oldId,
+      new_value_json: JSON.stringify('user intended revision'),
+      reason: 'User revised blocker',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 'revised',
+      expected_current_value_json: JSON.stringify('blocked on CI'),
+      session_id: 'session-1',
+      now: NOW,
+    });
+
+    expect(result.kind).toBe('requires_reconfirm');
+    if (result.kind !== 'requires_reconfirm') return;
+    expect(result.code).toBe('case.correction_requires_reconfirm');
+    expect(result.current_value_json).toBe('"drifted by another writer"');
+    expect(result.proposed_new_value_json).toBe('"user intended revision"');
+    expect(typeof result.reconfirm_token).toBe('string');
+  });
+
+  it('applies supersede on retry with the exact reconfirm token (P2-1 fix)', () => {
+    const oldId = applyInitialCorrection();
+    // Live state is 'blocked on CI' (written by applyInitialCorrection). Drift
+    // another writer's value so CAS is triggered by `expected != live`.
+    getAdapter()
+      .prepare('UPDATE case_truth SET status_reason = ? WHERE case_id = ?')
+      .run('drifted', CASE_ID);
+
+    const stale = supersedeCorrection(getAdapter(), {
+      old_correction_id: oldId,
+      new_value_json: JSON.stringify('revision'),
+      reason: 'r',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 's',
+      expected_current_value_json: JSON.stringify('blocked on CI'),
+      session_id: 'sess',
+      now: NOW,
+    });
+    if (stale.kind !== 'requires_reconfirm') throw new Error('expected drift');
+
+    // Retry with the same expected (still mismatches live 'drifted') and the
+    // token — this keeps CAS triggered so the token path is exercised.
+    const retry = supersedeCorrection(getAdapter(), {
+      old_correction_id: oldId,
+      new_value_json: JSON.stringify('revision'),
+      reason: 'r',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 's',
+      expected_current_value_json: JSON.stringify('blocked on CI'),
+      reconfirm_token: stale.reconfirm_token,
+      session_id: 'sess',
+      now: NOW,
+    });
+
+    expect(retry.kind).toBe('superseded');
+    if (retry.kind !== 'superseded') return;
+
+    const after = getAdapter()
+      .prepare('SELECT status_reason FROM case_truth WHERE case_id = ?')
+      .get(CASE_ID) as { status_reason: string };
+    expect(after.status_reason).toBe('revision');
+  });
+
+  it('rejects replay of consumed reconfirm token on supersede (P2-1 fix)', () => {
+    const oldId = applyInitialCorrection();
+    getAdapter()
+      .prepare('UPDATE case_truth SET status_reason = ? WHERE case_id = ?')
+      .run('drifted', CASE_ID);
+
+    const stale = supersedeCorrection(getAdapter(), {
+      old_correction_id: oldId,
+      new_value_json: JSON.stringify('revision'),
+      reason: 'r',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 's',
+      expected_current_value_json: JSON.stringify('blocked on CI'),
+      session_id: 'sess',
+      now: NOW,
+    });
+    if (stale.kind !== 'requires_reconfirm') throw new Error('expected drift');
+
+    const firstRetry = supersedeCorrection(getAdapter(), {
+      old_correction_id: oldId,
+      new_value_json: JSON.stringify('revision'),
+      reason: 'r',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 's',
+      expected_current_value_json: JSON.stringify('blocked on CI'),
+      reconfirm_token: stale.reconfirm_token,
+      session_id: 'sess',
+      now: NOW,
+    });
+    expect(firstRetry.kind).toBe('superseded');
+    if (firstRetry.kind !== 'superseded') return;
+
+    // Replay: token already burned by firstRetry. Passing it again with an
+    // expected that still triggers CAS must reject BEFORE any row writes.
+    const replay = supersedeCorrection(getAdapter(), {
+      old_correction_id: firstRetry.new_correction_id,
+      new_value_json: JSON.stringify('revision'),
+      reason: 'r',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 's',
+      expected_current_value_json: JSON.stringify('blocked on CI'),
+      reconfirm_token: stale.reconfirm_token,
+      session_id: 'sess',
+      now: NOW,
+    });
+
+    expect(replay).toMatchObject({
+      kind: 'rejected',
+      code: 'case.reconfirm_token_replayed',
+    });
+  });
+
+  it('supersede on membership target mutates case_memberships live state (review P3-5)', () => {
+    const applyResult = applyCorrection(getAdapter(), {
+      case_id: CASE_ID,
+      target_kind: 'membership',
+      target_ref: { kind: 'membership', source_type: 'decision', source_id: 'dec-mem-1' },
+      old_value_json: null,
+      new_value_json: JSON.stringify({
+        status: 'active',
+        role: 'supporting',
+        confidence: 0.8,
+        reason: 'user-included',
+      }),
+      reason: 'user-included',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 'inc',
+      now: NOW,
+    });
+    if (applyResult.kind !== 'applied') throw new Error('apply failed');
+
+    // Supersede the membership correction: flip status to removed.
+    const result = supersedeCorrection(getAdapter(), {
+      old_correction_id: applyResult.correction_id,
+      new_value_json: JSON.stringify({ status: 'removed' }),
+      reason: 'user-changed-mind',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 'removed',
+      now: NOW,
+    });
+    expect(result.kind).toBe('superseded');
+
+    // Live case_memberships row must reflect the superseded value.
+    const row = getAdapter()
+      .prepare(
+        `
+          SELECT status, user_locked, added_by
+          FROM case_memberships
+          WHERE case_id = ? AND source_type = 'decision' AND source_id = 'dec-mem-1'
+        `
+      )
+      .get(CASE_ID) as { status: string; user_locked: number; added_by: string };
+    expect(row).toMatchObject({ status: 'removed', user_locked: 1, added_by: 'user-correction' });
+  });
+
+  it('supersede on wiki_section target is overlay-only (no DB mutation path) (review P3-5)', () => {
+    const targetRefJson = JSON.stringify({ kind: 'wiki_section', section_heading: 'Blockers' });
+    const correctionId = 'corr-wiki-1';
+    // Seed a wiki_section correction directly.
+    getAdapter()
+      .prepare(
+        `
+          INSERT INTO case_corrections (
+            correction_id, case_id, target_kind, target_ref_json, target_ref_hash,
+            field_name, old_value_json, new_value_json, reason, is_lock_active,
+            superseded_by, reverted_at, applied_by, applied_at
+          )
+          VALUES (?, ?, 'wiki_section', ?, ?, NULL, ?, ?, 'seed', 1, NULL, NULL, 'user-1', ?)
+        `
+      )
+      .run(
+        correctionId,
+        CASE_ID,
+        targetRefJson,
+        require('node:crypto').createHash('sha256').update(targetRefJson).digest(),
+        JSON.stringify('old narrative'),
+        JSON.stringify('new narrative'),
+        NOW
+      );
+
+    const result = supersedeCorrection(getAdapter(), {
+      old_correction_id: correctionId,
+      new_value_json: JSON.stringify('revised narrative'),
+      reason: 'r',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 's',
+      now: NOW,
+    });
+    expect(result.kind).toBe('superseded');
+
+    // Overlay semantics: the NEW row carries the revised narrative but no
+    // live case_truth mutation occurs (wiki sections aren't DB-backed here).
+    const rows = getAdapter()
+      .prepare(
+        'SELECT correction_id, target_kind, is_lock_active, superseded_by FROM case_corrections ORDER BY applied_at'
+      )
+      .all() as Array<{
+      correction_id: string;
+      target_kind: string;
+      is_lock_active: number;
+      superseded_by: string | null;
+    }>;
+    expect(rows).toHaveLength(2);
+    const newRow = rows.find((r) => r.correction_id !== correctionId);
+    expect(newRow).toMatchObject({ target_kind: 'wiki_section', is_lock_active: 1 });
+  });
+
+  // Note: "case_truth deleted mid-flight" is prevented at the schema layer
+  // by the FK on case_corrections.case_id → case_truth.case_id. The
+  // precompile_gap branch in supersedeCorrection is defensive and
+  // intentionally unreachable under normal FK enforcement.
+
+  it('canonicalizes expected_current_value_json before CAS comparison (review P2-3)', () => {
+    const oldId = applyInitialCorrection();
+    // Live status_reason is "blocked on CI". Passing the same value with
+    // extra whitespace must NOT trigger bogus CAS drift.
+    const result = supersedeCorrection(getAdapter(), {
+      old_correction_id: oldId,
+      new_value_json: JSON.stringify('revision'),
+      reason: 'r',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 's',
+      expected_current_value_json: '  "blocked on CI"  ',
+      session_id: 'sess',
+      now: NOW,
+    });
+    expect(result.kind).toBe('superseded');
+  });
+
+  it('rejects supersede when case_truth is in terminal status (case_field target) (review P1-1)', () => {
+    const oldId = applyInitialCorrection();
+    // Mark the case as merged post-apply — simulates case merged into a
+    // survivor AFTER the original correction landed.
+    getAdapter().prepare("UPDATE case_truth SET status = 'merged' WHERE case_id = ?").run(CASE_ID);
+
+    const result = supersedeCorrection(getAdapter(), {
+      old_correction_id: oldId,
+      new_value_json: JSON.stringify('revision'),
+      reason: 'r',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 's',
+      now: NOW,
+    });
+
+    expect(result).toMatchObject({
+      kind: 'rejected',
+      code: 'case.terminal_status',
+    });
+    // No new row, no memory event, OLD row still locked.
+    const rows = getAdapter()
+      .prepare('SELECT correction_id, is_lock_active, superseded_by FROM case_corrections')
+      .all() as Array<{
+      correction_id: string;
+      is_lock_active: number;
+      superseded_by: string | null;
+    }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ is_lock_active: 1, superseded_by: null });
+    const events = getAdapter()
+      .prepare(
+        "SELECT COUNT(*) AS c FROM memory_events WHERE event_type = 'case.correction_superseded'"
+      )
+      .get() as { c: number };
+    expect(events.c).toBe(0);
+  });
+
+  it('rejects supersede when case_truth is terminal (membership target) (review P1-1)', () => {
+    // Seed a membership correction.
+    const applyResult = applyCorrection(getAdapter(), {
+      case_id: CASE_ID,
+      target_kind: 'membership',
+      target_ref: { kind: 'membership', source_type: 'decision', source_id: 'dec-1' },
+      old_value_json: null,
+      new_value_json: JSON.stringify({
+        status: 'active',
+        role: 'supporting',
+        confidence: 0.9,
+        reason: 'included by user',
+      }),
+      reason: 'user-included',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 'inc',
+      now: NOW,
+    });
+    if (applyResult.kind !== 'applied') throw new Error('seed failed');
+
+    getAdapter()
+      .prepare("UPDATE case_truth SET status = 'archived' WHERE case_id = ?")
+      .run(CASE_ID);
+
+    const result = supersedeCorrection(getAdapter(), {
+      old_correction_id: applyResult.correction_id,
+      new_value_json: JSON.stringify({ status: 'removed' }),
+      reason: 'r',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 's',
+      now: NOW,
+    });
+
+    expect(result).toMatchObject({
+      kind: 'rejected',
+      code: 'case.terminal_status',
+    });
+  });
+
+  it('supersede chain: new correction can itself be superseded', () => {
+    const old1 = applyInitialCorrection();
+    const s1 = supersedeCorrection(getAdapter(), {
+      old_correction_id: old1,
+      new_value_json: JSON.stringify('mid'),
+      reason: 'first supersede',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 'mid',
+      now: NOW,
+    });
+    if (s1.kind !== 'superseded') throw new Error('s1 failed');
+
+    const s2 = supersedeCorrection(getAdapter(), {
+      old_correction_id: s1.new_correction_id,
+      new_value_json: JSON.stringify('final'),
+      reason: 'second supersede',
+      confirmed: true,
+      confirmed_by: 'user-1',
+      confirmation_summary: 'final',
+      now: NOW,
+    });
+    expect(s2.kind).toBe('superseded');
+    if (s2.kind !== 'superseded') return;
+
+    // Verify chain: old1 → s1.new → s2.new
+    const rows = getAdapter()
+      .prepare('SELECT correction_id, is_lock_active, superseded_by FROM case_corrections')
+      .all() as Array<{
+      correction_id: string;
+      is_lock_active: number;
+      superseded_by: string | null;
+    }>;
+
+    expect(rows).toHaveLength(3);
+    const map = new Map(rows.map((r) => [r.correction_id, r]));
+    expect(map.get(old1)).toMatchObject({ is_lock_active: 0, superseded_by: s1.new_correction_id });
+    expect(map.get(s1.new_correction_id)).toMatchObject({
+      is_lock_active: 0,
+      superseded_by: s2.new_correction_id,
+    });
+    expect(map.get(s2.new_correction_id)).toMatchObject({
+      is_lock_active: 1,
+      superseded_by: null,
+    });
+  });
+});

--- a/packages/mama-core/tests/cases/case-corrections-schema.test.ts
+++ b/packages/mama-core/tests/cases/case-corrections-schema.test.ts
@@ -1,0 +1,195 @@
+import { createHash } from 'node:crypto';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import { getAdapter } from '../../src/db-manager.js';
+
+function seedCase(caseId: string, title = 'Seed case'): void {
+  const adapter = getAdapter();
+  const now = new Date().toISOString();
+  adapter
+    .prepare(
+      `INSERT INTO case_truth (case_id, title, created_at, updated_at)
+       VALUES (?, ?, ?, ?)`
+    )
+    .run(caseId, title, now, now);
+}
+
+function sha256(s: string): Buffer {
+  return createHash('sha256').update(s, 'utf8').digest();
+}
+
+function insertCorrection(
+  overrides: Partial<{
+    correction_id: string;
+    case_id: string;
+    target_kind: string;
+    target_ref_json: string;
+    target_ref_hash: Buffer;
+    field_name: string | null;
+    old_value_json: string | null;
+    new_value_json: string;
+    reason: string;
+    is_lock_active: number;
+    reverted_at: string | null;
+    applied_by: string;
+  }> = {}
+): void {
+  const adapter = getAdapter();
+  const now = new Date().toISOString();
+  const target_ref_json = overrides.target_ref_json ?? '{"field":"status"}';
+  const params = {
+    correction_id: overrides.correction_id ?? `corr-${Math.random().toString(16).slice(2, 10)}`,
+    case_id: overrides.case_id ?? '00000000-0000-0000-0000-0000000000C0',
+    target_kind: overrides.target_kind ?? 'case_field',
+    target_ref_json,
+    target_ref_hash: overrides.target_ref_hash ?? sha256(target_ref_json),
+    field_name: overrides.field_name ?? 'status',
+    old_value_json: overrides.old_value_json ?? null,
+    new_value_json: overrides.new_value_json ?? '"blocked"',
+    reason: overrides.reason ?? 'user-intent',
+    is_lock_active: overrides.is_lock_active ?? 1,
+    reverted_at: overrides.reverted_at ?? null,
+    applied_by: overrides.applied_by ?? 'user',
+  };
+  adapter
+    .prepare(
+      `INSERT INTO case_corrections
+         (correction_id, case_id, target_kind, target_ref_json, target_ref_hash,
+          field_name, old_value_json, new_value_json, reason, is_lock_active,
+          reverted_at, applied_by, applied_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .run(
+      params.correction_id,
+      params.case_id,
+      params.target_kind,
+      params.target_ref_json,
+      params.target_ref_hash,
+      params.field_name,
+      params.old_value_json,
+      params.new_value_json,
+      params.reason,
+      params.is_lock_active,
+      params.reverted_at,
+      params.applied_by,
+      now
+    );
+}
+
+describe('case-first substrate — case_corrections schema', () => {
+  let testDbPath = '';
+  const caseA = '00000000-0000-0000-0000-0000000000C0';
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('case-corrections-schema');
+    seedCase(caseA);
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  it('creates the case_corrections table', () => {
+    const adapter = getAdapter();
+    const row = adapter
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='case_corrections'")
+      .get() as { name?: string } | undefined;
+    expect(row?.name).toBe('case_corrections');
+  });
+
+  it('has target_ref_json and target_ref_hash columns', () => {
+    const adapter = getAdapter();
+    const cols = adapter.prepare('PRAGMA table_info(case_corrections)').all() as Array<{
+      name: string;
+      type: string;
+    }>;
+    const json = cols.find((c) => c.name === 'target_ref_json')!;
+    const hash = cols.find((c) => c.name === 'target_ref_hash')!;
+    expect(json.type).toBe('TEXT');
+    expect(hash.type).toBe('BLOB');
+  });
+
+  it('rejects target_ref_hash that is not exactly 32 bytes', () => {
+    expect(() => insertCorrection({ target_ref_hash: Buffer.from('short') })).toThrow(
+      /CHECK constraint/i
+    );
+    expect(() => insertCorrection({ target_ref_hash: Buffer.alloc(64) })).toThrow(
+      /CHECK constraint/i
+    );
+  });
+
+  it('rejects NULL on target_kind', () => {
+    const adapter = getAdapter();
+    const target_ref_json = '{"field":"status"}';
+    expect(() =>
+      adapter
+        .prepare(
+          `INSERT INTO case_corrections
+             (correction_id, case_id, target_kind, target_ref_json, target_ref_hash,
+              new_value_json, reason, applied_by, applied_at)
+           VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          'corr-null-kind',
+          caseA,
+          target_ref_json,
+          sha256(target_ref_json),
+          '"blocked"',
+          'r',
+          'user',
+          new Date().toISOString()
+        )
+    ).toThrow(/NOT NULL constraint/i);
+  });
+
+  it('partial UNIQUE: active duplicate target_ref_hash for the same case is rejected', () => {
+    const ref = '{"field":"status"}';
+    const hash = sha256(ref);
+    insertCorrection({
+      correction_id: 'corr-active-1',
+      target_ref_json: ref,
+      target_ref_hash: hash,
+      is_lock_active: 1,
+    });
+    expect(() =>
+      insertCorrection({
+        correction_id: 'corr-active-2',
+        target_ref_json: ref,
+        target_ref_hash: hash,
+        is_lock_active: 1,
+      })
+    ).toThrow(/UNIQUE constraint/i);
+  });
+
+  it('partial UNIQUE: reverted or inactive duplicate target_ref_hash is ALLOWED', () => {
+    const ref = '{"field":"last_activity_at"}';
+    const hash = sha256(ref);
+    insertCorrection({
+      correction_id: 'corr-inactive-orig',
+      target_ref_json: ref,
+      target_ref_hash: hash,
+      is_lock_active: 0,
+    });
+    // A second row with the same hash is allowed because neither is active
+    expect(() =>
+      insertCorrection({
+        correction_id: 'corr-inactive-dup',
+        target_ref_json: ref,
+        target_ref_hash: hash,
+        is_lock_active: 0,
+      })
+    ).not.toThrow();
+    // A reverted row with the same hash is also allowed (active=1 but reverted_at set)
+    expect(() =>
+      insertCorrection({
+        correction_id: 'corr-reverted',
+        target_ref_json: ref,
+        target_ref_hash: hash,
+        is_lock_active: 1,
+        reverted_at: new Date().toISOString(),
+      })
+    ).not.toThrow();
+  });
+
+});

--- a/packages/mama-core/tests/cases/case-corrections-write-flow.test.ts
+++ b/packages/mama-core/tests/cases/case-corrections-write-flow.test.ts
@@ -205,7 +205,7 @@ describe('Phase 2 case correction write flows', () => {
     expect(envelope.signature_hex).toMatch(/^[0-9a-f]+$/);
   });
 
-  it('applies after reconfirm, rejects replay before mutation, and reverts without restoring truth', () => {
+  it('applies after reconfirm, rejects replay before mutation, and reverts by restoring truth', () => {
     insertCase({ case_id: 'case-reconfirm', status: 'active' });
 
     const reconfirm = applyStatusCorrection({
@@ -281,7 +281,7 @@ describe('Phase 2 case correction write flows', () => {
     const afterRevert = getAdapter()
       .prepare('SELECT status FROM case_truth WHERE case_id = ?')
       .get('case-reconfirm') as { status: string };
-    expect(afterRevert.status).toBe('blocked');
+    expect(afterRevert.status).toBe('active');
 
     const events = getAdapter()
       .prepare('SELECT event_type FROM memory_events ORDER BY created_at ASC')
@@ -311,6 +311,35 @@ describe('Phase 2 case correction write flows', () => {
       kind: 'rejected',
       code: 'case.correction_active_conflict',
     });
+  });
+
+  it('accepts numeric confidence case-field corrections', () => {
+    insertCase({
+      case_id: 'case-confidence',
+      status: 'active',
+      confidence: '0.4',
+    });
+
+    const applied = applyCorrection(getAdapter(), {
+      case_id: 'case-confidence',
+      target_kind: 'case_field',
+      field_name: 'confidence',
+      target_ref: { kind: 'case_field', field: 'confidence' },
+      old_value_json: canonicalizeJSON(0.4),
+      new_value_json: canonicalizeJSON(0.8),
+      reason: 'raise confidence',
+      confirmed: true,
+      confirmed_by: 'user:test',
+      confirmation_summary: 'raise confidence to numeric value',
+      now: '2026-04-18T01:20:00.000Z',
+    });
+
+    expect(applied).toMatchObject({ kind: 'applied' });
+
+    const row = getAdapter()
+      .prepare('SELECT confidence FROM case_truth WHERE case_id = ?')
+      .get('case-confidence') as { confidence: string | null };
+    expect(row.confidence).toBe('0.8');
   });
 
   it('rejects active corrections against archived and merged cases', () => {

--- a/packages/mama-core/tests/cases/case-corrections-write-flow.test.ts
+++ b/packages/mama-core/tests/cases/case-corrections-write-flow.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import { canonicalizeJSON } from '../../src/canonicalize.js';
@@ -203,6 +205,48 @@ describe('Phase 2 case correction write flows', () => {
     expect(typeof envelope.kid).toBe('string');
     expect(envelope.kid).toBe(envelope.payload.kid);
     expect(envelope.signature_hex).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it('derives reconfirm token kid from explicitly prefixed secrets', () => {
+    insertCase({ case_id: 'case-prefixed-secret', status: 'active' });
+
+    const rawSecret = '0123456789abcdef0123456789abcdef';
+    const expectedKid = createHash('sha256')
+      .update(Buffer.from(rawSecret, 'utf8'))
+      .digest('hex')
+      .slice(0, 16);
+    const previous = process.env.MAMA_RECONFIRM_TOKEN_SECRET;
+    const prefixedSecrets = [
+      `utf8:${rawSecret}`,
+      `hex:${Buffer.from(rawSecret, 'utf8').toString('hex')}`,
+      `base64:${Buffer.from(rawSecret, 'utf8').toString('base64')}`,
+    ];
+
+    try {
+      for (const secret of prefixedSecrets) {
+        process.env.MAMA_RECONFIRM_TOKEN_SECRET = secret;
+        const result = applyStatusCorrection({
+          case_id: 'case-prefixed-secret',
+          old_value_json: canonicalizeJSON('stale'),
+          new_value_json: canonicalizeJSON('blocked'),
+        });
+
+        expect(result.kind).toBe('requires_reconfirm');
+        if (result.kind !== 'requires_reconfirm') {
+          throw new Error('Expected reconfirm result');
+        }
+
+        const envelope = decodeToken(result.reconfirm_token);
+        expect(envelope.kid).toBe(expectedKid);
+        expect(envelope.payload.kid).toBe(expectedKid);
+      }
+    } finally {
+      if (previous === undefined) {
+        delete process.env.MAMA_RECONFIRM_TOKEN_SECRET;
+      } else {
+        process.env.MAMA_RECONFIRM_TOKEN_SECRET = previous;
+      }
+    }
   });
 
   it('canonicalizes old_value_json before deciding requires_reconfirm for membership targets', () => {

--- a/packages/mama-core/tests/cases/case-corrections-write-flow.test.ts
+++ b/packages/mama-core/tests/cases/case-corrections-write-flow.test.ts
@@ -205,6 +205,42 @@ describe('Phase 2 case correction write flows', () => {
     expect(envelope.signature_hex).toMatch(/^[0-9a-f]+$/);
   });
 
+  it('canonicalizes old_value_json before deciding requires_reconfirm for membership targets', () => {
+    insertCase({ case_id: 'case-membership-cas', status: 'active' });
+    insertMembership({
+      case_id: 'case-membership-cas',
+      source_type: 'decision',
+      source_id: 'dec-membership-cas',
+      status: 'active',
+      role: 'owner',
+      confidence: 0.6,
+      reason: 'existing',
+      user_locked: 0,
+    });
+
+    const result = applyCorrection(getAdapter(), {
+      case_id: 'case-membership-cas',
+      target_kind: 'membership',
+      target_ref: buildMembershipTargetRef('decision', 'dec-membership-cas'),
+      old_value_json:
+        '{"user_locked":0,"reason":"existing","confidence":0.6,"role":"owner","status":"active"}',
+      new_value_json: canonicalizeJSON({
+        status: 'removed',
+        role: 'owner',
+        confidence: 0.6,
+        reason: 'existing',
+        user_locked: 0,
+      }),
+      reason: 'remove membership',
+      confirmed: true,
+      confirmed_by: 'user:test',
+      confirmation_summary: 'remove membership',
+      now: '2026-04-18T01:00:00.000Z',
+    });
+
+    expect(result).toMatchObject({ kind: 'applied' });
+  });
+
   it('applies after reconfirm, rejects replay before mutation, and reverts by restoring truth', () => {
     insertCase({ case_id: 'case-reconfirm', status: 'active' });
 
@@ -310,6 +346,39 @@ describe('Phase 2 case correction write flows', () => {
     expect(second).toMatchObject({
       kind: 'rejected',
       code: 'case.correction_active_conflict',
+    });
+  });
+
+  it('rejects revert on merged cases with a terminal-status result instead of throwing', () => {
+    insertCase({ case_id: 'case-revert-merged', status: 'active' });
+    insertCase({ case_id: 'case-survivor', status: 'active' });
+
+    const applied = applyStatusCorrection({
+      case_id: 'case-revert-merged',
+      old_value_json: canonicalizeJSON('active'),
+      new_value_json: canonicalizeJSON('blocked'),
+    });
+    expect(applied.kind).toBe('applied');
+    if (applied.kind !== 'applied') {
+      throw new Error('Expected correction to apply');
+    }
+
+    getAdapter()
+      .prepare(`UPDATE case_truth SET status = 'merged', canonical_case_id = ? WHERE case_id = ?`)
+      .run('case-survivor', 'case-revert-merged');
+
+    const reverted = revertCorrection(getAdapter(), {
+      correction_id: applied.correction_id,
+      confirmed: true,
+      confirmed_by: 'user:test',
+      confirmation_summary: 'attempt revert on merged case',
+      now: '2026-04-18T01:10:00.000Z',
+    });
+
+    expect(reverted).toMatchObject({
+      kind: 'rejected',
+      code: 'case.terminal_status',
+      case_id: 'case-revert-merged',
     });
   });
 

--- a/packages/mama-core/tests/cases/case-corrections-write-flow.test.ts
+++ b/packages/mama-core/tests/cases/case-corrections-write-flow.test.ts
@@ -612,6 +612,60 @@ describe('Phase 2 case correction write flows', () => {
     });
   });
 
+  it('reverting a membership insertion with no prior row restores the target to removed state', () => {
+    insertCase({ case_id: 'case-membership-revert-missing' });
+
+    const applied = applyCorrection(getAdapter(), {
+      case_id: 'case-membership-revert-missing',
+      target_kind: 'membership',
+      target_ref: buildMembershipTargetRef('decision', 'dec-revert-missing'),
+      new_value_json: canonicalizeJSON({
+        status: 'active',
+        role: 'primary',
+        confidence: 0.91,
+        reason: 'user said this is the key source',
+      }),
+      reason: 'add source',
+      confirmed: true,
+      confirmed_by: 'user:test',
+      confirmation_summary: 'add source',
+      now: '2026-04-18T02:20:00.000Z',
+    });
+
+    expect(applied.kind).toBe('applied');
+    if (applied.kind !== 'applied') {
+      throw new Error('expected applied correction');
+    }
+
+    const reverted = revertCorrection(getAdapter(), {
+      correction_id: applied.correction_id,
+      confirmed_by: 'user:test',
+      confirmation_summary: 'undo source add',
+      now: '2026-04-18T02:25:00.000Z',
+    });
+
+    expect(reverted).toEqual({
+      kind: 'reverted',
+      correction_id: applied.correction_id,
+      case_id: 'case-membership-revert-missing',
+    });
+
+    const row = getAdapter()
+      .prepare(
+        `
+          SELECT status, user_locked, added_by
+          FROM case_memberships
+          WHERE case_id = ? AND source_type = 'decision' AND source_id = ?
+        `
+      )
+      .get('case-membership-revert-missing', 'dec-revert-missing') as {
+      status: string;
+      user_locked: number;
+      added_by: string;
+    };
+    expect(row).toEqual({ status: 'removed', user_locked: 1, added_by: 'user-correction' });
+  });
+
   it('wiki_section correction inserts a canonical lock row without mutating case_truth fields', () => {
     insertCase({ case_id: 'case-wiki-section', status_reason: 'before' });
     const target = canonicalTargetRef(buildWikiSectionTargetRef('## Status'));

--- a/packages/mama-core/tests/cases/case-corrections-write-flow.test.ts
+++ b/packages/mama-core/tests/cases/case-corrections-write-flow.test.ts
@@ -1,0 +1,555 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { canonicalizeJSON } from '../../src/canonicalize.js';
+import { getAdapter, type DatabaseAdapter } from '../../src/db-manager.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import {
+  applyCorrection,
+  insertCaseCorrectionLock,
+  revertCorrection,
+} from '../../src/cases/corrections.js';
+import {
+  buildCaseFieldTargetRef,
+  buildMembershipTargetRef,
+  buildWikiSectionTargetRef,
+  canonicalTargetRef,
+} from '../../src/cases/target-ref.js';
+
+function resetCaseTables(): void {
+  const adapter = getAdapter();
+  adapter.prepare('DELETE FROM memory_events').run();
+  adapter.prepare('DELETE FROM case_corrections').run();
+  adapter.prepare('DELETE FROM case_memberships').run();
+  adapter.prepare('DELETE FROM case_truth').run();
+}
+
+function insertCase(
+  overrides: Partial<{
+    case_id: string;
+    status: string;
+    title: string;
+    status_reason: string | null;
+    primary_actors: string | null;
+    blockers: string | null;
+    confidence: string | null;
+  }>
+): void {
+  const now = '2026-04-18T00:00:00.000Z';
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO case_truth (
+          case_id, current_wiki_path, title, status, status_reason, primary_actors,
+          blockers, confidence, created_at, updated_at
+        )
+        VALUES (?, NULL, ?, ?, ?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      overrides.case_id,
+      overrides.title ?? overrides.case_id,
+      overrides.status ?? 'active',
+      overrides.status_reason ?? null,
+      overrides.primary_actors ?? null,
+      overrides.blockers ?? null,
+      overrides.confidence ?? null,
+      now,
+      now
+    );
+}
+
+function insertMembership(input: {
+  case_id: string;
+  source_type?: 'decision' | 'event' | 'observation' | 'artifact';
+  source_id: string;
+  status?: string;
+  role?: string | null;
+  confidence?: number | null;
+  reason?: string | null;
+  user_locked?: 0 | 1;
+  added_by?: string;
+}): void {
+  const now = '2026-04-18T00:00:00.000Z';
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO case_memberships (
+          case_id, source_type, source_id, role, confidence, reason, status,
+          added_by, added_at, user_locked, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      input.case_id,
+      input.source_type ?? 'decision',
+      input.source_id,
+      input.role ?? null,
+      input.confidence ?? null,
+      input.reason ?? null,
+      input.status ?? 'active',
+      input.added_by ?? 'wiki-compiler',
+      now,
+      input.user_locked ?? 0,
+      now
+    );
+}
+
+function countRows(table: 'case_corrections' | 'case_memberships' | 'memory_events'): number {
+  const row = getAdapter().prepare(`SELECT COUNT(*) AS count FROM ${table}`).get() as {
+    count: number;
+  };
+  return row.count;
+}
+
+function decodeToken(token: string): {
+  kid: string;
+  payload: Record<string, unknown>;
+  signature_hex: string;
+} {
+  return JSON.parse(Buffer.from(token, 'base64url').toString('utf8')) as {
+    kid: string;
+    payload: Record<string, unknown>;
+    signature_hex: string;
+  };
+}
+
+function applyStatusCorrection(input: {
+  case_id: string;
+  old_value_json?: string | null;
+  reconfirm_token?: string | null;
+  new_value_json?: string;
+}) {
+  return applyCorrection(getAdapter(), {
+    case_id: input.case_id,
+    target_kind: 'case_field',
+    target_ref: buildCaseFieldTargetRef('status'),
+    field_name: 'status',
+    old_value_json: input.old_value_json,
+    reconfirm_token: input.reconfirm_token,
+    session_id: 'turn-1',
+    new_value_json: input.new_value_json ?? canonicalizeJSON('blocked'),
+    reason: 'status correction',
+    confirmed: true,
+    confirmed_by: 'user:test',
+    confirmation_summary: 'user confirmed status correction',
+    now: '2026-04-18T01:00:00.000Z',
+  });
+}
+
+describe('Phase 2 case correction write flows', () => {
+  let testDbPath = '';
+  const previousSecret = process.env.MAMA_RECONFIRM_TOKEN_SECRET;
+
+  beforeAll(async () => {
+    process.env.MAMA_FORCE_TIER_3 = 'true';
+    process.env.MAMA_RECONFIRM_TOKEN_SECRET = Buffer.alloc(32, 7).toString('hex');
+    testDbPath = await initTestDB('case-corrections-write-flow');
+  });
+
+  beforeEach(() => {
+    resetCaseTables();
+  });
+
+  afterAll(async () => {
+    if (previousSecret === undefined) {
+      delete process.env.MAMA_RECONFIRM_TOKEN_SECRET;
+    } else {
+      process.env.MAMA_RECONFIRM_TOKEN_SECRET = previousSecret;
+    }
+    await cleanupTestDB(testDbPath);
+  });
+
+  it('returns precompile_gap without inserting correction or audit rows', () => {
+    const result = applyStatusCorrection({ case_id: 'case-missing' });
+
+    expect(result).toEqual({
+      kind: 'precompile_gap',
+      code: 'case.precompile_gap',
+      case_id: 'case-missing',
+    });
+    expect(countRows('case_corrections')).toBe(0);
+    expect(countRows('memory_events')).toBe(0);
+  });
+
+  it('returns a bound reconfirm token on CAS mismatch without inserting a correction row', () => {
+    insertCase({ case_id: 'case-cas', status: 'active' });
+    const target = canonicalTargetRef(buildCaseFieldTargetRef('status'));
+
+    const result = applyStatusCorrection({
+      case_id: 'case-cas',
+      old_value_json: canonicalizeJSON('stale'),
+      new_value_json: canonicalizeJSON('blocked'),
+    });
+
+    expect(result.kind).toBe('requires_reconfirm');
+    if (result.kind !== 'requires_reconfirm') {
+      throw new Error('Expected reconfirm result');
+    }
+    expect(countRows('case_corrections')).toBe(0);
+
+    const envelope = decodeToken(result.reconfirm_token);
+    expect(envelope.payload).toMatchObject({
+      v: 1,
+      case_id: 'case-cas',
+      target_kind: 'case_field',
+      target_ref_hash_hex: target.hash.toString('hex'),
+      current_value_hash_hex: expect.any(String),
+      proposed_value_hash_hex: expect.any(String),
+      confirmed_by: 'user:test',
+      session_id: 'turn-1',
+      expires_at: expect.any(String),
+    });
+    expect(typeof envelope.kid).toBe('string');
+    expect(envelope.kid).toBe(envelope.payload.kid);
+    expect(envelope.signature_hex).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it('applies after reconfirm, rejects replay before mutation, and reverts without restoring truth', () => {
+    insertCase({ case_id: 'case-reconfirm', status: 'active' });
+
+    const reconfirm = applyStatusCorrection({
+      case_id: 'case-reconfirm',
+      old_value_json: canonicalizeJSON('stale'),
+      new_value_json: canonicalizeJSON('blocked'),
+    });
+    expect(reconfirm.kind).toBe('requires_reconfirm');
+    if (reconfirm.kind !== 'requires_reconfirm') {
+      throw new Error('Expected reconfirm result');
+    }
+
+    const applied = applyStatusCorrection({
+      case_id: 'case-reconfirm',
+      old_value_json: canonicalizeJSON('stale'),
+      reconfirm_token: reconfirm.reconfirm_token,
+      new_value_json: canonicalizeJSON('blocked'),
+    });
+
+    expect(applied.kind).toBe('applied');
+    if (applied.kind !== 'applied') {
+      throw new Error('Expected correction to apply');
+    }
+
+    const statusRow = getAdapter()
+      .prepare('SELECT status FROM case_truth WHERE case_id = ?')
+      .get('case-reconfirm') as { status: string };
+    expect(statusRow.status).toBe('blocked');
+
+    const correctionRow = getAdapter()
+      .prepare(
+        `
+          SELECT correction_id, length(target_ref_hash) AS hash_length, is_lock_active
+          FROM case_corrections
+          WHERE correction_id = ?
+        `
+      )
+      .get(applied.correction_id) as {
+      correction_id: string;
+      hash_length: number;
+      is_lock_active: number;
+    };
+    expect(correctionRow).toMatchObject({
+      correction_id: applied.correction_id,
+      hash_length: 32,
+      is_lock_active: 1,
+    });
+
+    const replay = applyStatusCorrection({
+      case_id: 'case-reconfirm',
+      old_value_json: canonicalizeJSON('stale'),
+      reconfirm_token: reconfirm.reconfirm_token,
+      new_value_json: canonicalizeJSON('blocked'),
+    });
+    expect(replay).toMatchObject({
+      kind: 'rejected',
+      code: 'case.reconfirm_token_replayed',
+    });
+
+    const reverted = revertCorrection(getAdapter(), {
+      correction_id: applied.correction_id,
+      confirmed: true,
+      confirmed_by: 'user:test',
+      confirmation_summary: 'release lock',
+      now: '2026-04-18T01:10:00.000Z',
+    });
+    expect(reverted).toEqual({
+      kind: 'reverted',
+      correction_id: applied.correction_id,
+      case_id: 'case-reconfirm',
+    });
+
+    const afterRevert = getAdapter()
+      .prepare('SELECT status FROM case_truth WHERE case_id = ?')
+      .get('case-reconfirm') as { status: string };
+    expect(afterRevert.status).toBe('blocked');
+
+    const events = getAdapter()
+      .prepare('SELECT event_type FROM memory_events ORDER BY created_at ASC')
+      .all() as Array<{ event_type: string }>;
+    expect(events.map((event) => event.event_type)).toEqual([
+      'case.correction_applied',
+      'case.correction_reverted',
+    ]);
+  });
+
+  it('returns active correction conflict for a second active lock on the same target', () => {
+    insertCase({ case_id: 'case-conflict', status: 'active' });
+
+    const first = applyStatusCorrection({
+      case_id: 'case-conflict',
+      old_value_json: canonicalizeJSON('active'),
+      new_value_json: canonicalizeJSON('blocked'),
+    });
+    expect(first.kind).toBe('applied');
+
+    const second = applyStatusCorrection({
+      case_id: 'case-conflict',
+      old_value_json: canonicalizeJSON('blocked'),
+      new_value_json: canonicalizeJSON('resolved'),
+    });
+    expect(second).toMatchObject({
+      kind: 'rejected',
+      code: 'case.correction_active_conflict',
+    });
+  });
+
+  it('rejects active corrections against archived and merged cases', () => {
+    for (const status of ['archived', 'merged'] as const) {
+      resetCaseTables();
+      insertCase({ case_id: `case-${status}`, status });
+
+      const result = applyStatusCorrection({
+        case_id: `case-${status}`,
+        old_value_json: canonicalizeJSON(status),
+        new_value_json: canonicalizeJSON('active'),
+      });
+
+      expect(result).toMatchObject({
+        kind: 'rejected',
+        code: 'case.terminal_status',
+        case_id: `case-${status}`,
+      });
+      expect(countRows('case_corrections')).toBe(0);
+    }
+  });
+
+  it('prepares the migration 041 correction INSERT shape without created_at or created_by', () => {
+    const preparedSql: string[] = [];
+    const fakeAdapter = {
+      prepare(sql: string) {
+        preparedSql.push(sql.replace(/\s+/g, ' ').trim());
+        return {
+          run: (..._args: unknown[]) => ({ changes: 1, lastInsertRowid: 0 }),
+          get: (..._args: unknown[]) => undefined,
+          all: (..._args: unknown[]) => [],
+        };
+      },
+      transaction<T>(fn: () => T): T {
+        return fn();
+      },
+    } as unknown as DatabaseAdapter;
+
+    insertCaseCorrectionLock(fakeAdapter, {
+      correction_id: 'corr-sql-shape',
+      case_id: 'case-sql-shape',
+      target_kind: 'case_field',
+      target_ref: buildCaseFieldTargetRef('status'),
+      field_name: 'status',
+      old_value_json: canonicalizeJSON('active'),
+      new_value_json: canonicalizeJSON('blocked'),
+      reason: 'shape',
+      applied_by: 'user:test',
+      applied_at: '2026-04-18T00:00:00.000Z',
+    });
+
+    expect(preparedSql[0]).toBe(
+      'INSERT INTO case_corrections ( correction_id, case_id, target_kind, target_ref_json, target_ref_hash, field_name, old_value_json, new_value_json, reason, applied_by, applied_at, is_lock_active, reverted_at, superseded_by ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?);'
+    );
+    expect(preparedSql[0]).not.toContain('created_at');
+    expect(preparedSql[0]).not.toContain('created_by');
+  });
+
+  it('rolls back correction row, target mutation, and audit row when verification path fails', () => {
+    insertCase({ case_id: 'case-rollback', status: 'active' });
+
+    expect(() =>
+      applyStatusCorrection({
+        case_id: 'case-rollback',
+        old_value_json: canonicalizeJSON('active'),
+        new_value_json: canonicalizeJSON('not-a-status'),
+      })
+    ).toThrow(/constraint|CHECK/i);
+
+    const row = getAdapter()
+      .prepare('SELECT status FROM case_truth WHERE case_id = ?')
+      .get('case-rollback') as { status: string };
+    expect(row.status).toBe('active');
+    expect(countRows('case_corrections')).toBe(0);
+    expect(countRows('memory_events')).toBe(0);
+  });
+
+  it('remove active membership flips it to removed and user_locked=1', () => {
+    insertCase({ case_id: 'case-remove-member' });
+    insertMembership({ case_id: 'case-remove-member', source_id: 'dec-remove' });
+
+    const result = applyCorrection(getAdapter(), {
+      case_id: 'case-remove-member',
+      target_kind: 'membership',
+      target_ref: buildMembershipTargetRef('decision', 'dec-remove'),
+      new_value_json: canonicalizeJSON({ status: 'removed' }),
+      reason: 'does not belong',
+      confirmed: true,
+      confirmed_by: 'user:test',
+      confirmation_summary: 'remove source',
+      now: '2026-04-18T02:00:00.000Z',
+    });
+
+    expect(result.kind).toBe('applied');
+    const row = getAdapter()
+      .prepare(
+        `
+          SELECT status, user_locked, added_by
+          FROM case_memberships
+          WHERE case_id = ? AND source_type = 'decision' AND source_id = ?
+        `
+      )
+      .get('case-remove-member', 'dec-remove') as {
+      status: string;
+      user_locked: number;
+      added_by: string;
+    };
+    expect(row).toEqual({ status: 'removed', user_locked: 1, added_by: 'user-correction' });
+  });
+
+  it('exclude source inserts or updates a non-active source to excluded and user_locked=1', () => {
+    insertCase({ case_id: 'case-exclude-member' });
+
+    const result = applyCorrection(getAdapter(), {
+      case_id: 'case-exclude-member',
+      target_kind: 'membership',
+      target_ref: buildMembershipTargetRef('decision', 'dec-exclude'),
+      new_value_json: canonicalizeJSON({
+        status: 'excluded',
+        confidence: 0.4,
+        reason: 'explicitly out of scope',
+      }),
+      reason: 'exclude source',
+      confirmed: true,
+      confirmed_by: 'user:test',
+      confirmation_summary: 'exclude source',
+      now: '2026-04-18T02:10:00.000Z',
+    });
+
+    expect(result.kind).toBe('applied');
+    const row = getAdapter()
+      .prepare(
+        `
+          SELECT status, role, confidence, reason, user_locked, added_by
+          FROM case_memberships
+          WHERE case_id = ? AND source_type = 'decision' AND source_id = ?
+        `
+      )
+      .get('case-exclude-member', 'dec-exclude') as {
+      status: string;
+      role: string | null;
+      confidence: number;
+      reason: string;
+      user_locked: number;
+      added_by: string;
+    };
+    expect(row).toEqual({
+      status: 'excluded',
+      role: null,
+      confidence: 0.4,
+      reason: 'explicitly out of scope',
+      user_locked: 1,
+      added_by: 'user-correction',
+    });
+  });
+
+  it("should belong inserts active membership with added_by='user-correction'", () => {
+    insertCase({ case_id: 'case-should-belong' });
+
+    const result = applyCorrection(getAdapter(), {
+      case_id: 'case-should-belong',
+      target_kind: 'membership',
+      target_ref: buildMembershipTargetRef('decision', 'dec-add'),
+      new_value_json: canonicalizeJSON({
+        status: 'active',
+        role: 'primary',
+        confidence: 0.91,
+        reason: 'user said this is the key source',
+      }),
+      reason: 'add source',
+      confirmed: true,
+      confirmed_by: 'user:test',
+      confirmation_summary: 'add source',
+      now: '2026-04-18T02:20:00.000Z',
+    });
+
+    expect(result.kind).toBe('applied');
+    const row = getAdapter()
+      .prepare(
+        `
+          SELECT status, role, confidence, reason, user_locked, added_by
+          FROM case_memberships
+          WHERE case_id = ? AND source_type = 'decision' AND source_id = ?
+        `
+      )
+      .get('case-should-belong', 'dec-add') as {
+      status: string;
+      role: string;
+      confidence: number;
+      reason: string;
+      user_locked: number;
+      added_by: string;
+    };
+    expect(row).toEqual({
+      status: 'active',
+      role: 'primary',
+      confidence: 0.91,
+      reason: 'user said this is the key source',
+      user_locked: 1,
+      added_by: 'user-correction',
+    });
+  });
+
+  it('wiki_section correction inserts a canonical lock row without mutating case_truth fields', () => {
+    insertCase({ case_id: 'case-wiki-section', status_reason: 'before' });
+    const target = canonicalTargetRef(buildWikiSectionTargetRef('## Status'));
+
+    const result = applyCorrection(getAdapter(), {
+      case_id: 'case-wiki-section',
+      target_kind: 'wiki_section',
+      target_ref: buildWikiSectionTargetRef('## Status'),
+      new_value_json: canonicalizeJSON({ markdown: '## Status\n\nHuman correction.' }),
+      reason: 'wrong narrative section',
+      confirmed: true,
+      confirmed_by: 'user:test',
+      confirmation_summary: 'correct wiki section',
+      now: '2026-04-18T02:30:00.000Z',
+    });
+
+    expect(result.kind).toBe('applied');
+    const correction = getAdapter()
+      .prepare(
+        `
+          SELECT target_ref_json, length(target_ref_hash) AS hash_length
+          FROM case_corrections
+          WHERE case_id = ?
+        `
+      )
+      .get('case-wiki-section') as { target_ref_json: string; hash_length: number };
+    expect(correction).toEqual({ target_ref_json: target.json, hash_length: 32 });
+
+    const truth = getAdapter()
+      .prepare('SELECT status_reason FROM case_truth WHERE case_id = ?')
+      .get('case-wiki-section') as { status_reason: string };
+    expect(truth.status_reason).toBe('before');
+  });
+
+  // BLOCKER(P1-2) resolved by spec amendment-8 (2026-04-18). supersedeCorrection
+  // shipped as Phase 2b with its own dedicated test file
+  // `case-correction-supersede.test.ts` covering chain integrity, live-state
+  // mutation, and the CAS/reconfirm protocol.
+});

--- a/packages/mama-core/tests/cases/case-freshness.test.ts
+++ b/packages/mama-core/tests/cases/case-freshness.test.ts
@@ -252,6 +252,7 @@ describe('Task 15: Wiki freshness core helper', () => {
 
     expect(secondSweep.results[0].changed).toBe(false);
     expect(second.freshness_checked_at).toBe(first.freshness_checked_at);
+    expect(secondSweep.results[0]?.freshness_checked_at).toBe(first.freshness_checked_at);
   });
 
   it('sweeper emits drift memory event on transition into drifted', () => {

--- a/packages/mama-core/tests/cases/case-freshness.test.ts
+++ b/packages/mama-core/tests/cases/case-freshness.test.ts
@@ -324,6 +324,35 @@ describe('Task 15: Wiki freshness core helper', () => {
     expect(freshnessRow('case-survivor').freshness_state).toBe('fresh');
   });
 
+  it('batch explicit case_ids reports terminal cases in rejected output', () => {
+    insertCase({
+      case_id: 'case-active',
+      current_wiki_path: 'Cases/case-active.md',
+      compiled_at: '2026-04-18T01:00:00.000Z',
+      last_activity_at: '2026-04-18T00:00:00.000Z',
+    });
+    insertCase({
+      case_id: 'case-archived',
+      status: 'archived',
+    });
+    insertWikiIndex('case-active');
+
+    const result = sweepCaseFreshness(getAdapter(), {
+      case_ids: ['case-active', 'case-archived'],
+      now: '2026-04-18T02:00:00.000Z',
+    });
+
+    expect(result.rejected).toEqual(
+      expect.arrayContaining([
+        {
+          case_id: 'case-archived',
+          code: 'case.terminal_status',
+          message: 'Freshness cannot be written to terminal case status archived.',
+        },
+      ])
+    );
+  });
+
   it('response includes terminal_case_id, resolved_via_case_id, and chain', () => {
     insertCase({
       case_id: 'case-response',
@@ -375,6 +404,40 @@ describe('Task 15: Wiki freshness core helper', () => {
       'case-a',
       'case-b',
       'case-c',
+    ]);
+  });
+
+  it('listDriftedCases excludes terminal cases that still carry stale drift metadata', () => {
+    insertCase({
+      case_id: 'case-terminal-drifted',
+      status: 'merged',
+      current_wiki_path: 'Cases/case-terminal-drifted.md',
+      compiled_at: '2026-04-18T01:00:00.000Z',
+      last_activity_at: '2026-04-18T02:00:00.000Z',
+      state_updated_at: '2026-04-18T02:30:00.000Z',
+    });
+    insertCase({
+      case_id: 'case-live-drifted',
+      current_wiki_path: 'Cases/case-live-drifted.md',
+      compiled_at: '2026-04-18T01:00:00.000Z',
+      last_activity_at: '2026-04-18T02:00:00.000Z',
+      state_updated_at: '2026-04-18T02:30:00.000Z',
+    });
+
+    getAdapter()
+      .prepare(
+        `
+          UPDATE case_truth
+          SET freshness_state = 'drifted',
+              freshness_score = 0.1,
+              freshness_score_is_drifted = 1
+          WHERE case_id IN (?, ?)
+        `
+      )
+      .run('case-terminal-drifted', 'case-live-drifted');
+
+    expect(listDriftedCases(getAdapter()).map((row) => row.case_id)).toEqual([
+      'case-live-drifted',
     ]);
   });
 

--- a/packages/mama-core/tests/cases/case-freshness.test.ts
+++ b/packages/mama-core/tests/cases/case-freshness.test.ts
@@ -228,7 +228,7 @@ describe('Task 15: Wiki freshness core helper', () => {
     expect(result.reasons.map((reason) => reason.code)).toContain('timestamps_absent');
   });
 
-  it('sweeper updates only changed rows', () => {
+  it('sweeper refreshes freshness_checked_at even when the calculated state is unchanged', () => {
     insertCase({
       case_id: 'case-idempotent',
       current_wiki_path: 'Cases/case-idempotent.md',
@@ -251,8 +251,9 @@ describe('Task 15: Wiki freshness core helper', () => {
     const second = freshnessRow('case-idempotent');
 
     expect(secondSweep.results[0].changed).toBe(false);
-    expect(second.freshness_checked_at).toBe(first.freshness_checked_at);
-    expect(secondSweep.results[0]?.freshness_checked_at).toBe(first.freshness_checked_at);
+    expect(second.freshness_checked_at).toBe('2026-04-18T03:00:00.000Z');
+    expect(second.freshness_checked_at).not.toBe(first.freshness_checked_at);
+    expect(secondSweep.results[0]?.freshness_checked_at).toBe('2026-04-18T03:00:00.000Z');
   });
 
   it('sweeper emits drift memory event on transition into drifted', () => {

--- a/packages/mama-core/tests/cases/case-freshness.test.ts
+++ b/packages/mama-core/tests/cases/case-freshness.test.ts
@@ -1,0 +1,429 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { canonicalizeJSON } from '../../src/canonicalize.js';
+import { getAdapter } from '../../src/db-manager.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import {
+  calculateCaseFreshness,
+  listDriftedCases,
+  sweepCaseFreshness,
+} from '../../src/cases/freshness.js';
+import { insertCaseCorrectionLock } from '../../src/cases/corrections.js';
+import { buildCaseFieldTargetRef } from '../../src/cases/target-ref.js';
+
+function resetCaseTables(): void {
+  const adapter = getAdapter();
+  adapter.prepare('DELETE FROM memory_events').run();
+  adapter.prepare('DELETE FROM wiki_page_embeddings').run();
+  adapter.prepare('DELETE FROM wiki_page_index').run();
+  adapter.prepare('DELETE FROM case_links').run();
+  adapter.prepare('DELETE FROM case_corrections').run();
+  adapter.prepare('DELETE FROM case_memberships').run();
+  adapter.prepare('DELETE FROM case_truth').run();
+}
+
+function insertCase(
+  overrides: Partial<{
+    case_id: string;
+    title: string;
+    status: string;
+    current_wiki_path: string | null;
+    last_activity_at: string | null;
+    state_updated_at: string | null;
+    compiled_at: string | null;
+    status_reason: string | null;
+    canonical_case_id: string | null;
+    created_at: string;
+    updated_at: string;
+  }>
+): void {
+  const now = '2026-04-18T00:00:00.000Z';
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO case_truth (
+          case_id, current_wiki_path, title, status, status_reason, last_activity_at,
+          state_updated_at, compiled_at, canonical_case_id, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      overrides.case_id,
+      overrides.current_wiki_path ?? null,
+      overrides.title ?? overrides.case_id,
+      overrides.status ?? 'active',
+      overrides.status_reason ?? null,
+      overrides.last_activity_at ?? null,
+      overrides.state_updated_at ?? null,
+      overrides.compiled_at ?? null,
+      overrides.canonical_case_id ?? null,
+      overrides.created_at ?? now,
+      overrides.updated_at ?? now
+    );
+}
+
+function insertWikiIndex(caseId: string, updatedAt = '2026-04-18T02:00:00.000Z'): void {
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO wiki_page_index (
+          page_id, source_type, source_locator, case_id, title, page_type,
+          content, confidence, compiled_at, updated_at
+        )
+        VALUES (?, 'wiki_page', ?, ?, ?, 'case', 'content', 'high', ?, ?)
+      `
+    )
+    .run(`page-${caseId}`, `Cases/${caseId}.md`, caseId, `Case ${caseId}`, updatedAt, updatedAt);
+}
+
+function freshnessRow(caseId: string): {
+  freshness_score: number | null;
+  freshness_state: string | null;
+  freshness_score_is_drifted: number;
+  freshness_drift_threshold: number | null;
+  freshness_checked_at: string | null;
+  freshness_reason_json: string | null;
+  status_reason: string | null;
+} {
+  return getAdapter()
+    .prepare(
+      `
+        SELECT freshness_score, freshness_state, freshness_score_is_drifted,
+               freshness_drift_threshold, freshness_checked_at, freshness_reason_json,
+               status_reason
+        FROM case_truth
+        WHERE case_id = ?
+      `
+    )
+    .get(caseId) as {
+    freshness_score: number | null;
+    freshness_state: string | null;
+    freshness_score_is_drifted: number;
+    freshness_drift_threshold: number | null;
+    freshness_checked_at: string | null;
+    freshness_reason_json: string | null;
+    status_reason: string | null;
+  };
+}
+
+describe('Task 15: Wiki freshness core helper', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    process.env.MAMA_FORCE_TIER_3 = 'true';
+    testDbPath = await initTestDB('case-freshness');
+  });
+
+  beforeEach(() => {
+    resetCaseTables();
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  it('classifies fresh when compile is after activity', () => {
+    const result = calculateCaseFreshness({
+      last_activity_at: '2026-04-18T00:00:00.000Z',
+      state_updated_at: '2026-04-18T00:30:00.000Z',
+      compiled_at: '2026-04-18T01:00:00.000Z',
+      wiki_index_updated_at: '2026-04-18T01:05:00.000Z',
+      current_wiki_path: 'Cases/Fresh.md',
+    });
+
+    expect(result).toMatchObject({
+      freshness_score: 1,
+      freshness_state: 'fresh',
+      freshness_score_is_drifted: 0,
+    });
+  });
+
+  it('classifies stale when activity is after compile', () => {
+    const result = calculateCaseFreshness({
+      last_activity_at: '2026-04-18T02:00:00.000Z',
+      state_updated_at: '2026-04-18T00:30:00.000Z',
+      compiled_at: '2026-04-18T01:00:00.000Z',
+      wiki_index_updated_at: '2026-04-18T01:05:00.000Z',
+      current_wiki_path: 'Cases/Stale.md',
+    });
+
+    expect(result).toMatchObject({
+      freshness_score: 0.65,
+      freshness_state: 'stale',
+      freshness_score_is_drifted: 0,
+    });
+  });
+
+  it('classifies drifted below the default threshold', () => {
+    const result = calculateCaseFreshness({
+      last_activity_at: '2026-04-18T02:00:00.000Z',
+      state_updated_at: '2026-04-18T02:30:00.000Z',
+      compiled_at: '2026-04-18T01:00:00.000Z',
+      wiki_index_updated_at: null,
+      current_wiki_path: 'Cases/Drifted.md',
+    });
+
+    expect(result).toMatchObject({
+      freshness_score: 0.15,
+      freshness_state: 'drifted',
+      freshness_score_is_drifted: 1,
+      freshness_drift_threshold: 0.5,
+    });
+  });
+
+  it('custom drift_threshold changes classification', () => {
+    const baseInput = {
+      last_activity_at: '2026-04-18T02:00:00.000Z',
+      state_updated_at: '2026-04-18T00:30:00.000Z',
+      compiled_at: '2026-04-18T01:00:00.000Z',
+      wiki_index_updated_at: '2026-04-18T01:05:00.000Z',
+      current_wiki_path: 'Cases/Threshold.md',
+    };
+
+    expect(calculateCaseFreshness({ ...baseInput, drift_threshold: 0.7 }).freshness_state).toBe(
+      'drifted'
+    );
+    expect(calculateCaseFreshness({ ...baseInput, drift_threshold: 0.5 }).freshness_state).toBe(
+      'stale'
+    );
+  });
+
+  it('persisted freshness_score_is_drifted changes with distinct thresholds', () => {
+    insertCase({
+      case_id: 'case-threshold',
+      current_wiki_path: 'Cases/case-threshold.md',
+      compiled_at: '2026-04-18T01:00:00.000Z',
+      last_activity_at: '2026-04-18T02:00:00.000Z',
+      state_updated_at: '2026-04-18T00:00:00.000Z',
+    });
+    insertWikiIndex('case-threshold');
+
+    sweepCaseFreshness(getAdapter(), {
+      case_ids: ['case-threshold'],
+      drift_threshold: 0.7,
+      now: '2026-04-18T03:00:00.000Z',
+    });
+    expect(freshnessRow('case-threshold').freshness_score_is_drifted).toBe(1);
+
+    sweepCaseFreshness(getAdapter(), {
+      case_ids: ['case-threshold'],
+      drift_threshold: 0.5,
+      now: '2026-04-18T04:00:00.000Z',
+    });
+    expect(freshnessRow('case-threshold').freshness_score_is_drifted).toBe(0);
+  });
+
+  it('classifies unknown when timestamps are absent', () => {
+    const result = calculateCaseFreshness({
+      last_activity_at: null,
+      state_updated_at: null,
+      compiled_at: null,
+      wiki_index_updated_at: null,
+      current_wiki_path: null,
+    });
+
+    expect(result.freshness_state).toBe('unknown');
+    expect(result.freshness_score_is_drifted).toBe(0);
+    expect(result.reasons.map((reason) => reason.code)).toContain('timestamps_absent');
+  });
+
+  it('sweeper updates only changed rows', () => {
+    insertCase({
+      case_id: 'case-idempotent',
+      current_wiki_path: 'Cases/case-idempotent.md',
+      compiled_at: '2026-04-18T01:00:00.000Z',
+      last_activity_at: '2026-04-18T00:00:00.000Z',
+      state_updated_at: '2026-04-18T00:30:00.000Z',
+    });
+    insertWikiIndex('case-idempotent');
+
+    sweepCaseFreshness(getAdapter(), {
+      case_ids: ['case-idempotent'],
+      now: '2026-04-18T02:00:00.000Z',
+    });
+    const first = freshnessRow('case-idempotent');
+
+    const secondSweep = sweepCaseFreshness(getAdapter(), {
+      case_ids: ['case-idempotent'],
+      now: '2026-04-18T03:00:00.000Z',
+    });
+    const second = freshnessRow('case-idempotent');
+
+    expect(secondSweep.results[0].changed).toBe(false);
+    expect(second.freshness_checked_at).toBe(first.freshness_checked_at);
+  });
+
+  it('sweeper emits drift memory event on transition into drifted', () => {
+    insertCase({
+      case_id: 'case-transition',
+      current_wiki_path: 'Cases/case-transition.md',
+      compiled_at: '2026-04-18T01:00:00.000Z',
+      last_activity_at: '2026-04-18T02:00:00.000Z',
+      state_updated_at: '2026-04-18T00:30:00.000Z',
+    });
+    insertWikiIndex('case-transition');
+
+    sweepCaseFreshness(getAdapter(), {
+      case_ids: ['case-transition'],
+      now: '2026-04-18T03:00:00.000Z',
+    });
+    expect(freshnessRow('case-transition').freshness_state).toBe('stale');
+
+    getAdapter().prepare('DELETE FROM wiki_page_index WHERE case_id = ?').run('case-transition');
+
+    sweepCaseFreshness(getAdapter(), {
+      case_ids: ['case-transition'],
+      now: '2026-04-18T04:00:00.000Z',
+    });
+
+    const event = getAdapter()
+      .prepare(
+        `
+          SELECT event_type, topic
+          FROM memory_events
+          WHERE event_type = 'case.freshness_drifted'
+        `
+      )
+      .get() as { event_type: string; topic: string } | undefined;
+
+    expect(event).toEqual({
+      event_type: 'case.freshness_drifted',
+      topic: 'case:case-transition',
+    });
+  });
+
+  it('single-case sweep resolves loser to terminal survivor', () => {
+    insertCase({
+      case_id: 'case-survivor',
+      current_wiki_path: 'Cases/case-survivor.md',
+      compiled_at: '2026-04-18T01:00:00.000Z',
+      last_activity_at: '2026-04-18T00:00:00.000Z',
+      state_updated_at: '2026-04-18T00:30:00.000Z',
+    });
+    insertCase({
+      case_id: 'case-loser',
+      status: 'merged',
+      canonical_case_id: 'case-survivor',
+    });
+    insertWikiIndex('case-survivor');
+
+    const result = sweepCaseFreshness(getAdapter(), {
+      case_ids: ['case-loser'],
+      now: '2026-04-18T02:00:00.000Z',
+    });
+
+    expect(result.results[0]).toMatchObject({
+      case_id: 'case-loser',
+      terminal_case_id: 'case-survivor',
+      resolved_via_case_id: 'case-loser',
+      chain: ['case-loser', 'case-survivor'],
+    });
+    expect(freshnessRow('case-survivor').freshness_state).toBe('fresh');
+  });
+
+  it('response includes terminal_case_id, resolved_via_case_id, and chain', () => {
+    insertCase({
+      case_id: 'case-response',
+      current_wiki_path: 'Cases/case-response.md',
+      compiled_at: '2026-04-18T01:00:00.000Z',
+      last_activity_at: '2026-04-18T00:00:00.000Z',
+    });
+    insertWikiIndex('case-response');
+
+    const result = sweepCaseFreshness(getAdapter(), { case_ids: ['case-response'] });
+
+    expect(result.results[0]).toMatchObject({
+      case_id: 'case-response',
+      terminal_case_id: 'case-response',
+      resolved_via_case_id: null,
+      chain: ['case-response'],
+    });
+  });
+
+  it('listDriftedCases orders by freshness_score ASC, case_id ASC', () => {
+    insertCase({
+      case_id: 'case-b',
+      current_wiki_path: 'Cases/case-b.md',
+      compiled_at: '2026-04-18T01:00:00.000Z',
+      last_activity_at: '2026-04-18T02:00:00.000Z',
+      state_updated_at: '2026-04-18T02:30:00.000Z',
+    });
+    insertCase({
+      case_id: 'case-a',
+      current_wiki_path: 'Cases/case-a.md',
+      compiled_at: '2026-04-18T01:00:00.000Z',
+      last_activity_at: '2026-04-18T02:00:00.000Z',
+      state_updated_at: '2026-04-18T02:30:00.000Z',
+    });
+    insertCase({
+      case_id: 'case-c',
+      current_wiki_path: 'Cases/case-c.md',
+      compiled_at: '2026-04-18T01:00:00.000Z',
+      last_activity_at: '2026-04-18T02:00:00.000Z',
+      state_updated_at: '2026-04-18T00:30:00.000Z',
+    });
+
+    sweepCaseFreshness(getAdapter(), {
+      case_ids: ['case-b', 'case-a', 'case-c'],
+      now: '2026-04-18T03:00:00.000Z',
+    });
+
+    expect(listDriftedCases(getAdapter()).map((row) => row.case_id)).toEqual([
+      'case-a',
+      'case-b',
+      'case-c',
+    ]);
+  });
+
+  it('coexists with active correction locks without touching protected live fields', () => {
+    insertCase({
+      case_id: 'case-lock-coexist',
+      current_wiki_path: 'Cases/case-lock-coexist.md',
+      compiled_at: '2026-04-18T01:00:00.000Z',
+      last_activity_at: '2026-04-18T02:00:00.000Z',
+      state_updated_at: '2026-04-18T00:30:00.000Z',
+      status_reason: 'locked status reason',
+    });
+    insertWikiIndex('case-lock-coexist');
+
+    insertCaseCorrectionLock(getAdapter(), {
+      correction_id: 'corr-status-reason-lock',
+      case_id: 'case-lock-coexist',
+      target_kind: 'case_field',
+      target_ref: buildCaseFieldTargetRef('status_reason'),
+      field_name: 'status_reason',
+      old_value_json: canonicalizeJSON('locked status reason'),
+      new_value_json: canonicalizeJSON('user corrected status reason'),
+      reason: 'protect status reason',
+      applied_by: 'user:test',
+      applied_at: '2026-04-18T01:30:00.000Z',
+      is_lock_active: 1,
+    });
+
+    sweepCaseFreshness(getAdapter(), {
+      case_ids: ['case-lock-coexist'],
+      now: '2026-04-18T03:00:00.000Z',
+    });
+
+    const row = freshnessRow('case-lock-coexist');
+    expect(row.freshness_state).toBe('stale');
+    expect(row.status_reason).toBe('locked status reason');
+
+    const correction = getAdapter()
+      .prepare('SELECT is_lock_active FROM case_corrections WHERE correction_id = ?')
+      .get('corr-status-reason-lock') as { is_lock_active: number };
+    expect(correction.is_lock_active).toBe(1);
+
+    const correctionEvents = getAdapter()
+      .prepare(
+        `
+          SELECT COUNT(*) AS count
+          FROM memory_events
+          WHERE event_type LIKE 'case.correction_%'
+        `
+      )
+      .get() as { count: number };
+    expect(correctionEvents.count).toBe(0);
+  });
+});

--- a/packages/mama-core/tests/cases/case-freshness.test.ts
+++ b/packages/mama-core/tests/cases/case-freshness.test.ts
@@ -228,6 +228,24 @@ describe('Task 15: Wiki freshness core helper', () => {
     expect(result.reasons.map((reason) => reason.code)).toContain('timestamps_absent');
   });
 
+  it('rejects invalid now timestamps instead of silently falling back', () => {
+    insertCase({
+      case_id: 'case-invalid-now',
+      current_wiki_path: 'Cases/case-invalid-now.md',
+      compiled_at: '2026-04-18T01:00:00.000Z',
+      last_activity_at: '2026-04-18T00:00:00.000Z',
+      state_updated_at: '2026-04-18T00:30:00.000Z',
+    });
+    insertWikiIndex('case-invalid-now');
+
+    expect(() =>
+      sweepCaseFreshness(getAdapter(), {
+        case_ids: ['case-invalid-now'],
+        now: 'not-a-real-timestamp',
+      })
+    ).toThrow('invalid now timestamp');
+  });
+
   it('sweeper refreshes freshness_checked_at even when the calculated state is unchanged', () => {
     insertCase({
       case_id: 'case-idempotent',
@@ -436,9 +454,7 @@ describe('Task 15: Wiki freshness core helper', () => {
       )
       .run('case-terminal-drifted', 'case-live-drifted');
 
-    expect(listDriftedCases(getAdapter()).map((row) => row.case_id)).toEqual([
-      'case-live-drifted',
-    ]);
+    expect(listDriftedCases(getAdapter()).map((row) => row.case_id)).toEqual(['case-live-drifted']);
   });
 
   it('coexists with active correction locks without touching protected live fields', () => {

--- a/packages/mama-core/tests/cases/case-links-schema.test.ts
+++ b/packages/mama-core/tests/cases/case-links-schema.test.ts
@@ -1,0 +1,245 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+
+import { applyMigrationsThrough } from '../../src/test-utils.js';
+
+const MCP_MIGRATIONS_DIR = join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'mcp-server',
+  'src',
+  'db',
+  'migrations'
+);
+
+function sha256(value: string): Buffer {
+  return createHash('sha256').update(value, 'utf8').digest();
+}
+
+function seedCase(
+  db: Database.Database,
+  caseId: string,
+  overrides: Partial<{
+    title: string;
+    status: string;
+    canonical_case_id: string | null;
+    split_from_case_id: string | null;
+  }> = {}
+): void {
+  db.prepare(
+    `
+      INSERT INTO case_truth (
+        case_id, title, status, canonical_case_id, split_from_case_id, created_at, updated_at
+      )
+      VALUES (?, ?, ?, ?, ?, '2026-04-18T00:00:00.000Z', '2026-04-18T00:00:00.000Z')
+    `
+  ).run(
+    caseId,
+    overrides.title ?? `Case ${caseId}`,
+    overrides.status ?? 'active',
+    overrides.canonical_case_id ?? null,
+    overrides.split_from_case_id ?? null
+  );
+}
+
+function insertLink(
+  db: Database.Database,
+  overrides: Partial<{
+    link_id: string;
+    case_id_from: string;
+    case_id_to: string;
+    link_type: string;
+    source_kind: string;
+    revoked_at: string | null;
+    confidence: number | null;
+  }> = {}
+): void {
+  db.prepare(
+    `
+      INSERT INTO case_links (
+        link_id, case_id_from, case_id_to, link_type, created_at, created_by, confidence,
+        reason_json, source_kind, source_ref, source_ref_fingerprint, revoked_at, revoked_by,
+        revoke_reason
+      )
+      VALUES (?, ?, ?, ?, '2026-04-18T00:00:00.000Z', 'actor:test', ?, '{}', ?, NULL, NULL,
+              ?, NULL, NULL)
+    `
+  ).run(
+    overrides.link_id ?? `link-${Math.random().toString(16).slice(2)}`,
+    overrides.case_id_from ?? 'case-a',
+    overrides.case_id_to ?? 'case-b',
+    overrides.link_type ?? 'related',
+    overrides.confidence ?? null,
+    overrides.source_kind ?? 'manual',
+    overrides.revoked_at ?? null
+  );
+}
+
+function insertTombstone(
+  db: Database.Database,
+  overrides: Partial<{
+    tombstone_id: string;
+    case_id_from: string;
+    case_id_to: string;
+    link_type: string;
+    source_ref_fingerprint: Buffer;
+    unsuppressed_at: string | null;
+  }> = {}
+): void {
+  db.prepare(
+    `
+      INSERT INTO case_links_revoked_wiki_tombstones (
+        tombstone_id, case_id_from, case_id_to, link_type, source_ref_fingerprint,
+        source_ref, created_at, created_by, revoke_reason, unsuppressed_at, unsuppressed_by
+      )
+      VALUES (?, ?, ?, ?, ?, 'wiki://case-a', '2026-04-18T00:00:00.000Z', 'actor:test',
+              'user revoked wiki link', ?, NULL)
+    `
+  ).run(
+    overrides.tombstone_id ?? `tomb-${Math.random().toString(16).slice(2)}`,
+    overrides.case_id_from ?? 'case-a',
+    overrides.case_id_to ?? 'case-b',
+    overrides.link_type ?? 'related',
+    overrides.source_ref_fingerprint ?? sha256('case-a:case-b:related'),
+    overrides.unsuppressed_at ?? null
+  );
+}
+
+describe('case-first substrate — case_links schema', () => {
+  it('accepts every first-class link type', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+    seedCase(db, 'case-a');
+
+    for (const [index, type] of [
+      'related',
+      'supersedes-case',
+      'subcase-of',
+      'blocked-by',
+      'duplicate-of',
+    ].entries()) {
+      const targetId = `case-target-${index}`;
+      seedCase(db, targetId);
+      expect(() =>
+        insertLink(db, {
+          link_id: `link-${type}`,
+          case_id_from: 'case-a',
+          case_id_to: targetId,
+          link_type: type,
+        })
+      ).not.toThrow();
+    }
+
+    db.close();
+  });
+
+  it('rejects self-links', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+    seedCase(db, 'case-a');
+
+    expect(() =>
+      insertLink(db, {
+        link_id: 'self-link',
+        case_id_from: 'case-a',
+        case_id_to: 'case-a',
+      })
+    ).toThrow(/CHECK constraint/i);
+
+    db.close();
+  });
+
+  it('enforces active uniqueness but permits revoked historical duplicates', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+    seedCase(db, 'case-a');
+    seedCase(db, 'case-b');
+
+    insertLink(db, { link_id: 'link-active-1' });
+    expect(() => insertLink(db, { link_id: 'link-active-2' })).toThrow(/UNIQUE constraint/i);
+
+    db.prepare('UPDATE case_links SET revoked_at = ? WHERE link_id = ?').run(
+      '2026-04-18T01:00:00.000Z',
+      'link-active-1'
+    );
+    expect(() => insertLink(db, { link_id: 'link-active-3' })).not.toThrow();
+
+    db.close();
+  });
+
+  it('creates the wiki tombstone table and enforces active tombstone uniqueness', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    const row = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='case_links_revoked_wiki_tombstones'"
+      )
+      .get() as { name?: string } | undefined;
+    expect(row?.name).toBe('case_links_revoked_wiki_tombstones');
+
+    const fingerprint = sha256('wiki-link');
+    insertTombstone(db, {
+      tombstone_id: 'tomb-active-1',
+      source_ref_fingerprint: fingerprint,
+    });
+
+    expect(() =>
+      insertTombstone(db, {
+        tombstone_id: 'tomb-active-2',
+        source_ref_fingerprint: fingerprint,
+      })
+    ).toThrow(/UNIQUE constraint/i);
+
+    db.close();
+  });
+
+  it('allows a new active tombstone after the previous tombstone is unsuppressed', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    const fingerprint = sha256('wiki-link-unsuppressed');
+    insertTombstone(db, {
+      tombstone_id: 'tomb-old',
+      source_ref_fingerprint: fingerprint,
+    });
+    db.prepare(
+      `UPDATE case_links_revoked_wiki_tombstones
+       SET unsuppressed_at = ?, unsuppressed_by = ?
+       WHERE tombstone_id = ?`
+    ).run('2026-04-18T02:00:00.000Z', 'actor:test', 'tomb-old');
+
+    expect(() =>
+      insertTombstone(db, {
+        tombstone_id: 'tomb-new',
+        source_ref_fingerprint: fingerprint,
+      })
+    ).not.toThrow();
+
+    db.close();
+  });
+
+  // Runtime case_links backfill behavior for canonical_case_id and
+  // split_from_case_id is covered by case-links-store.test.ts.
+
+  it('does not add Phase 3 migrations to the legacy MCP migration directory', () => {
+    if (!existsSync(MCP_MIGRATIONS_DIR)) {
+      return;
+    }
+
+    const mcpMigrations = readdirSync(MCP_MIGRATIONS_DIR);
+    expect(mcpMigrations.some((file) => /^047-/.test(file))).toBe(false);
+    expect(mcpMigrations.some((file) => /^04[5-9]-/.test(file))).toBe(false);
+  });
+});

--- a/packages/mama-core/tests/cases/case-links-store.test.ts
+++ b/packages/mama-core/tests/cases/case-links-store.test.ts
@@ -263,6 +263,46 @@ describe('Task 13: Case links core store', () => {
     });
   });
 
+  it('does not unsuppress a tombstone when creation is rejected by an active-link conflict', () => {
+    insertCase({ case_id: 'case-a' });
+    insertCase({ case_id: 'case-b' });
+
+    const existing = createCaseLink(getAdapter(), {
+      link_id: 'link-existing',
+      case_id_from: 'case-a',
+      case_id_to: 'case-b',
+      link_type: 'related',
+      created_by: 'user:test',
+      source_kind: 'manual',
+    });
+    expect(existing.kind).toBe('created');
+
+    seedTombstone({ case_id_from: 'case-a', case_id_to: 'case-b', link_type: 'related' });
+
+    const result = createCaseLink(getAdapter(), {
+      link_id: 'link-conflict-unsuppress',
+      case_id_from: 'case-a',
+      case_id_to: 'case-b',
+      link_type: 'related',
+      created_by: 'user:test',
+      source_kind: 'manual',
+      unsuppress_wiki_tombstone: true,
+      now: '2026-04-18T01:30:00.000Z',
+    });
+
+    expect(result).toMatchObject({
+      kind: 'rejected',
+      code: 'case.correction_active_conflict',
+    });
+    expect(
+      isWikiTombstoneActive(getAdapter(), {
+        source_case_id: 'case-a',
+        target_case_id: 'case-b',
+        link_type: 'related',
+      })
+    ).toBe(true);
+  });
+
   it('revoking a wiki_compiler link writes a durable tombstone', () => {
     insertCase({ case_id: 'case-a' });
     insertCase({ case_id: 'case-b' });

--- a/packages/mama-core/tests/cases/case-links-store.test.ts
+++ b/packages/mama-core/tests/cases/case-links-store.test.ts
@@ -1,0 +1,496 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { getAdapter } from '../../src/db-manager.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import {
+  backfillStructuralLinks,
+  createCaseLink,
+  isWikiTombstoneActive,
+  listActiveCaseLinks,
+  revokeCaseLink,
+  sha256TombstoneFingerprint,
+} from '../../src/cases/case-links.js';
+import type { CaseLinkType } from '../../src/cases/case-links.js';
+
+function resetCaseTables(): void {
+  const adapter = getAdapter();
+  adapter.prepare('DELETE FROM memory_events').run();
+  adapter.prepare('DELETE FROM case_links_revoked_wiki_tombstones').run();
+  adapter.prepare('DELETE FROM case_links').run();
+  adapter.prepare('DELETE FROM case_memberships').run();
+  adapter.prepare('DELETE FROM case_corrections').run();
+  adapter.prepare('DELETE FROM case_truth').run();
+}
+
+function insertCase(
+  overrides: Partial<{
+    case_id: string;
+    title: string;
+    status: string;
+    canonical_case_id: string | null;
+    split_from_case_id: string | null;
+    current_wiki_path: string | null;
+    created_at: string;
+    updated_at: string;
+  }>
+): void {
+  const now = '2026-04-18T00:00:00.000Z';
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO case_truth (
+          case_id, current_wiki_path, title, status, canonical_case_id,
+          split_from_case_id, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      overrides.case_id,
+      overrides.current_wiki_path ?? null,
+      overrides.title ?? overrides.case_id,
+      overrides.status ?? 'active',
+      overrides.canonical_case_id ?? null,
+      overrides.split_from_case_id ?? null,
+      overrides.created_at ?? now,
+      overrides.updated_at ?? now
+    );
+}
+
+function tombstoneCount(): number {
+  const row = getAdapter()
+    .prepare('SELECT COUNT(*) AS count FROM case_links_revoked_wiki_tombstones')
+    .get() as { count: number };
+  return row.count;
+}
+
+function seedTombstone(input: {
+  case_id_from: string;
+  case_id_to: string;
+  link_type: CaseLinkType;
+}): Buffer {
+  const fingerprint = sha256TombstoneFingerprint({
+    source_case_id: input.case_id_from,
+    target_case_id: input.case_id_to,
+    link_type: input.link_type,
+  });
+
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO case_links_revoked_wiki_tombstones (
+          tombstone_id, case_id_from, case_id_to, link_type, source_ref_fingerprint,
+          source_ref, created_at, created_by, revoke_reason, unsuppressed_at, unsuppressed_by
+        )
+        VALUES (?, ?, ?, ?, ?, 'wiki://case-a', '2026-04-18T00:00:00.000Z',
+                'user:test', 'revoked wiki link', NULL, NULL)
+      `
+    )
+    .run(
+      `tomb-${input.case_id_from}-${input.case_id_to}-${input.link_type}`,
+      input.case_id_from,
+      input.case_id_to,
+      input.link_type,
+      fingerprint
+    );
+
+  return fingerprint;
+}
+
+describe('Task 13: Case links core store', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    process.env.MAMA_FORCE_TIER_3 = 'true';
+    testDbPath = await initTestDB('case-links-store');
+  });
+
+  beforeEach(() => {
+    resetCaseTables();
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  it('creates active links for every first-class link type', () => {
+    insertCase({ case_id: 'case-a' });
+
+    for (const [index, linkType] of [
+      'related',
+      'supersedes-case',
+      'subcase-of',
+      'blocked-by',
+      'duplicate-of',
+    ].entries() as IterableIterator<[number, CaseLinkType]>) {
+      const targetId = `case-target-${index}`;
+      insertCase({ case_id: targetId });
+
+      const result = createCaseLink(getAdapter(), {
+        link_id: `link-${linkType}`,
+        case_id_from: 'case-a',
+        case_id_to: targetId,
+        link_type: linkType,
+        created_by: 'user:test',
+        now: `2026-04-18T00:0${index}:00.000Z`,
+      });
+
+      expect(result.kind).toBe('created');
+    }
+
+    const rows = listActiveCaseLinks(getAdapter(), 'case-a').links;
+    expect(rows.map((row) => row.link_type).sort()).toEqual([
+      'blocked-by',
+      'duplicate-of',
+      'related',
+      'subcase-of',
+      'supersedes-case',
+    ]);
+  });
+
+  it('rejects self-links', () => {
+    insertCase({ case_id: 'case-self' });
+
+    const result = createCaseLink(getAdapter(), {
+      case_id_from: 'case-self',
+      case_id_to: 'case-self',
+      link_type: 'related',
+      created_by: 'user:test',
+    });
+
+    expect(result).toMatchObject({ kind: 'rejected', code: 'case.self_link' });
+  });
+
+  it('rejects terminal-status cases', () => {
+    insertCase({ case_id: 'case-archived', status: 'archived' });
+    insertCase({ case_id: 'case-active' });
+
+    const result = createCaseLink(getAdapter(), {
+      case_id_from: 'case-archived',
+      case_id_to: 'case-active',
+      link_type: 'related',
+      created_by: 'user:test',
+    });
+
+    expect(result).toMatchObject({ kind: 'rejected', code: 'case.terminal_status' });
+  });
+
+  it('rejects duplicate active links', () => {
+    insertCase({ case_id: 'case-a' });
+    insertCase({ case_id: 'case-b' });
+
+    expect(
+      createCaseLink(getAdapter(), {
+        link_id: 'link-first',
+        case_id_from: 'case-a',
+        case_id_to: 'case-b',
+        link_type: 'related',
+        created_by: 'user:test',
+      }).kind
+    ).toBe('created');
+
+    const duplicate = createCaseLink(getAdapter(), {
+      link_id: 'link-second',
+      case_id_from: 'case-a',
+      case_id_to: 'case-b',
+      link_type: 'related',
+      created_by: 'user:test',
+    });
+
+    expect(duplicate).toMatchObject({
+      kind: 'rejected',
+      code: 'case.correction_active_conflict',
+    });
+  });
+
+  it('rejects manual create against an active wiki tombstone without explicit unsuppress', () => {
+    insertCase({ case_id: 'case-a' });
+    insertCase({ case_id: 'case-b' });
+    seedTombstone({ case_id_from: 'case-a', case_id_to: 'case-b', link_type: 'related' });
+
+    const result = createCaseLink(getAdapter(), {
+      case_id_from: 'case-a',
+      case_id_to: 'case-b',
+      link_type: 'related',
+      created_by: 'user:test',
+      source_kind: 'manual',
+    });
+
+    expect(result).toMatchObject({
+      kind: 'rejected',
+      code: 'case.wiki_tombstone_conflict',
+    });
+  });
+
+  it('manual create with unsuppress_wiki_tombstone=true clears tombstone in the same transaction', () => {
+    insertCase({ case_id: 'case-a' });
+    insertCase({ case_id: 'case-b' });
+    seedTombstone({ case_id_from: 'case-a', case_id_to: 'case-b', link_type: 'related' });
+
+    const result = createCaseLink(getAdapter(), {
+      link_id: 'link-unsuppress',
+      case_id_from: 'case-a',
+      case_id_to: 'case-b',
+      link_type: 'related',
+      created_by: 'user:test',
+      source_kind: 'manual',
+      unsuppress_wiki_tombstone: true,
+      now: '2026-04-18T01:00:00.000Z',
+    });
+
+    expect(result.kind).toBe('created');
+    expect(
+      isWikiTombstoneActive(getAdapter(), {
+        source_case_id: 'case-a',
+        target_case_id: 'case-b',
+        link_type: 'related',
+      })
+    ).toBe(false);
+
+    const tombstone = getAdapter()
+      .prepare(
+        `
+          SELECT unsuppressed_at, unsuppressed_by
+          FROM case_links_revoked_wiki_tombstones
+          LIMIT 1
+        `
+      )
+      .get() as { unsuppressed_at: string; unsuppressed_by: string };
+
+    expect(tombstone).toEqual({
+      unsuppressed_at: '2026-04-18T01:00:00.000Z',
+      unsuppressed_by: 'user:test',
+    });
+  });
+
+  it('revoking a wiki_compiler link writes a durable tombstone', () => {
+    insertCase({ case_id: 'case-a' });
+    insertCase({ case_id: 'case-b' });
+
+    const created = createCaseLink(getAdapter(), {
+      link_id: 'link-wiki',
+      case_id_from: 'case-a',
+      case_id_to: 'case-b',
+      link_type: 'related',
+      created_by: 'wiki',
+      source_kind: 'wiki_compiler',
+      source_ref: 'Cases/Old Title.md#related',
+      now: '2026-04-18T00:00:00.000Z',
+    });
+
+    expect(created.kind).toBe('created');
+
+    const revoked = revokeCaseLink(getAdapter(), {
+      link_id: 'link-wiki',
+      revoked_by: 'user:test',
+      revoke_reason: 'not related',
+      now: '2026-04-18T01:00:00.000Z',
+    });
+
+    expect(revoked).toEqual({ kind: 'revoked', link_id: 'link-wiki' });
+    expect(tombstoneCount()).toBe(1);
+
+    const tombstone = getAdapter()
+      .prepare(
+        `
+          SELECT source_ref_fingerprint, source_ref, created_by, revoke_reason
+          FROM case_links_revoked_wiki_tombstones
+          WHERE case_id_from = 'case-a' AND case_id_to = 'case-b'
+        `
+      )
+      .get() as {
+      source_ref_fingerprint: Buffer;
+      source_ref: string;
+      created_by: string;
+      revoke_reason: string;
+    };
+
+    expect(tombstone.source_ref_fingerprint.toString('hex')).toBe(
+      created.kind === 'created' ? created.source_ref_fingerprint_hex : ''
+    );
+    expect(tombstone.source_ref).toBe('Cases/Old Title.md#related');
+    expect(tombstone.created_by).toBe('user:test');
+    expect(tombstone.revoke_reason).toBe('not related');
+  });
+
+  it('tombstone fingerprint is stable across path and title changes', () => {
+    insertCase({
+      case_id: 'case-a',
+      title: 'Old Title',
+      current_wiki_path: 'Cases/Old Title.md',
+    });
+    insertCase({
+      case_id: 'case-b',
+      title: 'Target',
+      current_wiki_path: 'Cases/Target.md',
+    });
+
+    const before = sha256TombstoneFingerprint({
+      source_case_id: 'case-a',
+      target_case_id: 'case-b',
+      link_type: 'related',
+    });
+
+    getAdapter()
+      .prepare(
+        `
+          UPDATE case_truth
+          SET title = 'New Title',
+              current_wiki_path = 'Cases/New Title.md',
+              updated_at = '2026-04-18T02:00:00.000Z'
+          WHERE case_id = 'case-a'
+        `
+      )
+      .run();
+
+    const after = sha256TombstoneFingerprint({
+      source_case_id: 'case-a',
+      target_case_id: 'case-b',
+      link_type: 'related',
+    });
+
+    expect(after.toString('hex')).toBe(before.toString('hex'));
+  });
+
+  it('revoking a manual link does not write a tombstone', () => {
+    insertCase({ case_id: 'case-a' });
+    insertCase({ case_id: 'case-b' });
+
+    createCaseLink(getAdapter(), {
+      link_id: 'link-manual',
+      case_id_from: 'case-a',
+      case_id_to: 'case-b',
+      link_type: 'blocked-by',
+      created_by: 'user:test',
+      source_kind: 'manual',
+    });
+
+    const revoked = revokeCaseLink(getAdapter(), {
+      link_id: 'link-manual',
+      revoked_by: 'user:test',
+      revoke_reason: 'resolved',
+    });
+
+    expect(revoked).toEqual({ kind: 'revoked', link_id: 'link-manual' });
+    expect(tombstoneCount()).toBe(0);
+  });
+
+  it('listActiveCaseLinks returns chain-aware loser links from the survivor view', () => {
+    insertCase({ case_id: 'case-survivor' });
+    insertCase({ case_id: 'case-loser' });
+    insertCase({ case_id: 'case-target' });
+
+    createCaseLink(getAdapter(), {
+      link_id: 'link-before-merge',
+      case_id_from: 'case-loser',
+      case_id_to: 'case-target',
+      link_type: 'related',
+      created_by: 'user:test',
+      now: '2026-04-18T00:00:00.000Z',
+    });
+
+    getAdapter()
+      .prepare(
+        `
+          UPDATE case_truth
+          SET status = 'merged', canonical_case_id = 'case-survivor'
+          WHERE case_id = 'case-loser'
+        `
+      )
+      .run();
+
+    const result = listActiveCaseLinks(getAdapter(), 'case-survivor');
+
+    expect(result.terminal_case_id).toBe('case-survivor');
+    expect(result.resolved_via_case_id).toBe(null);
+    expect(result.chain).toEqual(['case-survivor', 'case-loser']);
+    expect(result.links.map((link) => link.link_id)).toEqual(['link-before-merge']);
+  });
+
+  it('orders active links by created_at DESC, link_id ASC', () => {
+    insertCase({ case_id: 'case-a' });
+    insertCase({ case_id: 'case-b' });
+    insertCase({ case_id: 'case-c' });
+    insertCase({ case_id: 'case-d' });
+
+    createCaseLink(getAdapter(), {
+      link_id: 'link-b',
+      case_id_from: 'case-a',
+      case_id_to: 'case-b',
+      link_type: 'related',
+      created_by: 'user:test',
+      now: '2026-04-18T02:00:00.000Z',
+    });
+    createCaseLink(getAdapter(), {
+      link_id: 'link-a',
+      case_id_from: 'case-a',
+      case_id_to: 'case-c',
+      link_type: 'related',
+      created_by: 'user:test',
+      now: '2026-04-18T02:00:00.000Z',
+    });
+    createCaseLink(getAdapter(), {
+      link_id: 'link-c',
+      case_id_from: 'case-a',
+      case_id_to: 'case-d',
+      link_type: 'related',
+      created_by: 'user:test',
+      now: '2026-04-18T01:00:00.000Z',
+    });
+
+    expect(listActiveCaseLinks(getAdapter(), 'case-a').links.map((link) => link.link_id)).toEqual([
+      'link-a',
+      'link-b',
+      'link-c',
+    ]);
+  });
+
+  it('backfills duplicate-of and subcase-of structural links idempotently', () => {
+    insertCase({ case_id: 'case-survivor' });
+    insertCase({
+      case_id: 'case-loser',
+      status: 'merged',
+      canonical_case_id: 'case-survivor',
+    });
+    insertCase({ case_id: 'case-parent' });
+    insertCase({
+      case_id: 'case-child',
+      status: 'split',
+      split_from_case_id: 'case-parent',
+    });
+
+    expect(backfillStructuralLinks(getAdapter())).toEqual({
+      duplicate_of_inserted: 1,
+      subcase_of_inserted: 1,
+    });
+    expect(backfillStructuralLinks(getAdapter())).toEqual({
+      duplicate_of_inserted: 0,
+      subcase_of_inserted: 0,
+    });
+
+    const rows = getAdapter()
+      .prepare(
+        `
+          SELECT case_id_from, case_id_to, link_type, source_kind
+          FROM case_links
+          ORDER BY link_id ASC
+        `
+      )
+      .all();
+
+    expect(rows).toEqual([
+      {
+        case_id_from: 'case-loser',
+        case_id_to: 'case-survivor',
+        link_type: 'duplicate-of',
+        source_kind: 'system_backfill',
+      },
+      {
+        case_id_from: 'case-child',
+        case_id_to: 'case-parent',
+        link_type: 'subcase-of',
+        source_kind: 'system_backfill',
+      },
+    ]);
+  });
+});

--- a/packages/mama-core/tests/cases/case-live-state.test.ts
+++ b/packages/mama-core/tests/cases/case-live-state.test.ts
@@ -1,0 +1,601 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { canonicalizeJSON } from '../../src/canonicalize.js';
+import { getAdapter, type DatabaseAdapter } from '../../src/db-manager.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import {
+  buildCaseFieldTargetRef,
+  buildMembershipTargetRef,
+  canonicalTargetRef,
+} from '../../src/cases/target-ref.js';
+import { writeCaseLiveStateFromEvent } from '../../src/cases/live-state.js';
+
+function resetCaseTables(): void {
+  const adapter = getAdapter();
+  adapter.prepare('DELETE FROM memory_events').run();
+  adapter.prepare('DELETE FROM case_corrections').run();
+  adapter.prepare('DELETE FROM case_memberships').run();
+  adapter.prepare('DELETE FROM case_truth').run();
+}
+
+function insertCase(
+  overrides: Partial<{
+    case_id: string;
+    title: string;
+    status: string;
+    canonical_case_id: string | null;
+    last_activity_at: string | null;
+    created_at: string;
+    updated_at: string;
+  }>
+): void {
+  const adapter = getAdapter();
+  const now = overrides.created_at ?? '2026-04-18T00:00:00.000Z';
+  adapter
+    .prepare(
+      `
+        INSERT INTO case_truth (
+          case_id, current_wiki_path, title, status, last_activity_at,
+          canonical_case_id, created_at, updated_at
+        )
+        VALUES (?, NULL, ?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      overrides.case_id,
+      overrides.title ?? overrides.case_id,
+      overrides.status ?? 'active',
+      overrides.last_activity_at ?? null,
+      overrides.canonical_case_id ?? null,
+      now,
+      overrides.updated_at ?? now
+    );
+}
+
+function insertMembership(
+  overrides: Partial<{
+    case_id: string;
+    source_type: string;
+    source_id: string;
+    role: string | null;
+    confidence: number | null;
+    reason: string | null;
+    status: string;
+    added_by: string;
+    added_at: string;
+    updated_at: string;
+    user_locked: 0 | 1;
+  }>
+): void {
+  const adapter = getAdapter();
+  const now = '2026-04-18T00:00:00.000Z';
+  adapter
+    .prepare(
+      `
+        INSERT INTO case_memberships (
+          case_id, source_type, source_id, role, confidence, reason, status,
+          added_by, added_at, updated_at, user_locked
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      overrides.case_id,
+      overrides.source_type ?? 'event',
+      overrides.source_id ?? 'event-1',
+      overrides.role ?? null,
+      overrides.confidence ?? null,
+      overrides.reason ?? null,
+      overrides.status ?? 'active',
+      overrides.added_by ?? 'user-correction',
+      overrides.added_at ?? now,
+      overrides.updated_at ?? now,
+      overrides.user_locked ?? 0
+    );
+}
+
+function insertCorrectionLock(input: {
+  correction_id: string;
+  case_id: string;
+  target_kind: 'case_field' | 'membership';
+  target_ref_json: string;
+  target_ref_hash: Buffer;
+  field_name?: string | null;
+}): void {
+  const adapter = getAdapter();
+  adapter
+    .prepare(
+      `
+        INSERT INTO case_corrections (
+          correction_id, case_id, target_kind, target_ref_json, target_ref_hash,
+          field_name, old_value_json, new_value_json, reason, is_lock_active,
+          superseded_by, reverted_at, applied_by, applied_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, NULL, ?, 'test lock', 1, NULL, NULL, 'user', ?)
+      `
+    )
+    .run(
+      input.correction_id,
+      input.case_id,
+      input.target_kind,
+      input.target_ref_json,
+      input.target_ref_hash,
+      input.field_name ?? null,
+      canonicalizeJSON({ locked: true }),
+      '2026-04-18T00:00:00.000Z'
+    );
+}
+
+function caseRow(caseId: string): { status: string; last_activity_at: string | null } {
+  return getAdapter()
+    .prepare('SELECT status, last_activity_at FROM case_truth WHERE case_id = ?')
+    .get(caseId) as { status: string; last_activity_at: string | null };
+}
+
+describe('Story CF2.5: Lock-aware case live-state writer', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    process.env.MAMA_FORCE_TIER_3 = 'true';
+    testDbPath = await initTestDB('case-live-state');
+  });
+
+  beforeEach(() => {
+    resetCaseTables();
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  it('returns precompile_gap when case_id is missing', () => {
+    const result = writeCaseLiveStateFromEvent(getAdapter(), {
+      case_id: 'case-missing',
+      source_event_id: 'event-missing',
+      source_type: 'event',
+      last_activity_at: '2026-04-18T01:00:00.000Z',
+    });
+
+    expect(result).toEqual({
+      kind: 'precompile_gap',
+      code: 'case.precompile_gap',
+      case_id: 'case-missing',
+    });
+  });
+
+  it('precompile gap path does not update case_truth, case_memberships, or memory_events', () => {
+    const result = writeCaseLiveStateFromEvent(getAdapter(), {
+      case_id: 'case-gap-no-write',
+      source_event_id: 'event-gap-no-write',
+      source_type: 'event',
+      status: 'blocked',
+      last_activity_at: '2026-04-18T02:00:00.000Z',
+      membership: {
+        source_type: 'event',
+        source_id: 'event-gap-no-write',
+        confidence: 0.8,
+        reason: 'gap test',
+        status: 'active',
+      },
+    });
+
+    expect(result.kind).toBe('precompile_gap');
+    expect(getAdapter().prepare('SELECT COUNT(*) AS count FROM case_truth').get()).toMatchObject({
+      count: 0,
+    });
+    expect(
+      getAdapter().prepare('SELECT COUNT(*) AS count FROM case_memberships').get()
+    ).toMatchObject({ count: 0 });
+    expect(getAdapter().prepare('SELECT COUNT(*) AS count FROM memory_events').get()).toMatchObject(
+      { count: 0 }
+    );
+  });
+
+  it('first prepared SQL statement inside transaction is the case_truth gap gate', () => {
+    const preparedSql: string[] = [];
+    const fakeAdapter = {
+      transaction<T>(fn: () => T): T {
+        return fn();
+      },
+      prepare(sql: string) {
+        preparedSql.push(sql.replace(/\s+/g, ' ').trim());
+        return {
+          get: () => undefined,
+          all: () => [],
+          run: () => ({ changes: 0, lastInsertRowid: 0 }),
+        };
+      },
+    } as unknown as DatabaseAdapter;
+
+    writeCaseLiveStateFromEvent(fakeAdapter, {
+      case_id: 'case-first-sql',
+      source_event_id: 'event-first-sql',
+      source_type: 'event',
+      last_activity_at: '2026-04-18T03:00:00.000Z',
+    });
+
+    expect(preparedSql[0]).toBe('SELECT case_id, status FROM case_truth WHERE case_id = ?');
+  });
+
+  it('writes status and last_activity_at when no locks exist', () => {
+    insertCase({ case_id: 'case-live-write' });
+
+    const result = writeCaseLiveStateFromEvent(getAdapter(), {
+      case_id: 'case-live-write',
+      source_event_id: 'event-live-write',
+      source_type: 'event',
+      status: 'blocked',
+      last_activity_at: '2026-04-18T04:00:00.000Z',
+      now: '2026-04-18T04:00:01.000Z',
+    });
+
+    expect(result.kind).toBe('applied');
+    expect(caseRow('case-live-write')).toEqual({
+      status: 'blocked',
+      last_activity_at: '2026-04-18T04:00:00.000Z',
+    });
+  });
+
+  it("writes membership with added_by='memory-agent'", () => {
+    insertCase({ case_id: 'case-membership-write' });
+
+    const result = writeCaseLiveStateFromEvent(getAdapter(), {
+      case_id: 'case-membership-write',
+      source_event_id: 'event-membership-write',
+      source_type: 'event',
+      membership: {
+        source_type: 'event',
+        source_id: 'event-membership-write',
+        role: 'implementer',
+        confidence: 0.82,
+        reason: 'actor overlap',
+        status: 'active',
+      },
+      now: '2026-04-18T05:00:00.000Z',
+    });
+
+    const row = getAdapter()
+      .prepare(
+        `
+          SELECT role, confidence, reason, status, added_by, user_locked
+          FROM case_memberships
+          WHERE case_id = ? AND source_type = 'event' AND source_id = ?
+        `
+      )
+      .get('case-membership-write', 'event-membership-write') as {
+      role: string;
+      confidence: number;
+      reason: string;
+      status: string;
+      added_by: string;
+      user_locked: number;
+    };
+
+    expect(result.kind).toBe('applied');
+    expect(row).toMatchObject({
+      role: 'implementer',
+      confidence: 0.82,
+      reason: 'actor overlap',
+      status: 'active',
+      added_by: 'memory-agent',
+      user_locked: 0,
+    });
+  });
+
+  it("does not reactivate a status='stale' membership", () => {
+    insertCase({ case_id: 'case-stale-membership' });
+    insertMembership({
+      case_id: 'case-stale-membership',
+      source_id: 'event-stale',
+      status: 'stale',
+      added_by: 'user-correction',
+      user_locked: 0,
+    });
+
+    writeCaseLiveStateFromEvent(getAdapter(), {
+      case_id: 'case-stale-membership',
+      source_event_id: 'event-stale',
+      source_type: 'event',
+      membership: {
+        source_type: 'event',
+        source_id: 'event-stale',
+        confidence: 0.9,
+        reason: 'seen again',
+        status: 'active',
+      },
+    });
+
+    const row = getAdapter()
+      .prepare(
+        `
+          SELECT status, added_by
+          FROM case_memberships
+          WHERE case_id = ? AND source_type = 'event' AND source_id = ?
+        `
+      )
+      .get('case-stale-membership', 'event-stale') as {
+      status: string;
+      added_by: string;
+    };
+
+    expect(row).toEqual({ status: 'stale', added_by: 'user-correction' });
+  });
+
+  it('skips locked status but writes unlocked last_activity_at', () => {
+    insertCase({ case_id: 'case-partial-lock' });
+    const statusTarget = canonicalTargetRef(buildCaseFieldTargetRef('status'));
+    insertCorrectionLock({
+      correction_id: 'corr-status-lock',
+      case_id: 'case-partial-lock',
+      target_kind: 'case_field',
+      target_ref_json: statusTarget.json,
+      target_ref_hash: statusTarget.hash,
+      field_name: 'status',
+    });
+
+    const result = writeCaseLiveStateFromEvent(getAdapter(), {
+      case_id: 'case-partial-lock',
+      source_event_id: 'event-partial-lock',
+      source_type: 'event',
+      status: 'blocked',
+      last_activity_at: '2026-04-18T06:00:00.000Z',
+    });
+
+    expect(result.kind).toBe('applied');
+    if (result.kind === 'applied') {
+      expect(result.skipped_targets).toHaveLength(1);
+      expect(result.skipped_targets[0].correction_id).toBe('corr-status-lock');
+    }
+    expect(caseRow('case-partial-lock')).toEqual({
+      status: 'active',
+      last_activity_at: '2026-04-18T06:00:00.000Z',
+    });
+  });
+
+  it('skips locked membership and emits case.fast_write_lock_skipped', () => {
+    insertCase({ case_id: 'case-membership-lock' });
+    const membershipTarget = canonicalTargetRef(
+      buildMembershipTargetRef('event', 'event-membership-lock')
+    );
+    insertCorrectionLock({
+      correction_id: 'corr-membership-lock',
+      case_id: 'case-membership-lock',
+      target_kind: 'membership',
+      target_ref_json: membershipTarget.json,
+      target_ref_hash: membershipTarget.hash,
+    });
+
+    const result = writeCaseLiveStateFromEvent(getAdapter(), {
+      case_id: 'case-membership-lock',
+      source_event_id: 'event-membership-lock',
+      source_type: 'event',
+      membership: {
+        source_type: 'event',
+        source_id: 'event-membership-lock',
+        confidence: 0.9,
+        reason: 'locked membership',
+        status: 'active',
+      },
+    });
+
+    const membershipCount = getAdapter()
+      .prepare('SELECT COUNT(*) AS count FROM case_memberships')
+      .get() as { count: number };
+    const eventRow = getAdapter()
+      .prepare('SELECT event_type, actor, topic FROM memory_events')
+      .get() as { event_type: string; actor: string; topic: string };
+
+    expect(result.kind).toBe('applied');
+    if (result.kind === 'applied') {
+      expect(result.skipped_targets[0].correction_id).toBe('corr-membership-lock');
+      expect(result.audit_event_ids).toHaveLength(1);
+    }
+    expect(membershipCount.count).toBe(0);
+    expect(eventRow).toEqual({
+      event_type: 'case.fast_write_lock_skipped',
+      actor: 'memory_agent',
+      topic: 'case:case-membership-lock',
+    });
+  });
+
+  it('does not update merged, split, or archived case_truth rows', () => {
+    for (const status of ['merged', 'split', 'archived']) {
+      resetCaseTables();
+      insertCase({ case_id: `case-terminal-${status}`, status });
+
+      const result = writeCaseLiveStateFromEvent(getAdapter(), {
+        case_id: `case-terminal-${status}`,
+        source_event_id: `event-terminal-${status}`,
+        source_type: 'event',
+        last_activity_at: '2026-04-18T07:00:00.000Z',
+      });
+
+      expect(result).toMatchObject({
+        kind: 'rejected',
+        code: 'case.terminal_status',
+        case_id: `case-terminal-${status}`,
+      });
+      expect(caseRow(`case-terminal-${status}`).last_activity_at).toBeNull();
+    }
+  });
+
+  it('rejects proposed memory-agent statuses merged, split, and archived', () => {
+    for (const status of ['merged', 'split', 'archived']) {
+      resetCaseTables();
+      insertCase({ case_id: `case-proposed-${status}` });
+
+      const result = writeCaseLiveStateFromEvent(getAdapter(), {
+        case_id: `case-proposed-${status}`,
+        source_event_id: `event-proposed-${status}`,
+        source_type: 'event',
+        status: status as never,
+      });
+
+      expect(result).toMatchObject({
+        kind: 'rejected',
+        code: 'case.terminal_status',
+        case_id: `case-proposed-${status}`,
+      });
+      expect(caseRow(`case-proposed-${status}`).status).toBe('active');
+    }
+  });
+
+  it('honors user_locked=1 membership row', () => {
+    insertCase({ case_id: 'case-user-locked-membership' });
+    insertMembership({
+      case_id: 'case-user-locked-membership',
+      source_id: 'event-user-locked',
+      role: 'reviewer',
+      confidence: 0.2,
+      reason: 'manual',
+      status: 'candidate',
+      added_by: 'user-correction',
+      user_locked: 1,
+    });
+
+    writeCaseLiveStateFromEvent(getAdapter(), {
+      case_id: 'case-user-locked-membership',
+      source_event_id: 'event-user-locked',
+      source_type: 'event',
+      membership: {
+        source_type: 'event',
+        source_id: 'event-user-locked',
+        role: 'implementer',
+        confidence: 0.95,
+        reason: 'agent',
+        status: 'active',
+      },
+    });
+
+    const row = getAdapter()
+      .prepare(
+        `
+          SELECT role, confidence, reason, status, added_by, user_locked
+          FROM case_memberships
+          WHERE case_id = ? AND source_id = ?
+        `
+      )
+      .get('case-user-locked-membership', 'event-user-locked') as {
+      role: string;
+      confidence: number;
+      reason: string;
+      status: string;
+      added_by: string;
+      user_locked: number;
+    };
+
+    expect(row).toMatchObject({
+      role: 'reviewer',
+      confidence: 0.2,
+      reason: 'manual',
+      status: 'candidate',
+      added_by: 'user-correction',
+      user_locked: 1,
+    });
+  });
+
+  it('skips survivor status write when an active status correction lock exists on a merged loser', () => {
+    insertCase({ case_id: 'case-chain-survivor' });
+    insertCase({
+      case_id: 'case-chain-loser',
+      status: 'merged',
+      canonical_case_id: 'case-chain-survivor',
+    });
+    const statusTarget = canonicalTargetRef(buildCaseFieldTargetRef('status'));
+    insertCorrectionLock({
+      correction_id: 'corr-loser-status',
+      case_id: 'case-chain-loser',
+      target_kind: 'case_field',
+      target_ref_json: statusTarget.json,
+      target_ref_hash: statusTarget.hash,
+      field_name: 'status',
+    });
+
+    const result = writeCaseLiveStateFromEvent(getAdapter(), {
+      case_id: 'case-chain-survivor',
+      source_event_id: 'event-chain-status',
+      source_type: 'event',
+      status: 'blocked',
+    });
+
+    expect(result.kind).toBe('applied');
+    if (result.kind === 'applied') {
+      expect(result.skipped_targets[0].correction_id).toBe('corr-loser-status');
+    }
+    expect(caseRow('case-chain-survivor').status).toBe('active');
+  });
+
+  it('skips survivor membership write when an active membership correction lock exists on a merged loser', () => {
+    insertCase({ case_id: 'case-chain-membership-survivor' });
+    insertCase({
+      case_id: 'case-chain-membership-loser',
+      status: 'merged',
+      canonical_case_id: 'case-chain-membership-survivor',
+    });
+    const membershipTarget = canonicalTargetRef(
+      buildMembershipTargetRef('event', 'event-chain-membership')
+    );
+    insertCorrectionLock({
+      correction_id: 'corr-loser-membership',
+      case_id: 'case-chain-membership-loser',
+      target_kind: 'membership',
+      target_ref_json: membershipTarget.json,
+      target_ref_hash: membershipTarget.hash,
+    });
+
+    const result = writeCaseLiveStateFromEvent(getAdapter(), {
+      case_id: 'case-chain-membership-survivor',
+      source_event_id: 'event-chain-membership',
+      source_type: 'event',
+      membership: {
+        source_type: 'event',
+        source_id: 'event-chain-membership',
+        confidence: 0.88,
+        reason: 'chain lock',
+        status: 'active',
+      },
+    });
+
+    const membershipCount = getAdapter()
+      .prepare('SELECT COUNT(*) AS count FROM case_memberships')
+      .get() as { count: number };
+
+    expect(result.kind).toBe('applied');
+    if (result.kind === 'applied') {
+      expect(result.skipped_targets[0].correction_id).toBe('corr-loser-membership');
+    }
+    expect(membershipCount.count).toBe(0);
+  });
+
+  it('uses target_ref_hash BLOB comparison by creating lock via canonicalTargetRef', () => {
+    insertCase({ case_id: 'case-hash-blob' });
+    const statusTarget = canonicalTargetRef(buildCaseFieldTargetRef('status'));
+    insertCorrectionLock({
+      correction_id: 'corr-hash-blob',
+      case_id: 'case-hash-blob',
+      target_kind: 'case_field',
+      target_ref_json: statusTarget.json,
+      target_ref_hash: statusTarget.hash,
+      field_name: 'status',
+    });
+
+    const result = writeCaseLiveStateFromEvent(getAdapter(), {
+      case_id: 'case-hash-blob',
+      source_event_id: 'event-hash-blob',
+      source_type: 'event',
+      status: 'blocked',
+    });
+
+    expect(result.kind).toBe('applied');
+    if (result.kind === 'applied') {
+      expect(result.skipped_targets).toEqual([
+        {
+          target_kind: 'case_field',
+          target_ref_json: statusTarget.json,
+          correction_id: 'corr-hash-blob',
+        },
+      ]);
+    }
+    expect(caseRow('case-hash-blob').status).toBe('active');
+  });
+});

--- a/packages/mama-core/tests/cases/case-membership-explain.test.ts
+++ b/packages/mama-core/tests/cases/case-membership-explain.test.ts
@@ -183,6 +183,61 @@ describe('Task 16: Membership explanation core helper', () => {
     });
   });
 
+  it('prefers the effective active membership over a newer removed row in the chain', () => {
+    insertCase({ case_id: 'case-survivor' });
+    insertCase({
+      case_id: 'case-loser',
+      status: 'merged',
+      canonical_case_id: 'case-survivor',
+    });
+    insertMembership({
+      case_id: 'case-loser',
+      source_type: 'event',
+      source_id: 'evt-effective',
+      score_breakdown_json: canonicalizeJSON({
+        entity_overlap: 1,
+        embedding_similarity: 0.3,
+        temporal_proximity: 0.8,
+        explicit_from_wiki: 0,
+      }),
+      source_locator: 'event://effective-active',
+    });
+    getAdapter()
+      .prepare(
+        `
+          INSERT INTO case_memberships (
+            case_id, source_type, source_id, role, confidence, reason, status,
+            added_by, added_at, updated_at, user_locked, assignment_strategy,
+            score_breakdown_json, source_locator, explanation_updated_at
+          )
+          VALUES (
+            'case-survivor', 'event', 'evt-effective', 'evidence', 0.2, 'removed row',
+            'removed', 'memory-agent', '2026-04-18T00:00:00.000Z', '2026-04-18T01:00:00.000Z',
+            0, 'memory-agent-match', ?, 'event://removed-row', '2026-04-18T01:00:00.000Z'
+          )
+        `
+      )
+      .run(
+        canonicalizeJSON({
+          entity_overlap: 0,
+          embedding_similarity: 0,
+          temporal_proximity: 0,
+          explicit_from_wiki: 0,
+        })
+      );
+
+    const result = explainCaseMembership(getAdapter(), {
+      case_id: 'case-survivor',
+      source_type: 'event',
+      source_id: 'evt-effective',
+    });
+
+    expect(result).toMatchObject({
+      case_id: 'case-loser',
+      source_locator: 'event://effective-active',
+    });
+  });
+
   it('is deterministic and performs no query-time LLM call', () => {
     insertCase({ case_id: 'case-deterministic' });
     insertMembership({

--- a/packages/mama-core/tests/cases/case-membership-explain.test.ts
+++ b/packages/mama-core/tests/cases/case-membership-explain.test.ts
@@ -1,0 +1,261 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { canonicalizeJSON } from '../../src/canonicalize.js';
+import { getAdapter } from '../../src/db-manager.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import {
+  explainCaseMembership,
+  populateScoreBreakdown,
+} from '../../src/cases/membership-explain.js';
+
+function resetCaseTables(): void {
+  const adapter = getAdapter();
+  adapter.prepare('DELETE FROM case_links').run();
+  adapter.prepare('DELETE FROM case_corrections').run();
+  adapter.prepare('DELETE FROM case_memberships').run();
+  adapter.prepare('DELETE FROM case_truth').run();
+}
+
+function insertCase(
+  overrides: Partial<{
+    case_id: string;
+    title: string;
+    status: string;
+    canonical_case_id: string | null;
+  }>
+): void {
+  const now = '2026-04-18T00:00:00.000Z';
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO case_truth (case_id, title, status, canonical_case_id, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      overrides.case_id,
+      overrides.title ?? overrides.case_id,
+      overrides.status ?? 'active',
+      overrides.canonical_case_id ?? null,
+      now,
+      now
+    );
+}
+
+function insertMembership(input: {
+  case_id: string;
+  source_type?: 'decision' | 'event' | 'observation' | 'artifact';
+  source_id: string;
+  score_breakdown_json?: string | null;
+  source_locator?: string | null;
+  assignment_strategy?: string | null;
+}): void {
+  const now = '2026-04-18T00:00:00.000Z';
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO case_memberships (
+          case_id, source_type, source_id, role, confidence, reason, status,
+          added_by, added_at, updated_at, user_locked, assignment_strategy,
+          score_breakdown_json, source_locator, explanation_updated_at
+        )
+        VALUES (?, ?, ?, 'evidence', 0.88, 'matched', 'active', 'memory-agent',
+                ?, ?, 0, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      input.case_id,
+      input.source_type ?? 'decision',
+      input.source_id,
+      now,
+      now,
+      input.assignment_strategy ?? null,
+      input.score_breakdown_json ?? null,
+      input.source_locator ?? null,
+      input.score_breakdown_json === undefined ? null : now
+    );
+}
+
+describe('Task 16: Membership explanation core helper', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    process.env.MAMA_FORCE_TIER_3 = 'true';
+    testDbPath = await initTestDB('case-membership-explain');
+  });
+
+  beforeEach(() => {
+    resetCaseTables();
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  it('explanation returns score_breakdown when stored', () => {
+    insertCase({ case_id: 'case-explained' });
+    insertMembership({
+      case_id: 'case-explained',
+      source_id: 'dec-explained',
+      assignment_strategy: 'memory-agent-match',
+      score_breakdown_json: canonicalizeJSON({
+        entity_overlap: 0.8,
+        embedding_similarity: 0.7,
+        temporal_proximity: 0.6,
+        explicit_from_wiki: 0,
+      }),
+      source_locator: 'decision://dec-explained',
+    });
+
+    const result = explainCaseMembership(getAdapter(), {
+      case_id: 'case-explained',
+      source_type: 'decision',
+      source_id: 'dec-explained',
+    });
+
+    expect(result).toMatchObject({
+      case_id: 'case-explained',
+      terminal_case_id: 'case-explained',
+      resolved_via_case_id: null,
+      chain: ['case-explained'],
+      score_breakdown: {
+        entity_overlap: 0.8,
+        embedding_similarity: 0.7,
+        temporal_proximity: 0.6,
+        explicit_from_wiki: 0,
+      },
+      source_locator: 'decision://dec-explained',
+      warnings: [],
+    });
+  });
+
+  it('explanation returns null breakdown and reason when not stored', () => {
+    insertCase({ case_id: 'case-legacy' });
+    insertMembership({
+      case_id: 'case-legacy',
+      source_id: 'dec-legacy',
+    });
+
+    const result = explainCaseMembership(getAdapter(), {
+      case_id: 'case-legacy',
+      source_type: 'decision',
+      source_id: 'dec-legacy',
+    });
+
+    expect(result).toMatchObject({
+      score_breakdown: null,
+      score_breakdown_reason: 'breakdown_not_recorded',
+      warnings: ['breakdown_not_recorded'],
+    });
+  });
+
+  it('chain resolution finds a membership on a merged loser case', () => {
+    insertCase({ case_id: 'case-survivor' });
+    insertCase({
+      case_id: 'case-loser',
+      status: 'merged',
+      canonical_case_id: 'case-survivor',
+    });
+    insertMembership({
+      case_id: 'case-loser',
+      source_type: 'event',
+      source_id: 'evt-loser',
+      score_breakdown_json: canonicalizeJSON({
+        entity_overlap: 1,
+        embedding_similarity: 0.4,
+        temporal_proximity: 0.9,
+        explicit_from_wiki: 0,
+      }),
+      source_locator: 'event://evt-loser',
+    });
+
+    const result = explainCaseMembership(getAdapter(), {
+      case_id: 'case-survivor',
+      source_type: 'event',
+      source_id: 'evt-loser',
+    });
+
+    expect(result).toMatchObject({
+      case_id: 'case-loser',
+      terminal_case_id: 'case-survivor',
+      chain: ['case-survivor', 'case-loser'],
+      source_locator: 'event://evt-loser',
+    });
+  });
+
+  it('is deterministic and performs no query-time LLM call', () => {
+    insertCase({ case_id: 'case-deterministic' });
+    insertMembership({
+      case_id: 'case-deterministic',
+      source_id: 'dec-deterministic',
+      score_breakdown_json: canonicalizeJSON({
+        entity_overlap: 0.3,
+        embedding_similarity: 0.2,
+        temporal_proximity: 0.1,
+        explicit_from_wiki: 1,
+      }),
+      source_locator: 'decision://dec-deterministic',
+    });
+
+    const first = explainCaseMembership(getAdapter(), {
+      case_id: 'case-deterministic',
+      source_type: 'decision',
+      source_id: 'dec-deterministic',
+    });
+    const second = explainCaseMembership(getAdapter(), {
+      case_id: 'case-deterministic',
+      source_type: 'decision',
+      source_id: 'dec-deterministic',
+    });
+
+    expect(second).toEqual(first);
+  });
+
+  it('source_locator round-trips through populateScoreBreakdown', () => {
+    insertCase({ case_id: 'case-populate' });
+    insertMembership({
+      case_id: 'case-populate',
+      source_type: 'observation',
+      source_id: 'obs-populate',
+    });
+
+    const populated = populateScoreBreakdown(
+      getAdapter(),
+      {
+        case_id: 'case-populate',
+        source_type: 'observation',
+        source_id: 'obs-populate',
+        assignment_strategy: 'memory-agent-match',
+        source_locator: 'obsidian://Cases/Alpha.md#evidence',
+        now: '2026-04-18T01:00:00.000Z',
+      },
+      {
+        entity_overlap: 0.5,
+        embedding_similarity: 0.6,
+        temporal_proximity: 0.7,
+        explicit_from_wiki: 0,
+      }
+    );
+
+    expect(populated).toEqual({ kind: 'populated', changes: 1 });
+
+    const result = explainCaseMembership(getAdapter(), {
+      case_id: 'case-populate',
+      source_type: 'observation',
+      source_id: 'obs-populate',
+    });
+
+    expect(result).toMatchObject({
+      source_locator: 'obsidian://Cases/Alpha.md#evidence',
+      membership: {
+        assignment_strategy: 'memory-agent-match',
+      },
+      score_breakdown: {
+        entity_overlap: 0.5,
+        embedding_similarity: 0.6,
+        temporal_proximity: 0.7,
+        explicit_from_wiki: 0,
+      },
+    });
+  });
+});

--- a/packages/mama-core/tests/cases/case-membership-explanation-columns-schema.test.ts
+++ b/packages/mama-core/tests/cases/case-membership-explanation-columns-schema.test.ts
@@ -1,0 +1,128 @@
+
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+
+import { applyMigrationsThrough } from '../../src/test-utils.js';
+function columnNames(db: Database.Database): string[] {
+  return (db.prepare('PRAGMA table_info(case_memberships)').all() as Array<{ name: string }>)
+    .map((col) => col.name)
+    .sort();
+}
+
+function seedCase(db: Database.Database, caseId = 'case-membership-explain'): void {
+  db.prepare(
+    `
+      INSERT INTO case_truth (case_id, title, created_at, updated_at)
+      VALUES (?, 'Membership explanation', '2026-04-18T00:00:00.000Z',
+              '2026-04-18T00:00:00.000Z')
+    `
+  ).run(caseId);
+}
+
+describe('case-first substrate — case_memberships explanation columns', () => {
+  it('adds nullable explanation columns', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    const names = columnNames(db);
+    expect(names).toContain('assignment_strategy');
+    expect(names).toContain('score_breakdown_json');
+    expect(names).toContain('source_locator');
+    expect(names).toContain('explanation_updated_at');
+
+    db.close();
+  });
+
+  it('preserves existing membership inserts that omit explanation fields', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+    seedCase(db);
+
+    expect(() =>
+      db
+        .prepare(
+          `
+            INSERT INTO case_memberships (
+              case_id, source_type, source_id, status, added_by, added_at, updated_at
+            )
+            VALUES (?, 'decision', 'dec-legacy', 'active', 'wiki-compiler',
+                    '2026-04-18T00:00:00.000Z', '2026-04-18T00:00:00.000Z')
+          `
+        )
+        .run('case-membership-explain')
+    ).not.toThrow();
+
+    const row = db
+      .prepare(
+        `SELECT assignment_strategy, score_breakdown_json, source_locator, explanation_updated_at
+         FROM case_memberships
+         WHERE case_id = ? AND source_type = 'decision' AND source_id = 'dec-legacy'`
+      )
+      .get('case-membership-explain') as {
+      assignment_strategy: string | null;
+      score_breakdown_json: string | null;
+      source_locator: string | null;
+      explanation_updated_at: string | null;
+    };
+
+    expect(row).toEqual({
+      assignment_strategy: null,
+      score_breakdown_json: null,
+      source_locator: null,
+      explanation_updated_at: null,
+    });
+
+    db.close();
+  });
+
+  it('stores deterministic score breakdown JSON and source locator values', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+    seedCase(db);
+
+    const scoreBreakdown = {
+      entity_overlap: 0.8,
+      embedding_similarity: 0.7,
+      temporal_proximity: 0.6,
+      explicit_from_wiki: 1,
+      total: 0.77,
+    };
+
+    db.prepare(
+      `
+        INSERT INTO case_memberships (
+          case_id, source_type, source_id, status, added_by, added_at, updated_at,
+          assignment_strategy, score_breakdown_json, source_locator, explanation_updated_at
+        )
+        VALUES (?, 'decision', 'dec-explained', 'active', 'wiki-compiler',
+                '2026-04-18T00:00:00.000Z', '2026-04-18T00:00:00.000Z',
+                'wiki_explicit_source', ?, 'obsidian://Cases/Alpha.md#evidence',
+                '2026-04-18T00:00:00.000Z')
+      `
+    ).run('case-membership-explain', JSON.stringify(scoreBreakdown));
+
+    const row = db
+      .prepare(
+        `SELECT assignment_strategy, score_breakdown_json, source_locator, explanation_updated_at
+         FROM case_memberships
+         WHERE case_id = ? AND source_type = 'decision' AND source_id = 'dec-explained'`
+      )
+      .get('case-membership-explain') as {
+      assignment_strategy: string;
+      score_breakdown_json: string;
+      source_locator: string;
+      explanation_updated_at: string;
+    };
+
+    expect(row.assignment_strategy).toBe('wiki_explicit_source');
+    expect(JSON.parse(row.score_breakdown_json)).toEqual(scoreBreakdown);
+    expect(row.source_locator).toBe('obsidian://Cases/Alpha.md#evidence');
+    expect(row.explanation_updated_at).toBe('2026-04-18T00:00:00.000Z');
+
+    db.close();
+  });
+
+});

--- a/packages/mama-core/tests/cases/case-membership-matcher.test.ts
+++ b/packages/mama-core/tests/cases/case-membership-matcher.test.ts
@@ -1,0 +1,283 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { getAdapter } from '../../src/db-manager.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import { matchEventToExistingCases } from '../../src/cases/membership-matcher.js';
+
+function resetCaseTables(): void {
+  const adapter = getAdapter();
+  adapter.prepare('DELETE FROM wiki_page_embeddings').run();
+  adapter.prepare('DELETE FROM wiki_page_index').run();
+  adapter.prepare('DELETE FROM case_memberships').run();
+  adapter.prepare('DELETE FROM case_truth').run();
+}
+
+function insertCase(
+  overrides: Partial<{
+    case_id: string;
+    title: string;
+    status: string;
+    primary_actors: unknown;
+    last_activity_at: string | null;
+    compiled_at: string | null;
+    confidence: string | null;
+    created_at: string;
+    updated_at: string;
+  }>
+): void {
+  const now = '2026-04-18T00:00:00.000Z';
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO case_truth (
+          case_id, current_wiki_path, title, status, primary_actors,
+          last_activity_at, confidence, compiled_at, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      overrides.case_id,
+      `cases/${overrides.case_id}.md`,
+      overrides.title ?? overrides.case_id,
+      overrides.status ?? 'active',
+      JSON.stringify(overrides.primary_actors ?? []),
+      overrides.last_activity_at ?? null,
+      overrides.confidence ?? null,
+      overrides.compiled_at ?? null,
+      overrides.created_at ?? now,
+      overrides.updated_at ?? now
+    );
+}
+
+function insertWikiCaseEmbedding(input: {
+  page_id: string;
+  case_id: string;
+  embedding: Float32Array;
+}): void {
+  const now = '2026-04-18T00:00:00.000Z';
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO wiki_page_index (
+          page_id, source_type, source_locator, case_id, title, page_type,
+          content, confidence, compiled_at, updated_at
+        )
+        VALUES (?, 'wiki_page', ?, ?, ?, 'case', ?, 'high', ?, ?)
+      `
+    )
+    .run(
+      input.page_id,
+      `cases/${input.case_id}.md`,
+      input.case_id,
+      `Case ${input.case_id}`,
+      `Case content ${input.case_id}`,
+      now,
+      now
+    );
+
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO wiki_page_embeddings (page_id, embedding)
+        VALUES (?, ?)
+      `
+    )
+    .run(input.page_id, Buffer.from(input.embedding.buffer));
+}
+
+describe('Story CF2.6: Case membership matching scorer', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    process.env.MAMA_FORCE_TIER_3 = 'true';
+    testDbPath = await initTestDB('case-membership-matcher');
+  });
+
+  beforeEach(() => {
+    resetCaseTables();
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  it('explicit case_id wins even with no actor overlap', () => {
+    insertCase({ case_id: 'case-explicit', primary_actors: [] });
+
+    const result = matchEventToExistingCases(getAdapter(), {
+      event_id: 'event-explicit',
+      event_text: 'unrelated text',
+      event_entities: [],
+      observed_at: '2026-04-18T00:00:00.000Z',
+      explicit_case_id: 'case-explicit',
+    });
+
+    expect(result).toEqual([
+      {
+        case_id: 'case-explicit',
+        score: 1,
+        status: 'active',
+        reason: 'explicit_case_id',
+      },
+    ]);
+  });
+
+  it('explicit case_id missing from case_truth returns precompile_gap', () => {
+    const result = matchEventToExistingCases(getAdapter(), {
+      event_id: 'event-missing-explicit',
+      event_text: 'missing case',
+      event_entities: [],
+      observed_at: '2026-04-18T00:00:00.000Z',
+      explicit_case_id: 'case-does-not-exist',
+    });
+
+    expect(result).toEqual({
+      kind: 'precompile_gap',
+      code: 'case.precompile_gap',
+      case_id: 'case-does-not-exist',
+    });
+  });
+
+  it('actor overlap creates active membership', () => {
+    insertCase({
+      case_id: 'case-actor-active',
+      primary_actors: [
+        { entity_id: 'entity_alice', role: 'owner' },
+        { entity_id: 'entity_project', role: 'subject' },
+      ],
+    });
+
+    const result = matchEventToExistingCases(getAdapter(), {
+      event_id: 'event-actor-active',
+      event_text: 'Alice updated the project.',
+      event_entities: ['entity_alice', 'entity_project'],
+      observed_at: '2026-04-18T00:00:00.000Z',
+    });
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toEqual([
+      expect.objectContaining({
+        case_id: 'case-actor-active',
+        status: 'active',
+        score: 0.9,
+      }),
+    ]);
+  });
+
+  it('borderline score creates candidate membership', () => {
+    insertCase({
+      case_id: 'case-borderline',
+      primary_actors: [{ entity_id: 'entity_borderline', role: 'owner' }],
+      last_activity_at: '2026-04-17T00:00:00.000Z',
+    });
+
+    const result = matchEventToExistingCases(getAdapter(), {
+      event_id: 'event-borderline',
+      event_text: 'Borderline actor update.',
+      event_entities: ['entity_borderline'],
+      observed_at: '2026-04-18T00:00:00.000Z',
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        case_id: 'case-borderline',
+        status: 'candidate',
+        score: 0.6,
+      }),
+    ]);
+  });
+
+  it('no score below threshold returns []', () => {
+    insertCase({
+      case_id: 'case-low-score',
+      primary_actors: [{ entity_id: 'entity_other', role: 'owner' }],
+      last_activity_at: '2026-01-01T00:00:00.000Z',
+    });
+
+    const result = matchEventToExistingCases(getAdapter(), {
+      event_id: 'event-low-score',
+      event_text: 'No overlap.',
+      event_entities: ['entity_unmatched'],
+      observed_at: '2026-04-18T00:00:00.000Z',
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('embedding hit contributes to score when query_embedding is provided', () => {
+    const queryEmbedding = new Float32Array([1, 0, 0, 0]);
+    insertCase({
+      case_id: 'case-embedding',
+      primary_actors: [{ entity_id: 'entity_embedding', role: 'owner' }],
+    });
+    insertWikiCaseEmbedding({
+      page_id: 'page-embedding',
+      case_id: 'case-embedding',
+      embedding: queryEmbedding,
+    });
+
+    const result = matchEventToExistingCases(getAdapter(), {
+      event_id: 'event-embedding',
+      event_text: 'Embedding related event.',
+      event_entities: ['entity_embedding'],
+      observed_at: '2026-04-18T00:00:00.000Z',
+      query_embedding: queryEmbedding,
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        case_id: 'case-embedding',
+        status: 'active',
+        score: 0.75,
+      }),
+    ]);
+  });
+
+  it('missing wiki embedding does not throw and falls back to other signals', () => {
+    insertCase({
+      case_id: 'case-no-embedding',
+      primary_actors: [{ entity_id: 'entity_no_embedding', role: 'owner' }],
+      last_activity_at: '2026-04-17T00:00:00.000Z',
+    });
+
+    const result = matchEventToExistingCases(getAdapter(), {
+      event_id: 'event-no-embedding',
+      event_text: 'Fallback event.',
+      event_entities: ['entity_no_embedding'],
+      observed_at: '2026-04-18T00:00:00.000Z',
+      query_embedding: new Float32Array([0, 1, 0, 0]),
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        case_id: 'case-no-embedding',
+        status: 'candidate',
+        score: 0.6,
+      }),
+    ]);
+  });
+
+  it('stale, resolved, merged, split, and archived cases are not matched', () => {
+    for (const status of ['stale', 'resolved', 'merged', 'split', 'archived']) {
+      insertCase({
+        case_id: `case-${status}`,
+        status,
+        primary_actors: [
+          { entity_id: 'entity_status', role: 'owner' },
+          { entity_id: 'entity_project', role: 'subject' },
+        ],
+        last_activity_at: '2026-04-18T00:00:00.000Z',
+      });
+    }
+
+    const result = matchEventToExistingCases(getAdapter(), {
+      event_id: 'event-status-filter',
+      event_text: 'Status filter.',
+      event_entities: ['entity_status', 'entity_project'],
+      observed_at: '2026-04-18T00:00:00.000Z',
+    });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/mama-core/tests/cases/case-memberships-schema.test.ts
+++ b/packages/mama-core/tests/cases/case-memberships-schema.test.ts
@@ -1,0 +1,204 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import { getAdapter } from '../../src/db-manager.js';
+
+/**
+ * Helper: insert a case_truth row so memberships can reference it via FK.
+ */
+function seedCase(caseId: string, title = 'Seed case'): void {
+  const adapter = getAdapter();
+  const now = new Date().toISOString();
+  adapter
+    .prepare(
+      `INSERT INTO case_truth (case_id, title, created_at, updated_at)
+       VALUES (?, ?, ?, ?)`
+    )
+    .run(caseId, title, now, now);
+}
+
+describe('case-first substrate — case_memberships schema', () => {
+  let testDbPath = '';
+  const caseA = '00000000-0000-0000-0000-000000000A00';
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('case-memberships-schema');
+    seedCase(caseA);
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  it('creates the case_memberships table', () => {
+    const adapter = getAdapter();
+    const row = adapter
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='case_memberships'")
+      .get() as { name?: string } | undefined;
+    expect(row?.name).toBe('case_memberships');
+  });
+
+  it('has primary key (case_id, source_type, source_id)', () => {
+    const adapter = getAdapter();
+    const cols = adapter.prepare('PRAGMA table_info(case_memberships)').all() as Array<{
+      name: string;
+      pk: number;
+    }>;
+    const pkCols = cols
+      .filter((c) => c.pk > 0)
+      .sort((a, b) => a.pk - b.pk)
+      .map((c) => c.name);
+    expect(pkCols).toEqual(['case_id', 'source_type', 'source_id']);
+  });
+
+  it('user_locked defaults to 0 and is NOT NULL', () => {
+    const adapter = getAdapter();
+    const cols = adapter.prepare('PRAGMA table_info(case_memberships)').all() as Array<{
+      name: string;
+      notnull: number;
+      dflt_value: string | null;
+    }>;
+    const ul = cols.find((c) => c.name === 'user_locked')!;
+    expect(ul.notnull).toBe(1);
+    expect(ul.dflt_value).toBe('0');
+
+    const now = new Date().toISOString();
+    adapter
+      .prepare(
+        `INSERT INTO case_memberships
+           (case_id, source_type, source_id, status, added_by, added_at, updated_at)
+         VALUES (?, 'decision', 'dec-default-lock', 'active', 'wiki-compiler', ?, ?)`
+      )
+      .run(caseA, now, now);
+    const row = adapter
+      .prepare(
+        `SELECT user_locked FROM case_memberships
+         WHERE case_id = ? AND source_type = 'decision' AND source_id = 'dec-default-lock'`
+      )
+      .get(caseA) as { user_locked: number };
+    expect(row.user_locked).toBe(0);
+  });
+
+  it('rejects invalid source_type / status / added_by values', () => {
+    const adapter = getAdapter();
+    const now = new Date().toISOString();
+
+    expect(() =>
+      adapter
+        .prepare(
+          `INSERT INTO case_memberships
+             (case_id, source_type, source_id, status, added_by, added_at, updated_at)
+           VALUES (?, 'not_a_type', 'src-1', 'active', 'wiki-compiler', ?, ?)`
+        )
+        .run(caseA, now, now)
+    ).toThrow(/CHECK constraint/i);
+
+    expect(() =>
+      adapter
+        .prepare(
+          `INSERT INTO case_memberships
+             (case_id, source_type, source_id, status, added_by, added_at, updated_at)
+           VALUES (?, 'decision', 'src-2', 'not_a_status', 'wiki-compiler', ?, ?)`
+        )
+        .run(caseA, now, now)
+    ).toThrow(/CHECK constraint/i);
+
+    expect(() =>
+      adapter
+        .prepare(
+          `INSERT INTO case_memberships
+             (case_id, source_type, source_id, status, added_by, added_at, updated_at)
+           VALUES (?, 'decision', 'src-3', 'active', 'not_an_added_by', ?, ?)`
+        )
+        .run(caseA, now, now)
+    ).toThrow(/CHECK constraint/i);
+  });
+
+  it('rejects NULL on source_type / status / added_by (NOT NULL enforcement)', () => {
+    const adapter = getAdapter();
+    const now = new Date().toISOString();
+
+    // NULL source_type
+    expect(() =>
+      adapter
+        .prepare(
+          `INSERT INTO case_memberships
+             (case_id, source_type, source_id, status, added_by, added_at, updated_at)
+           VALUES (?, NULL, 'src-null-st', 'active', 'wiki-compiler', ?, ?)`
+        )
+        .run(caseA, now, now)
+    ).toThrow(/NOT NULL constraint/i);
+
+    // NULL status
+    expect(() =>
+      adapter
+        .prepare(
+          `INSERT INTO case_memberships
+             (case_id, source_type, source_id, status, added_by, added_at, updated_at)
+           VALUES (?, 'decision', 'src-null-status', NULL, 'wiki-compiler', ?, ?)`
+        )
+        .run(caseA, now, now)
+    ).toThrow(/NOT NULL constraint/i);
+
+    // NULL added_by
+    expect(() =>
+      adapter
+        .prepare(
+          `INSERT INTO case_memberships
+             (case_id, source_type, source_id, status, added_by, added_at, updated_at)
+           VALUES (?, 'decision', 'src-null-ab', 'active', NULL, ?, ?)`
+        )
+        .run(caseA, now, now)
+    ).toThrow(/NOT NULL constraint/i);
+  });
+
+  it("accepts locked tombstone encoding (status='stale', user_locked=1)", () => {
+    const adapter = getAdapter();
+    const now = new Date().toISOString();
+    expect(() =>
+      adapter
+        .prepare(
+          `INSERT INTO case_memberships
+             (case_id, source_type, source_id, status, added_by, added_at, updated_at, user_locked)
+           VALUES (?, 'decision', 'src-locked-tombstone', 'stale', 'user-correction', ?, ?, 1)`
+        )
+        .run(caseA, now, now)
+    ).not.toThrow();
+
+    const row = adapter
+      .prepare(
+        `SELECT status, user_locked FROM case_memberships
+         WHERE case_id = ? AND source_type = 'decision' AND source_id = 'src-locked-tombstone'`
+      )
+      .get(caseA) as { status: string; user_locked: number };
+    expect(row.status).toBe('stale');
+    expect(row.user_locked).toBe(1);
+  });
+
+  it("rejects status='stale_locked' (Option B enum stays at 5 values)", () => {
+    const adapter = getAdapter();
+    const now = new Date().toISOString();
+    expect(() =>
+      adapter
+        .prepare(
+          `INSERT INTO case_memberships
+             (case_id, source_type, source_id, status, added_by, added_at, updated_at)
+           VALUES (?, 'decision', 'src-stale-locked', 'stale_locked', 'user-correction', ?, ?)`
+        )
+        .run(caseA, now, now)
+    ).toThrow(/CHECK constraint/i);
+  });
+
+  it('expected indexes exist', () => {
+    const adapter = getAdapter();
+    const rows = adapter
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='case_memberships' AND name LIKE 'idx_case_memberships_%'"
+      )
+      .all() as Array<{ name: string }>;
+    const names = rows.map((r) => r.name).sort();
+    expect(names).toEqual(
+      ['idx_case_memberships_case_status', 'idx_case_memberships_source'].sort()
+    );
+  });
+});

--- a/packages/mama-core/tests/cases/case-merge-split.test.ts
+++ b/packages/mama-core/tests/cases/case-merge-split.test.ts
@@ -292,6 +292,41 @@ describe('Story CF2.9: HITL-only case merge and split', () => {
           .get(LOSER_ID)
       ).toMatchObject({ count: 2 });
     });
+
+    it('writes merge state against resolved canonical ids when aliases are provided', () => {
+      insertCase({ case_id: LOSER_ID, title: 'Canonical loser' });
+      insertCase({ case_id: SURVIVOR_ID, title: 'Canonical survivor' });
+      insertCase({
+        case_id: '77777777-7777-4777-8777-777777777777',
+        title: 'Loser alias',
+        canonical_case_id: LOSER_ID,
+      });
+      insertCase({
+        case_id: '88888888-8888-4888-8888-888888888888',
+        title: 'Survivor alias',
+        canonical_case_id: SURVIVOR_ID,
+      });
+
+      const result = mergeCases(
+        getAdapter(),
+        mergeInput({
+          loser_case_id: '77777777-7777-4777-8777-777777777777',
+          survivor_case_id: '88888888-8888-4888-8888-888888888888',
+        }) as never
+      );
+
+      expect(result).toMatchObject({ kind: 'merged' });
+      expect(
+        getAdapter()
+          .prepare('SELECT status, canonical_case_id FROM case_truth WHERE case_id = ?')
+          .get(LOSER_ID)
+      ).toMatchObject({ status: 'merged', canonical_case_id: SURVIVOR_ID });
+      expect(
+        getAdapter()
+          .prepare('SELECT status FROM case_truth WHERE case_id = ?')
+          .get('77777777-7777-4777-8777-777777777777')
+      ).toMatchObject({ status: 'active' });
+    });
   });
 
   describe('splitCase', () => {

--- a/packages/mama-core/tests/cases/case-merge-split.test.ts
+++ b/packages/mama-core/tests/cases/case-merge-split.test.ts
@@ -1,0 +1,472 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { canonicalizeJSON } from '../../src/canonicalize.js';
+import { getAdapter } from '../../src/db-manager.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import { assembleCase } from '../../src/cases/store.js';
+import { mergeCases, splitCase } from '../../src/cases/merge-split.js';
+
+const NOW = '2026-04-18T05:00:00.000Z';
+const LOSER_ID = '11111111-1111-4111-8111-111111111111';
+const SURVIVOR_ID = '22222222-2222-4222-8222-222222222222';
+const PARENT_ID = '33333333-3333-4333-8333-333333333333';
+const CHILD_A = '44444444-4444-4444-8444-444444444444';
+const CHILD_B = '55555555-5555-4555-8555-555555555555';
+
+function resetTables(): void {
+  const adapter = getAdapter();
+  adapter.prepare('DELETE FROM memory_events').run();
+  adapter.prepare('DELETE FROM case_corrections').run();
+  adapter.prepare('DELETE FROM case_memberships').run();
+  adapter.prepare('DELETE FROM case_truth').run();
+  adapter.prepare('DELETE FROM decision_entity_sources').run();
+  adapter.prepare('DELETE FROM decisions').run();
+}
+
+function insertCase(input: {
+  case_id: string;
+  title?: string;
+  status?: string;
+  canonical_case_id?: string | null;
+  split_from_case_id?: string | null;
+}): void {
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO case_truth (
+          case_id, current_wiki_path, title, status, canonical_case_id, split_from_case_id,
+          scope_refs, confidence, created_at, updated_at
+        )
+        VALUES (?, NULL, ?, ?, ?, ?, '[]', 'high', ?, ?)
+      `
+    )
+    .run(
+      input.case_id,
+      input.title ?? input.case_id,
+      input.status ?? 'active',
+      input.canonical_case_id ?? null,
+      input.split_from_case_id ?? null,
+      NOW,
+      NOW
+    );
+}
+
+function insertDecision(decisionId: string): void {
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO decisions (
+          id, topic, decision, reasoning, confidence, user_involvement, status, created_at,
+          updated_at
+        )
+        VALUES (?, 'case/merge-split', 'Seed decision', 'test', 0.9, 'approved', 'active', ?, ?)
+      `
+    )
+    .run(decisionId, NOW, NOW);
+}
+
+function insertMembership(input: {
+  case_id: string;
+  source_id: string;
+  status?: string;
+  user_locked?: 0 | 1;
+}): void {
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO case_memberships (
+          case_id, source_type, source_id, role, confidence, reason, status, added_by,
+          added_at, updated_at, user_locked
+        )
+        VALUES (?, 'decision', ?, 'supporting', 0.8, 'seeded', ?, 'wiki-compiler', ?, ?, ?)
+      `
+    )
+    .run(
+      input.case_id,
+      input.source_id,
+      input.status ?? 'active',
+      NOW,
+      NOW,
+      input.user_locked ?? 0
+    );
+}
+
+function insertInactiveCorrection(caseId: string, correctionId: string): void {
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO case_corrections (
+          correction_id, case_id, target_kind, target_ref_json, target_ref_hash, field_name,
+          old_value_json, new_value_json, reason, is_lock_active, superseded_by, reverted_at,
+          applied_by, applied_at
+        )
+        VALUES (?, ?, 'case_field', ?, ?, 'status', ?, ?, 'seed audit', 0, NULL, NULL, 'user', ?)
+      `
+    )
+    .run(
+      correctionId,
+      caseId,
+      canonicalizeJSON({ kind: 'case_field', field: 'status' }),
+      Buffer.alloc(32, 0x11),
+      canonicalizeJSON('active'),
+      canonicalizeJSON('blocked'),
+      NOW
+    );
+}
+
+function mergeInput(overrides: Record<string, unknown> = {}) {
+  return {
+    loser_case_id: LOSER_ID,
+    survivor_case_id: SURVIVOR_ID,
+    reason: 'User confirmed duplicate cases.',
+    confirmed: true,
+    confirmed_by: 'user-1',
+    confirmation_summary: 'Loser belongs under survivor.',
+    now: NOW,
+    ...overrides,
+  };
+}
+
+function splitInput(overrides: Record<string, unknown> = {}) {
+  return {
+    parent_case_id: PARENT_ID,
+    children: [
+      {
+        title: 'Child A',
+        membership_sources: [
+          { source_type: 'decision', source_id: 'dec-split-a', remove_from_parent: true },
+        ],
+      },
+      {
+        title: 'Child B',
+        membership_sources: [{ source_type: 'decision', source_id: 'dec-split-b' }],
+      },
+    ],
+    trusted_child_case_ids: [CHILD_A, CHILD_B],
+    reason: 'User confirmed separate workstreams.',
+    confirmed: true,
+    confirmed_by: 'user-1',
+    confirmation_summary: 'Parent case should split into two child cases.',
+    now: NOW,
+    ...overrides,
+  };
+}
+
+describe('Story CF2.9: HITL-only case merge and split', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    process.env.MAMA_FORCE_TIER_3 = 'true';
+    testDbPath = await initTestDB('case-merge-split');
+  });
+
+  beforeEach(resetTables);
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  describe('mergeCases', () => {
+    it('rejects without confirmed=true', () => {
+      const result = mergeCases(getAdapter(), mergeInput({ confirmed: false }) as never);
+
+      expect(result).toMatchObject({
+        kind: 'rejected',
+        code: 'case.confirmation_required',
+      });
+    });
+
+    it('rejects self merge', () => {
+      insertCase({ case_id: LOSER_ID });
+
+      const result = mergeCases(getAdapter(), mergeInput({ survivor_case_id: LOSER_ID }) as never);
+
+      expect(result).toMatchObject({ kind: 'rejected', code: 'case.merge_self' });
+    });
+
+    it('missing loser or survivor returns precompile_gap', () => {
+      insertCase({ case_id: SURVIVOR_ID });
+
+      expect(mergeCases(getAdapter(), mergeInput())).toMatchObject({
+        kind: 'precompile_gap',
+        code: 'case.precompile_gap',
+        case_id: LOSER_ID,
+      });
+
+      resetTables();
+      insertCase({ case_id: LOSER_ID });
+      expect(mergeCases(getAdapter(), mergeInput())).toMatchObject({
+        kind: 'precompile_gap',
+        code: 'case.precompile_gap',
+        case_id: SURVIVOR_ID,
+      });
+    });
+
+    it('rejects canonical cycle', () => {
+      insertCase({ case_id: LOSER_ID });
+      insertCase({ case_id: SURVIVOR_ID });
+      insertCase({ case_id: '66666666-6666-4666-8666-666666666666' });
+      // Build the cycle via UPDATE (bypasses insert-order FK constraint)
+      getAdapter()
+        .prepare('UPDATE case_truth SET canonical_case_id = ? WHERE case_id = ?')
+        .run(SURVIVOR_ID, LOSER_ID);
+      getAdapter()
+        .prepare('UPDATE case_truth SET canonical_case_id = ? WHERE case_id = ?')
+        .run(LOSER_ID, SURVIVOR_ID);
+
+      const result = mergeCases(
+        getAdapter(),
+        mergeInput({ survivor_case_id: '66666666-6666-4666-8666-666666666666' })
+      );
+
+      expect(result).toMatchObject({ kind: 'rejected', code: 'case.merge_chain_cycle' });
+    });
+
+    it('sets loser merged, keeps loser memberships/corrections, and reads them through survivor', () => {
+      insertCase({ case_id: LOSER_ID, title: 'Loser' });
+      insertCase({ case_id: SURVIVOR_ID, title: 'Survivor' });
+      insertDecision('dec-loser');
+      insertMembership({ case_id: LOSER_ID, source_id: 'dec-loser' });
+      insertInactiveCorrection(LOSER_ID, 'corr-loser-audit');
+
+      const result = mergeCases(getAdapter(), mergeInput());
+
+      expect(result).toMatchObject({
+        kind: 'merged',
+        loser_case_id: LOSER_ID,
+        survivor_case_id: SURVIVOR_ID,
+        audit_event_id: expect.any(String),
+      });
+      expect(
+        getAdapter()
+          .prepare('SELECT status, canonical_case_id FROM case_truth WHERE case_id = ?')
+          .get(LOSER_ID)
+      ).toMatchObject({ status: 'merged', canonical_case_id: SURVIVOR_ID });
+      expect(
+        getAdapter()
+          .prepare('SELECT case_id FROM case_memberships WHERE source_id = ?')
+          .get('dec-loser')
+      ).toMatchObject({ case_id: LOSER_ID });
+      expect(
+        getAdapter()
+          .prepare('SELECT case_id FROM case_corrections WHERE correction_id = ?')
+          .get('corr-loser-audit')
+      ).toMatchObject({ case_id: LOSER_ID });
+
+      const survivorAssembly = assembleCase(getAdapter(), SURVIVOR_ID);
+      expect(survivorAssembly.decisions.map((decision) => decision.id)).toContain('dec-loser');
+
+      const loserAssembly = assembleCase(getAdapter(), LOSER_ID);
+      expect(loserAssembly.case_id).toBe(SURVIVOR_ID);
+      expect(loserAssembly.resolved_via_case_id).toBe(LOSER_ID);
+      expect(loserAssembly.decisions.map((decision) => decision.id)).toContain('dec-loser');
+
+      expect(getAdapter().prepare('SELECT event_type FROM memory_events').get()).toMatchObject({
+        event_type: 'case.merged',
+      });
+      expect(
+        getAdapter()
+          .prepare(
+            `
+              SELECT COUNT(*) AS count
+                FROM case_corrections
+               WHERE case_id = ?
+                 AND is_lock_active = 1
+            `
+          )
+          .get(LOSER_ID)
+      ).toMatchObject({ count: 0 });
+      expect(
+        getAdapter()
+          .prepare(
+            `
+              SELECT COUNT(*) AS count
+                FROM case_corrections
+               WHERE case_id = ?
+                 AND is_lock_active = 0
+            `
+          )
+          .get(LOSER_ID)
+      ).toMatchObject({ count: 2 });
+    });
+  });
+
+  describe('splitCase', () => {
+    beforeEach(() => {
+      insertCase({ case_id: PARENT_ID, title: 'Parent' });
+      insertDecision('dec-split-a');
+      insertDecision('dec-split-b');
+      insertDecision('dec-split-stays');
+      insertMembership({ case_id: PARENT_ID, source_id: 'dec-split-a' });
+      insertMembership({ case_id: PARENT_ID, source_id: 'dec-split-b' });
+      insertMembership({ case_id: PARENT_ID, source_id: 'dec-split-stays' });
+    });
+
+    it('rejects without confirmation and one-child split', () => {
+      expect(splitCase(getAdapter(), splitInput({ confirmed: false }) as never)).toMatchObject({
+        kind: 'rejected',
+        code: 'case.confirmation_required',
+      });
+
+      expect(
+        splitCase(
+          getAdapter(),
+          splitInput({
+            children: [{ title: 'Only Child', membership_sources: [] }],
+            trusted_child_case_ids: [CHILD_A],
+          })
+        )
+      ).toMatchObject({ kind: 'rejected', code: 'case.split_requires_two_children' });
+    });
+
+    it('missing parent returns precompile_gap and terminal parent is rejected', () => {
+      resetTables();
+
+      expect(splitCase(getAdapter(), splitInput())).toMatchObject({
+        kind: 'precompile_gap',
+        code: 'case.precompile_gap',
+        case_id: PARENT_ID,
+      });
+
+      insertCase({ case_id: PARENT_ID, status: 'archived' });
+      expect(splitCase(getAdapter(), splitInput())).toMatchObject({
+        kind: 'rejected',
+        code: 'case.terminal_status',
+      });
+    });
+
+    it('rejects caller-supplied child case_id and untrusted child ids', () => {
+      expect(
+        splitCase(
+          getAdapter(),
+          splitInput({
+            children: [
+              { title: 'Child A', case_id: 'case_bad', membership_sources: [] },
+              { title: 'Child B', membership_sources: [] },
+            ],
+          }) as never
+        )
+      ).toMatchObject({ kind: 'rejected', code: 'case.child_id_not_trusted' });
+
+      expect(
+        splitCase(getAdapter(), splitInput({ trusted_child_case_ids: ['case_bad', CHILD_B] }))
+      ).toMatchObject({ kind: 'rejected', code: 'case.child_id_not_trusted' });
+
+      expect(
+        splitCase(getAdapter(), splitInput({ trusted_child_case_ids: [CHILD_A] }))
+      ).toMatchObject({ kind: 'rejected', code: 'case.child_id_count_mismatch' });
+    });
+
+    it('creates children, marks parent split, audits inactive correction, and moves memberships explicitly', () => {
+      const result = splitCase(getAdapter(), splitInput());
+
+      expect(result).toMatchObject({
+        kind: 'split',
+        parent_case_id: PARENT_ID,
+        child_case_ids: [CHILD_A, CHILD_B],
+        audit_event_id: expect.any(String),
+      });
+      for (const childId of [CHILD_A, CHILD_B]) {
+        expect(childId).toMatch(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+        );
+        expect(childId.startsWith('case_')).toBe(false);
+      }
+
+      expect(
+        getAdapter().prepare('SELECT status FROM case_truth WHERE case_id = ?').get(PARENT_ID)
+      ).toMatchObject({ status: 'split' });
+      expect(
+        getAdapter()
+          .prepare('SELECT split_from_case_id FROM case_truth WHERE case_id = ?')
+          .get(CHILD_A)
+      ).toMatchObject({ split_from_case_id: PARENT_ID });
+
+      expect(
+        getAdapter()
+          .prepare(
+            `
+              SELECT status, user_locked
+                FROM case_memberships
+               WHERE case_id = ?
+                 AND source_id = 'dec-split-a'
+            `
+          )
+          .get(PARENT_ID)
+      ).toMatchObject({ status: 'removed', user_locked: 1 });
+      expect(
+        getAdapter()
+          .prepare(
+            `
+              SELECT status, user_locked
+                FROM case_memberships
+               WHERE case_id = ?
+                 AND source_id = 'dec-split-b'
+            `
+          )
+          .get(PARENT_ID)
+      ).toMatchObject({ status: 'active', user_locked: 0 });
+      expect(
+        getAdapter()
+          .prepare(
+            `
+              SELECT status, user_locked
+                FROM case_memberships
+               WHERE case_id = ?
+                 AND source_id = 'dec-split-stays'
+            `
+          )
+          .get(PARENT_ID)
+      ).toMatchObject({ status: 'active', user_locked: 0 });
+      expect(
+        getAdapter()
+          .prepare(
+            `
+              SELECT status, user_locked, added_by
+                FROM case_memberships
+               WHERE case_id = ?
+                 AND source_id = 'dec-split-a'
+            `
+          )
+          .get(CHILD_A)
+      ).toMatchObject({ status: 'active', user_locked: 1, added_by: 'user-correction' });
+
+      const correction = getAdapter()
+        .prepare(
+          `
+            SELECT target_ref_json, is_lock_active
+              FROM case_corrections
+             WHERE case_id = ?
+          `
+        )
+        .get(PARENT_ID) as { target_ref_json: string; is_lock_active: number };
+      expect(JSON.parse(correction.target_ref_json)).toEqual({
+        field: 'status',
+        kind: 'case_field',
+      });
+      expect(correction.is_lock_active).toBe(0);
+
+      expect(getAdapter().prepare('SELECT event_type FROM memory_events').get()).toMatchObject({
+        event_type: 'case.split',
+      });
+
+      const parentAssembly = assembleCase(getAdapter(), PARENT_ID);
+      expect(parentAssembly.linked_cases).toEqual(
+        expect.arrayContaining([
+          { case_id: CHILD_A, relation: 'split_into' },
+          { case_id: CHILD_B, relation: 'split_into' },
+        ])
+      );
+    });
+
+    it('merge-split uses correction helper rather than raw case_corrections INSERT', () => {
+      const source = readFileSync(resolve(process.cwd(), 'src/cases/merge-split.ts'), 'utf8');
+
+      expect(source).not.toMatch(/INSERT\s+INTO\s+case_corrections/i);
+      expect(source).toContain('insertCaseCorrectionLock');
+    });
+  });
+});

--- a/packages/mama-core/tests/cases/case-proposal-queue-schema.test.ts
+++ b/packages/mama-core/tests/cases/case-proposal-queue-schema.test.ts
@@ -1,0 +1,200 @@
+import { createHash } from 'node:crypto';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import { getAdapter } from '../../src/db-manager.js';
+
+function sha256(s: string): Buffer {
+  return createHash('sha256').update(s, 'utf8').digest();
+}
+
+function insertProposal(
+  overrides: Partial<{
+    proposal_id: string;
+    project: string;
+    proposal_kind: string;
+    proposed_payload: string;
+    payload_fingerprint: Buffer;
+    conflicting_case_id: string | null;
+    resolved_at: string | null;
+    resolution: string | null;
+  }> = {}
+): void {
+  const adapter = getAdapter();
+  const now = new Date().toISOString();
+  adapter
+    .prepare(
+      `INSERT INTO case_proposal_queue
+         (proposal_id, project, proposal_kind, proposed_payload, payload_fingerprint,
+          conflicting_case_id, detected_at, resolved_at, resolution, resolution_note)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`
+    )
+    .run(
+      overrides.proposal_id ?? `prop-${Math.random().toString(16).slice(2, 10)}`,
+      overrides.project ?? 'alpha',
+      overrides.proposal_kind ?? 'ambiguous_slug',
+      overrides.proposed_payload ?? '{"slug":"test"}',
+      overrides.payload_fingerprint ?? sha256(overrides.proposed_payload ?? '{"slug":"test"}'),
+      overrides.conflicting_case_id ?? null,
+      now,
+      overrides.resolved_at ?? null,
+      overrides.resolution ?? null
+    );
+}
+
+describe('case-first substrate — case_proposal_queue schema', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('case-proposal-queue-schema');
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  it('creates the case_proposal_queue table', () => {
+    const adapter = getAdapter();
+    const row = adapter
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='case_proposal_queue'")
+      .get() as { name?: string } | undefined;
+    expect(row?.name).toBe('case_proposal_queue');
+  });
+
+  it('accepts every amended proposal_kind value', () => {
+    const kinds = [
+      'ambiguous_slug',
+      'duplicate_frontmatter',
+      'missing_frontmatter',
+      'unknown_case_id',
+      'stale_case_id',
+      'merged_target',
+      'archived_target',
+      'lock_conflict',
+      'corrupt_frontmatter',
+      'quarantined_accepted_case',
+    ];
+    for (const kind of kinds) {
+      const payload = `{"kind":"${kind}"}`;
+      expect(() =>
+        insertProposal({
+          proposal_id: `prop-kind-${kind}`,
+          proposal_kind: kind,
+          proposed_payload: payload,
+          payload_fingerprint: sha256(payload),
+        })
+      ).not.toThrow();
+    }
+  });
+
+  it('rejects an unknown proposal_kind', () => {
+    expect(() =>
+      insertProposal({ proposal_kind: 'not_a_kind', proposal_id: 'prop-bad-kind' })
+    ).toThrow(/CHECK constraint/i);
+  });
+
+  it('rejects payload_fingerprint that is not exactly 32 bytes', () => {
+    expect(() =>
+      insertProposal({
+        proposal_id: 'prop-bad-hash-short',
+        payload_fingerprint: Buffer.from('short'),
+      })
+    ).toThrow(/CHECK constraint/i);
+    expect(() =>
+      insertProposal({
+        proposal_id: 'prop-bad-hash-long',
+        payload_fingerprint: Buffer.alloc(64),
+      })
+    ).toThrow(/CHECK constraint/i);
+  });
+
+  it('partial UNIQUE: unresolved duplicate fingerprint is rejected', () => {
+    const payload = '{"slug":"duplicate-case"}';
+    const fp = sha256(payload);
+    insertProposal({
+      proposal_id: 'prop-dup-1',
+      project: 'dup-proj',
+      proposal_kind: 'ambiguous_slug',
+      proposed_payload: payload,
+      payload_fingerprint: fp,
+      conflicting_case_id: 'case-X',
+    });
+    expect(() =>
+      insertProposal({
+        proposal_id: 'prop-dup-2',
+        project: 'dup-proj',
+        proposal_kind: 'ambiguous_slug',
+        proposed_payload: payload,
+        payload_fingerprint: fp,
+        conflicting_case_id: 'case-X',
+      })
+    ).toThrow(/UNIQUE constraint/i);
+  });
+
+  it('partial UNIQUE: resolved duplicates are retained for audit', () => {
+    const payload = '{"slug":"resolved-case"}';
+    const fp = sha256(payload);
+    const now = new Date().toISOString();
+    // First row is resolved
+    insertProposal({
+      proposal_id: 'prop-resolved-1',
+      project: 'audit-proj',
+      proposal_kind: 'ambiguous_slug',
+      proposed_payload: payload,
+      payload_fingerprint: fp,
+      conflicting_case_id: 'case-Y',
+      resolved_at: now,
+      resolution: 'rejected',
+    });
+    // Second resolved row with the same fingerprint is allowed (partial index
+    // only dedupes where resolved_at IS NULL)
+    expect(() =>
+      insertProposal({
+        proposal_id: 'prop-resolved-2',
+        project: 'audit-proj',
+        proposal_kind: 'ambiguous_slug',
+        proposed_payload: payload,
+        payload_fingerprint: fp,
+        conflicting_case_id: 'case-Y',
+        resolved_at: now,
+        resolution: 'rejected',
+      })
+    ).not.toThrow();
+    // An unresolved row with the same fingerprint is allowed once all prior
+    // rows for the same composite key are resolved
+    expect(() =>
+      insertProposal({
+        proposal_id: 'prop-new-active',
+        project: 'audit-proj',
+        proposal_kind: 'ambiguous_slug',
+        proposed_payload: payload,
+        payload_fingerprint: fp,
+        conflicting_case_id: 'case-Y',
+      })
+    ).not.toThrow();
+  });
+
+  it('COALESCE allows dedup when conflicting_case_id is NULL', () => {
+    const payload = '{"path":"corrupt.md"}';
+    const fp = sha256(payload);
+    insertProposal({
+      proposal_id: 'prop-corrupt-1',
+      project: 'corrupt-proj',
+      proposal_kind: 'corrupt_frontmatter',
+      proposed_payload: payload,
+      payload_fingerprint: fp,
+      conflicting_case_id: null,
+    });
+    expect(() =>
+      insertProposal({
+        proposal_id: 'prop-corrupt-2',
+        project: 'corrupt-proj',
+        proposal_kind: 'corrupt_frontmatter',
+        proposed_payload: payload,
+        payload_fingerprint: fp,
+        conflicting_case_id: null,
+      })
+    ).toThrow(/UNIQUE constraint/i);
+  });
+
+});

--- a/packages/mama-core/tests/cases/case-role-inference.test.ts
+++ b/packages/mama-core/tests/cases/case-role-inference.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { inferTimelineEventRole, type InferredCaseRole } from '../../src/cases/role-inference.js';
+
+describe('case role inference', () => {
+  it('infers requester from English and Korean request language', () => {
+    expect(inferTimelineEventRole({ userText: 'Please create the rollout plan.' })).toBe(
+      'requester'
+    );
+    expect(
+      inferTimelineEventRole({ userText: '\ubc30\ud3ec \uacc4\ud68d \uc815\ub9ac\ud574\uc918' })
+    ).toBe('requester');
+  });
+
+  it('infers implementer from English and Korean work language', () => {
+    expect(
+      inferTimelineEventRole({
+        userText: '',
+        assistantText: 'I will handle the migration update.',
+      })
+    ).toBe('implementer');
+    expect(
+      inferTimelineEventRole({
+        userText: '',
+        assistantText: '\uc81c\uac00 \uc218\uc815\ud588\uc2b5\ub2c8\ub2e4.',
+      })
+    ).toBe('implementer');
+  });
+
+  it('infers reviewer from English and Korean review language', () => {
+    expect(
+      inferTimelineEventRole({
+        userText: '',
+        assistantText: 'I reviewed and approved the change.',
+      })
+    ).toBe('reviewer');
+    expect(
+      inferTimelineEventRole({
+        userText: '',
+        assistantText:
+          '\ubcc0\uacbd\uc0ac\ud56d\uc744 \uac80\ud1a0\ud558\uace0 \uc2b9\uc778\ud588\uc2b5\ub2c8\ub2e4.',
+      })
+    ).toBe('reviewer');
+  });
+
+  it('infers affected from English and Korean blocked language', () => {
+    expect(inferTimelineEventRole({ userText: 'The release is blocked waiting on CI.' })).toBe(
+      'affected'
+    );
+    expect(
+      inferTimelineEventRole({
+        userText: '\ub9b4\ub9ac\uc2a4\uac00 CI \ub300\uae30\ub85c \ub9c9\ud614\uc2b5\ub2c8\ub2e4.',
+      })
+    ).toBe('affected');
+  });
+
+  it('infers observer from English and Korean status-only language', () => {
+    expect(inferTimelineEventRole({ userText: 'FYI only: deploy finished.' })).toBe('observer');
+    expect(
+      inferTimelineEventRole({
+        userText: '\ucc38\uace0\uc6a9 \uc0c1\ud0dc \uacf5\uc720\uc785\ub2c8\ub2e4.',
+      })
+    ).toBe('observer');
+  });
+
+  it('returns null when patterns conflict', () => {
+    expect(
+      inferTimelineEventRole({
+        userText: 'Please update the case.',
+        assistantText: 'I will handle it.',
+      })
+    ).toBeNull();
+  });
+
+  it('does not map owner or blocker wording without clear actor role mapping', () => {
+    expect(inferTimelineEventRole({ userText: 'Alice is the owner.' })).toBeNull();
+    expect(inferTimelineEventRole({ userText: 'Bob is the blocker.' })).toBeNull();
+  });
+
+  it('maps owner or blocker wording only when the actor role is clear', () => {
+    expect(
+      inferTimelineEventRole({
+        userText: 'Alice owns the work and will handle the migration.',
+        actorHints: ['Alice'],
+      })
+    ).toBe('implementer');
+    expect(
+      inferTimelineEventRole({
+        userText: 'Alice is blocked waiting for the migration window.',
+        actorHints: ['Alice'],
+      })
+    ).toBe('affected');
+  });
+
+  it('never returns non-enum role labels', () => {
+    const values = [
+      inferTimelineEventRole({ userText: 'Alice is the owner.' }),
+      inferTimelineEventRole({ userText: 'Bob is the blocker.' }),
+      inferTimelineEventRole({ userText: 'Merged source was retained.' }),
+      inferTimelineEventRole({ userText: '', assistantText: 'I fixed the broken tests.' }),
+    ];
+
+    expect(values).not.toContain('owner');
+    expect(values).not.toContain('blocker');
+    expect(values).not.toContain('merged_source');
+
+    const allowed = new Set<InferredCaseRole>([
+      'requester',
+      'implementer',
+      'reviewer',
+      'observer',
+      'affected',
+    ]);
+    for (const value of values) {
+      expect(value === null || allowed.has(value)).toBe(true);
+    }
+  });
+});

--- a/packages/mama-core/tests/cases/case-sqlite-transaction.test.ts
+++ b/packages/mama-core/tests/cases/case-sqlite-transaction.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  runImmediateTransaction,
+  type ImmediateTransactionAdapter,
+} from '../../src/cases/sqlite-transaction.js';
+
+describe('runImmediateTransaction', () => {
+  it('wraps successful callbacks with BEGIN IMMEDIATE and COMMIT', () => {
+    const execCalls: string[] = [];
+    const adapter: ImmediateTransactionAdapter = {
+      exec(sql: string) {
+        execCalls.push(sql);
+      },
+      transaction: vi.fn(),
+    };
+
+    const result = runImmediateTransaction(adapter, () => 'ok');
+
+    expect(result).toBe('ok');
+    expect(execCalls).toEqual(['BEGIN IMMEDIATE', 'COMMIT']);
+    expect(adapter.transaction).not.toHaveBeenCalled();
+  });
+
+  it('runs ROLLBACK when the callback throws', () => {
+    const execCalls: string[] = [];
+    const adapter: ImmediateTransactionAdapter = {
+      exec(sql: string) {
+        execCalls.push(sql);
+      },
+      transaction: vi.fn(),
+    };
+
+    expect(() =>
+      runImmediateTransaction(adapter, () => {
+        throw new Error('write failed');
+      })
+    ).toThrow('write failed');
+
+    expect(execCalls).toEqual(['BEGIN IMMEDIATE', 'ROLLBACK']);
+  });
+
+  it('retries SQLITE_BUSY errors up to maxBusyRetries and then rethrows', () => {
+    const execCalls: string[] = [];
+    const busy = new Error('database is locked');
+    (busy as { code?: string }).code = 'SQLITE_BUSY';
+    const adapter: ImmediateTransactionAdapter = {
+      exec(sql: string) {
+        execCalls.push(sql);
+        throw busy;
+      },
+      transaction: vi.fn(),
+    };
+
+    expect(() =>
+      runImmediateTransaction(adapter, () => 'unreachable', {
+        maxBusyRetries: 2,
+        busyRetryDelayMs: 0,
+      })
+    ).toThrow('database is locked');
+
+    expect(execCalls).toEqual(['BEGIN IMMEDIATE', 'BEGIN IMMEDIATE', 'BEGIN IMMEDIATE']);
+  });
+
+  it('retries a busy BEGIN IMMEDIATE and commits once a later attempt succeeds', () => {
+    const execCalls: string[] = [];
+    let beginAttempts = 0;
+    const adapter: ImmediateTransactionAdapter = {
+      exec(sql: string) {
+        execCalls.push(sql);
+        if (sql === 'BEGIN IMMEDIATE') {
+          beginAttempts += 1;
+          if (beginAttempts < 2) {
+            const busy = new Error('SQLITE_BUSY');
+            (busy as { code?: string }).code = 'SQLITE_BUSY';
+            throw busy;
+          }
+        }
+      },
+      transaction: vi.fn(),
+    };
+
+    const result = runImmediateTransaction(adapter, () => 'committed', {
+      maxBusyRetries: 2,
+      busyRetryDelayMs: 0,
+    });
+
+    expect(result).toBe('committed');
+    expect(execCalls).toEqual(['BEGIN IMMEDIATE', 'BEGIN IMMEDIATE', 'COMMIT']);
+  });
+
+  it('rejects async callback thenables', () => {
+    const execCalls: string[] = [];
+    const adapter: ImmediateTransactionAdapter = {
+      exec(sql: string) {
+        execCalls.push(sql);
+      },
+      transaction: vi.fn(),
+    };
+
+    expect(() =>
+      runImmediateTransaction(adapter, () => Promise.resolve('later') as unknown as string)
+    ).toThrow('callbacks must be synchronous');
+
+    expect(execCalls).toEqual(['BEGIN IMMEDIATE', 'ROLLBACK']);
+  });
+});

--- a/packages/mama-core/tests/cases/case-store.test.ts
+++ b/packages/mama-core/tests/cases/case-store.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import { canonicalizeJSON } from '../../src/canonicalize.js';
 import { getAdapter } from '../../src/db-manager.js';
 import { CaseMergeChainCycleError } from '../../src/entities/errors.js';
 import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
@@ -629,6 +630,116 @@ describe('Story CF1.7: Core case store and error surface', () => {
       expect(result.recent_evidence.map((o) => o.observation_id)).toContain('obs-surv-1');
       expect(result.active_corrections.map((c) => c.correction_id)).toContain('corr-assemble');
       expect(result.wiki_page).toBeNull();
+    });
+
+    it('assembleCase keeps membership explanations aligned with the deduped membership row', () => {
+      const adapter = getAdapter();
+      insertCase({ case_id: 'case-explain-survivor', title: 'Survivor' });
+      insertCase({
+        case_id: 'case-explain-loser',
+        canonical_case_id: 'case-explain-survivor',
+        status: 'merged',
+        title: 'Loser',
+      });
+
+      insertMembership({
+        case_id: 'case-explain-loser',
+        source_id: 'dec-shared',
+        role: 'primary',
+        user_locked: 1,
+        updated_at: '2026-04-18T00:00:00.000Z',
+      });
+      adapter
+        .prepare(
+          `
+            UPDATE case_memberships
+            SET score_breakdown_json = ?, source_locator = ?, assignment_strategy = ?, explanation_updated_at = ?
+            WHERE case_id = ? AND source_type = 'decision' AND source_id = ?
+          `
+        )
+        .run(
+          canonicalizeJSON({
+            entity_overlap: 1,
+            embedding_similarity: 0.4,
+            temporal_proximity: 0.9,
+            explicit_from_wiki: 0,
+          }),
+          'decision://locked',
+          'manual-pin',
+          '2026-04-18T00:00:00.000Z',
+          'case-explain-loser',
+          'dec-shared'
+        );
+
+      insertMembership({
+        case_id: 'case-explain-survivor',
+        source_id: 'dec-shared',
+        role: 'primary',
+        user_locked: 0,
+        updated_at: '2026-04-18T01:00:00.000Z',
+      });
+      adapter
+        .prepare(
+          `
+            UPDATE case_memberships
+            SET score_breakdown_json = ?, source_locator = ?, assignment_strategy = ?, explanation_updated_at = ?
+            WHERE case_id = ? AND source_type = 'decision' AND source_id = ?
+          `
+        )
+        .run(
+          canonicalizeJSON({
+            entity_overlap: 0,
+            embedding_similarity: 0,
+            temporal_proximity: 0,
+            explicit_from_wiki: 0,
+          }),
+          'decision://unlocked',
+          'memory-agent-match',
+          '2026-04-18T01:00:00.000Z',
+          'case-explain-survivor',
+          'dec-shared'
+        );
+
+      const result = assembleCase(adapter, 'case-explain-survivor');
+
+      expect(result.memberships).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            source_id: 'dec-shared',
+            user_locked: true,
+          }),
+        ])
+      );
+      expect(result.membership_explanations['decision:dec-shared']).toMatchObject({
+        source_locator: 'decision://locked',
+        assignment_strategy: 'manual-pin',
+      });
+    });
+
+    it('assembleCase rethrows malformed explanation JSON instead of silently dropping it', () => {
+      const adapter = getAdapter();
+      insertCase({ case_id: 'case-explain-json', title: 'Explain JSON' });
+      insertMembership({
+        case_id: 'case-explain-json',
+        source_id: 'dec-bad-json',
+      });
+      adapter
+        .prepare(
+          `
+            UPDATE case_memberships
+            SET score_breakdown_json = ?, source_locator = ?, explanation_updated_at = ?
+            WHERE case_id = ? AND source_type = 'decision' AND source_id = ?
+          `
+        )
+        .run(
+          '{not-json',
+          'decision://bad-json',
+          '2026-04-18T00:00:00.000Z',
+          'case-explain-json',
+          'dec-bad-json'
+        );
+
+      expect(() => assembleCase(adapter, 'case-explain-json')).toThrow();
     });
   });
 });

--- a/packages/mama-core/tests/cases/case-store.test.ts
+++ b/packages/mama-core/tests/cases/case-store.test.ts
@@ -1,0 +1,634 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { getAdapter } from '../../src/db-manager.js';
+import { CaseMergeChainCycleError } from '../../src/entities/errors.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import {
+  assembleCase,
+  enqueueCaseProposal,
+  listActiveCorrectionsForCaseChain,
+  listActiveMembershipsForCaseChain,
+  listUnresolvedCaseProposals,
+  resolveCanonicalCaseChain,
+  upsertCaseTruthSlowFields,
+  upsertExplicitCaseMemberships,
+} from '../../src/cases/store.js';
+
+function insertCase(
+  overrides: Partial<{
+    case_id: string;
+    title: string;
+    status: string;
+    current_wiki_path: string | null;
+    canonical_case_id: string | null;
+    split_from_case_id: string | null;
+    created_at: string;
+    updated_at: string;
+  }>
+): void {
+  const adapter = getAdapter();
+  const now = new Date().toISOString();
+
+  adapter
+    .prepare(
+      `
+        INSERT INTO case_truth (
+          case_id, current_wiki_path, title, status, canonical_case_id,
+          split_from_case_id, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      overrides.case_id,
+      overrides.current_wiki_path ?? null,
+      overrides.title ?? overrides.case_id,
+      overrides.status ?? 'active',
+      overrides.canonical_case_id ?? null,
+      overrides.split_from_case_id ?? null,
+      overrides.created_at ?? now,
+      overrides.updated_at ?? now
+    );
+}
+
+function updateCanonicalCase(
+  caseId: string,
+  canonicalCaseId: string | null,
+  status = 'merged'
+): void {
+  const adapter = getAdapter();
+
+  adapter
+    .prepare(
+      `
+        UPDATE case_truth
+        SET canonical_case_id = ?, status = ?, updated_at = ?
+        WHERE case_id = ?
+      `
+    )
+    .run(canonicalCaseId, status, new Date().toISOString(), caseId);
+}
+
+function insertMembership(
+  overrides: Partial<{
+    case_id: string;
+    source_type: string;
+    source_id: string;
+    role: string | null;
+    confidence: number | null;
+    reason: string | null;
+    status: string;
+    added_by: string;
+    added_at: string;
+    updated_at: string;
+    user_locked: 0 | 1;
+  }>
+): void {
+  const adapter = getAdapter();
+  const now = new Date().toISOString();
+
+  adapter
+    .prepare(
+      `
+        INSERT INTO case_memberships (
+          case_id, source_type, source_id, role, confidence, reason, status,
+          added_by, added_at, updated_at, user_locked
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      overrides.case_id,
+      overrides.source_type ?? 'decision',
+      overrides.source_id ?? 'dec-X',
+      overrides.role ?? null,
+      overrides.confidence ?? null,
+      overrides.reason ?? null,
+      overrides.status ?? 'active',
+      overrides.added_by ?? 'wiki-compiler',
+      overrides.added_at ?? now,
+      overrides.updated_at ?? now,
+      overrides.user_locked ?? 0
+    );
+}
+
+describe('Story CF1.7: Core case store and error surface', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    process.env.MAMA_FORCE_TIER_3 = 'true';
+    testDbPath = await initTestDB('case-store');
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  describe('AC #1: Canonical case chain resolution', () => {
+    it('resolves an active case to itself', () => {
+      const adapter = getAdapter();
+      insertCase({ case_id: 'case-active-self', title: 'Active self' });
+
+      const resolution = resolveCanonicalCaseChain(adapter, 'case-active-self');
+
+      expect(resolution).toEqual({
+        terminal_case_id: 'case-active-self',
+        chain: ['case-active-self'],
+        resolved_via_case_id: null,
+      });
+    });
+
+    it('resolves a merged loser to the survivor and reports resolved_via_case_id', () => {
+      const adapter = getAdapter();
+      insertCase({ case_id: 'case-merge-survivor', title: 'Survivor' });
+      insertCase({
+        case_id: 'case-merge-loser',
+        title: 'Loser',
+        status: 'merged',
+        canonical_case_id: 'case-merge-survivor',
+      });
+
+      const resolution = resolveCanonicalCaseChain(adapter, 'case-merge-loser');
+      const assembly = assembleCase(adapter, 'case-merge-loser');
+
+      expect(resolution.terminal_case_id).toBe('case-merge-survivor');
+      expect(resolution.chain).toEqual(['case-merge-loser', 'case-merge-survivor']);
+      expect(resolution.resolved_via_case_id).toBe('case-merge-loser');
+      expect(assembly.case_id).toBe('case-merge-survivor');
+      expect(assembly.resolved_via_case_id).toBe('case-merge-loser');
+    });
+
+    it('throws case.merge_chain_cycle when a canonical chain cycles', () => {
+      const adapter = getAdapter();
+      insertCase({ case_id: 'case-cycle-a', title: 'Cycle A' });
+      insertCase({ case_id: 'case-cycle-b', title: 'Cycle B' });
+      updateCanonicalCase('case-cycle-a', 'case-cycle-b');
+      updateCanonicalCase('case-cycle-b', 'case-cycle-a');
+
+      expect(() => resolveCanonicalCaseChain(adapter, 'case-cycle-a')).toThrow(
+        CaseMergeChainCycleError
+      );
+
+      try {
+        resolveCanonicalCaseChain(adapter, 'case-cycle-a');
+      } catch (error) {
+        expect((error as CaseMergeChainCycleError).code).toBe('case.merge_chain_cycle');
+        expect((error as CaseMergeChainCycleError).context.case_id).toBe('case-cycle-a');
+        expect((error as CaseMergeChainCycleError).context.chain).toEqual([
+          'case-cycle-a',
+          'case-cycle-b',
+          'case-cycle-a',
+        ]);
+      }
+    });
+
+    it('throws case.merge_chain_cycle with depth payload when a 65-deep chain exceeds cap', () => {
+      const adapter = getAdapter();
+
+      for (let i = 64; i >= 0; i -= 1) {
+        insertCase({
+          case_id: `case-deep-${i}`,
+          title: `Deep ${i}`,
+          status: i === 64 ? 'active' : 'merged',
+          canonical_case_id: i === 64 ? null : `case-deep-${i + 1}`,
+        });
+      }
+
+      try {
+        resolveCanonicalCaseChain(adapter, 'case-deep-0');
+        throw new Error('Expected resolveCanonicalCaseChain to throw.');
+      } catch (error) {
+        expect(error).toBeInstanceOf(CaseMergeChainCycleError);
+        expect((error as CaseMergeChainCycleError).code).toBe('case.merge_chain_cycle');
+        expect((error as CaseMergeChainCycleError).context.detected_at_depth).toBe(65);
+        expect((error as Error).message).toContain('depth 65');
+      }
+    });
+
+    it('does not follow split_from_case_id during canonicalization', () => {
+      const adapter = getAdapter();
+      insertCase({ case_id: 'case-split-parent', title: 'Split parent' });
+      insertCase({
+        case_id: 'case-split-child',
+        title: 'Split child',
+        split_from_case_id: 'case-split-parent',
+      });
+
+      const resolution = resolveCanonicalCaseChain(adapter, 'case-split-child');
+
+      expect(resolution.terminal_case_id).toBe('case-split-child');
+      expect(resolution.chain).toEqual(['case-split-child']);
+      expect(resolution.resolved_via_case_id).toBeNull();
+    });
+  });
+
+  describe('AC #2: Case membership read and write semantics', () => {
+    it('de-dupes duplicate memberships by user_locked first, then updated_at', () => {
+      const adapter = getAdapter();
+      insertCase({ case_id: 'case-dedupe-survivor', title: 'Dedupe survivor' });
+      insertCase({
+        case_id: 'case-dedupe-loser',
+        title: 'Dedupe loser',
+        status: 'merged',
+        canonical_case_id: 'case-dedupe-survivor',
+      });
+      insertMembership({
+        case_id: 'case-dedupe-survivor',
+        source_type: 'decision',
+        source_id: 'dec-X',
+        role: 'compiler-newer',
+        updated_at: '2026-04-17T12:00:00.000Z',
+        user_locked: 0,
+      });
+      insertMembership({
+        case_id: 'case-dedupe-loser',
+        source_type: 'decision',
+        source_id: 'dec-X',
+        role: 'user-locked-older',
+        updated_at: '2026-04-17T10:00:00.000Z',
+        user_locked: 1,
+      });
+
+      const memberships = listActiveMembershipsForCaseChain(adapter, [
+        'case-dedupe-loser',
+        'case-dedupe-survivor',
+      ]);
+
+      expect(memberships).toHaveLength(1);
+      expect(memberships[0]).toMatchObject({
+        source_type: 'decision',
+        source_id: 'dec-X',
+        role: 'user-locked-older',
+        user_locked: true,
+      });
+    });
+
+    it('does not overwrite user_locked=1 rows during wiki-compiler upsert', () => {
+      const adapter = getAdapter();
+      insertCase({ case_id: 'case-locked-membership', title: 'Locked membership' });
+      insertMembership({
+        case_id: 'case-locked-membership',
+        source_type: 'decision',
+        source_id: 'dec-locked',
+        role: 'user-kept',
+        confidence: 0.95,
+        reason: 'user lock',
+        added_by: 'user-correction',
+        user_locked: 1,
+      });
+
+      upsertExplicitCaseMemberships(adapter, {
+        case_id: 'case-locked-membership',
+        rows: [
+          {
+            source_type: 'decision',
+            source_id: 'dec-locked',
+            role: 'compiler-overwrite',
+            confidence: 0.2,
+            reason: 'compiler pass',
+          },
+        ],
+      });
+
+      const row = adapter
+        .prepare(
+          `
+            SELECT role, confidence, reason, added_by, user_locked
+            FROM case_memberships
+            WHERE case_id = ? AND source_type = 'decision' AND source_id = ?
+          `
+        )
+        .get('case-locked-membership', 'dec-locked') as {
+        role: string;
+        confidence: number;
+        reason: string;
+        added_by: string;
+        user_locked: number;
+      };
+
+      expect(row.role).toBe('user-kept');
+      expect(row.confidence).toBe(0.95);
+      expect(row.reason).toBe('user lock');
+      expect(row.added_by).toBe('user-correction');
+      expect(row.user_locked).toBe(1);
+    });
+  });
+
+  describe('AC #3: Proposal queue idempotency', () => {
+    it('returns the same proposal_id and inserted=false for unresolved duplicate fingerprints', () => {
+      const adapter = getAdapter();
+
+      const first = enqueueCaseProposal(adapter, {
+        project: 'queue-project',
+        proposal_kind: 'ambiguous_slug',
+        proposed_payload: '{"slug":"same-case"}',
+        stable_fingerprint_input: { slug: 'same-case', reason: 'ambiguous' },
+      });
+
+      const second = enqueueCaseProposal(adapter, {
+        project: 'queue-project',
+        proposal_kind: 'ambiguous_slug',
+        proposed_payload: '{"slug":"same-case","rerun":true}',
+        stable_fingerprint_input: { reason: 'ambiguous', slug: 'same-case' },
+      });
+
+      expect(first.inserted).toBe(true);
+      expect(second.inserted).toBe(false);
+      expect(second.proposal_id).toBe(first.proposal_id);
+    });
+
+    it('refreshes detected_at when a re-detected duplicate is enqueued (§5.7 L355)', async () => {
+      const adapter = getAdapter();
+
+      const first = enqueueCaseProposal(adapter, {
+        project: 'refresh-project',
+        proposal_kind: 'corrupt_frontmatter',
+        proposed_payload: '{"path":"cases/corrupt.md"}',
+        stable_fingerprint_input: { path: 'cases/corrupt.md' },
+      });
+      const firstDetected = adapter
+        .prepare('SELECT detected_at FROM case_proposal_queue WHERE proposal_id = ?')
+        .get(first.proposal_id) as { detected_at: string };
+
+      // Wait one millisecond so ISO timestamps differ
+      await new Promise((resolve) => setTimeout(resolve, 2));
+
+      const second = enqueueCaseProposal(adapter, {
+        project: 'refresh-project',
+        proposal_kind: 'corrupt_frontmatter',
+        proposed_payload: '{"path":"cases/corrupt.md","rerun":true}',
+        stable_fingerprint_input: { path: 'cases/corrupt.md' },
+      });
+      const secondDetected = adapter
+        .prepare('SELECT detected_at FROM case_proposal_queue WHERE proposal_id = ?')
+        .get(second.proposal_id) as { detected_at: string };
+
+      expect(second.inserted).toBe(false);
+      expect(second.proposal_id).toBe(first.proposal_id);
+      expect(new Date(secondDetected.detected_at).getTime()).toBeGreaterThan(
+        new Date(firstDetected.detected_at).getTime()
+      );
+    });
+  });
+
+  describe('AC #4: Coverage for remaining exported store helpers', () => {
+    it('upsertCaseTruthSlowFields writes every spec §5.2 slow field and is idempotent', () => {
+      const adapter = getAdapter();
+      insertCase({ case_id: 'case-slow-fields', title: 'Slow fields target' });
+
+      upsertCaseTruthSlowFields(adapter, {
+        case_id: 'case-slow-fields',
+        current_wiki_path: 'cases/slow-fields.md',
+        title: 'Slow Fields',
+        status_reason: 'in progress',
+        primary_actors: JSON.stringify([{ entity_id: 'actor-1', role: 'owner' }]),
+        blockers: JSON.stringify([{ text: 'pending decision' }]),
+        confidence: 'high',
+        scope_refs: JSON.stringify([{ kind: 'project', id: 'alpha' }]),
+        wiki_path_history: JSON.stringify([
+          { path: 'cases/old.md', valid_from: '2026-04-01', valid_to: '2026-04-17' },
+        ]),
+        compiled_at: '2026-04-17T00:00:00Z',
+      });
+
+      const row = adapter
+        .prepare('SELECT * FROM case_truth WHERE case_id = ?')
+        .get('case-slow-fields') as Record<string, unknown>;
+      expect(row.current_wiki_path).toBe('cases/slow-fields.md');
+      expect(row.title).toBe('Slow Fields');
+      expect(row.status_reason).toBe('in progress');
+      expect(row.confidence).toBe('high');
+      expect(row.compiled_at).toBe('2026-04-17T00:00:00Z');
+
+      // Spec §5.2 L196-197: wiki-compiler must NOT touch status / last_activity_at /
+      // state_updated_at (those are memory-agent Phase 2 fast-write fields).
+      // The default status from migration 039 is 'active'; after the slow-field
+      // upsert it must remain 'active' and the fast-write timestamps stay NULL.
+      expect(row.status).toBe('active');
+      expect(row.last_activity_at).toBeNull();
+      expect(row.state_updated_at).toBeNull();
+
+      // Idempotent re-upsert with a different wiki path should update the path
+      // without touching status/fast fields.
+      upsertCaseTruthSlowFields(adapter, {
+        case_id: 'case-slow-fields',
+        current_wiki_path: 'cases/slow-fields-renamed.md',
+        title: 'Slow Fields',
+        compiled_at: '2026-04-17T01:00:00Z',
+      });
+      const afterRow = adapter
+        .prepare(
+          'SELECT current_wiki_path, status, last_activity_at FROM case_truth WHERE case_id = ?'
+        )
+        .get('case-slow-fields') as {
+        current_wiki_path: string;
+        status: string;
+        last_activity_at: string | null;
+      };
+      expect(afterRow.current_wiki_path).toBe('cases/slow-fields-renamed.md');
+      expect(afterRow.status).toBe('active');
+      expect(afterRow.last_activity_at).toBeNull();
+    });
+
+    it('listActiveCorrectionsForCaseChain returns only active corrections across a canonical chain', () => {
+      const adapter = getAdapter();
+      insertCase({ case_id: 'case-chain-active' });
+      insertCase({
+        case_id: 'case-chain-loser',
+        canonical_case_id: 'case-chain-active',
+        status: 'merged',
+      });
+
+      const now = new Date().toISOString();
+      const hash = (seed: string): Buffer => {
+        // use SHA-256 via canonicalize/targetRefHash (available via cases/store),
+        // but inline a small helper to avoid importing another module.
+        return Buffer.concat([Buffer.alloc(32, seed.length & 0xff)]);
+      };
+      // Active correction on survivor
+      adapter
+        .prepare(
+          `INSERT INTO case_corrections
+             (correction_id, case_id, target_kind, target_ref_json, target_ref_hash,
+              new_value_json, reason, is_lock_active, applied_by, applied_at)
+           VALUES (?, ?, 'case_field', ?, ?, ?, ?, 1, 'user', ?)`
+        )
+        .run(
+          'corr-active-surv',
+          'case-chain-active',
+          '{"field":"status"}',
+          hash('survivor'),
+          '"blocked"',
+          'r',
+          now
+        );
+      // Active correction on loser (should surface via chain read)
+      adapter
+        .prepare(
+          `INSERT INTO case_corrections
+             (correction_id, case_id, target_kind, target_ref_json, target_ref_hash,
+              new_value_json, reason, is_lock_active, applied_by, applied_at)
+           VALUES (?, ?, 'case_field', ?, ?, ?, ?, 1, 'user', ?)`
+        )
+        .run(
+          'corr-active-loser',
+          'case-chain-loser',
+          '{"field":"title"}',
+          hash('loserA'),
+          '"New title"',
+          'r',
+          now
+        );
+      // Reverted (inactive) correction on loser — must be excluded
+      adapter
+        .prepare(
+          `INSERT INTO case_corrections
+             (correction_id, case_id, target_kind, target_ref_json, target_ref_hash,
+              new_value_json, reason, is_lock_active, applied_by, applied_at, reverted_at)
+           VALUES (?, ?, 'case_field', ?, ?, ?, ?, 0, 'user', ?, ?)`
+        )
+        .run(
+          'corr-reverted',
+          'case-chain-loser',
+          '{"field":"confidence"}',
+          hash('revertedB'),
+          '"low"',
+          'r',
+          now,
+          now
+        );
+
+      const active = listActiveCorrectionsForCaseChain(adapter, [
+        'case-chain-active',
+        'case-chain-loser',
+      ]);
+      const ids = active.map((c) => c.correction_id).sort();
+      expect(ids).toEqual(['corr-active-loser', 'corr-active-surv']);
+    });
+
+    it('listUnresolvedCaseProposals returns only unresolved rows ordered by detected_at ASC', async () => {
+      const adapter = getAdapter();
+
+      // Oldest unresolved
+      enqueueCaseProposal(adapter, {
+        project: 'list-project',
+        proposal_kind: 'ambiguous_slug',
+        proposed_payload: '{"slug":"alpha"}',
+        stable_fingerprint_input: { slug: 'alpha', project: 'list-project' },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      // Newer unresolved
+      const newer = enqueueCaseProposal(adapter, {
+        project: 'list-project',
+        proposal_kind: 'ambiguous_slug',
+        proposed_payload: '{"slug":"beta"}',
+        stable_fingerprint_input: { slug: 'beta', project: 'list-project' },
+      });
+      // Resolved — should be filtered out
+      const resolvedId = 'prop-resolved-list';
+      const now = new Date().toISOString();
+      adapter
+        .prepare(
+          `INSERT INTO case_proposal_queue
+             (proposal_id, project, proposal_kind, proposed_payload, payload_fingerprint,
+              conflicting_case_id, detected_at, resolved_at, resolution, resolution_note)
+           VALUES (?, 'list-project', 'ambiguous_slug', ?, ?, NULL, ?, ?, 'rejected', NULL)`
+        )
+        .run(resolvedId, '{"slug":"gamma"}', Buffer.alloc(32, 0x42), now, now);
+
+      const rows = listUnresolvedCaseProposals(adapter, 'list-project');
+      const ids = rows.map((r) => r.proposal_id);
+      expect(ids).toContain(newer.proposal_id);
+      expect(ids).not.toContain(resolvedId);
+      // detected_at ASC — oldest comes first, newer second
+      const timestamps = rows.map((r) => new Date(r.detected_at).getTime());
+      const sorted = [...timestamps].sort((a, b) => a - b);
+      expect(timestamps).toEqual(sorted);
+    });
+
+    it('assembleCase resolves decisions, timeline events, observations, and active corrections via the chain', () => {
+      const adapter = getAdapter();
+      insertCase({ case_id: 'case-assemble-surv', title: 'Survivor' });
+      insertCase({
+        case_id: 'case-assemble-loser',
+        canonical_case_id: 'case-assemble-surv',
+        status: 'merged',
+        title: 'Loser',
+      });
+
+      // Seed a decision referenced by the loser's membership
+      const now = new Date().toISOString();
+      adapter
+        .prepare(
+          `INSERT INTO decisions (id, topic, decision, reasoning, confidence, user_involvement, status, created_at, updated_at)
+           VALUES ('dec-surv-1', 'project_alpha/topic', 'Ship read-only viewer', 'Phase 1 scope', 0.9, 'approved', 'active', ?, ?)`
+        )
+        .run(now, now);
+      // Seed an entity + timeline event + observation to exercise bulk resolve
+      adapter
+        .prepare(
+          `INSERT INTO entity_nodes (id, kind, preferred_label, status, created_at, updated_at)
+           VALUES ('ent-surv', 'project', 'Alpha', 'active', unixepoch()*1000, unixepoch()*1000)`
+        )
+        .run();
+      adapter
+        .prepare(
+          `INSERT INTO entity_timeline_events (id, entity_id, event_type, role, summary, observed_at, created_at)
+           VALUES ('evt-surv-1', 'ent-surv', 'decision_made', 'observer', 'kickoff', unixepoch()*1000, unixepoch()*1000)`
+        )
+        .run();
+      adapter
+        .prepare(
+          `INSERT INTO entity_timeline_events (id, entity_id, event_type, role, summary, observed_at, created_at)
+           VALUES ('evt-surv-2', 'ent-surv', 'implementation_update', 'implementer', 'build shipped', unixepoch()*1000, unixepoch()*1000)`
+        )
+        .run();
+      adapter
+        .prepare(
+          `INSERT INTO entity_observations
+             (id, surface_form, normalized_form, related_surface_forms, extractor_version,
+              source_connector, source_raw_record_id, source_locator, created_at)
+           VALUES ('obs-surv-1', 'Alpha kickoff', 'alpha kickoff', '[]', 'test', 'slack',
+                   'slack-msg-1', 'slack://alpha#msg1', unixepoch()*1000)`
+        )
+        .run();
+
+      // Membership on the loser referencing each source kind
+      upsertExplicitCaseMemberships(adapter, {
+        case_id: 'case-assemble-loser',
+        rows: [
+          { source_type: 'decision', source_id: 'dec-surv-1', role: 'primary' },
+          { source_type: 'event', source_id: 'evt-surv-1', role: 'supporting' },
+          { source_type: 'event', source_id: 'evt-surv-2', role: null },
+          { source_type: 'observation', source_id: 'obs-surv-1', role: 'supporting' },
+        ],
+      });
+
+      // Active correction on the loser — should surface under survivor's view
+      adapter
+        .prepare(
+          `INSERT INTO case_corrections
+             (correction_id, case_id, target_kind, target_ref_json, target_ref_hash,
+              new_value_json, reason, is_lock_active, applied_by, applied_at)
+           VALUES ('corr-assemble', 'case-assemble-loser', 'case_field', ?, ?, ?, ?, 1, 'user', ?)`
+        )
+        .run('{"field":"status"}', Buffer.alloc(32, 0xab), '"resolved"', 'user decision', now);
+
+      const result = assembleCase(adapter, 'case-assemble-loser');
+      expect(result.case_id).toBe('case-assemble-surv');
+      expect(result.resolved_via_case_id).toBe('case-assemble-loser');
+      expect(result.decisions.map((d) => d.id)).toContain('dec-surv-1');
+      expect(result.timeline_events.map((e) => e.event_id)).toEqual(
+        expect.arrayContaining(['evt-surv-1', 'evt-surv-2'])
+      );
+      const timelineRoleByEventId = new Map(
+        result.timeline_events.map((event) => [event.event_id, event.role])
+      );
+      expect(timelineRoleByEventId.get('evt-surv-1')).toBe('supporting');
+      expect(timelineRoleByEventId.get('evt-surv-2')).toBe('implementer');
+      expect(result.recent_evidence.map((o) => o.observation_id)).toContain('obs-surv-1');
+      expect(result.active_corrections.map((c) => c.correction_id)).toContain('corr-assemble');
+      expect(result.wiki_page).toBeNull();
+    });
+  });
+});

--- a/packages/mama-core/tests/cases/case-target-ref.test.ts
+++ b/packages/mama-core/tests/cases/case-target-ref.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { CanonicalizeError } from '../../src/canonicalize.js';
+import {
+  buildCaseFieldTargetRef,
+  buildMembershipTargetRef,
+  buildWikiSectionTargetRef,
+  canonicalTargetRef,
+  type CaseTargetRef,
+} from '../../src/cases/target-ref.js';
+
+describe('case target ref helpers', () => {
+  it('keeps object key order from changing the canonical hash', () => {
+    const fromBuilder = canonicalTargetRef(buildCaseFieldTargetRef('status'));
+    const reordered = canonicalTargetRef({ field: 'status', kind: 'case_field' } as CaseTargetRef);
+
+    expect(fromBuilder.json).toBe('{"field":"status","kind":"case_field"}');
+    expect(fromBuilder.json).toBe(reordered.json);
+    expect(fromBuilder.hash.equals(reordered.hash)).toBe(true);
+  });
+
+  it('preserves membership source_type and source_id in the canonical hash', () => {
+    const ref = canonicalTargetRef(buildMembershipTargetRef('event', 'evt-123'));
+    const parsed = JSON.parse(ref.json) as {
+      kind: string;
+      source_type: string;
+      source_id: string;
+    };
+    const otherSource = canonicalTargetRef(buildMembershipTargetRef('event', 'evt-456'));
+
+    expect(parsed).toEqual({
+      kind: 'membership',
+      source_type: 'event',
+      source_id: 'evt-123',
+    });
+    expect(ref.hash.equals(otherSource.hash)).toBe(false);
+  });
+
+  it('hashes wiki section target refs to a 32-byte Buffer', () => {
+    const ref = canonicalTargetRef(buildWikiSectionTargetRef('Current status'));
+
+    expect(ref.json).toBe('{"kind":"wiki_section","section_heading":"Current status"}');
+    expect(Buffer.isBuffer(ref.hash)).toBe(true);
+    expect(ref.hash.length).toBe(32);
+  });
+
+  it('throws canonicalize.undefined_value for undefined target values', () => {
+    const invalid = {
+      kind: 'wiki_section',
+      section_heading: undefined,
+    } as unknown as CaseTargetRef;
+
+    expect(() => canonicalTargetRef(invalid)).toThrow(CanonicalizeError);
+
+    try {
+      canonicalTargetRef(invalid);
+    } catch (error) {
+      expect((error as CanonicalizeError).code).toBe('canonicalize.undefined_value');
+    }
+  });
+});

--- a/packages/mama-core/tests/cases/case-tombstone-sweeper.test.ts
+++ b/packages/mama-core/tests/cases/case-tombstone-sweeper.test.ts
@@ -1,0 +1,383 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { getAdapter, type DatabaseAdapter } from '../../src/db-manager.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import { assembleCase } from '../../src/cases/store.js';
+import { sweepStaleCaseMemberships } from '../../src/cases/tombstone-sweeper.js';
+
+const NOW = '2026-04-18T03:00:00.000Z';
+
+function resetTables(): void {
+  const adapter = getAdapter();
+  adapter.prepare('DELETE FROM memory_events').run();
+  adapter.prepare('DELETE FROM case_corrections').run();
+  adapter.prepare('DELETE FROM case_memberships').run();
+  adapter.prepare('DELETE FROM case_truth').run();
+  adapter.prepare('DELETE FROM decision_entity_sources').run();
+  adapter.prepare('DELETE FROM decisions').run();
+  adapter.prepare('DELETE FROM entity_timeline_events').run();
+  adapter.prepare('DELETE FROM entity_observations').run();
+  adapter.prepare('DELETE FROM entity_nodes').run();
+}
+
+function insertCase(caseId: string): void {
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO case_truth (case_id, title, status, created_at, updated_at)
+        VALUES (?, ?, 'active', ?, ?)
+      `
+    )
+    .run(caseId, caseId, NOW, NOW);
+}
+
+function insertDecision(decisionId: string): void {
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO decisions (
+          id, topic, decision, reasoning, confidence, user_involvement, status, created_at,
+          updated_at
+        )
+        VALUES (?, 'case/tombstone', 'Seed decision', 'test', 0.9, 'approved', 'active', ?, ?)
+      `
+    )
+    .run(decisionId, NOW, NOW);
+}
+
+function insertEntityNode(): void {
+  getAdapter()
+    .prepare(
+      `
+        INSERT OR IGNORE INTO entity_nodes (
+          id, kind, preferred_label, status, created_at, updated_at
+        )
+        VALUES ('ent-sweep', 'project', 'Sweep', 'active', unixepoch() * 1000, unixepoch() * 1000)
+      `
+    )
+    .run();
+}
+
+function insertEvent(eventId: string): void {
+  insertEntityNode();
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO entity_timeline_events (
+          id, entity_id, event_type, summary, observed_at, created_at
+        )
+        VALUES (?, 'ent-sweep', 'decision_made', 'Seed event', unixepoch() * 1000,
+                unixepoch() * 1000)
+      `
+    )
+    .run(eventId);
+}
+
+function insertObservation(observationId: string): void {
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO entity_observations (
+          id, surface_form, normalized_form, related_surface_forms, extractor_version,
+          source_connector, source_raw_record_id, source_locator, created_at
+        )
+        VALUES (?, 'Sweep observation', 'sweep observation', '[]', 'test', 'slack', ?, ?,
+                unixepoch() * 1000)
+      `
+    )
+    .run(observationId, `raw-${observationId}`, `slack://sweep/${observationId}`);
+}
+
+function insertMembership(input: {
+  case_id: string;
+  source_type: 'decision' | 'event' | 'observation' | 'artifact';
+  source_id: string;
+  status?: 'active' | 'candidate' | 'removed' | 'excluded' | 'stale';
+  user_locked?: 0 | 1;
+  updated_at?: string;
+}): void {
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO case_memberships (
+          case_id, source_type, source_id, role, confidence, reason, status, added_by,
+          added_at, updated_at, user_locked
+        )
+        VALUES (?, ?, ?, 'supporting', 0.8, 'seeded', ?, 'wiki-compiler', ?, ?, ?)
+      `
+    )
+    .run(
+      input.case_id,
+      input.source_type,
+      input.source_id,
+      input.status ?? 'active',
+      NOW,
+      input.updated_at ?? NOW,
+      input.user_locked ?? 0
+    );
+}
+
+function membershipRow(
+  caseId: string,
+  sourceId: string
+): { status: string; updated_at: string; user_locked: number } {
+  return getAdapter()
+    .prepare(
+      `
+        SELECT status, updated_at, user_locked
+          FROM case_memberships
+         WHERE case_id = ?
+           AND source_id = ?
+      `
+    )
+    .get(caseId, sourceId) as { status: string; updated_at: string; user_locked: number };
+}
+
+function interceptStaleUpdate(onUpdate: (args: unknown[]) => void): DatabaseAdapter {
+  const base = getAdapter() as unknown as {
+    prepare: DatabaseAdapter['prepare'];
+    transaction: DatabaseAdapter['transaction'];
+    exec?: (sql: string) => void;
+  };
+
+  return {
+    prepare(sql: string) {
+      const stmt = base.prepare(sql);
+      if (sql.includes('UPDATE case_memberships') && sql.includes("status = 'stale'")) {
+        return {
+          all: (...args: unknown[]) => stmt.all(...args),
+          get: (...args: unknown[]) => stmt.get(...args),
+          run: (...args: unknown[]) => {
+            onUpdate(args);
+            return stmt.run(...args);
+          },
+        };
+      }
+      return stmt;
+    },
+    transaction: base.transaction.bind(base),
+    exec: base.exec?.bind(base),
+  } as unknown as DatabaseAdapter;
+}
+
+describe('Story CF2.8: stale case membership tombstone sweeper', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    process.env.MAMA_FORCE_TIER_3 = 'true';
+    testDbPath = await initTestDB('case-tombstone-sweeper');
+  });
+
+  beforeEach(resetTables);
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  it('deleted decision membership becomes stale and emits an audit event', () => {
+    insertCase('case-decision');
+    insertDecision('dec-deleted');
+    insertMembership({
+      case_id: 'case-decision',
+      source_type: 'decision',
+      source_id: 'dec-deleted',
+    });
+    getAdapter().prepare('DELETE FROM decisions WHERE id = ?').run('dec-deleted');
+
+    const result = sweepStaleCaseMemberships(getAdapter(), { now: NOW });
+
+    expect(result).toMatchObject({ scanned_count: 1, stale_count: 1, locked_stale_count: 0 });
+    expect(result.audit_event_ids).toHaveLength(1);
+    expect(membershipRow('case-decision', 'dec-deleted')).toMatchObject({
+      status: 'stale',
+      user_locked: 0,
+      updated_at: NOW,
+    });
+    expect(getAdapter().prepare('SELECT event_type FROM memory_events').get()).toMatchObject({
+      event_type: 'case.membership_tombstoned',
+    });
+  });
+
+  it('deleted event membership becomes stale', () => {
+    insertCase('case-event');
+    insertEvent('evt-deleted');
+    insertMembership({ case_id: 'case-event', source_type: 'event', source_id: 'evt-deleted' });
+    getAdapter().prepare('DELETE FROM entity_timeline_events WHERE id = ?').run('evt-deleted');
+
+    const result = sweepStaleCaseMemberships(getAdapter(), { now: NOW });
+
+    expect(result.stale_count).toBe(1);
+    expect(membershipRow('case-event', 'evt-deleted').status).toBe('stale');
+  });
+
+  it('deleted observation membership becomes stale', () => {
+    insertCase('case-observation');
+    insertObservation('obs-deleted');
+    insertMembership({
+      case_id: 'case-observation',
+      source_type: 'observation',
+      source_id: 'obs-deleted',
+    });
+    getAdapter().prepare('DELETE FROM entity_observations WHERE id = ?').run('obs-deleted');
+
+    const result = sweepStaleCaseMemberships(getAdapter(), { now: NOW });
+
+    expect(result.stale_count).toBe(1);
+    expect(membershipRow('case-observation', 'obs-deleted').status).toBe('stale');
+  });
+
+  it('artifact memberships are ignored in Phase 2', () => {
+    insertCase('case-artifact');
+    insertMembership({
+      case_id: 'case-artifact',
+      source_type: 'artifact',
+      source_id: 'artifact-missing',
+    });
+
+    const result = sweepStaleCaseMemberships(getAdapter(), { now: NOW });
+
+    expect(result).toMatchObject({ scanned_count: 0, stale_count: 0 });
+    expect(membershipRow('case-artifact', 'artifact-missing').status).toBe('active');
+  });
+
+  it('preserves user_locked when tombstoning a locked membership', () => {
+    insertCase('case-locked');
+    insertMembership({
+      case_id: 'case-locked',
+      source_type: 'decision',
+      source_id: 'dec-locked-missing',
+      user_locked: 1,
+    });
+
+    const result = sweepStaleCaseMemberships(getAdapter(), { now: NOW });
+
+    expect(result.locked_stale_count).toBe(1);
+    expect(membershipRow('case-locked', 'dec-locked-missing')).toMatchObject({
+      status: 'stale',
+      user_locked: 1,
+    });
+  });
+
+  it('already stale rows do not churn updated_at', () => {
+    insertCase('case-idempotent');
+    insertMembership({
+      case_id: 'case-idempotent',
+      source_type: 'decision',
+      source_id: 'dec-already-stale',
+      status: 'stale',
+      updated_at: '2026-04-17T00:00:00.000Z',
+    });
+
+    const result = sweepStaleCaseMemberships(getAdapter(), { now: NOW });
+
+    expect(result).toMatchObject({ scanned_count: 0, stale_count: 0 });
+    expect(membershipRow('case-idempotent', 'dec-already-stale').updated_at).toBe(
+      '2026-04-17T00:00:00.000Z'
+    );
+  });
+
+  it('case_assemble no longer surfaces stale rows', () => {
+    insertCase('case-assemble-stale');
+    insertDecision('dec-stale-assemble');
+    insertMembership({
+      case_id: 'case-assemble-stale',
+      source_type: 'decision',
+      source_id: 'dec-stale-assemble',
+    });
+    getAdapter().prepare('DELETE FROM decisions WHERE id = ?').run('dec-stale-assemble');
+
+    sweepStaleCaseMemberships(getAdapter(), { now: NOW });
+
+    const assembly = assembleCase(getAdapter(), 'case-assemble-stale');
+    expect(assembly.memberships).toEqual([]);
+    expect(assembly.decisions).toEqual([]);
+  });
+
+  it('source restored between candidate read and UPDATE is protected by NOT EXISTS', () => {
+    insertCase('case-race-restore');
+    insertMembership({
+      case_id: 'case-race-restore',
+      source_type: 'decision',
+      source_id: 'dec-race-restore',
+    });
+
+    let restored = false;
+    const adapter = interceptStaleUpdate((args) => {
+      if (!restored && args[2] === 'dec-race-restore') {
+        insertDecision('dec-race-restore');
+        restored = true;
+      }
+    });
+
+    const result = sweepStaleCaseMemberships(adapter, { now: NOW });
+
+    expect(restored).toBe(true);
+    expect(result.stale_count).toBe(0);
+    expect(membershipRow('case-race-restore', 'dec-race-restore').status).toBe('active');
+  });
+
+  it('restoring a source after tombstone does not auto-reactivate membership', () => {
+    insertCase('case-restore-after');
+    insertMembership({
+      case_id: 'case-restore-after',
+      source_type: 'decision',
+      source_id: 'dec-restore-after',
+    });
+
+    sweepStaleCaseMemberships(getAdapter(), { now: NOW });
+    insertDecision('dec-restore-after');
+    const second = sweepStaleCaseMemberships(getAdapter(), { now: '2026-04-18T04:00:00.000Z' });
+
+    expect(second.stale_count).toBe(0);
+    expect(membershipRow('case-restore-after', 'dec-restore-after')).toMatchObject({
+      status: 'stale',
+      updated_at: NOW,
+    });
+  });
+
+  it('compiler-style upsert during sweep is deterministic and never clears a lock', () => {
+    insertCase('case-race-upsert');
+    insertMembership({
+      case_id: 'case-race-upsert',
+      source_type: 'decision',
+      source_id: 'dec-race-upsert',
+      user_locked: 1,
+    });
+
+    let compilerRan = false;
+    const adapter = interceptStaleUpdate((args) => {
+      if (!compilerRan && args[2] === 'dec-race-upsert') {
+        insertDecision('dec-race-upsert');
+        getAdapter()
+          .prepare(
+            `
+              INSERT INTO case_memberships (
+                case_id, source_type, source_id, role, confidence, reason, status, added_by,
+                added_at, updated_at, user_locked
+              )
+              VALUES ('case-race-upsert', 'decision', 'dec-race-upsert', 'primary', 1,
+                      'compiler restored', 'active', 'wiki-compiler', ?, ?, 0)
+              ON CONFLICT(case_id, source_type, source_id) DO UPDATE SET
+                role = excluded.role,
+                confidence = excluded.confidence,
+                reason = excluded.reason,
+                status = 'active',
+                added_by = 'wiki-compiler',
+                updated_at = excluded.updated_at
+              WHERE case_memberships.user_locked = 0
+            `
+          )
+          .run(NOW, NOW);
+        compilerRan = true;
+      }
+    });
+
+    const result = sweepStaleCaseMemberships(adapter, { now: NOW });
+
+    expect(result.stale_count).toBe(0);
+    expect(membershipRow('case-race-upsert', 'dec-race-upsert')).toMatchObject({
+      status: 'active',
+      user_locked: 1,
+    });
+  });
+});

--- a/packages/mama-core/tests/cases/case-truth-phase-3-columns-schema.test.ts
+++ b/packages/mama-core/tests/cases/case-truth-phase-3-columns-schema.test.ts
@@ -1,0 +1,127 @@
+
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+
+import { applyMigrationsThrough } from '../../src/test-utils.js';
+function columnNames(db: Database.Database): string[] {
+  return (db.prepare('PRAGMA table_info(case_truth)').all() as Array<{ name: string }>)
+    .map((col) => col.name)
+    .sort();
+}
+
+function seedCase(db: Database.Database, caseId = 'case-phase-3-columns'): void {
+  db.prepare(
+    `
+      INSERT INTO case_truth (case_id, title, created_at, updated_at)
+      VALUES (?, 'Phase 3 columns', '2026-04-18T00:00:00.000Z', '2026-04-18T00:00:00.000Z')
+    `
+  ).run(caseId);
+}
+
+describe('case-first substrate — case_truth Phase 3 promotion and freshness columns', () => {
+  it('adds promotion columns', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    const names = columnNames(db);
+    for (const column of [
+      'canonical_decision_id',
+      'canonical_event_id',
+      'promoted_at',
+      'promoted_by',
+      'promotion_reason',
+    ]) {
+      expect(names).toContain(column);
+    }
+
+    db.close();
+  });
+
+  it('adds freshness columns', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    const names = columnNames(db);
+    for (const column of [
+      'freshness_score',
+      'freshness_state',
+      'freshness_score_is_drifted',
+      'freshness_drift_threshold',
+      'freshness_checked_at',
+      'freshness_reason_json',
+    ]) {
+      expect(names).toContain(column);
+    }
+
+    db.close();
+  });
+
+  it('rejects invalid freshness scores and thresholds', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+    seedCase(db);
+
+    expect(() =>
+      db
+        .prepare('UPDATE case_truth SET freshness_score = ? WHERE case_id = ?')
+        .run(1.01, 'case-phase-3-columns')
+    ).toThrow(/CHECK constraint/i);
+
+    expect(() =>
+      db
+        .prepare('UPDATE case_truth SET freshness_drift_threshold = ? WHERE case_id = ?')
+        .run(-0.01, 'case-phase-3-columns')
+    ).toThrow(/CHECK constraint/i);
+
+    db.close();
+  });
+
+  it('rejects invalid drift flags', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+    seedCase(db);
+
+    expect(() =>
+      db
+        .prepare('UPDATE case_truth SET freshness_score_is_drifted = ? WHERE case_id = ?')
+        .run(2, 'case-phase-3-columns')
+    ).toThrow(/CHECK constraint/i);
+
+    db.close();
+  });
+
+  it('rejects invalid freshness states', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+    seedCase(db);
+
+    expect(() =>
+      db
+        .prepare('UPDATE case_truth SET freshness_state = ? WHERE case_id = ?')
+        .run('expired', 'case-phase-3-columns')
+    ).toThrow(/CHECK constraint/i);
+
+    db.close();
+  });
+
+  it('defaults freshness_score_is_drifted to 0', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+    seedCase(db);
+
+    const row = db
+      .prepare('SELECT freshness_score_is_drifted FROM case_truth WHERE case_id = ?')
+      .get('case-phase-3-columns') as { freshness_score_is_drifted: number };
+
+    expect(row.freshness_score_is_drifted).toBe(0);
+
+    db.close();
+  });
+
+});

--- a/packages/mama-core/tests/cases/case-truth-schema.test.ts
+++ b/packages/mama-core/tests/cases/case-truth-schema.test.ts
@@ -1,0 +1,187 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import { getAdapter } from '../../src/db-manager.js';
+
+describe('case-first substrate — case_truth schema', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('case-truth-schema');
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  it('creates the case_truth table', () => {
+    const adapter = getAdapter();
+    const row = adapter
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='case_truth'")
+      .get() as { name?: string } | undefined;
+    expect(row?.name).toBe('case_truth');
+  });
+
+  it('includes every §5.2 column', () => {
+    const adapter = getAdapter();
+    const cols = adapter.prepare('PRAGMA table_info(case_truth)').all() as Array<{
+      name: string;
+      type: string;
+      notnull: number;
+      dflt_value: string | null;
+      pk: number;
+    }>;
+    const names = new Set(cols.map((c) => c.name));
+    const required = [
+      'blockers',
+      'canonical_case_id',
+      'case_id',
+      'compiled_at',
+      'confidence',
+      'created_at',
+      'current_wiki_path',
+      'last_activity_at',
+      'primary_actors',
+      'scope_refs',
+      'split_from_case_id',
+      'state_updated_at',
+      'status',
+      'status_reason',
+      'title',
+      'updated_at',
+      'wiki_path_history',
+    ];
+    for (const col of required) {
+      expect(names.has(col)).toBe(true);
+    }
+    // Phase 3 migration 048 adds promotion + freshness columns on top of
+    // this §5.2 baseline; those are verified by
+    // tests/cases/case-truth-phase-3-columns-schema.test.ts.
+  });
+
+  it('marks case_id as primary key and title/created_at/updated_at NOT NULL', () => {
+    const adapter = getAdapter();
+    const cols = adapter.prepare('PRAGMA table_info(case_truth)').all() as Array<{
+      name: string;
+      notnull: number;
+      pk: number;
+    }>;
+    const byName = Object.fromEntries(cols.map((c) => [c.name, c]));
+    expect(byName.case_id.pk).toBe(1);
+    expect(byName.title.notnull).toBe(1);
+    expect(byName.created_at.notnull).toBe(1);
+    expect(byName.updated_at.notnull).toBe(1);
+    // nullable columns per spec §5.2
+    expect(byName.current_wiki_path.notnull).toBe(0);
+    expect(byName.canonical_case_id.notnull).toBe(0);
+    expect(byName.split_from_case_id.notnull).toBe(0);
+  });
+
+  it('status is NOT NULL and defaults to active', () => {
+    const adapter = getAdapter();
+    const cols = adapter.prepare('PRAGMA table_info(case_truth)').all() as Array<{
+      name: string;
+      notnull: number;
+      dflt_value: string | null;
+    }>;
+    const status = cols.find((c) => c.name === 'status')!;
+    expect(status.notnull).toBe(1);
+    // SQLite stores the default as the SQL literal including quotes
+    expect(status.dflt_value).toMatch(/^'active'$/);
+
+    // Insert a row without status and verify it lands as 'active'
+    const now = new Date().toISOString();
+    adapter
+      .prepare(
+        `INSERT INTO case_truth (case_id, title, created_at, updated_at)
+         VALUES (?, ?, ?, ?)`
+      )
+      .run('00000000-0000-0000-0000-000000000001', 'Default status test', now, now);
+    const row = adapter
+      .prepare('SELECT status FROM case_truth WHERE case_id = ?')
+      .get('00000000-0000-0000-0000-000000000001') as { status: string };
+    expect(row.status).toBe('active');
+  });
+
+  it('status CHECK rejects an invalid value', () => {
+    const adapter = getAdapter();
+    const now = new Date().toISOString();
+    expect(() =>
+      adapter
+        .prepare(
+          `INSERT INTO case_truth (case_id, title, status, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?)`
+        )
+        .run(
+          '00000000-0000-0000-0000-000000000002',
+          'Invalid status',
+          'not_a_valid_status',
+          now,
+          now
+        )
+    ).toThrow(/CHECK constraint/i);
+  });
+
+  it('current_wiki_path unique index is case-insensitive (COLLATE NOCASE)', () => {
+    const adapter = getAdapter();
+    const now = new Date().toISOString();
+
+    // Insert first row with a mixed-case path
+    adapter
+      .prepare(
+        `INSERT INTO case_truth (case_id, current_wiki_path, title, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?)`
+      )
+      .run('00000000-0000-0000-0000-000000000010', 'Cases/Foo.md', 'First', now, now);
+
+    // Attempting to insert a row with the same path in a different case
+    // must fail via the UNIQUE index that uses COLLATE NOCASE
+    expect(() =>
+      adapter
+        .prepare(
+          `INSERT INTO case_truth (case_id, current_wiki_path, title, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?)`
+        )
+        .run('00000000-0000-0000-0000-000000000011', 'cases/foo.md', 'Second', now, now)
+    ).toThrow(/UNIQUE constraint/i);
+
+    // A NULL current_wiki_path is allowed (partial index)
+    expect(() =>
+      adapter
+        .prepare(
+          `INSERT INTO case_truth (case_id, title, created_at, updated_at)
+           VALUES (?, ?, ?, ?)`
+        )
+        .run('00000000-0000-0000-0000-000000000012', 'No path', now, now)
+    ).not.toThrow();
+
+    // Two rows with NULL current_wiki_path are allowed (partial index
+    // skips NULL rows)
+    expect(() =>
+      adapter
+        .prepare(
+          `INSERT INTO case_truth (case_id, title, created_at, updated_at)
+           VALUES (?, ?, ?, ?)`
+        )
+        .run('00000000-0000-0000-0000-000000000013', 'Another no path', now, now)
+    ).not.toThrow();
+  });
+
+  it('expected indexes exist', () => {
+    const adapter = getAdapter();
+    const rows = adapter
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='case_truth' AND name LIKE 'idx_case_truth_%'"
+      )
+      .all() as Array<{ name: string }>;
+    const names = rows.map((r) => r.name).sort();
+    expect(names).toEqual(
+      [
+        'idx_case_truth_canonical',
+        'idx_case_truth_current_path',
+        'idx_case_truth_last_activity',
+        'idx_case_truth_status',
+      ].sort()
+    );
+  });
+});

--- a/packages/mama-core/tests/cases/entity-timeline-role-schema.test.ts
+++ b/packages/mama-core/tests/cases/entity-timeline-role-schema.test.ts
@@ -1,0 +1,76 @@
+
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+
+import { applyMigrationsThrough } from '../../src/test-utils.js';
+describe('Phase 2 Task 1 — entity_timeline_events.role', () => {
+  it('adds a nullable role column after applying 044', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    const columns = db.prepare('PRAGMA table_info(entity_timeline_events)').all() as Array<{
+      name: string;
+      type: string;
+      notnull: number;
+      dflt_value: unknown;
+    }>;
+
+    const roleColumn = columns.find((col) => col.name === 'role');
+    expect(roleColumn).toBeDefined();
+    expect(roleColumn?.type).toBe('TEXT');
+    expect(roleColumn?.notnull).toBe(0);
+    expect(roleColumn?.dflt_value).toBeNull();
+
+    db.close();
+  });
+
+  it('role column is present after migration 030 (Phase 2 consolidated)', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    const cols = db.prepare('PRAGMA table_info(entity_timeline_events)').all() as Array<{
+      name: string;
+    }>;
+    expect(cols.some((col) => col.name === 'role')).toBe(true);
+
+    db.close();
+  });
+
+  it('role column accepts all spec §5.1 values and NULL', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    db.prepare(
+      `
+        INSERT OR IGNORE INTO entity_nodes
+          (id, kind, preferred_label, status, scope_kind, scope_id, created_at, updated_at)
+        VALUES (?, 'project', 'Test', 'active', 'project', 'test-project', ?, ?)
+      `
+    ).run('entity_role_test', Date.now(), Date.now());
+
+    const insert = db.prepare(
+      `
+        INSERT INTO entity_timeline_events
+          (id, entity_id, event_type, valid_from, valid_to, observed_at, source_ref,
+           summary, details, role, created_at)
+        VALUES (?, ?, 'status_changed', NULL, NULL, ?, 'test', 'summary', 'details', ?, ?)
+      `
+    );
+
+    for (const role of ['requester', 'implementer', 'reviewer', 'observer', 'affected', null]) {
+      expect(() =>
+        insert.run(`evt_${role ?? 'null'}`, 'entity_role_test', Date.now(), role, Date.now())
+      ).not.toThrow();
+    }
+
+    const rows = db
+      .prepare("SELECT role FROM entity_timeline_events WHERE id LIKE 'evt_%' ORDER BY id")
+      .all() as Array<{ role: string | null }>;
+    expect(rows).toHaveLength(6);
+
+    db.close();
+  });
+});

--- a/packages/mama-core/tests/cases/mama-search-case-rollup.test.ts
+++ b/packages/mama-core/tests/cases/mama-search-case-rollup.test.ts
@@ -77,7 +77,11 @@ function insertCase(input: {
     );
 }
 
-function insertMembership(caseId: string, sourceId: string): void {
+function insertMembership(
+  caseId: string,
+  sourceId: string,
+  sourceType: 'decision' | 'checkpoint' = 'decision'
+): void {
   const adapter = getAdapter();
   const now = nowIso();
   adapter
@@ -87,10 +91,10 @@ function insertMembership(caseId: string, sourceId: string): void {
           case_id, source_type, source_id, role, confidence, reason, status,
           added_by, added_at, updated_at, user_locked
         )
-        VALUES (?, 'decision', ?, 'supporting', 0.9, 'test', 'active', 'wiki-compiler', ?, ?, 0)
+        VALUES (?, ?, ?, 'supporting', 0.9, 'test', 'active', 'wiki-compiler', ?, ?, 0)
       `
     )
-    .run(caseId, sourceId, now, now);
+    .run(caseId, sourceType, sourceId, now, now);
 }
 
 function insertDecision(input: {
@@ -298,6 +302,38 @@ describe('Task 11: mama_search case membership roll-up', () => {
       case_id: 'case-wiki-direct',
       score: 6,
       contributing_leaves: ['cases/direct.md'],
+    });
+  });
+
+  it('does not return the same case twice when a direct wiki hit arrives after grouped leaves', () => {
+    const adapter = getAdapter();
+    insertCase({ case_id: 'case-wiki-late' });
+    insertMembership('case-wiki-late', 'D-late');
+
+    const results = rollUpSearchHits({
+      adapter,
+      fusedHits: [
+        leaf('D-late', 4),
+        {
+          source_type: 'wiki_page',
+          source_id: 'cases/late-direct.md',
+          fused_rank_score: 7,
+          page_type: 'case',
+          case_id: 'case-wiki-late',
+          record: {
+            source_locator: 'cases/late-direct.md',
+            title: 'Late direct hit',
+            content: 'body',
+          },
+        },
+      ],
+    });
+
+    expect(results.filter((result) => result.case_id === 'case-wiki-late')).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      source_type: 'case',
+      case_id: 'case-wiki-late',
+      score: 7,
     });
   });
 

--- a/packages/mama-core/tests/cases/mama-search-case-rollup.test.ts
+++ b/packages/mama-core/tests/cases/mama-search-case-rollup.test.ts
@@ -1,0 +1,452 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/embeddings.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../src/embeddings.js')>('../../src/embeddings.js');
+  return {
+    ...actual,
+    generateEmbedding: vi.fn(async () => queryVector()),
+  };
+});
+
+import { fts5Search, getAdapter, vectorSearch } from '../../src/db-manager.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import { rollUpSearchHits, type SearchRollupLeafHit } from '../../src/cases/search-rollup.js';
+import { upsertWikiPageIndexEntry } from '../../src/cases/wiki-page-index.js';
+import { suggest } from '../../src/mama-api.js';
+import { handleSearch } from '../../../standalone/src/agent/mama-tool-handlers.js';
+import type { MAMAApiInterface } from '../../../standalone/src/agent/types.js';
+
+let testDbPath = '';
+let originalProjectionMode: string | undefined;
+
+function queryVector(): Float32Array {
+  const vector = new Float32Array(1024);
+  vector[0] = 1;
+  return vector;
+}
+
+function unitVector(cosine: number): Float32Array {
+  const vector = new Float32Array(1024);
+  vector[0] = cosine;
+  vector[1] = Math.sqrt(Math.max(0, 1 - cosine * cosine));
+  return vector;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function cleanupRows(): void {
+  const adapter = getAdapter();
+  adapter.prepare('DELETE FROM case_memberships').run();
+  adapter.prepare('DELETE FROM wiki_page_index').run();
+  adapter
+    .prepare('UPDATE case_truth SET canonical_case_id = NULL, split_from_case_id = NULL')
+    .run();
+  adapter.prepare('DELETE FROM case_truth').run();
+  adapter.prepare('DELETE FROM embeddings').run();
+  adapter.prepare('DELETE FROM decisions').run();
+}
+
+function insertCase(input: {
+  case_id: string;
+  title?: string;
+  status?: string;
+  canonical_case_id?: string | null;
+}): void {
+  const adapter = getAdapter();
+  const now = nowIso();
+  adapter
+    .prepare(
+      `
+        INSERT INTO case_truth (
+          case_id, current_wiki_path, title, status, canonical_case_id, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      input.case_id,
+      `cases/${input.case_id}.md`,
+      input.title ?? input.case_id,
+      input.status ?? 'active',
+      input.canonical_case_id ?? null,
+      now,
+      now
+    );
+}
+
+function insertMembership(caseId: string, sourceId: string): void {
+  const adapter = getAdapter();
+  const now = nowIso();
+  adapter
+    .prepare(
+      `
+        INSERT INTO case_memberships (
+          case_id, source_type, source_id, role, confidence, reason, status,
+          added_by, added_at, updated_at, user_locked
+        )
+        VALUES (?, 'decision', ?, 'supporting', 0.9, 'test', 'active', 'wiki-compiler', ?, ?, 0)
+      `
+    )
+    .run(caseId, sourceId, now, now);
+}
+
+function insertDecision(input: {
+  id: string;
+  topic?: string;
+  decision?: string;
+  reasoning?: string;
+  embedding?: Float32Array;
+}): void {
+  const adapter = getAdapter();
+  const now = Date.now();
+  adapter
+    .prepare(
+      `
+        INSERT INTO decisions (
+          id, topic, decision, reasoning, confidence, created_at, updated_at,
+          kind, status, summary, event_datetime
+        )
+        VALUES (?, ?, ?, ?, 0.8, ?, ?, 'decision', 'active', ?, ?)
+      `
+    )
+    .run(
+      input.id,
+      input.topic ?? input.id,
+      input.decision ?? input.id,
+      input.reasoning ?? '',
+      now,
+      now,
+      input.decision ?? input.id,
+      now
+    );
+
+  if (input.embedding) {
+    const row = adapter.prepare('SELECT rowid FROM decisions WHERE id = ?').get(input.id) as {
+      rowid: number;
+    };
+    adapter.insertEmbedding(row.rowid, input.embedding);
+  }
+
+  // Rebuild FTS5 index — external-content FTS5 with trigger-based sync requires
+  // an explicit rebuild to populate the tokenized index after raw SQL INSERTs.
+  adapter.prepare("INSERT INTO decisions_fts(decisions_fts) VALUES('rebuild')").run();
+}
+
+function leaf(
+  sourceId: string,
+  score: number,
+  record: Record<string, unknown> = {}
+): SearchRollupLeafHit {
+  return {
+    source_type: 'decision',
+    source_id: sourceId,
+    fused_rank_score: score,
+    record: {
+      id: sourceId,
+      topic: sourceId,
+      summary: sourceId,
+      details: '',
+      ...record,
+    },
+  };
+}
+
+describe('Task 11: mama_search case membership roll-up', () => {
+  beforeAll(async () => {
+    originalProjectionMode = process.env.MAMA_ENTITY_PROJECTION_MODE;
+    process.env.MAMA_ENTITY_PROJECTION_MODE = 'off';
+    testDbPath = await initTestDB('mama-search-case-rollup');
+  });
+
+  afterEach(() => {
+    cleanupRows();
+  });
+
+  afterAll(async () => {
+    if (originalProjectionMode === undefined) {
+      delete process.env.MAMA_ENTITY_PROJECTION_MODE;
+    } else {
+      process.env.MAMA_ENTITY_PROJECTION_MODE = originalProjectionMode;
+    }
+    await cleanupTestDB(testDbPath);
+  });
+
+  it('rolls a decision hit with one active membership up to one case result', () => {
+    const adapter = getAdapter();
+    insertCase({ case_id: 'case-one' });
+    insertMembership('case-one', 'D1');
+
+    const results = rollUpSearchHits({
+      adapter,
+      fusedHits: [leaf('D1', 10)],
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      source_type: 'case',
+      source_id: 'case-one',
+      case_id: 'case-one',
+      score: 10,
+      contributing_leaves: ['D1'],
+    });
+  });
+
+  it('emits one case result per active membership when a decision belongs to two cases', () => {
+    const adapter = getAdapter();
+    insertCase({ case_id: 'case-a' });
+    insertCase({ case_id: 'case-b' });
+    insertMembership('case-a', 'D1');
+    insertMembership('case-b', 'D1');
+
+    const results = rollUpSearchHits({
+      adapter,
+      fusedHits: [leaf('D1', 7)],
+    });
+
+    expect(results.map((result) => result.case_id).sort()).toEqual(['case-a', 'case-b']);
+    expect(results.every((result) => result.score === 7)).toBe(true);
+  });
+
+  it('de-dupes duplicate leaf contributions by case_id and leaf source_id', () => {
+    const adapter = getAdapter();
+    insertCase({ case_id: 'case-dedupe' });
+    insertMembership('case-dedupe', 'D1');
+
+    const results = rollUpSearchHits({
+      adapter,
+      fusedHits: [leaf('D1', 10), leaf('D1', 10)],
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].score).toBe(10);
+    expect(results[0].contributing_leaves).toEqual(['D1']);
+  });
+
+  it('canonicalizes merged loser memberships to the survivor before de-duplication', () => {
+    const adapter = getAdapter();
+    insertCase({ case_id: 'case-survivor' });
+    insertCase({
+      case_id: 'case-loser',
+      status: 'merged',
+      canonical_case_id: 'case-survivor',
+    });
+    insertMembership('case-survivor', 'D1');
+    insertMembership('case-loser', 'D1');
+
+    const results = rollUpSearchHits({
+      adapter,
+      fusedHits: [leaf('D1', 10)],
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      source_type: 'case',
+      source_id: 'case-survivor',
+      case_id: 'case-survivor',
+      score: 10,
+      contributing_leaves: ['D1'],
+    });
+  });
+
+  it('leaves orphan decisions as leaf results with case_id null', () => {
+    const adapter = getAdapter();
+
+    const results = rollUpSearchHits({
+      adapter,
+      fusedHits: [leaf('D-orphan', 5)],
+    });
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        source_type: 'decision',
+        source_id: 'D-orphan',
+        case_id: null,
+        score: 5,
+      }),
+    ]);
+  });
+
+  it('returns case wiki page hits directly without joining memberships', () => {
+    const adapter = getAdapter();
+    insertCase({ case_id: 'case-wiki-direct' });
+
+    const results = rollUpSearchHits({
+      adapter,
+      fusedHits: [
+        {
+          source_type: 'wiki_page',
+          source_id: 'cases/direct.md',
+          fused_rank_score: 6,
+          page_type: 'case',
+          case_id: 'case-wiki-direct',
+          record: {
+            source_locator: 'cases/direct.md',
+            title: 'Direct wiki case',
+            content: 'body',
+          },
+        },
+      ],
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      source_type: 'case',
+      source_id: 'case-wiki-direct',
+      case_id: 'case-wiki-direct',
+      score: 6,
+      contributing_leaves: ['cases/direct.md'],
+    });
+  });
+
+  it('orders summed case scores above lower-scored cases in injected fixture 1', () => {
+    const adapter = getAdapter();
+    insertCase({ case_id: 'C1' });
+    insertCase({ case_id: 'C2' });
+    insertMembership('C1', 'D1');
+    insertMembership('C1', 'D2');
+    insertMembership('C2', 'D3');
+
+    const results = rollUpSearchHits({
+      adapter,
+      fusedHits: [leaf('D1', 10), leaf('D2', 5), leaf('D3', 8)],
+    });
+
+    expect(results.map((result) => [result.case_id, result.score])).toEqual([
+      ['C1', 15],
+      ['C2', 8],
+    ]);
+  });
+
+  it('interleaves orphan leaves on the shared score axis in injected fixture 2', () => {
+    const adapter = getAdapter();
+    insertCase({ case_id: 'C1' });
+    insertCase({ case_id: 'C2' });
+    insertMembership('C1', 'D1');
+    insertMembership('C2', 'D3');
+
+    const results = rollUpSearchHits({
+      adapter,
+      fusedHits: [leaf('D1', 10), leaf('D2', 5), leaf('D3', 8)],
+    });
+
+    expect(
+      results.map((result) => [result.source_type, result.case_id, result.source_id, result.score])
+    ).toEqual([
+      ['case', 'C1', 'C1', 10],
+      ['case', 'C2', 'C2', 8],
+      ['decision', null, 'D2', 5],
+    ]);
+  });
+
+  it.each([
+    {
+      name: 'suggest',
+      run: async (query: string) => suggest(query, { limit: 5 }),
+    },
+    {
+      name: 'handleSearch',
+      run: async (query: string) =>
+        handleSearch(
+          {
+            suggest,
+            listDecisions: async () => [],
+            loadCheckpoint: async () => null,
+          } as unknown as MAMAApiInterface,
+          { query, limit: 5 }
+        ),
+    },
+  ])('$name applies roll-up and preserves plugin-compatible fields', async ({ run }) => {
+    insertCase({ case_id: 'case-public-path', title: 'Public Path Case' });
+    insertMembership('case-public-path', 'decision_public_path');
+    insertDecision({
+      id: 'decision_public_path',
+      topic: 'public path topic',
+      decision: 'publicpathtoken decision body',
+      reasoning: 'public path reasoning',
+      embedding: unitVector(1),
+    });
+
+    const result = await run('publicpathtoken');
+    const rows = (result.results ?? []) as Array<Record<string, unknown>>;
+
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows[0]).toMatchObject({
+      id: 'case-public-path',
+      source_type: 'case',
+      case_id: 'case-public-path',
+    });
+    expect(rows[0]).toHaveProperty('topic');
+    expect(rows[0]).toHaveProperty('decision');
+    expect(rows[0]).toHaveProperty('reasoning');
+    expect(rows[0]).toHaveProperty('confidence');
+    expect(rows[0]).toHaveProperty('retrieval_score');
+  });
+
+  it('returns a case result when the query matches only wiki_page_index content', async () => {
+    const adapter = getAdapter();
+    insertCase({ case_id: 'case-wiki-only', title: 'Wiki Only Case' });
+
+    upsertWikiPageIndexEntry(adapter, {
+      source_locator: 'cases/wiki-only.md',
+      page_type: 'case',
+      title: 'Wiki Only',
+      content: 'wikionlytoken appears only in compiled markdown',
+      case_id: 'case-wiki-only',
+      source_ids: [],
+      entity_refs: [],
+      confidence: 'high',
+      compiled_at: nowIso(),
+    });
+
+    const result = await suggest('wikionlytoken', { limit: 5 });
+    const rows = result.results as Array<Record<string, unknown>>;
+
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows[0]).toMatchObject({
+      source_type: 'case',
+      case_id: 'case-wiki-only',
+      id: 'case-wiki-only',
+    });
+  });
+
+  it('feeds fused RRF scores into roll-up before case scoring in the production search path', async () => {
+    insertCase({ case_id: 'C1' });
+    insertCase({ case_id: 'C2' });
+    insertMembership('C1', 'D1');
+    insertMembership('C1', 'D2');
+    insertMembership('C2', 'D3');
+
+    insertDecision({
+      id: 'D3',
+      topic: 'rrffusiontoken rrffusiontoken rrffusiontoken',
+      decision: 'rrffusiontoken rrffusiontoken rrffusiontoken',
+      embedding: unitVector(0.9),
+    });
+    insertDecision({
+      id: 'D1',
+      topic: 'rrffusiontoken rrffusiontoken',
+      decision: 'rrffusiontoken rrffusiontoken',
+      embedding: unitVector(1),
+    });
+    insertDecision({
+      id: 'D2',
+      topic: 'rrffusiontoken',
+      decision: 'rrffusiontoken',
+      embedding: unitVector(0.95),
+    });
+
+    const ftsIds = (await fts5Search('rrffusiontoken', 3)).map((row) => row.id);
+    const vectorIds = (await vectorSearch(queryVector(), 3, 0)).map((row) => row.id);
+    expect(ftsIds).toEqual(['D3', 'D1', 'D2']);
+    expect(vectorIds).toEqual(['D1', 'D2', 'D3']);
+
+    const result = await suggest('rrffusiontoken', { limit: 5 });
+    const rows = result.results as Array<Record<string, unknown>>;
+
+    expect(rows.slice(0, 2).map((row) => row.case_id)).toEqual(['C1', 'C2']);
+    expect(Number(rows[0].retrieval_score)).toBeGreaterThan(Number(rows[1].retrieval_score));
+  });
+});

--- a/packages/mama-core/tests/cases/mama-search-case-rollup.vector.test.ts
+++ b/packages/mama-core/tests/cases/mama-search-case-rollup.vector.test.ts
@@ -1,0 +1,93 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/embeddings.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../src/embeddings.js')>('../../src/embeddings.js');
+  return {
+    ...actual,
+    generateEmbedding: vi.fn(async () => deterministicVector()),
+  };
+});
+
+import { getAdapter } from '../../src/db-manager.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import { upsertWikiPageIndexEntry } from '../../src/cases/wiki-page-index.js';
+import { suggest } from '../../src/mama-api.js';
+
+let testDbPath = '';
+let originalTier3: string | undefined;
+let originalProjectionMode: string | undefined;
+
+function deterministicVector(): Float32Array {
+  const vector = new Float32Array(1024);
+  vector.fill(0.1);
+  return vector;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function cleanupRows(): void {
+  const adapter = getAdapter();
+  adapter.prepare('DELETE FROM wiki_page_index').run();
+  adapter.prepare('DELETE FROM embeddings').run();
+  adapter.prepare('DELETE FROM decisions').run();
+}
+
+describe('Task 11: vector-only wiki page search path', () => {
+  beforeAll(async () => {
+    originalTier3 = process.env.MAMA_FORCE_TIER_3;
+    originalProjectionMode = process.env.MAMA_ENTITY_PROJECTION_MODE;
+    delete process.env.MAMA_FORCE_TIER_3;
+    process.env.MAMA_ENTITY_PROJECTION_MODE = 'off';
+    testDbPath = await initTestDB('mama-search-case-rollup-vector');
+  });
+
+  afterEach(() => {
+    cleanupRows();
+  });
+
+  afterAll(async () => {
+    if (originalTier3 === undefined) {
+      delete process.env.MAMA_FORCE_TIER_3;
+    } else {
+      process.env.MAMA_FORCE_TIER_3 = originalTier3;
+    }
+
+    if (originalProjectionMode === undefined) {
+      delete process.env.MAMA_ENTITY_PROJECTION_MODE;
+    } else {
+      process.env.MAMA_ENTITY_PROJECTION_MODE = originalProjectionMode;
+    }
+
+    await cleanupTestDB(testDbPath);
+  });
+
+  it('returns a wiki page whose text does not match FTS but whose stored vector matches the query', async () => {
+    const adapter = getAdapter();
+    upsertWikiPageIndexEntry(adapter, {
+      source_locator: 'wiki/vector-only.md',
+      page_type: 'entity',
+      title: 'Vector Only Page',
+      content: 'plain compiled markdown without the needle term',
+      case_id: null,
+      source_ids: [],
+      entity_refs: [],
+      confidence: 'medium',
+      compiled_at: nowIso(),
+      embedding: deterministicVector(),
+    });
+
+    const result = await suggest('spectralneedle', { limit: 5 });
+    const rows = result.results as Array<Record<string, unknown>>;
+
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows[0]).toMatchObject({
+      id: 'wiki/vector-only.md',
+      source_type: 'wiki_page',
+      case_id: null,
+    });
+    expect(String(rows[0].decision)).toContain('plain compiled markdown');
+  });
+});

--- a/packages/mama-core/tests/cases/migration-chain.test.ts
+++ b/packages/mama-core/tests/cases/migration-chain.test.ts
@@ -1,0 +1,232 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+
+const MIGRATIONS_DIR = join(__dirname, '..', '..', 'db', 'migrations');
+
+function migrationFiles(): string[] {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((file) => /^\d{3}-.+\.sql$/.test(file))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function applyAll(db: Database.Database): void {
+  for (const file of migrationFiles()) {
+    db.exec(readFileSync(join(MIGRATIONS_DIR, file), 'utf8'));
+  }
+}
+
+function tableExists(db: Database.Database, name: string): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?")
+    .get(name) as { name?: string } | undefined;
+  return Boolean(row?.name);
+}
+
+function indexExists(db: Database.Database, name: string): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name = ?")
+    .get(name) as { name?: string } | undefined;
+  return Boolean(row?.name);
+}
+
+function triggerExists(db: Database.Database, name: string): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='trigger' AND name = ?")
+    .get(name) as { name?: string } | undefined;
+  return Boolean(row?.name);
+}
+
+function columnExists(db: Database.Database, table: string, column: string): boolean {
+  const cols = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  return cols.some((col) => col.name === column);
+}
+
+describe('Case-First Memory Substrate (migration 030, consolidated Phase 1+2+3)', () => {
+  it('creates every Phase 1 table/index/trigger on a fresh DB', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyAll(db);
+
+    expect(tableExists(db, 'case_truth')).toBe(true);
+    expect(tableExists(db, 'case_memberships')).toBe(true);
+    expect(tableExists(db, 'case_corrections')).toBe(true);
+    expect(tableExists(db, 'case_proposal_queue')).toBe(true);
+    expect(tableExists(db, 'wiki_page_index')).toBe(true);
+    expect(tableExists(db, 'wiki_page_embeddings')).toBe(true);
+    expect(tableExists(db, 'wiki_pages_fts')).toBe(true);
+
+    const ctSql = (
+      db
+        .prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='case_truth'")
+        .get() as { sql: string }
+    ).sql;
+    expect(ctSql).toMatch(/status[^,]*DEFAULT\s*'active'/i);
+
+    const cmSql = (
+      db
+        .prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='case_memberships'")
+        .get() as { sql: string }
+    ).sql;
+    expect(cmSql).toMatch(/source_type\s+TEXT\s+NOT\s+NULL/i);
+    expect(cmSql).toMatch(/status\s+TEXT\s+NOT\s+NULL/i);
+    expect(cmSql).toMatch(/added_by\s+TEXT\s+NOT\s+NULL/i);
+
+    const ccSql = (
+      db
+        .prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='case_corrections'")
+        .get() as { sql: string }
+    ).sql;
+    expect(ccSql).toMatch(/target_ref_json\s+TEXT/i);
+    expect(ccSql).toMatch(/target_ref_hash\s+BLOB/i);
+    expect(ccSql).toMatch(/length\s*\(\s*target_ref_hash\s*\)\s*=\s*32/i);
+
+    expect(indexExists(db, 'idx_case_corrections_active_target')).toBe(true);
+
+    const cpqSql = (
+      db
+        .prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='case_proposal_queue'")
+        .get() as { sql: string }
+    ).sql;
+    for (const kind of [
+      'unknown_case_id',
+      'merged_target',
+      'archived_target',
+      'stale_case_id',
+      'ambiguous_slug',
+      'corrupt_frontmatter',
+      'missing_frontmatter',
+      'duplicate_frontmatter',
+      'quarantined_accepted_case',
+    ]) {
+      expect(cpqSql).toContain(kind);
+    }
+
+    expect(triggerExists(db, 'trg_wiki_page_index_ai')).toBe(true);
+    expect(triggerExists(db, 'trg_wiki_page_index_au')).toBe(true);
+    expect(triggerExists(db, 'trg_wiki_page_index_ad')).toBe(true);
+
+    db.close();
+  });
+
+  it('creates Phase 2 live-state artefact (entity_timeline_events.role column)', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyAll(db);
+    expect(columnExists(db, 'entity_timeline_events', 'role')).toBe(true);
+    db.close();
+  });
+
+  it('creates Phase 3 tables and extends case_truth/case_memberships', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyAll(db);
+
+    expect(tableExists(db, 'connector_event_index')).toBe(true);
+    expect(tableExists(db, 'connector_event_index_cursors')).toBe(true);
+    expect(tableExists(db, 'connector_event_index_fts')).toBe(true);
+    expect(triggerExists(db, 'trg_connector_event_index_ai')).toBe(true);
+
+    expect(tableExists(db, 'search_feedback')).toBe(true);
+    expect(tableExists(db, 'ranker_model_versions')).toBe(true);
+    expect(tableExists(db, 'search_ranker_settings')).toBe(true);
+
+    expect(tableExists(db, 'case_links')).toBe(true);
+    expect(tableExists(db, 'case_links_revoked_wiki_tombstones')).toBe(true);
+
+    expect(columnExists(db, 'case_truth', 'canonical_decision_id')).toBe(true);
+    expect(columnExists(db, 'case_truth', 'canonical_event_id')).toBe(true);
+    expect(columnExists(db, 'case_truth', 'freshness_score')).toBe(true);
+    expect(columnExists(db, 'case_truth', 'freshness_score_is_drifted')).toBe(true);
+
+    expect(columnExists(db, 'case_memberships', 'assignment_strategy')).toBe(true);
+    expect(columnExists(db, 'case_memberships', 'score_breakdown_json')).toBe(true);
+    expect(columnExists(db, 'case_memberships', 'source_locator')).toBe(true);
+    expect(columnExists(db, 'case_memberships', 'explanation_updated_at')).toBe(true);
+
+    db.close();
+  });
+
+  it('is idempotent — re-running migration 030 after the schema_version guard fires is a no-op', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyAll(db);
+
+    const baselineTables = (
+      db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+        .all() as Array<{ name: string }>
+    ).map((row) => row.name);
+
+    const alreadyApplied = !!db
+      .prepare('SELECT 1 FROM schema_version WHERE version = ?')
+      .get(30);
+    expect(alreadyApplied).toBe(true);
+
+    const afterTables = (
+      db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+        .all() as Array<{ name: string }>
+    ).map((row) => row.name);
+    expect(afterTables).toEqual(baselineTables);
+
+    db.close();
+  });
+
+  it('a mid-migration failure inside a transaction leaves no partial artefacts', () => {
+    // Rollback invariant: a partial failure inside a BEGIN/COMMIT block must
+    // leave the baseline schema unchanged.
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyAll(db);
+
+    const baselineTables = (
+      db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+        .all() as Array<{ name: string }>
+    ).map((row) => row.name);
+
+    const badSql = `
+      CREATE TABLE fixture_partial_999 (id INTEGER PRIMARY KEY);
+      CREATE TABLE case_truth (id INTEGER PRIMARY KEY);
+    `;
+    let threw = false;
+    try {
+      db.exec(`BEGIN;\n${badSql}\nCOMMIT;`);
+    } catch {
+      threw = true;
+      try {
+        db.exec('ROLLBACK;');
+      } catch {
+        // already rolled back
+      }
+    }
+    expect(threw).toBe(true);
+    expect(tableExists(db, 'fixture_partial_999')).toBe(false);
+
+    const afterTables = (
+      db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+        .all() as Array<{ name: string }>
+    ).map((row) => row.name);
+    expect(afterTables).toEqual(baselineTables);
+
+    db.close();
+  });
+
+  it('records migration 030 in schema_version after apply', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyAll(db);
+
+    const row = db
+      .prepare('SELECT version, description FROM schema_version WHERE version = 30')
+      .get() as { version: number; description: string } | undefined;
+    expect(row?.version).toBe(30);
+    expect(row?.description).toContain('Case-First Memory Substrate');
+
+    db.close();
+  });
+});

--- a/packages/mama-core/tests/cases/wiki-page-search-index.test.ts
+++ b/packages/mama-core/tests/cases/wiki-page-search-index.test.ts
@@ -1,0 +1,259 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import { getAdapter } from '../../src/db-manager.js';
+
+function insertPage(
+  overrides: Partial<{
+    page_id: string;
+    source_type: string;
+    source_locator: string;
+    case_id: string | null;
+    title: string;
+    page_type: string;
+    content: string;
+    confidence: string | null;
+    compiled_at: string;
+    updated_at: string;
+  }> = {}
+): void {
+  const adapter = getAdapter();
+  const now = new Date().toISOString();
+  adapter
+    .prepare(
+      `INSERT INTO wiki_page_index
+         (page_id, source_type, source_locator, case_id, title, page_type,
+          content, confidence, compiled_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .run(
+      overrides.page_id ?? 'page-1',
+      overrides.source_type ?? 'wiki_page',
+      overrides.source_locator ?? 'cases/foo.md',
+      overrides.case_id ?? null,
+      overrides.title ?? 'Foo case',
+      overrides.page_type ?? 'case',
+      overrides.content ?? 'original content alpha',
+      overrides.confidence ?? null,
+      overrides.compiled_at ?? now,
+      overrides.updated_at ?? now
+    );
+}
+
+describe('case-first substrate — wiki_page_search_index schema', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('wiki-page-search-index');
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  it('creates wiki_page_index, wiki_page_embeddings, and wiki_pages_fts', () => {
+    const adapter = getAdapter();
+    const tables = adapter
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type IN ('table','virtual table') AND name IN ('wiki_page_index','wiki_page_embeddings','wiki_pages_fts')"
+      )
+      .all() as Array<{ name: string }>;
+    const names = tables.map((t) => t.name).sort();
+    // virtual tables show up as type='table' in sqlite_master
+    expect(names).toEqual(['wiki_page_embeddings', 'wiki_page_index', 'wiki_pages_fts'].sort());
+  });
+
+  it('source_type is constrained to wiki_page', () => {
+    const adapter = getAdapter();
+    const now = new Date().toISOString();
+    expect(() =>
+      adapter
+        .prepare(
+          `INSERT INTO wiki_page_index
+             (page_id, source_type, source_locator, title, page_type, content, compiled_at, updated_at)
+           VALUES ('page-bad-type', 'decision', 'cases/x.md', 't', 'case', 'c', ?, ?)`
+        )
+        .run(now, now)
+    ).toThrow(/CHECK constraint/i);
+  });
+
+  it('(source_type, source_locator) is unique', () => {
+    insertPage({ page_id: 'page-uniq-1', source_locator: 'cases/dup.md' });
+    expect(() => insertPage({ page_id: 'page-uniq-2', source_locator: 'cases/dup.md' })).toThrow(
+      /UNIQUE constraint/i
+    );
+  });
+
+  it('page_type accepts every spec §5.6 enum value', () => {
+    const kinds: Array<'entity' | 'lesson' | 'synthesis' | 'process' | 'case'> = [
+      'entity',
+      'lesson',
+      'synthesis',
+      'process',
+      'case',
+    ];
+    for (const kind of kinds) {
+      expect(() =>
+        insertPage({
+          page_id: `page-pt-${kind}`,
+          source_locator: `cases/pt-${kind}.md`,
+          page_type: kind,
+        })
+      ).not.toThrow();
+    }
+  });
+
+  it('page_type rejects a value outside spec §5.6 enum', () => {
+    expect(() =>
+      insertPage({
+        page_id: 'page-pt-bad',
+        source_locator: 'cases/pt-bad.md',
+        page_type: 'not_a_page_type',
+      })
+    ).toThrow(/CHECK constraint/i);
+  });
+
+  it('FTS returns an inserted page by content keyword', () => {
+    const adapter = getAdapter();
+    insertPage({
+      page_id: 'page-fts-1',
+      source_locator: 'cases/fts1.md',
+      title: 'FTS Insert Test',
+      content: 'SearchableKeyword inside body',
+    });
+    const rows = adapter
+      .prepare("SELECT page_id FROM wiki_pages_fts WHERE wiki_pages_fts MATCH 'SearchableKeyword'")
+      .all() as Array<{ page_id: string }>;
+    const ids = rows.map((r) => r.page_id);
+    expect(ids).toContain('page-fts-1');
+  });
+
+  it('FTS reflects UPDATE: old keyword no longer matches, new keyword matches', () => {
+    const adapter = getAdapter();
+    insertPage({
+      page_id: 'page-upd',
+      source_locator: 'cases/upd.md',
+      title: 'Updatable',
+      content: 'OldKeyword zebra',
+    });
+    // Confirm baseline
+    const before = adapter
+      .prepare(
+        "SELECT page_id FROM wiki_pages_fts WHERE wiki_pages_fts MATCH 'OldKeyword' AND page_id = 'page-upd'"
+      )
+      .all();
+    expect(before.length).toBe(1);
+
+    // Update content via a regular UPDATE (NOT INSERT OR REPLACE)
+    const now = new Date().toISOString();
+    adapter
+      .prepare(
+        `UPDATE wiki_page_index SET content = 'NewKeyword tiger', updated_at = ? WHERE page_id = 'page-upd'`
+      )
+      .run(now);
+
+    const oldAfter = adapter
+      .prepare(
+        "SELECT page_id FROM wiki_pages_fts WHERE wiki_pages_fts MATCH 'OldKeyword' AND page_id = 'page-upd'"
+      )
+      .all();
+    expect(oldAfter.length).toBe(0);
+
+    const newAfter = adapter
+      .prepare(
+        "SELECT page_id FROM wiki_pages_fts WHERE wiki_pages_fts MATCH 'NewKeyword' AND page_id = 'page-upd'"
+      )
+      .all();
+    expect(newAfter.length).toBe(1);
+  });
+
+  it('FTS returns 0 hits after DELETE', () => {
+    const adapter = getAdapter();
+    insertPage({
+      page_id: 'page-del',
+      source_locator: 'cases/del.md',
+      title: 'Deletable',
+      content: 'DeleteMeToken content',
+    });
+    const before = adapter
+      .prepare(
+        "SELECT page_id FROM wiki_pages_fts WHERE wiki_pages_fts MATCH 'DeleteMeToken' AND page_id = 'page-del'"
+      )
+      .all();
+    expect(before.length).toBe(1);
+
+    adapter.prepare(`DELETE FROM wiki_page_index WHERE page_id = 'page-del'`).run();
+
+    const after = adapter
+      .prepare(
+        "SELECT page_id FROM wiki_pages_fts WHERE wiki_pages_fts MATCH 'DeleteMeToken' AND page_id = 'page-del'"
+      )
+      .all();
+    expect(after.length).toBe(0);
+  });
+
+  it('ON CONFLICT(page_id) DO UPDATE keeps FTS consistent (idempotent re-insert)', () => {
+    const adapter = getAdapter();
+    const now = new Date().toISOString();
+    // First write
+    insertPage({
+      page_id: 'page-upsert',
+      source_locator: 'cases/upsert.md',
+      title: 'Upsertable',
+      content: 'UpsertAlpha initial',
+    });
+    // UPSERT with same page_id but new content — MUST NOT use INSERT OR REPLACE
+    adapter
+      .prepare(
+        `INSERT INTO wiki_page_index
+           (page_id, source_type, source_locator, title, page_type, content, compiled_at, updated_at)
+         VALUES ('page-upsert', 'wiki_page', 'cases/upsert.md', 'Upsertable',
+                 'case', 'UpsertBeta revised', ?, ?)
+         ON CONFLICT(page_id) DO UPDATE SET
+           title = excluded.title,
+           content = excluded.content,
+           source_locator = excluded.source_locator,
+           updated_at = excluded.updated_at`
+      )
+      .run(now, now);
+
+    const alphaHits = adapter
+      .prepare(
+        "SELECT page_id FROM wiki_pages_fts WHERE wiki_pages_fts MATCH 'UpsertAlpha' AND page_id = 'page-upsert'"
+      )
+      .all();
+    expect(alphaHits.length).toBe(0);
+
+    const betaHits = adapter
+      .prepare(
+        "SELECT page_id FROM wiki_pages_fts WHERE wiki_pages_fts MATCH 'UpsertBeta' AND page_id = 'page-upsert'"
+      )
+      .all();
+    expect(betaHits.length).toBe(1);
+  });
+
+  it('wiki_page_embeddings cascade-deletes when wiki_page_index row is deleted', () => {
+    const adapter = getAdapter();
+    insertPage({
+      page_id: 'page-cascade',
+      source_locator: 'cases/cascade.md',
+      title: 'Cascade',
+      content: 'cascade content',
+    });
+    adapter
+      .prepare(`INSERT INTO wiki_page_embeddings (page_id, embedding) VALUES (?, ?)`)
+      .run('page-cascade', Buffer.alloc(16, 0x7f));
+    const before = adapter
+      .prepare(`SELECT page_id FROM wiki_page_embeddings WHERE page_id = 'page-cascade'`)
+      .all();
+    expect(before.length).toBe(1);
+
+    adapter.prepare(`DELETE FROM wiki_page_index WHERE page_id = 'page-cascade'`).run();
+
+    const after = adapter
+      .prepare(`SELECT page_id FROM wiki_page_embeddings WHERE page_id = 'page-cascade'`)
+      .all();
+    expect(after.length).toBe(0);
+  });
+
+});

--- a/packages/mama-core/tests/cases/wiki-page-search-index.test.ts
+++ b/packages/mama-core/tests/cases/wiki-page-search-index.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
 import { getAdapter } from '../../src/db-manager.js';
+import { upsertWikiPageIndexEntry } from '../../src/cases/wiki-page-index.js';
 
 function insertPage(
   overrides: Partial<{
@@ -256,4 +257,30 @@ describe('case-first substrate — wiki_page_search_index schema', () => {
     expect(after.length).toBe(0);
   });
 
+  it('persists source_ids and entity_refs through the page_id schema path', () => {
+    const record = upsertWikiPageIndexEntry(getAdapter(), {
+      source_locator: 'cases/provenance.md',
+      page_type: 'case',
+      title: 'Provenance Case',
+      content: 'case provenance content',
+      case_id: null,
+      source_ids: ['decision:1', 'checkpoint:2'],
+      entity_refs: ['entity:alpha'],
+      confidence: 'high',
+      compiled_at: '2026-04-18T00:00:00.000Z',
+    });
+
+    const row = getAdapter()
+      .prepare(
+        `
+          SELECT source_ids, entity_refs
+          FROM wiki_page_index
+          WHERE rowid = ?
+        `
+      )
+      .get(record.id) as { source_ids: string | null; entity_refs: string | null };
+
+    expect(JSON.parse(row.source_ids ?? '[]')).toEqual(['decision:1', 'checkpoint:2']);
+    expect(JSON.parse(row.entity_refs ?? '[]')).toEqual(['entity:alpha']);
+  });
 });

--- a/packages/mama-core/tests/connectors/connector-event-index-schema.test.ts
+++ b/packages/mama-core/tests/connectors/connector-event-index-schema.test.ts
@@ -1,0 +1,264 @@
+
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+
+import { applyMigrationsThrough } from '../../src/test-utils.js';
+function columnNames(db: Database.Database, table: string): string[] {
+  return (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>)
+    .map((col) => col.name)
+    .sort();
+}
+
+function tableExists(db: Database.Database, name: string): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?")
+    .get(name) as { name?: string } | undefined;
+  return Boolean(row?.name);
+}
+
+function triggerExists(db: Database.Database, name: string): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='trigger' AND name = ?")
+    .get(name) as { name?: string } | undefined;
+  return Boolean(row?.name);
+}
+
+function insertConnectorEvent(
+  db: Database.Database,
+  overrides: Partial<{
+    event_index_id: string;
+    source_connector: string;
+    source_id: string;
+    title: string | null;
+    content: string;
+    content_hash: Buffer;
+    artifact_locator: string | null;
+    expires_at: string | null;
+  }> = {}
+): void {
+  const now = '2026-04-18T00:00:00.000Z';
+  db.prepare(
+    `
+      INSERT INTO connector_event_index (
+        event_index_id, source_connector, source_type, source_id, source_locator,
+        channel, author, title, content, event_datetime, event_date, source_timestamp_ms,
+        metadata_json, artifact_locator, artifact_title, content_hash, indexed_at, updated_at,
+        expires_at
+      )
+      VALUES (?, ?, 'message', ?, 'slack://C1/1', 'C1', 'alice', ?, ?, 1710000000000,
+              '2026-04-18', 1710000000000, '{}', ?, 'Artifact', ?, ?, ?, ?)
+    `
+  ).run(
+    overrides.event_index_id ?? 'evt-index-1',
+    overrides.source_connector ?? 'slack',
+    overrides.source_id ?? 'source-1',
+    overrides.title ?? 'Launch update',
+    overrides.content ?? 'Launch content from connector',
+    overrides.artifact_locator ?? null,
+    overrides.content_hash ?? Buffer.alloc(32, 1),
+    now,
+    now,
+    overrides.expires_at ?? null
+  );
+}
+
+describe('case-first substrate — connector_event_index schema', () => {
+  it('creates connector index tables on apply', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    expect(tableExists(db, 'connector_event_index')).toBe(true);
+    expect(tableExists(db, 'connector_event_index_cursors')).toBe(true);
+    expect(tableExists(db, 'connector_event_index_fts')).toBe(true);
+
+    db.close();
+  });
+
+  it('creates every connector_event_index column required by amendment 9', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    expect(columnNames(db, 'connector_event_index')).toEqual(
+      [
+        'artifact_locator',
+        'artifact_title',
+        'author',
+        'channel',
+        'content',
+        'content_hash',
+        'event_date',
+        'event_datetime',
+        'event_index_id',
+        'expires_at',
+        'indexed_at',
+        'metadata_json',
+        'source_connector',
+        'source_id',
+        'source_locator',
+        'source_timestamp_ms',
+        'source_type',
+        'title',
+        'updated_at',
+      ].sort()
+    );
+
+    db.close();
+  });
+
+  it('creates the FTS table and insert/update/delete triggers', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    expect(tableExists(db, 'connector_event_index_fts')).toBe(true);
+    expect(triggerExists(db, 'trg_connector_event_index_ai')).toBe(true);
+    expect(triggerExists(db, 'trg_connector_event_index_au')).toBe(true);
+    expect(triggerExists(db, 'trg_connector_event_index_ad')).toBe(true);
+
+    // Seed with content-unique tokens so we can verify AU trigger rebuilds
+    // FTS rows on update. Title is indexed too; use tokens that only exist
+    // in content to isolate content-column behavior.
+    insertConnectorEvent(db, { content: 'originaltoken body text' });
+    const ftsHit = db
+      .prepare(
+        `SELECT event_index_id
+         FROM connector_event_index_fts
+         WHERE connector_event_index_fts MATCH 'originaltoken'`
+      )
+      .get() as { event_index_id: string } | undefined;
+    expect(ftsHit?.event_index_id).toBe('evt-index-1');
+
+    db.prepare(
+      "UPDATE connector_event_index SET content = 'replacedtoken body text' WHERE event_index_id = ?"
+    ).run('evt-index-1');
+    const oldHit = db
+      .prepare(
+        `SELECT event_index_id
+         FROM connector_event_index_fts
+         WHERE connector_event_index_fts MATCH 'originaltoken'`
+      )
+      .get() as { event_index_id: string } | undefined;
+    const newHit = db
+      .prepare(
+        `SELECT event_index_id
+         FROM connector_event_index_fts
+         WHERE connector_event_index_fts MATCH 'replacedtoken'`
+      )
+      .get() as { event_index_id: string } | undefined;
+    expect(oldHit).toBeUndefined();
+    expect(newHit?.event_index_id).toBe('evt-index-1');
+
+    db.prepare('DELETE FROM connector_event_index WHERE event_index_id = ?').run('evt-index-1');
+    const deletedHit = db
+      .prepare(
+        `SELECT event_index_id
+         FROM connector_event_index_fts
+         WHERE connector_event_index_fts MATCH 'roadmap'`
+      )
+      .get() as { event_index_id: string } | undefined;
+    expect(deletedHit).toBeUndefined();
+
+    db.close();
+  });
+
+  it('enforces unique source identity on source_connector plus source_id', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    insertConnectorEvent(db, { event_index_id: 'evt-index-1', source_id: 'same-source' });
+    expect(() =>
+      insertConnectorEvent(db, { event_index_id: 'evt-index-2', source_id: 'same-source' })
+    ).toThrow(/UNIQUE constraint/i);
+
+    expect(() =>
+      insertConnectorEvent(db, {
+        event_index_id: 'evt-index-3',
+        source_connector: 'discord',
+        source_id: 'same-source',
+      })
+    ).not.toThrow();
+
+    db.close();
+  });
+
+  it('creates replay-safe cursor columns with defaults', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    expect(columnNames(db, 'connector_event_index_cursors')).toEqual(
+      [
+        'connector_name',
+        'indexed_count',
+        'last_error',
+        'last_error_at',
+        'last_seen_source_id',
+        'last_seen_timestamp_ms',
+        'last_success_at',
+        'last_sweep_at',
+      ].sort()
+    );
+
+    db.prepare('INSERT INTO connector_event_index_cursors (connector_name) VALUES (?)').run(
+      'slack'
+    );
+    const cursor = db
+      .prepare(
+        `SELECT last_seen_timestamp_ms, last_seen_source_id, indexed_count
+         FROM connector_event_index_cursors
+         WHERE connector_name = ?`
+      )
+      .get('slack') as {
+      last_seen_timestamp_ms: number;
+      last_seen_source_id: string;
+      indexed_count: number;
+    };
+
+    expect(cursor.last_seen_timestamp_ms).toBe(0);
+    expect(cursor.last_seen_source_id).toBe('');
+    expect(cursor.indexed_count).toBe(0);
+
+    db.close();
+  });
+
+  it('enforces 32-byte content_hash and keeps artifact and retention columns writable', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    expect(() => insertConnectorEvent(db, { content_hash: Buffer.from('short') })).toThrow(
+      /CHECK constraint/i
+    );
+
+    expect(() =>
+      insertConnectorEvent(db, {
+        event_index_id: 'evt-index-artifact',
+        source_id: 'artifact-source',
+        artifact_locator: 'obsidian://cases/alpha.md',
+        expires_at: '2026-07-17T00:00:00.000Z',
+      })
+    ).not.toThrow();
+
+    const row = db
+      .prepare(
+        `SELECT artifact_locator, artifact_title, expires_at
+         FROM connector_event_index
+         WHERE event_index_id = ?`
+      )
+      .get('evt-index-artifact') as {
+      artifact_locator: string;
+      artifact_title: string;
+      expires_at: string;
+    };
+
+    expect(row.artifact_locator).toBe('obsidian://cases/alpha.md');
+    expect(row.artifact_title).toBe('Artifact');
+    expect(row.expires_at).toBe('2026-07-17T00:00:00.000Z');
+
+    db.close();
+  });
+
+});

--- a/packages/mama-core/tests/connectors/connector-event-index.test.ts
+++ b/packages/mama-core/tests/connectors/connector-event-index.test.ts
@@ -1,0 +1,61 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { getAdapter } from '../../src/db-manager.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import {
+  deleteExpiredConnectorEvents,
+  searchConnectorEventsByFTS,
+  upsertConnectorEventIndex,
+} from '../../src/connectors/event-index.js';
+
+describe('connector event index behavior', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('connector-event-index');
+  });
+
+  beforeEach(() => {
+    const adapter = getAdapter();
+    adapter.prepare('DELETE FROM connector_event_index_cursors').run();
+    adapter.prepare('DELETE FROM connector_event_index').run();
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  it('preserves relevance differences when converting BM25 rank to score', () => {
+    const adapter = getAdapter();
+    upsertConnectorEventIndex(adapter, {
+      source_connector: 'slack',
+      source_type: 'message',
+      source_id: 'evt-strong',
+      source_locator: 'slack://alpha/1',
+      content: 'alpha alpha alpha rollout checkpoint',
+      event_datetime: Date.parse('2026-04-18T01:00:00.000Z'),
+    });
+    upsertConnectorEventIndex(adapter, {
+      source_connector: 'slack',
+      source_type: 'message',
+      source_id: 'evt-weak',
+      source_locator: 'slack://alpha/2',
+      content: 'alpha mention',
+      event_datetime: Date.parse('2026-04-18T00:00:00.000Z'),
+    });
+
+    const results = searchConnectorEventsByFTS(adapter, 'alpha', { limit: 10 });
+
+    expect(results).toHaveLength(2);
+    expect(results[0]!.score).toBeGreaterThan(results[1]!.score);
+  });
+
+  it('rejects invalid retention windows before deleting rows', () => {
+    expect(() =>
+      deleteExpiredConnectorEvents(getAdapter(), {
+        nowMs: Date.parse('2026-04-18T00:00:00.000Z'),
+        retentionMs: -1,
+      })
+    ).toThrow(/retentionMs must be a non-negative finite number/i);
+  });
+});

--- a/packages/mama-core/tests/entities/audit-metrics.test.ts
+++ b/packages/mama-core/tests/entities/audit-metrics.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   classifyAuditRun,
   computeAuditMetrics,
+  computeCrossLanguageRecallAt5,
   computeCrossLanguageRecallAt10,
+  computeCrossLanguageRecallAtK,
   computeFalseMergeRate,
   computeOntologyViolationCount,
   computeProjectionFragmentationRate,
@@ -51,6 +53,21 @@ describe('entity audit metrics', () => {
       expect(result.recall).toBe(0);
     });
 
+    it('scores only gold pairs that appear in the top 1 when k=1', () => {
+      const gold: AuditGoldPair[] = [
+        { canonical_id: 'gold_a', left_obs_id: 'o1', right_obs_id: 'o2' },
+        { canonical_id: 'gold_b', left_obs_id: 'o3', right_obs_id: 'o4' },
+      ];
+      const matches = [
+        { candidate_id: 'c1', matched_pair_key: 'gold_a:o1:o2', score_total: 0.99 },
+        { candidate_id: 'c2', matched_pair_key: 'gold_b:o3:o4', score_total: 0.01 },
+      ];
+      const result = computeCrossLanguageRecallAtK(gold, matches, 1);
+      expect(result.denominator).toBe(2);
+      expect(result.numerator).toBe(1);
+      expect(result.recall).toBe(0.5);
+    });
+
     it('scores only gold pairs that appear in the top 10', () => {
       const gold: AuditGoldPair[] = [
         { canonical_id: 'gold_a', left_obs_id: 'o1', right_obs_id: 'o2' },
@@ -64,6 +81,16 @@ describe('entity audit metrics', () => {
       expect(result.denominator).toBe(2);
       expect(result.numerator).toBe(2);
       expect(result.recall).toBe(1);
+    });
+
+    it('exposes a @5 convenience wrapper without changing the @10 result', () => {
+      const gold: AuditGoldPair[] = [
+        { canonical_id: 'gold_a', left_obs_id: 'o1', right_obs_id: 'o2' },
+      ];
+      const matches = [{ candidate_id: 'c1', matched_pair_key: 'gold_a:o1:o2', score_total: 0.42 }];
+
+      expect(computeCrossLanguageRecallAt5(gold, matches).recall).toBe(1);
+      expect(computeCrossLanguageRecallAt10(gold, matches).recall).toBe(1);
     });
   });
 

--- a/packages/mama-core/tests/entities/benchmark-e2e.test.ts
+++ b/packages/mama-core/tests/entities/benchmark-e2e.test.ts
@@ -88,7 +88,7 @@ function observationFor(group: GoldGroup, alias: GoldAlias, index: number): Enti
     extractor_version: 'history-extractor@v1',
     embedding_model_version: 'multilingual-e5-large',
     source_connector: 'synthetic',
-    source_raw_db_ref: '~/.mama/tests/entities/fixtures',
+    source_locator: '~/.mama/tests/entities/fixtures',
     source_raw_record_id: `${group.canonical_id}_${index}`,
     created_at: 1_710_000_000_000 + index,
   };

--- a/packages/mama-core/tests/entities/candidate-generator.test.ts
+++ b/packages/mama-core/tests/entities/candidate-generator.test.ts
@@ -235,6 +235,36 @@ describe('Story E1.5: Canonical entity candidate generation', () => {
       });
     });
 
+    it('does not let rejected deterministic pairs poison cross-scope probing', async () => {
+      const candidates = await generateResolutionCandidates(
+        [
+          makeObservation('alpha_same_label_scope_a', {
+            surface_form: 'Project Alpha',
+            normalized_form: 'project alpha',
+            scope_id: 'scope-a',
+            source_raw_record_id: 'raw_alpha_same_label_scope_a',
+          }),
+          makeObservation('alpha_same_label_scope_b', {
+            surface_form: 'Project Alpha',
+            normalized_form: 'project alpha',
+            scope_id: 'scope-b',
+            source_raw_record_id: 'raw_alpha_same_label_scope_b',
+          }),
+        ],
+        {
+          embeddingScorer: vi.fn(async () => 0.9),
+          topN: 5,
+        }
+      );
+
+      expect(candidates).toHaveLength(1);
+      expect(candidates[0]).toMatchObject({
+        left_ref: 'alpha_same_label_scope_a',
+        right_ref: 'alpha_same_label_scope_b',
+        score_embedding: 0.9,
+      });
+    });
+
     it('should generate a multilingual candidate when embedding similarity is high', async () => {
       const candidates = await generateResolutionCandidates(
         [
@@ -423,7 +453,6 @@ describe('Story E1.5: Canonical entity candidate generation', () => {
         }
       );
 
-      expect(candidates).toHaveLength(2);
       expect(candidates).toEqual(
         expect.arrayContaining([
           expect.objectContaining({

--- a/packages/mama-core/tests/entities/candidate-generator.test.ts
+++ b/packages/mama-core/tests/entities/candidate-generator.test.ts
@@ -80,6 +80,21 @@ describe('Story E1.5: Canonical entity candidate generation', () => {
 
       expect(deduped).toHaveLength(3);
     });
+
+    it('should keep observations distinct when source_locator is missing', () => {
+      const deduped = dedupeObservationsBySource([
+        makeObservation('one', {
+          source_raw_record_id: 'raw_missing_locator',
+          source_locator: null,
+        }),
+        makeObservation('two', {
+          source_raw_record_id: 'raw_missing_locator',
+          source_locator: null,
+        }),
+      ]);
+
+      expect(deduped).toHaveLength(2);
+    });
   });
 
   describe('AC #2: deterministic blocking surfaces obvious candidates', () => {

--- a/packages/mama-core/tests/entities/candidate-generator.test.ts
+++ b/packages/mama-core/tests/entities/candidate-generator.test.ts
@@ -9,6 +9,7 @@ import { EmbeddingUnavailableError } from '../../src/entities/errors.js';
 
 const KOREAN_PROJECT_ALPHA = '\uD504\uB85C\uC81D\uD2B8 \uC54C\uD30C';
 const JAPANESE_PROJECT_ALPHA = '\u30D7\u30ED\u30B8\u30A7\u30AF\u30C8\u30A2\u30EB\u30D5\u30A1';
+const KOREAN_PERSON_JAEHUN = '\uC815\uC7AC\uD6C8';
 
 function makeObservation(
   id: string,
@@ -30,7 +31,7 @@ function makeObservation(
     extractor_version: 'history-extractor@v1',
     embedding_model_version: 'multilingual-e5-large',
     source_connector: 'slack',
-    source_raw_db_ref: '~/.mama/connectors/slack/raw.db',
+    source_locator: '~/.mama/connectors/slack/raw.db',
     source_raw_record_id: `raw_${id}`,
     created_at: 1710000000000,
     ...overrides,
@@ -63,17 +64,17 @@ describe('Story E1.5: Canonical entity candidate generation', () => {
         makeObservation('one', {
           observation_type: 'author',
           source_raw_record_id: 'raw_dup',
-          source_raw_db_ref: '~/.mama/connectors/slack/raw-a.db',
+          source_locator: '~/.mama/connectors/slack/raw-a.db',
         }),
         makeObservation('two', {
           observation_type: 'channel',
           source_raw_record_id: 'raw_dup',
-          source_raw_db_ref: '~/.mama/connectors/slack/raw-a.db',
+          source_locator: '~/.mama/connectors/slack/raw-a.db',
         }),
         makeObservation('three', {
           observation_type: 'author',
           source_raw_record_id: 'raw_dup',
-          source_raw_db_ref: '~/.mama/connectors/slack/raw-b.db',
+          source_locator: '~/.mama/connectors/slack/raw-b.db',
         }),
       ]);
 
@@ -145,6 +146,80 @@ describe('Story E1.5: Canonical entity candidate generation', () => {
   });
 
   describe('AC #3: cross-language cases can enter the queue through embedding/context evidence', () => {
+    it('probes same-language pairs across scopes when embedding scoring is enabled', async () => {
+      const candidates = await generateResolutionCandidates(
+        [
+          makeObservation('alpha_same_lang_scope_a', {
+            observation_type: 'channel',
+            entity_kind_hint: 'project',
+            surface_form: 'Alpha North',
+            normalized_form: 'alpha north',
+            lang: 'en',
+            script: 'Latn',
+            context_summary: 'roadmap planning summit',
+            scope_kind: 'channel',
+            scope_id: 'scope-a',
+            source_raw_record_id: 'raw_alpha_same_lang_scope_a',
+          }),
+          makeObservation('alpha_same_lang_scope_b', {
+            observation_type: 'channel',
+            entity_kind_hint: 'project',
+            surface_form: 'Alpha Core',
+            normalized_form: 'alpha core',
+            lang: 'en',
+            script: 'Latn',
+            context_summary: 'billing audit retrospective',
+            scope_kind: 'channel',
+            scope_id: 'scope-b',
+            source_raw_record_id: 'raw_alpha_same_lang_scope_b',
+          }),
+        ],
+        {
+          embeddingScorer: vi.fn(async () => 0.86),
+          topN: 5,
+        }
+      );
+
+      expect(candidates).toHaveLength(1);
+      expect(candidates[0]).toMatchObject({
+        left_ref: 'alpha_same_lang_scope_a',
+        right_ref: 'alpha_same_lang_scope_b',
+        score_embedding: 0.86,
+      });
+    });
+
+    it('probes high-similarity multilingual pairs across scopes when embedding scoring is enabled', async () => {
+      const candidates = await generateResolutionCandidates(
+        [
+          makeObservation('alpha_en_scope_a', {
+            surface_form: 'Project Alpha',
+            normalized_form: 'project alpha',
+            scope_id: 'scope-a',
+            source_raw_record_id: 'raw_alpha_en_scope_a',
+          }),
+          makeObservation('alpha_ko_scope_b', {
+            surface_form: KOREAN_PROJECT_ALPHA,
+            normalized_form: KOREAN_PROJECT_ALPHA,
+            lang: 'ko',
+            script: 'Hang',
+            scope_id: 'scope-b',
+            source_raw_record_id: 'raw_alpha_ko_scope_b',
+          }),
+        ],
+        {
+          embeddingScorer: vi.fn(async () => 0.86),
+          topN: 5,
+        }
+      );
+
+      expect(candidates).toHaveLength(1);
+      expect(candidates[0]).toMatchObject({
+        left_ref: 'alpha_en_scope_a',
+        right_ref: 'alpha_ko_scope_b',
+        score_embedding: 0.86,
+      });
+    });
+
     it('should generate a multilingual candidate when embedding similarity is high', async () => {
       const candidates = await generateResolutionCandidates(
         [
@@ -231,6 +306,123 @@ describe('Story E1.5: Canonical entity candidate generation', () => {
       expect(candidates[0]?.score_structural).toBe(0);
       expect(candidates[0]?.score_string).toBe(0);
       expect(candidates[0]?.score_embedding).toBe(0.88);
+    });
+
+    it('drops deterministic zero-score pairs when embedding scoring also returns zero', async () => {
+      const candidates = await generateResolutionCandidates(
+        [
+          makeObservation('alpha_zero_a', {
+            observation_type: 'author',
+            entity_kind_hint: 'person',
+            surface_form: 'Kim',
+            normalized_form: 'kim',
+            lang: 'en',
+            script: 'Latn',
+            context_summary: 'totally different context',
+            related_surface_forms: ['shared-room'],
+            scope_kind: 'global',
+            scope_id: null,
+            source_raw_record_id: 'raw_alpha_zero_a',
+          }),
+          makeObservation('alpha_zero_b', {
+            observation_type: 'author',
+            entity_kind_hint: 'person',
+            surface_form: 'Lee',
+            normalized_form: 'lee',
+            lang: 'en',
+            script: 'Latn',
+            context_summary: 'another unrelated note',
+            related_surface_forms: ['shared-room'],
+            scope_kind: 'global',
+            scope_id: null,
+            source_raw_record_id: 'raw_alpha_zero_b',
+          }),
+        ],
+        {
+          embeddingScorer: vi.fn(async () => 0),
+          topN: 5,
+        }
+      );
+
+      expect(candidates).toHaveLength(0);
+    });
+
+    it('keeps only the highest-scoring candidate for a repeated multilingual pair family', async () => {
+      const embeddingScorer = vi.fn(async (left: EntityObservation, right: EntityObservation) => {
+        const scopedPair = [left.id, right.id].sort().join('::');
+        if (scopedPair === 'alpha_en_scope_b::alpha_es_scope_c') {
+          return 0.92;
+        }
+        if (scopedPair === 'jaehun_en_scope_a::jaehun_ko_scope_d') {
+          return 0.88;
+        }
+        return 0.84;
+      });
+
+      const candidates = await generateResolutionCandidates(
+        [
+          makeObservation('alpha_en_scope_a', {
+            surface_form: 'Project Alpha',
+            normalized_form: 'project alpha',
+            scope_id: 'scope-a',
+            source_raw_record_id: 'raw_alpha_en_scope_a_dupe',
+          }),
+          makeObservation('alpha_en_scope_b', {
+            surface_form: 'Project Alpha',
+            normalized_form: 'project alpha',
+            scope_id: 'scope-b',
+            source_raw_record_id: 'raw_alpha_en_scope_b',
+          }),
+          makeObservation('alpha_es_scope_c', {
+            surface_form: 'Proyecto Alpha',
+            normalized_form: 'proyecto alpha',
+            lang: 'es',
+            script: 'Latn',
+            scope_id: 'scope-c',
+            source_raw_record_id: 'raw_alpha_es_scope_c',
+          }),
+          makeObservation('jaehun_en_scope_a', {
+            observation_type: 'author',
+            entity_kind_hint: 'person',
+            surface_form: 'Jae Hun',
+            normalized_form: 'jae hun',
+            scope_id: 'scope-a',
+            related_surface_forms: ['Project Alpha'],
+            source_raw_record_id: 'raw_jaehun_en_scope_a',
+          }),
+          makeObservation('jaehun_ko_scope_d', {
+            observation_type: 'author',
+            entity_kind_hint: 'person',
+            surface_form: KOREAN_PERSON_JAEHUN,
+            normalized_form: KOREAN_PERSON_JAEHUN,
+            lang: 'ko',
+            script: 'Hang',
+            scope_id: 'scope-d',
+            related_surface_forms: [KOREAN_PROJECT_ALPHA],
+            source_raw_record_id: 'raw_jaehun_ko_scope_d',
+          }),
+        ],
+        {
+          embeddingScorer,
+          topN: 5,
+        }
+      );
+
+      expect(candidates).toHaveLength(2);
+      expect(candidates).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            left_ref: 'alpha_en_scope_b',
+            right_ref: 'alpha_es_scope_c',
+            score_embedding: 0.92,
+          }),
+          expect.objectContaining({
+            left_ref: 'jaehun_en_scope_a',
+            right_ref: 'jaehun_ko_scope_d',
+            score_embedding: 0.88,
+          }),
+        ])
+      );
     });
   });
 

--- a/packages/mama-core/tests/entities/entity-impact.test.ts
+++ b/packages/mama-core/tests/entities/entity-impact.test.ts
@@ -183,6 +183,27 @@ describe('Story E1.15: Entity inspector impact', () => {
         1710000002000,
         1710000003000
       );
+    adapter
+      .prepare(`UPDATE entity_ingest_runs SET audit_run_id = ? WHERE id = ?`)
+      .run('audit_alpha', 'eir_alpha');
+    adapter
+      .prepare(
+        `
+          INSERT INTO entity_audit_runs (
+            id, status, baseline_run_id, classification, metric_summary_json, reason, created_at, completed_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        'audit_unrelated',
+        'complete',
+        null,
+        'regressed',
+        JSON.stringify({ false_merge_rate: 1 }),
+        'unrelated',
+        1710000004000,
+        1710000005000
+      );
 
     const { getEntityImpact } = await import('../../src/entities/entity-impact.js');
     const result = await getEntityImpact('entity_project_alpha');
@@ -195,5 +216,6 @@ describe('Story E1.15: Entity inspector impact', () => {
         expect.objectContaining({ id: 'audit_alpha', classification: 'stable' }),
       ])
     );
+    expect(result.audit_runs.map((run) => run.id)).not.toContain('audit_unrelated');
   });
 });

--- a/packages/mama-core/tests/entities/entity-impact.test.ts
+++ b/packages/mama-core/tests/entities/entity-impact.test.ts
@@ -129,6 +129,35 @@ describe('Story E1.15: Entity inspector impact', () => {
     expect(result.history_incomplete).toBe(true);
   });
 
+  it('preserves nullable scope_kind values from entity_nodes', async () => {
+    const adapter = getAdapter();
+    adapter
+      .prepare(
+        `
+          INSERT INTO entity_nodes (
+            id, kind, preferred_label, status, scope_kind, scope_id, merged_into, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        'entity_scope_null',
+        'project',
+        'Scope Null',
+        'active',
+        null,
+        null,
+        null,
+        1710000000000,
+        1710000000000
+      );
+
+    const { getEntityInspectorDetail } = await import('../../src/entities/entity-impact.js');
+    const result = await getEntityInspectorDetail('entity_scope_null');
+
+    expect(result.entity.scope_kind).toBeNull();
+    expect(result.history_incomplete).toBe(true);
+  });
+
   it('returns recent audit summaries and ingest-run context', async () => {
     await seedInspectableEntity();
     const adapter = getAdapter();

--- a/packages/mama-core/tests/entities/entity-impact.test.ts
+++ b/packages/mama-core/tests/entities/entity-impact.test.ts
@@ -135,6 +135,24 @@ describe('Story E1.15: Entity inspector impact', () => {
     adapter
       .prepare(
         `
+          INSERT INTO entity_audit_runs (
+            id, status, baseline_run_id, classification, metric_summary_json, reason, created_at, completed_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        'audit_superseded',
+        'complete',
+        null,
+        'stable',
+        JSON.stringify({ false_merge_rate: 0 }),
+        'superseded only',
+        1710000002000,
+        1710000003000
+      );
+    adapter
+      .prepare(
+        `
           INSERT INTO entity_ingest_runs (
             id, connector, run_kind, status, scope_key, raw_count, observation_count,
             candidate_count, reviewable_count, created_at, completed_at
@@ -217,5 +235,102 @@ describe('Story E1.15: Entity inspector impact', () => {
       ])
     );
     expect(result.audit_runs.map((run) => run.id)).not.toContain('audit_unrelated');
+  });
+
+  it('ignores ingest and audit runs that are only reachable through superseded lineage', async () => {
+    await seedInspectableEntity();
+    const adapter = getAdapter();
+    adapter
+      .prepare(
+        `
+          INSERT INTO entity_audit_runs (
+            id, status, baseline_run_id, classification, metric_summary_json, reason, created_at, completed_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        'audit_superseded',
+        'complete',
+        null,
+        'stable',
+        JSON.stringify({ false_merge_rate: 0 }),
+        'superseded only',
+        1710000002000,
+        1710000003000
+      );
+    adapter
+      .prepare(
+        `
+          INSERT INTO entity_ingest_runs (
+            id, connector, run_kind, status, scope_key, raw_count, observation_count,
+            candidate_count, reviewable_count, created_at, completed_at, audit_run_id
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        'eir_superseded',
+        'slack',
+        'replay',
+        'complete',
+        'slack:C999',
+        1,
+        1,
+        0,
+        0,
+        1710000000000,
+        1710000001000,
+        'audit_superseded'
+      );
+    adapter
+      .prepare(
+        `
+          INSERT INTO entity_lineage_links (
+            id, canonical_entity_id, entity_observation_id, source_entity_id, contribution_kind,
+            run_id, candidate_id, review_action_id, status, capture_mode, confidence, created_at, superseded_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        'elin_superseded_only',
+        'entity_project_alpha',
+        'obs_project_alpha',
+        null,
+        'seed',
+        'eir_superseded',
+        null,
+        null,
+        'superseded',
+        'direct',
+        1,
+        1710000000000,
+        1710000004000
+      );
+
+    const { getEntityImpact } = await import('../../src/entities/entity-impact.js');
+    const result = await getEntityImpact('entity_project_alpha');
+
+    expect(result.ingest_runs.map((run) => run.id)).not.toContain('eir_superseded');
+    expect(result.audit_runs.map((run) => run.id)).not.toContain('audit_superseded');
+  });
+
+  it('clamps inspector lineage limits to a positive bounded value', async () => {
+    await seedInspectableEntity();
+    await appendEntityLineageLink({
+      canonical_entity_id: 'entity_project_alpha',
+      entity_observation_id: 'obs_project_alpha',
+      source_entity_id: null,
+      contribution_kind: 'seed',
+      run_id: null,
+      candidate_id: null,
+      review_action_id: null,
+      capture_mode: 'direct',
+      confidence: 1,
+    });
+
+    const { listEntityLineageForInspector } = await import('../../src/entities/entity-impact.js');
+    const result = await listEntityLineageForInspector('entity_project_alpha', 0);
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.history_incomplete).toBe(false);
   });
 });

--- a/packages/mama-core/tests/entities/entity-impact.test.ts
+++ b/packages/mama-core/tests/entities/entity-impact.test.ts
@@ -1,0 +1,199 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import { getAdapter } from '../../src/db-manager.js';
+import { appendEntityLineageLink } from '../../src/entities/lineage-store.js';
+import { createEntityNode, upsertEntityObservation } from '../../src/entities/store.js';
+import { saveMemory } from '../../src/memory/api.js';
+
+describe('Story E1.15: Entity inspector impact', () => {
+  let testDbPath = '';
+  const alphaKo = '\uC54C\uD30C \uD504\uB85C\uC81D\uD2B8';
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('entity-impact');
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  beforeEach(() => {
+    const adapter = getAdapter();
+    adapter.prepare('DELETE FROM decision_entity_sources').run();
+    adapter.prepare('DELETE FROM decisions').run();
+    adapter.prepare('DELETE FROM entity_lineage_links').run();
+    adapter.prepare('DELETE FROM entity_ingest_runs').run();
+    adapter.prepare('DELETE FROM entity_audit_runs').run();
+    adapter.prepare('DELETE FROM entity_observations').run();
+    adapter.prepare('DELETE FROM entity_nodes').run();
+  });
+
+  async function seedInspectableEntity(): Promise<void> {
+    await createEntityNode({
+      id: 'entity_project_alpha',
+      kind: 'project',
+      preferred_label: 'Project Alpha',
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: 'scope-alpha',
+      merged_into: null,
+    });
+    await upsertEntityObservation({
+      id: 'obs_project_alpha',
+      observation_type: 'generic',
+      entity_kind_hint: 'project',
+      surface_form: 'Project Alpha',
+      normalized_form: 'project alpha',
+      lang: 'en',
+      script: 'Latn',
+      context_summary: 'Kickoff decision',
+      related_surface_forms: [alphaKo],
+      timestamp_observed: 1710000000000,
+      scope_kind: 'project',
+      scope_id: 'scope-alpha',
+      extractor_version: 'history-extractor@v1',
+      embedding_model_version: 'multilingual-e5-large',
+      source_connector: 'slack',
+      source_locator: '/tmp/slack/raw.db',
+      source_raw_record_id: 'raw_alpha',
+    });
+  }
+
+  it('returns active lineage rows with raw evidence references', async () => {
+    await seedInspectableEntity();
+    await appendEntityLineageLink({
+      canonical_entity_id: 'entity_project_alpha',
+      entity_observation_id: 'obs_project_alpha',
+      source_entity_id: null,
+      contribution_kind: 'seed',
+      run_id: null,
+      candidate_id: null,
+      review_action_id: null,
+      capture_mode: 'direct',
+      confidence: 1,
+    });
+
+    const { listEntityLineageForInspector } = await import('../../src/entities/entity-impact.js');
+    const result = await listEntityLineageForInspector('entity_project_alpha');
+
+    expect(result.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          entity_observation_id: 'obs_project_alpha',
+          source_connector: 'slack',
+          source_raw_record_id: 'raw_alpha',
+        }),
+      ])
+    );
+    expect(result.history_incomplete).toBe(false);
+  });
+
+  it('returns related memories from decision_entity_sources', async () => {
+    await seedInspectableEntity();
+    await appendEntityLineageLink({
+      canonical_entity_id: 'entity_project_alpha',
+      entity_observation_id: 'obs_project_alpha',
+      source_entity_id: null,
+      contribution_kind: 'seed',
+      run_id: null,
+      candidate_id: null,
+      review_action_id: null,
+      capture_mode: 'direct',
+      confidence: 1,
+    });
+    const saved = await saveMemory({
+      topic: 'project_alpha/kickoff',
+      kind: 'decision',
+      summary: 'Kickoff approved',
+      details: 'Kickoff approved from entity evidence',
+      confidence: 0.9,
+      scopes: [{ kind: 'project', id: 'scope-alpha' }],
+      source: { package: 'mama-core', source_type: 'test' },
+      entityObservationIds: ['obs_project_alpha'],
+    } as never);
+
+    const { getEntityImpact } = await import('../../src/entities/entity-impact.js');
+    const result = await getEntityImpact('entity_project_alpha');
+
+    expect(result.related_memories).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: saved.id })])
+    );
+  });
+
+  it('reports history_incomplete when lineage is missing for current state', async () => {
+    await seedInspectableEntity();
+
+    const { getEntityInspectorDetail } = await import('../../src/entities/entity-impact.js');
+    const result = await getEntityInspectorDetail('entity_project_alpha');
+
+    expect(result.history_incomplete).toBe(true);
+  });
+
+  it('returns recent audit summaries and ingest-run context', async () => {
+    await seedInspectableEntity();
+    const adapter = getAdapter();
+    adapter
+      .prepare(
+        `
+          INSERT INTO entity_ingest_runs (
+            id, connector, run_kind, status, scope_key, raw_count, observation_count,
+            candidate_count, reviewable_count, created_at, completed_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        'eir_alpha',
+        'slack',
+        'replay',
+        'complete',
+        'slack:C123',
+        3,
+        1,
+        1,
+        1,
+        1710000000000,
+        1710000001000
+      );
+    await appendEntityLineageLink({
+      canonical_entity_id: 'entity_project_alpha',
+      entity_observation_id: 'obs_project_alpha',
+      source_entity_id: null,
+      contribution_kind: 'seed',
+      run_id: 'eir_alpha',
+      candidate_id: null,
+      review_action_id: null,
+      capture_mode: 'direct',
+      confidence: 1,
+    });
+    adapter
+      .prepare(
+        `
+          INSERT INTO entity_audit_runs (
+            id, status, baseline_run_id, classification, metric_summary_json, reason, created_at, completed_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        'audit_alpha',
+        'complete',
+        null,
+        'stable',
+        JSON.stringify({ false_merge_rate: 0 }),
+        'ok',
+        1710000002000,
+        1710000003000
+      );
+
+    const { getEntityImpact } = await import('../../src/entities/entity-impact.js');
+    const result = await getEntityImpact('entity_project_alpha');
+
+    expect(result.ingest_runs).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: 'eir_alpha' })])
+    );
+    expect(result.audit_runs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'audit_alpha', classification: 'stable' }),
+      ])
+    );
+  });
+});

--- a/packages/mama-core/tests/entities/entity-list.test.ts
+++ b/packages/mama-core/tests/entities/entity-list.test.ts
@@ -1,0 +1,231 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import { appendEntityLineageLink } from '../../src/entities/lineage-store.js';
+import { saveMemory } from '../../src/memory/api.js';
+import { createEntityNode, upsertEntityObservation } from '../../src/entities/store.js';
+import { getAdapter } from '../../src/db-manager.js';
+
+describe('Story E1.17: Canonical entity browse list', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('entity-list');
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  beforeEach(() => {
+    const adapter = getAdapter();
+    adapter.prepare('DELETE FROM decision_entity_sources').run();
+    adapter.prepare('DELETE FROM memory_scope_bindings').run();
+    adapter.prepare('DELETE FROM memory_scopes').run();
+    adapter.prepare('DELETE FROM decisions').run();
+    adapter.prepare('DELETE FROM entity_lineage_links').run();
+    adapter.prepare('DELETE FROM entity_observations').run();
+    adapter.prepare('DELETE FROM entity_aliases').run();
+    adapter.prepare('DELETE FROM entity_nodes').run();
+  });
+
+  it('lists active canonical entities in reverse creation order', async () => {
+    await createEntityNode({
+      id: 'entity_project_alpha',
+      kind: 'project',
+      preferred_label: 'Project Alpha',
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: 'scope-list',
+      merged_into: null,
+    });
+    await createEntityNode({
+      id: 'entity_person_bora',
+      kind: 'person',
+      preferred_label: 'Bora',
+      status: 'active',
+      scope_kind: 'channel',
+      scope_id: 'workspace',
+      merged_into: null,
+    });
+
+    const { listCanonicalEntities } = await import('../../src/entities/entity-list.js');
+    const result = await listCanonicalEntities({ limit: 10, include_noisy: true });
+
+    expect(result.entities.map((entity) => entity.id)).toEqual([
+      'entity_person_bora',
+      'entity_project_alpha',
+    ]);
+    expect(result.total_count).toBe(2);
+    expect(result.visible_count).toBe(2);
+  });
+
+  it('hides known noisy workspace metadata entities when requested', async () => {
+    await createEntityNode({
+      id: 'entity_person_user',
+      kind: 'person',
+      preferred_label: 'user',
+      status: 'active',
+      scope_kind: 'channel',
+      scope_id: 'workspace',
+      merged_into: null,
+    });
+    await createEntityNode({
+      id: 'entity_person_claude',
+      kind: 'person',
+      preferred_label: 'claude',
+      status: 'active',
+      scope_kind: 'channel',
+      scope_id: 'workspace',
+      merged_into: null,
+    });
+    await createEntityNode({
+      id: 'entity_project_workspace',
+      kind: 'project',
+      preferred_label: 'workspace',
+      status: 'active',
+      scope_kind: 'channel',
+      scope_id: 'workspace',
+      merged_into: null,
+    });
+    await createEntityNode({
+      id: 'entity_project_alpha',
+      kind: 'project',
+      preferred_label: 'Project Alpha',
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: 'scope-list',
+      merged_into: null,
+    });
+
+    const { listCanonicalEntities } = await import('../../src/entities/entity-list.js');
+    const result = await listCanonicalEntities({ limit: 10, include_noisy: false });
+
+    expect(result.entities.map((entity) => entity.id)).toEqual(['entity_project_alpha']);
+    expect(result.total_count).toBe(4);
+    expect(result.visible_count).toBe(1);
+  });
+
+  it('paginates filtered canonical browse results with a stable cursor', async () => {
+    await createEntityNode({
+      id: 'entity_project_alpha',
+      kind: 'project',
+      preferred_label: 'Project Alpha',
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: 'scope-list',
+      merged_into: null,
+    });
+    await createEntityNode({
+      id: 'entity_project_beta',
+      kind: 'project',
+      preferred_label: 'Project Beta',
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: 'scope-list',
+      merged_into: null,
+    });
+
+    const { listCanonicalEntities } = await import('../../src/entities/entity-list.js');
+    const first = await listCanonicalEntities({ limit: 1, include_noisy: true });
+    const second = await listCanonicalEntities({
+      limit: 1,
+      include_noisy: true,
+      cursor: first.next_cursor,
+    });
+
+    expect(first.entities).toHaveLength(1);
+    expect(typeof first.next_cursor).toBe('string');
+    expect(second.entities).toHaveLength(1);
+    expect(second.entities[0]?.id).not.toBe(first.entities[0]?.id);
+  });
+
+  it('collapses exact same-scope duplicates into one browse row', async () => {
+    await createEntityNode({
+      id: 'entity_calendar_a',
+      kind: 'project',
+      preferred_label: 'calendar',
+      status: 'active',
+      scope_kind: 'channel',
+      scope_id: 'calendar',
+      merged_into: null,
+    });
+    await createEntityNode({
+      id: 'entity_calendar_b',
+      kind: 'project',
+      preferred_label: 'calendar',
+      status: 'active',
+      scope_kind: 'channel',
+      scope_id: 'calendar',
+      merged_into: null,
+    });
+
+    const { listCanonicalEntities } = await import('../../src/entities/entity-list.js');
+    const result = await listCanonicalEntities({ limit: 10, include_noisy: true });
+
+    expect(result.entities).toHaveLength(1);
+    expect(result.total_count).toBe(2);
+    expect(result.visible_count).toBe(1);
+  });
+
+  it('includes linked decision counts for active lineage-backed memories', async () => {
+    await createEntityNode({
+      id: 'entity_project_alpha',
+      kind: 'project',
+      preferred_label: 'Project Alpha',
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: 'scope-alpha',
+      merged_into: null,
+    });
+    await upsertEntityObservation({
+      id: 'obs_project_alpha',
+      observation_type: 'generic',
+      entity_kind_hint: 'project',
+      surface_form: 'Project Alpha',
+      normalized_form: 'project alpha',
+      lang: 'en',
+      script: 'Latn',
+      context_summary: 'Alpha kickoff',
+      related_surface_forms: ['Alpha'],
+      timestamp_observed: 1710000000000,
+      scope_kind: 'project',
+      scope_id: 'scope-alpha',
+      extractor_version: 'history-extractor@v1',
+      embedding_model_version: 'multilingual-e5-large',
+      source_connector: 'slack',
+      source_locator: '/tmp/slack/raw.db',
+      source_raw_record_id: 'raw_alpha',
+    });
+    await appendEntityLineageLink({
+      canonical_entity_id: 'entity_project_alpha',
+      entity_observation_id: 'obs_project_alpha',
+      source_entity_id: null,
+      contribution_kind: 'seed',
+      run_id: null,
+      candidate_id: null,
+      review_action_id: null,
+      capture_mode: 'direct',
+      confidence: 1,
+    });
+    await saveMemory({
+      topic: 'project_alpha/kickoff',
+      kind: 'decision',
+      summary: 'Kickoff approved',
+      details: 'Kickoff approved from entity evidence',
+      confidence: 0.9,
+      scopes: [{ kind: 'project', id: 'scope-alpha' }],
+      source: { package: 'mama-core', source_type: 'test' },
+      entityObservationIds: ['obs_project_alpha'],
+    } as never);
+
+    const { listCanonicalEntities } = await import('../../src/entities/entity-list.js');
+    const result = await listCanonicalEntities({ limit: 10, include_noisy: true });
+
+    expect(result.entities[0]).toEqual(
+      expect.objectContaining({
+        id: 'entity_project_alpha',
+        linked_decision_count: 1,
+      })
+    );
+  });
+});

--- a/packages/mama-core/tests/entities/entity-list.test.ts
+++ b/packages/mama-core/tests/entities/entity-list.test.ts
@@ -140,29 +140,51 @@ describe('Story E1.17: Canonical entity browse list', () => {
   });
 
   it('collapses exact same-scope duplicates into one browse row', async () => {
-    await createEntityNode({
-      id: 'entity_calendar_a',
-      kind: 'project',
-      preferred_label: 'calendar',
-      status: 'active',
-      scope_kind: 'channel',
-      scope_id: 'calendar',
-      merged_into: null,
-    });
-    await createEntityNode({
-      id: 'entity_calendar_b',
-      kind: 'project',
-      preferred_label: 'calendar',
-      status: 'active',
-      scope_kind: 'channel',
-      scope_id: 'calendar',
-      merged_into: null,
-    });
+    const adapter = getAdapter();
+    adapter
+      .prepare(
+        `
+          INSERT INTO entity_nodes (
+            id, kind, preferred_label, status, scope_kind, scope_id, merged_into, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        'entity_calendar_a',
+        'project',
+        'calendar',
+        'active',
+        'channel',
+        'calendar',
+        null,
+        1710000000000,
+        1710000000000
+      );
+    adapter
+      .prepare(
+        `
+          INSERT INTO entity_nodes (
+            id, kind, preferred_label, status, scope_kind, scope_id, merged_into, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        'entity_calendar_b',
+        'project',
+        'calendar',
+        'active',
+        'channel',
+        'calendar',
+        null,
+        1710000001000,
+        1710000001000
+      );
 
     const { listCanonicalEntities } = await import('../../src/entities/entity-list.js');
     const result = await listCanonicalEntities({ limit: 10, include_noisy: true });
 
     expect(result.entities).toHaveLength(1);
+    expect(result.entities[0]?.id).toBe('entity_calendar_b');
     expect(result.total_count).toBe(2);
     expect(result.visible_count).toBe(1);
   });

--- a/packages/mama-core/tests/entities/entity-orphan-list.test.ts
+++ b/packages/mama-core/tests/entities/entity-orphan-list.test.ts
@@ -1,0 +1,206 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import { appendEntityLineageLink } from '../../src/entities/lineage-store.js';
+import { saveMemory } from '../../src/memory/api.js';
+import { createEntityNode, upsertEntityObservation } from '../../src/entities/store.js';
+import { getAdapter } from '../../src/db-manager.js';
+
+describe('canonical entity orphan list', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('entity-orphan-list');
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  beforeEach(() => {
+    const adapter = getAdapter();
+    adapter.prepare('DELETE FROM decision_entity_sources').run();
+    adapter.prepare('DELETE FROM memory_scope_bindings').run();
+    adapter.prepare('DELETE FROM memory_scopes').run();
+    adapter.prepare('DELETE FROM decisions').run();
+    adapter.prepare('DELETE FROM entity_lineage_links').run();
+    adapter.prepare('DELETE FROM entity_observations').run();
+    adapter.prepare('DELETE FROM entity_aliases').run();
+    adapter.prepare('DELETE FROM entity_nodes').run();
+  });
+
+  it('lists active lineage-backed zero-linked entities with evidence counts in deterministic order', async () => {
+    await seedOrphanEntity({
+      entityId: 'entity_project_orphan_b',
+      label: 'Project Orphan B',
+      scopeId: 'scope-orphan',
+      observedAt: 1710000001000,
+    });
+    await seedOrphanEntity({
+      entityId: 'entity_project_orphan_a',
+      label: 'Project Orphan A',
+      scopeId: 'scope-orphan',
+      observedAt: 1710000001000,
+    });
+
+    const { listCanonicalEntityOrphans } = await import('../../src/entities/entity-orphan-list.js');
+    const rows = await listCanonicalEntityOrphans();
+
+    expect(rows.map((row) => row.entity_id)).toEqual([
+      'entity_project_orphan_a',
+      'entity_project_orphan_b',
+    ]);
+    expect(rows[0]).toEqual(
+      expect.objectContaining({
+        title: 'Project Orphan A',
+        kind: 'project',
+        scope_label: 'project:scope-orphan',
+        linked_decision_count: 0,
+        evidence_summary: {
+          lineage_rows: 1,
+          raw_evidence_rows: 1,
+          last_seen_at: 1710000001000,
+        },
+      })
+    );
+  });
+
+  it('excludes linked, noisy, merged, and inactive entities from the orphan list', async () => {
+    await seedOrphanEntity({
+      entityId: 'entity_project_visible',
+      label: 'Visible Orphan',
+      scopeId: 'scope-visible',
+      observedAt: 1710000000000,
+    });
+    await seedOrphanEntity({
+      entityId: 'entity_person_user',
+      label: 'user',
+      scopeId: 'workspace',
+      observedAt: 1710000000100,
+      kind: 'person',
+      scopeKind: 'channel',
+    });
+    await seedOrphanEntity({
+      entityId: 'entity_project_merged',
+      label: 'Merged Orphan',
+      scopeId: 'scope-merged',
+      observedAt: 1710000000200,
+      mergedInto: 'entity_project_visible',
+    });
+    await seedOrphanEntity({
+      entityId: 'entity_project_inactive',
+      label: 'Inactive Orphan',
+      scopeId: 'scope-inactive',
+      observedAt: 1710000000300,
+      status: 'merged',
+    });
+    await seedLinkedEntity();
+
+    const { listCanonicalEntityOrphans } = await import('../../src/entities/entity-orphan-list.js');
+    const rows = await listCanonicalEntityOrphans();
+
+    expect(rows.map((row) => row.entity_id)).toEqual(['entity_project_visible']);
+  });
+});
+
+async function seedOrphanEntity(input: {
+  entityId: string;
+  label: string;
+  scopeId: string;
+  observedAt: number;
+  kind?: 'project' | 'person';
+  scopeKind?: 'project' | 'channel';
+  status?: 'active' | 'merged';
+  mergedInto?: string | null;
+}): Promise<void> {
+  await createEntityNode({
+    id: input.entityId,
+    kind: input.kind ?? 'project',
+    preferred_label: input.label,
+    status: input.status ?? 'active',
+    scope_kind: input.scopeKind ?? 'project',
+    scope_id: input.scopeId,
+    merged_into: input.mergedInto ?? null,
+  });
+  await upsertEntityObservation({
+    id: `obs_${input.entityId}`,
+    observation_type: 'generic',
+    entity_kind_hint: input.kind ?? 'project',
+    surface_form: input.label,
+    normalized_form: input.label.toLowerCase(),
+    lang: 'en',
+    script: 'Latn',
+    context_summary: `${input.label} evidence`,
+    related_surface_forms: [input.label],
+    timestamp_observed: input.observedAt,
+    scope_kind: input.scopeKind ?? 'project',
+    scope_id: input.scopeId,
+    extractor_version: 'history-extractor@v1',
+    embedding_model_version: 'multilingual-e5-large',
+    source_connector: 'slack',
+    source_locator: '/tmp/slack/raw.db',
+    source_raw_record_id: `raw_${input.entityId}`,
+  });
+  await appendEntityLineageLink({
+    canonical_entity_id: input.entityId,
+    entity_observation_id: `obs_${input.entityId}`,
+    source_entity_id: null,
+    contribution_kind: 'seed',
+    run_id: null,
+    candidate_id: null,
+    review_action_id: null,
+    capture_mode: 'direct',
+    confidence: 1,
+  });
+}
+
+async function seedLinkedEntity(): Promise<void> {
+  await createEntityNode({
+    id: 'entity_project_linked',
+    kind: 'project',
+    preferred_label: 'Linked Project',
+    status: 'active',
+    scope_kind: 'project',
+    scope_id: 'scope-linked',
+    merged_into: null,
+  });
+  await upsertEntityObservation({
+    id: 'obs_entity_project_linked',
+    observation_type: 'generic',
+    entity_kind_hint: 'project',
+    surface_form: 'Linked Project',
+    normalized_form: 'linked project',
+    lang: 'en',
+    script: 'Latn',
+    context_summary: 'Linked project evidence',
+    related_surface_forms: ['Linked Project'],
+    timestamp_observed: 1710000000400,
+    scope_kind: 'project',
+    scope_id: 'scope-linked',
+    extractor_version: 'history-extractor@v1',
+    embedding_model_version: 'multilingual-e5-large',
+    source_connector: 'slack',
+    source_locator: '/tmp/slack/raw.db',
+    source_raw_record_id: 'raw_entity_project_linked',
+  });
+  await appendEntityLineageLink({
+    canonical_entity_id: 'entity_project_linked',
+    entity_observation_id: 'obs_entity_project_linked',
+    source_entity_id: null,
+    contribution_kind: 'seed',
+    run_id: null,
+    candidate_id: null,
+    review_action_id: null,
+    capture_mode: 'direct',
+    confidence: 1,
+  });
+  await saveMemory({
+    topic: 'linked/project',
+    kind: 'decision',
+    summary: 'Linked project should not be orphaned',
+    details: 'linked project decision',
+    confidence: 0.9,
+    scopes: [{ kind: 'project', id: 'scope-linked' }],
+    source: { package: 'mama-core', source_type: 'test' },
+    entityObservationIds: ['obs_entity_project_linked'],
+  } as never);
+}

--- a/packages/mama-core/tests/entities/entity-search.test.ts
+++ b/packages/mama-core/tests/entities/entity-search.test.ts
@@ -1,0 +1,305 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import { attachEntityAlias, createEntityNode } from '../../src/entities/store.js';
+import { getAdapter } from '../../src/db-manager.js';
+import { appendEntityLineageLink } from '../../src/entities/lineage-store.js';
+import { upsertEntityObservation } from '../../src/entities/store.js';
+import { saveMemory } from '../../src/memory/api.js';
+
+describe('Story E1.14: Entity search', () => {
+  let testDbPath = '';
+  const alphaKo = '\uC54C\uD30C \uD504\uB85C\uC81D\uD2B8';
+  const alphaKoQuery = '\uC54C\uD30C';
+  const alphaJa = '\u30A2\u30EB\u30D5\u30A1\u30D7\u30ED\u30B8\u30A7\u30AF\u30C8';
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('entity-search');
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  beforeEach(() => {
+    const adapter = getAdapter();
+    adapter.prepare('DELETE FROM decision_entity_sources').run();
+    adapter.prepare('DELETE FROM memory_scope_bindings').run();
+    adapter.prepare('DELETE FROM memory_scopes').run();
+    adapter.prepare('DELETE FROM decisions').run();
+    adapter.prepare('DELETE FROM entity_lineage_links').run();
+    adapter.prepare('DELETE FROM entity_observations').run();
+    adapter.prepare('DELETE FROM entity_aliases').run();
+    adapter.prepare('DELETE FROM entity_nodes').run();
+  });
+
+  async function seedEntity(
+    id: string,
+    preferredLabel: string,
+    aliases: Array<{ id: string; label: string }>
+  ): Promise<void> {
+    await createEntityNode({
+      id,
+      kind: 'project',
+      preferred_label: preferredLabel,
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: 'scope-search',
+      merged_into: null,
+    });
+    for (const alias of aliases) {
+      await attachEntityAlias({
+        id: alias.id,
+        entity_id: id,
+        label: alias.label,
+        normalized_label: alias.label.toLowerCase(),
+        lang: null,
+        script: null,
+        label_type: 'alt',
+        source_type: 'synthetic',
+        source_ref: 'synthetic:test',
+        confidence: 0.9,
+        status: 'active',
+      });
+    }
+  }
+
+  it('finds one canonical entity from Korean/English/Japanese aliases', async () => {
+    await seedEntity('entity_project_alpha', 'Project Alpha', [
+      { id: 'alias_alpha_ko', label: alphaKo },
+      { id: 'alias_alpha_ja', label: alphaJa },
+    ]);
+
+    const { searchCanonicalEntities } = await import('../../src/entities/entity-search.js');
+    const result = await searchCanonicalEntities({ query: alphaKoQuery, limit: 10 });
+
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0]).toEqual(
+      expect.objectContaining({
+        id: 'entity_project_alpha',
+        preferred_label: 'Project Alpha',
+      })
+    );
+  });
+
+  it('paginates search results with stable ranking', async () => {
+    await seedEntity('entity_project_alpha', 'Project Alpha', []);
+    await seedEntity('entity_project_beta', 'Project Beta', []);
+
+    const { searchCanonicalEntities } = await import('../../src/entities/entity-search.js');
+    const first = await searchCanonicalEntities({ query: 'Project', limit: 1 });
+
+    expect(first.entities).toHaveLength(1);
+    expect(typeof first.next_cursor).toBe('string');
+
+    const second = await searchCanonicalEntities({
+      query: 'Project',
+      limit: 1,
+      cursor: first.next_cursor,
+    });
+
+    expect(second.entities).toHaveLength(1);
+    expect(second.entities[0]?.id).not.toBe(first.entities[0]?.id);
+  });
+
+  it('skips merged tombstones from primary results', async () => {
+    await createEntityNode({
+      id: 'entity_project_live',
+      kind: 'project',
+      preferred_label: 'Project Live',
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: 'scope-search',
+      merged_into: null,
+    });
+    await createEntityNode({
+      id: 'entity_project_merged',
+      kind: 'project',
+      preferred_label: 'Project Merged',
+      status: 'merged',
+      scope_kind: 'project',
+      scope_id: 'scope-search',
+      merged_into: 'entity_project_live',
+    });
+
+    const { searchCanonicalEntities } = await import('../../src/entities/entity-search.js');
+    const result = await searchCanonicalEntities({ query: 'Project', limit: 10 });
+
+    expect(result.entities.map((item) => item.id)).not.toContain('entity_project_merged');
+  });
+
+  it('surfaces merged labels through canonical resolution', async () => {
+    await createEntityNode({
+      id: 'entity_target_alias',
+      kind: 'project',
+      preferred_label: 'Project Alpha',
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: 'scope-search',
+      merged_into: null,
+    });
+    await createEntityNode({
+      id: 'entity_source_alias',
+      kind: 'project',
+      preferred_label: 'Old Alpha Name',
+      status: 'merged',
+      scope_kind: 'project',
+      scope_id: 'scope-search',
+      merged_into: 'entity_target_alias',
+    });
+    await attachEntityAlias({
+      id: 'alias_old_alpha',
+      entity_id: 'entity_source_alias',
+      label: 'Legacy Alpha',
+      normalized_label: 'legacy alpha',
+      lang: 'en',
+      script: 'Latn',
+      label_type: 'alt',
+      source_type: 'synthetic',
+      source_ref: 'synthetic:test',
+      confidence: 0.9,
+      status: 'active',
+    });
+
+    const { searchCanonicalEntities } = await import('../../src/entities/entity-search.js');
+    const result = await searchCanonicalEntities({ query: 'Legacy Alpha', limit: 10 });
+
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0]?.id).toBe('entity_target_alias');
+  });
+
+  it('collapses exact same-scope duplicate canonicals into one search result', async () => {
+    await createEntityNode({
+      id: 'entity_calendar_a',
+      kind: 'project',
+      preferred_label: 'calendar',
+      status: 'active',
+      scope_kind: 'channel',
+      scope_id: 'calendar',
+      merged_into: null,
+    });
+    await createEntityNode({
+      id: 'entity_calendar_b',
+      kind: 'project',
+      preferred_label: 'calendar',
+      status: 'active',
+      scope_kind: 'channel',
+      scope_id: 'calendar',
+      merged_into: null,
+    });
+
+    const { searchCanonicalEntities } = await import('../../src/entities/entity-search.js');
+    const result = await searchCanonicalEntities({ query: 'calendar', limit: 10 });
+
+    expect(result.entities).toHaveLength(1);
+  });
+
+  it('finds a canonical entity through active lineage observation surface forms', async () => {
+    await createEntityNode({
+      id: 'entity_project_alpha_lineage',
+      kind: 'project',
+      preferred_label: 'Project Alpha',
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: 'scope-search',
+      merged_into: null,
+    });
+    await upsertEntityObservation({
+      id: 'obs_project_alpha_ko',
+      observation_type: 'channel',
+      entity_kind_hint: 'project',
+      surface_form: alphaKo,
+      normalized_form: alphaKo,
+      lang: 'ko',
+      script: 'Hang',
+      context_summary: 'alpha kickoff',
+      related_surface_forms: ['Project Alpha'],
+      timestamp_observed: 1710000000000,
+      scope_kind: 'project',
+      scope_id: 'scope-search',
+      extractor_version: 'history-extractor@v1',
+      embedding_model_version: 'multilingual-e5-large',
+      source_connector: 'slack',
+      source_locator: '~/.mama/connectors/slack/raw.db',
+      source_raw_record_id: 'raw_lineage_alpha',
+    });
+    await appendEntityLineageLink({
+      canonical_entity_id: 'entity_project_alpha_lineage',
+      entity_observation_id: 'obs_project_alpha_ko',
+      source_entity_id: null,
+      contribution_kind: 'seed',
+      run_id: null,
+      candidate_id: null,
+      review_action_id: null,
+      capture_mode: 'direct',
+      confidence: 1,
+    });
+
+    const { searchCanonicalEntities } = await import('../../src/entities/entity-search.js');
+    const result = await searchCanonicalEntities({ query: alphaKoQuery, limit: 10 });
+
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0]?.id).toBe('entity_project_alpha_lineage');
+  });
+
+  it('returns linked decision counts for lineage-backed search results', async () => {
+    await createEntityNode({
+      id: 'entity_project_alpha',
+      kind: 'project',
+      preferred_label: 'Project Alpha',
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: 'scope-search',
+      merged_into: null,
+    });
+    await upsertEntityObservation({
+      id: 'obs_project_alpha',
+      observation_type: 'generic',
+      entity_kind_hint: 'project',
+      surface_form: 'Project Alpha',
+      normalized_form: 'project alpha',
+      lang: 'en',
+      script: 'Latn',
+      context_summary: 'Alpha kickoff',
+      related_surface_forms: ['Alpha'],
+      timestamp_observed: 1710000000000,
+      scope_kind: 'project',
+      scope_id: 'scope-search',
+      extractor_version: 'history-extractor@v1',
+      embedding_model_version: 'multilingual-e5-large',
+      source_connector: 'slack',
+      source_locator: '/tmp/slack/raw.db',
+      source_raw_record_id: 'raw_alpha',
+    });
+    await appendEntityLineageLink({
+      canonical_entity_id: 'entity_project_alpha',
+      entity_observation_id: 'obs_project_alpha',
+      source_entity_id: null,
+      contribution_kind: 'seed',
+      run_id: null,
+      candidate_id: null,
+      review_action_id: null,
+      capture_mode: 'direct',
+      confidence: 1,
+    });
+    await saveMemory({
+      topic: 'project_alpha/search',
+      kind: 'decision',
+      summary: 'Search linked to entity evidence',
+      details: 'Search should expose linked memory count',
+      confidence: 0.9,
+      scopes: [{ kind: 'project', id: 'scope-search' }],
+      source: { package: 'mama-core', source_type: 'test' },
+      entityObservationIds: ['obs_project_alpha'],
+    } as never);
+
+    const { searchCanonicalEntities } = await import('../../src/entities/entity-search.js');
+    const result = await searchCanonicalEntities({ query: 'Alpha', limit: 10 });
+
+    expect(result.entities[0]).toEqual(
+      expect.objectContaining({
+        id: 'entity_project_alpha',
+        linked_decision_count: 1,
+      })
+    );
+  });
+});

--- a/packages/mama-core/tests/entities/entity-search.test.ts
+++ b/packages/mama-core/tests/entities/entity-search.test.ts
@@ -302,4 +302,37 @@ describe('Story E1.14: Entity search', () => {
       })
     );
   });
+
+  it('treats literal percent characters as exact search text', async () => {
+    await seedEntity('entity_percent', '100% Coverage', []);
+    await seedEntity('entity_plain_percent', '100 Percent Coverage', []);
+
+    const { searchCanonicalEntities } = await import('../../src/entities/entity-search.js');
+    const result = await searchCanonicalEntities({ query: '%', limit: 10 });
+
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0]?.id).toBe('entity_percent');
+  });
+
+  it('treats literal underscore characters as exact search text', async () => {
+    await seedEntity('entity_underscore', 'alpha_beta', []);
+    await seedEntity('entity_plain_underscore', 'alpha beta', []);
+
+    const { searchCanonicalEntities } = await import('../../src/entities/entity-search.js');
+    const result = await searchCanonicalEntities({ query: '_', limit: 10 });
+
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0]?.id).toBe('entity_underscore');
+  });
+
+  it('treats literal backslashes as exact search text', async () => {
+    await seedEntity('entity_backslash', 'alpha\\beta', []);
+    await seedEntity('entity_plain_backslash', 'alpha beta', []);
+
+    const { searchCanonicalEntities } = await import('../../src/entities/entity-search.js');
+    const result = await searchCanonicalEntities({ query: '\\', limit: 10 });
+
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0]?.id).toBe('entity_backslash');
+  });
 });

--- a/packages/mama-core/tests/entities/exact-merge-backfill.test.ts
+++ b/packages/mama-core/tests/entities/exact-merge-backfill.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { getAdapter } from '../../src/db-manager.js';
+import { appendEntityLineageLink } from '../../src/entities/lineage-store.js';
 import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
 import {
   createEntityNode,
@@ -32,14 +33,15 @@ describe('Story E1.18: Exact duplicate canonical merge backfill', () => {
   async function seedObservationBackedEntity(
     id: string,
     label: string,
-    scopeId = 'calendar'
+    scopeId = 'calendar',
+    observationLabel = label
   ): Promise<void> {
     await upsertEntityObservation({
-      id,
+      id: `obs_${id}`,
       observation_type: 'channel',
       entity_kind_hint: 'project',
-      surface_form: label,
-      normalized_form: label.toLowerCase(),
+      surface_form: observationLabel,
+      normalized_form: observationLabel.toLowerCase(),
       lang: 'en',
       script: 'Latn',
       context_summary: `${label} context`,
@@ -62,13 +64,22 @@ describe('Story E1.18: Exact duplicate canonical merge backfill', () => {
       scope_id: scopeId,
       merged_into: null,
     });
+    await appendEntityLineageLink({
+      canonical_entity_id: id,
+      entity_observation_id: `obs_${id}`,
+      source_entity_id: null,
+      contribution_kind: 'seed',
+      run_id: null,
+      candidate_id: null,
+      review_action_id: null,
+      capture_mode: 'direct',
+      confidence: 1,
+    });
   }
 
   it('merges exact duplicate canonical roots into the oldest target and adopts lineage', async () => {
-    await seedObservationBackedEntity('obs_calendar_a', 'calendar');
-    await seedObservationBackedEntity('obs_calendar_b', 'calendar');
-    const { backfillEntityLineage } = await import('../../src/entities/lineage-backfill.js');
-    await backfillEntityLineage();
+    await seedObservationBackedEntity('entity_calendar_a', 'Calendar Alpha', 'calendar', 'calendar');
+    await seedObservationBackedEntity('entity_calendar_b', 'Calendar Beta', 'calendar', 'calendar');
 
     const { backfillExactDuplicateCanonicals } =
       await import('../../src/entities/exact-merge-backfill.js');
@@ -77,8 +88,8 @@ describe('Story E1.18: Exact duplicate canonical merge backfill', () => {
     expect(result.groups).toBe(1);
     expect(result.merged).toBe(1);
     expect(result.skipped).toBe(0);
-    expect(getEntityNode('obs_calendar_a')?.merged_into).toBeNull();
-    expect(getEntityNode('obs_calendar_b')?.merged_into).toBe('obs_calendar_a');
+    expect(getEntityNode('entity_calendar_a')?.merged_into).toBeNull();
+    expect(getEntityNode('entity_calendar_b')?.merged_into).toBe('entity_calendar_a');
 
     const lineageRows = getAdapter()
       .prepare(
@@ -89,7 +100,7 @@ describe('Story E1.18: Exact duplicate canonical merge backfill', () => {
           ORDER BY entity_observation_id ASC
         `
       )
-      .all('obs_calendar_a') as Array<{
+      .all('entity_calendar_a') as Array<{
       canonical_entity_id: string;
       entity_observation_id: string;
       contribution_kind: string;
@@ -99,12 +110,12 @@ describe('Story E1.18: Exact duplicate canonical merge backfill', () => {
     expect(lineageRows).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          entity_observation_id: 'obs_calendar_a',
+          entity_observation_id: 'obs_entity_calendar_a',
           contribution_kind: 'seed',
           status: 'active',
         }),
         expect.objectContaining({
-          entity_observation_id: 'obs_calendar_b',
+          entity_observation_id: 'obs_entity_calendar_b',
           contribution_kind: 'merge_adopt',
           status: 'active',
         }),
@@ -113,10 +124,8 @@ describe('Story E1.18: Exact duplicate canonical merge backfill', () => {
   });
 
   it('is idempotent after the first exact duplicate merge pass', async () => {
-    await seedObservationBackedEntity('obs_calendar_a', 'calendar');
-    await seedObservationBackedEntity('obs_calendar_b', 'calendar');
-    const { backfillEntityLineage } = await import('../../src/entities/lineage-backfill.js');
-    await backfillEntityLineage();
+    await seedObservationBackedEntity('entity_calendar_a', 'Calendar Alpha', 'calendar', 'calendar');
+    await seedObservationBackedEntity('entity_calendar_b', 'Calendar Beta', 'calendar', 'calendar');
 
     const { backfillExactDuplicateCanonicals } =
       await import('../../src/entities/exact-merge-backfill.js');

--- a/packages/mama-core/tests/entities/exact-merge-backfill.test.ts
+++ b/packages/mama-core/tests/entities/exact-merge-backfill.test.ts
@@ -1,0 +1,180 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { getAdapter } from '../../src/db-manager.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import {
+  createEntityNode,
+  getEntityNode,
+  upsertEntityObservation,
+} from '../../src/entities/store.js';
+
+describe('Story E1.18: Exact duplicate canonical merge backfill', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('exact-merge-backfill');
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  beforeEach(() => {
+    const adapter = getAdapter();
+    adapter.prepare('DELETE FROM entity_lineage_links').run();
+    adapter.prepare('DELETE FROM entity_ingest_runs').run();
+    adapter.prepare('DELETE FROM entity_merge_actions').run();
+    adapter.prepare('DELETE FROM entity_resolution_candidates').run();
+    adapter.prepare('DELETE FROM entity_timeline_events').run();
+    adapter.prepare('DELETE FROM entity_observations').run();
+    adapter.prepare('DELETE FROM entity_nodes').run();
+  });
+
+  async function seedObservationBackedEntity(
+    id: string,
+    label: string,
+    scopeId = 'calendar'
+  ): Promise<void> {
+    await upsertEntityObservation({
+      id,
+      observation_type: 'channel',
+      entity_kind_hint: 'project',
+      surface_form: label,
+      normalized_form: label.toLowerCase(),
+      lang: 'en',
+      script: 'Latn',
+      context_summary: `${label} context`,
+      related_surface_forms: [],
+      timestamp_observed: 1710000000000,
+      scope_kind: 'channel',
+      scope_id: scopeId,
+      extractor_version: 'history-extractor@v1',
+      embedding_model_version: 'multilingual-e5-large',
+      source_connector: 'slack',
+      source_locator: '/tmp/slack/raw.db',
+      source_raw_record_id: `raw_${id}`,
+    });
+    await createEntityNode({
+      id,
+      kind: 'project',
+      preferred_label: label,
+      status: 'active',
+      scope_kind: 'channel',
+      scope_id: scopeId,
+      merged_into: null,
+    });
+  }
+
+  it('merges exact duplicate canonical roots into the oldest target and adopts lineage', async () => {
+    await seedObservationBackedEntity('obs_calendar_a', 'calendar');
+    await seedObservationBackedEntity('obs_calendar_b', 'calendar');
+    const { backfillEntityLineage } = await import('../../src/entities/lineage-backfill.js');
+    await backfillEntityLineage();
+
+    const { backfillExactDuplicateCanonicals } =
+      await import('../../src/entities/exact-merge-backfill.js');
+    const result = await backfillExactDuplicateCanonicals();
+
+    expect(result.groups).toBe(1);
+    expect(result.merged).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(getEntityNode('obs_calendar_a')?.merged_into).toBeNull();
+    expect(getEntityNode('obs_calendar_b')?.merged_into).toBe('obs_calendar_a');
+
+    const lineageRows = getAdapter()
+      .prepare(
+        `
+          SELECT canonical_entity_id, entity_observation_id, contribution_kind, status
+          FROM entity_lineage_links
+          WHERE canonical_entity_id = ?
+          ORDER BY entity_observation_id ASC
+        `
+      )
+      .all('obs_calendar_a') as Array<{
+      canonical_entity_id: string;
+      entity_observation_id: string;
+      contribution_kind: string;
+      status: string;
+    }>;
+
+    expect(lineageRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          entity_observation_id: 'obs_calendar_a',
+          contribution_kind: 'seed',
+          status: 'active',
+        }),
+        expect.objectContaining({
+          entity_observation_id: 'obs_calendar_b',
+          contribution_kind: 'merge_adopt',
+          status: 'active',
+        }),
+      ])
+    );
+  });
+
+  it('is idempotent after the first exact duplicate merge pass', async () => {
+    await seedObservationBackedEntity('obs_calendar_a', 'calendar');
+    await seedObservationBackedEntity('obs_calendar_b', 'calendar');
+    const { backfillEntityLineage } = await import('../../src/entities/lineage-backfill.js');
+    await backfillEntityLineage();
+
+    const { backfillExactDuplicateCanonicals } =
+      await import('../../src/entities/exact-merge-backfill.js');
+    await backfillExactDuplicateCanonicals();
+    const second = await backfillExactDuplicateCanonicals();
+
+    expect(second.groups).toBe(0);
+    expect(second.merged).toBe(0);
+  });
+
+  it('reports incomplete rows when canonical nodes are missing a source observation', async () => {
+    await createEntityNode({
+      id: 'entity_without_observation',
+      kind: 'project',
+      preferred_label: 'calendar',
+      status: 'active',
+      scope_kind: 'channel',
+      scope_id: 'calendar',
+      merged_into: null,
+    });
+
+    const { backfillExactDuplicateCanonicals } =
+      await import('../../src/entities/exact-merge-backfill.js');
+    const result = await backfillExactDuplicateCanonicals({ dryRun: true });
+
+    expect(result.incomplete).toBe(1);
+    expect(result.groups).toBe(0);
+    expect(result.merged).toBe(0);
+  });
+
+  it('merges exact duplicate legacy roots even when observations are missing', async () => {
+    await createEntityNode({
+      id: 'entity_prov_demo_a',
+      kind: 'project',
+      preferred_label: 'Provenance Demo',
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: 'scope-provenance-demo',
+      merged_into: null,
+    });
+    await createEntityNode({
+      id: 'entity_prov_demo_b',
+      kind: 'project',
+      preferred_label: 'Provenance Demo',
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: 'scope-provenance-demo',
+      merged_into: null,
+    });
+
+    const { backfillExactDuplicateCanonicals } =
+      await import('../../src/entities/exact-merge-backfill.js');
+    const result = await backfillExactDuplicateCanonicals();
+
+    expect(result.groups).toBe(1);
+    expect(result.merged).toBe(1);
+    expect(result.incomplete).toBe(0);
+    expect(getEntityNode('entity_prov_demo_a')?.merged_into).toBeNull();
+    expect(getEntityNode('entity_prov_demo_b')?.merged_into).toBe('entity_prov_demo_a');
+  });
+});

--- a/packages/mama-core/tests/entities/exact-merge-backfill.test.ts
+++ b/packages/mama-core/tests/entities/exact-merge-backfill.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getAdapter } from '../../src/db-manager.js';
 import { appendEntityLineageLink } from '../../src/entities/lineage-store.js';
 import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
@@ -78,7 +78,12 @@ describe('Story E1.18: Exact duplicate canonical merge backfill', () => {
   }
 
   it('merges exact duplicate canonical roots into the oldest target and adopts lineage', async () => {
-    await seedObservationBackedEntity('entity_calendar_a', 'Calendar Alpha', 'calendar', 'calendar');
+    await seedObservationBackedEntity(
+      'entity_calendar_a',
+      'Calendar Alpha',
+      'calendar',
+      'calendar'
+    );
     await seedObservationBackedEntity('entity_calendar_b', 'Calendar Beta', 'calendar', 'calendar');
 
     const { backfillExactDuplicateCanonicals } =
@@ -124,7 +129,12 @@ describe('Story E1.18: Exact duplicate canonical merge backfill', () => {
   });
 
   it('is idempotent after the first exact duplicate merge pass', async () => {
-    await seedObservationBackedEntity('entity_calendar_a', 'Calendar Alpha', 'calendar', 'calendar');
+    await seedObservationBackedEntity(
+      'entity_calendar_a',
+      'Calendar Alpha',
+      'calendar',
+      'calendar'
+    );
     await seedObservationBackedEntity('entity_calendar_b', 'Calendar Beta', 'calendar', 'calendar');
 
     const { backfillExactDuplicateCanonicals } =
@@ -185,5 +195,77 @@ describe('Story E1.18: Exact duplicate canonical merge backfill', () => {
     expect(result.incomplete).toBe(0);
     expect(getEntityNode('entity_prov_demo_a')?.merged_into).toBeNull();
     expect(getEntityNode('entity_prov_demo_b')?.merged_into).toBe('entity_prov_demo_a');
+  });
+
+  it('requires adapter.transaction instead of using a non-transactional fallback', async () => {
+    vi.resetModules();
+    const mergeEntityNodes = vi.fn();
+    const adoptLineageAfterMergeSync = vi.fn();
+    const fakeAdapter = {
+      prepare(sql: string) {
+        if (sql.includes('FROM entity_nodes n')) {
+          return {
+            all: () =>
+              [
+                {
+                  id: 'entity_a',
+                  kind: 'project',
+                  preferred_label: 'Calendar',
+                  scope_kind: 'channel',
+                  scope_id: 'calendar',
+                  created_at: 1,
+                  normalized_form: 'calendar',
+                },
+                {
+                  id: 'entity_b',
+                  kind: 'project',
+                  preferred_label: 'Calendar',
+                  scope_kind: 'channel',
+                  scope_id: 'calendar',
+                  created_at: 2,
+                  normalized_form: 'calendar',
+                },
+              ] satisfies Array<{
+                id: string;
+                kind: 'project';
+                preferred_label: string;
+                scope_kind: 'channel';
+                scope_id: string;
+                created_at: number;
+                normalized_form: string;
+              }>,
+          };
+        }
+        throw new Error(`Unexpected SQL in test adapter: ${sql}`);
+      },
+    };
+
+    try {
+      vi.doMock('../../src/db-manager.js', () => ({
+        initDB: async () => {},
+        getAdapter: () => fakeAdapter,
+      }));
+      vi.doMock('../../src/entities/store.js', () => ({
+        EntityMergeError: class EntityMergeError extends Error {},
+        mergeEntityNodes,
+      }));
+      vi.doMock('../../src/entities/lineage-store.js', () => ({
+        adoptLineageAfterMergeSync,
+      }));
+
+      const { backfillExactDuplicateCanonicals } =
+        await import('../../src/entities/exact-merge-backfill.js');
+
+      await expect(backfillExactDuplicateCanonicals()).rejects.toThrow(
+        'exact-merge-backfill requires adapter.transaction'
+      );
+      expect(mergeEntityNodes).not.toHaveBeenCalled();
+      expect(adoptLineageAfterMergeSync).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock('../../src/db-manager.js');
+      vi.doUnmock('../../src/entities/store.js');
+      vi.doUnmock('../../src/entities/lineage-store.js');
+      vi.resetModules();
+    }
   });
 });

--- a/packages/mama-core/tests/entities/lineage-backfill.test.ts
+++ b/packages/mama-core/tests/entities/lineage-backfill.test.ts
@@ -1,0 +1,222 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { getAdapter } from '../../src/db-manager.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import {
+  createEntityNode,
+  mergeEntityNodes,
+  upsertEntityObservation,
+} from '../../src/entities/store.js';
+
+describe('Story E1.13: Entity lineage backfill', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('entity-lineage-backfill');
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  beforeEach(() => {
+    const adapter = getAdapter();
+    adapter.prepare('DELETE FROM entity_lineage_links').run();
+    adapter.prepare('DELETE FROM entity_ingest_runs').run();
+    adapter.prepare('DELETE FROM entity_merge_actions').run();
+    adapter.prepare('DELETE FROM entity_resolution_candidates').run();
+    adapter.prepare('DELETE FROM entity_timeline_events').run();
+    adapter.prepare('DELETE FROM entity_observations').run();
+    adapter.prepare('DELETE FROM entity_nodes').run();
+  });
+
+  async function seedObservationBackedEntity(
+    id: string,
+    label: string,
+    scopeId = 'scope-backfill'
+  ) {
+    await upsertEntityObservation({
+      id,
+      observation_type: 'generic',
+      entity_kind_hint: 'project',
+      surface_form: label,
+      normalized_form: label.toLowerCase(),
+      lang: 'en',
+      script: 'Latn',
+      context_summary: `${label} context`,
+      related_surface_forms: [label],
+      timestamp_observed: 1710000000000,
+      scope_kind: 'project',
+      scope_id: scopeId,
+      extractor_version: 'history-extractor@v1',
+      embedding_model_version: 'multilingual-e5-large',
+      source_connector: 'slack',
+      source_locator: '/tmp/slack/raw.db',
+      source_raw_record_id: `raw_${id}`,
+    });
+    await createEntityNode({
+      id,
+      kind: 'project',
+      preferred_label: label,
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: scopeId,
+      merged_into: null,
+    });
+  }
+
+  it('backfills seed lineage for existing active observation-backed entities', async () => {
+    await seedObservationBackedEntity('obs_seed_backfill', 'Seed Backfill');
+
+    const { backfillEntityLineage } = await import('../../src/entities/lineage-backfill.js');
+    const result = await backfillEntityLineage();
+
+    const rows = getAdapter()
+      .prepare(
+        `
+          SELECT contribution_kind, capture_mode, status
+          FROM entity_lineage_links
+          WHERE canonical_entity_id = ?
+        `
+      )
+      .all('obs_seed_backfill') as Array<{
+      contribution_kind: string;
+      capture_mode: string;
+      status: string;
+    }>;
+
+    expect(result.seeded).toBe(1);
+    expect(rows).toEqual([
+      {
+        contribution_kind: 'seed',
+        capture_mode: 'backfilled',
+        status: 'active',
+      },
+    ]);
+  });
+
+  it('backfills merge_adopt lineage from existing merge history', async () => {
+    await seedObservationBackedEntity('obs_merge_source', 'Merge Source');
+    await seedObservationBackedEntity('obs_merge_target', 'Merge Target');
+
+    const adapter = getAdapter();
+    const candidateId = 'cand_merge_backfill';
+    adapter
+      .prepare(
+        `
+          INSERT INTO entity_resolution_candidates (
+            id, candidate_kind, left_ref, right_ref, status, score_total,
+            score_structural, score_string, score_context, score_graph, score_embedding,
+            rule_trace, extractor_version, embedding_model_version, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        candidateId,
+        'entity_to_entity',
+        'obs_merge_source',
+        'obs_merge_target',
+        'approved',
+        0.95,
+        1,
+        0.5,
+        0.25,
+        0,
+        0,
+        '[]',
+        'history-extractor@v1',
+        'multilingual-e5-large',
+        Date.now(),
+        Date.now()
+      );
+
+    mergeEntityNodes({
+      adapter,
+      source_id: 'obs_merge_source',
+      target_id: 'obs_merge_target',
+      actor_type: 'user',
+      actor_id: 'tester',
+      reason: 'same entity',
+      candidate_id: candidateId,
+      evidence_json: '{}',
+    });
+
+    const { backfillEntityLineage } = await import('../../src/entities/lineage-backfill.js');
+    const result = await backfillEntityLineage();
+
+    const rows = adapter
+      .prepare(
+        `
+          SELECT entity_observation_id, contribution_kind, canonical_entity_id, source_entity_id
+          FROM entity_lineage_links
+          WHERE canonical_entity_id = ?
+          ORDER BY entity_observation_id ASC
+        `
+      )
+      .all('obs_merge_target') as Array<{
+      entity_observation_id: string;
+      contribution_kind: string;
+      canonical_entity_id: string;
+      source_entity_id: string | null;
+    }>;
+
+    expect(result.adopted).toBe(1);
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        {
+          entity_observation_id: 'obs_merge_source',
+          contribution_kind: 'merge_adopt',
+          canonical_entity_id: 'obs_merge_target',
+          source_entity_id: 'obs_merge_source',
+        },
+        {
+          entity_observation_id: 'obs_merge_target',
+          contribution_kind: 'seed',
+          canonical_entity_id: 'obs_merge_target',
+          source_entity_id: null,
+        },
+      ])
+    );
+  });
+
+  it('marks uncertain rows as capture_mode=backfilled with reduced confidence', async () => {
+    await seedObservationBackedEntity('obs_confidence_backfill', 'Confidence Backfill');
+
+    const { backfillEntityLineage } = await import('../../src/entities/lineage-backfill.js');
+    await backfillEntityLineage();
+
+    const row = getAdapter()
+      .prepare(
+        `
+          SELECT capture_mode, confidence
+          FROM entity_lineage_links
+          WHERE canonical_entity_id = ?
+        `
+      )
+      .get('obs_confidence_backfill') as { capture_mode: string; confidence: number } | undefined;
+
+    expect(row?.capture_mode).toBe('backfilled');
+    expect(row?.confidence).toBeLessThan(1);
+  });
+
+  it('never fabricates lineage when history is incomplete', async () => {
+    await createEntityNode({
+      id: 'entity_history_incomplete',
+      kind: 'project',
+      preferred_label: 'Incomplete',
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: 'scope-incomplete',
+      merged_into: null,
+    });
+
+    const { backfillEntityLineage } = await import('../../src/entities/lineage-backfill.js');
+    const result = await backfillEntityLineage();
+
+    const rows = getAdapter()
+      .prepare(`SELECT COUNT(*) AS total FROM entity_lineage_links WHERE canonical_entity_id = ?`)
+      .get('entity_history_incomplete') as { total: number };
+
+    expect(result.incomplete).toBe(1);
+    expect(rows.total).toBe(0);
+  });
+});

--- a/packages/mama-core/tests/entities/lineage-store.test.ts
+++ b/packages/mama-core/tests/entities/lineage-store.test.ts
@@ -94,6 +94,24 @@ describe('Story E1.12: Entity lineage substrate', () => {
       expect(row?.completed_at).toBeTypeOf('number');
     });
 
+    it('throws a clear error when completing or failing an unknown ingest run id', async () => {
+      const { completeEntityIngestRun, failEntityIngestRun } =
+        await import('../../src/entities/lineage-store.js');
+
+      await expect(
+        completeEntityIngestRun('eir_missing_complete', {
+          raw_count: 1,
+          observation_count: 1,
+          candidate_count: 0,
+          reviewable_count: 0,
+        })
+      ).rejects.toThrow(/Entity ingest run not found: eir_missing_complete/);
+
+      await expect(failEntityIngestRun('eir_missing_fail', 'boom')).rejects.toThrow(
+        /Entity ingest run not found: eir_missing_fail/
+      );
+    });
+
     it('appends active seed lineage rows idempotently', async () => {
       const { appendEntityLineageLink } = await import('../../src/entities/lineage-store.js');
       const adapter = getAdapter();

--- a/packages/mama-core/tests/entities/lineage-store.test.ts
+++ b/packages/mama-core/tests/entities/lineage-store.test.ts
@@ -168,7 +168,7 @@ describe('Story E1.12: Entity lineage substrate', () => {
           1710000000000
         );
 
-      await appendEntityLineageLink({
+      const first = await appendEntityLineageLink({
         canonical_entity_id: 'entity_project_seed',
         entity_observation_id: 'obs_project_seed',
         source_entity_id: null,
@@ -180,7 +180,7 @@ describe('Story E1.12: Entity lineage substrate', () => {
         confidence: 1,
       });
 
-      await appendEntityLineageLink({
+      const second = await appendEntityLineageLink({
         canonical_entity_id: 'entity_project_seed',
         entity_observation_id: 'obs_project_seed',
         source_entity_id: null,
@@ -204,6 +204,9 @@ describe('Story E1.12: Entity lineage substrate', () => {
         )
         .all('entity_project_seed', 'obs_project_seed') as Array<{ id: string }>;
 
+      expect(first.created).toBe(true);
+      expect(second.created).toBe(false);
+      expect(second.link.id).toBe(first.link.id);
       expect(rows).toHaveLength(1);
     });
 
@@ -276,13 +279,11 @@ describe('Story E1.12: Entity lineage substrate', () => {
         confidence: 1,
       });
 
-      await supersedeEntityLineageForEntity('entity_project_supersede', {
-        replacement_entity_id: 'entity_project_target',
-      });
+      await supersedeEntityLineageForEntity('entity_project_supersede');
 
       const row = adapter
         .prepare(`SELECT status, superseded_at FROM entity_lineage_links WHERE id = ?`)
-        .get(created.id) as { status: string; superseded_at: number | null } | undefined;
+        .get(created.link.id) as { status: string; superseded_at: number | null } | undefined;
 
       expect(row?.status).toBe('superseded');
       expect(row?.superseded_at).toBeTypeOf('number');

--- a/packages/mama-core/tests/entities/lineage-store.test.ts
+++ b/packages/mama-core/tests/entities/lineage-store.test.ts
@@ -1,0 +1,282 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { getAdapter } from '../../src/db-manager.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+
+describe('Story E1.12: Entity lineage substrate', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('entity-lineage-store');
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  describe('AC #1: migration creates lineage tables', () => {
+    it('creates entity_ingest_runs and entity_lineage_links tables', () => {
+      const adapter = getAdapter();
+      const tables = adapter
+        .prepare(
+          `
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'table'
+              AND name IN ('entity_ingest_runs', 'entity_lineage_links')
+            ORDER BY name
+          `
+        )
+        .all() as Array<{ name: string }>;
+
+      expect(tables.map((row) => row.name)).toEqual(['entity_ingest_runs', 'entity_lineage_links']);
+    });
+
+    it('creates the active-lineage uniqueness constraint', () => {
+      const adapter = getAdapter();
+      const indexes = adapter
+        .prepare(
+          `
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'index'
+              AND tbl_name = 'entity_lineage_links'
+            ORDER BY name
+          `
+        )
+        .all() as Array<{ name: string }>;
+
+      expect(indexes.map((row) => row.name)).toContain('ux_entity_lineage_active_pair');
+    });
+  });
+
+  describe('AC #2: lineage store helpers manage append-only state', () => {
+    it('creates entity_ingest_runs rows and updates completion fields', async () => {
+      const { completeEntityIngestRun, createEntityIngestRun } =
+        await import('../../src/entities/lineage-store.js');
+
+      const created = await createEntityIngestRun({
+        id: 'eir_test_1',
+        connector: 'slack',
+        run_kind: 'replay',
+        scope_key: 'slack:C123',
+        source_window_start: 1710000000000,
+        source_window_end: 1710003600000,
+      });
+
+      await completeEntityIngestRun(created.id, {
+        raw_count: 3,
+        observation_count: 6,
+        candidate_count: 2,
+        reviewable_count: 1,
+        audit_classification: 'stable',
+      });
+
+      const row = getAdapter()
+        .prepare(`SELECT * FROM entity_ingest_runs WHERE id = ?`)
+        .get(created.id) as
+        | {
+            status: string;
+            raw_count: number;
+            observation_count: number;
+            candidate_count: number;
+            reviewable_count: number;
+            audit_classification: string;
+            completed_at: number | null;
+          }
+        | undefined;
+
+      expect(row?.status).toBe('complete');
+      expect(row?.raw_count).toBe(3);
+      expect(row?.observation_count).toBe(6);
+      expect(row?.candidate_count).toBe(2);
+      expect(row?.reviewable_count).toBe(1);
+      expect(row?.audit_classification).toBe('stable');
+      expect(row?.completed_at).toBeTypeOf('number');
+    });
+
+    it('appends active seed lineage rows idempotently', async () => {
+      const { appendEntityLineageLink } = await import('../../src/entities/lineage-store.js');
+      const adapter = getAdapter();
+
+      adapter
+        .prepare(
+          `
+            INSERT INTO entity_nodes (
+              id, kind, preferred_label, status, scope_kind, scope_id, merged_into, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `
+        )
+        .run(
+          'entity_project_seed',
+          'project',
+          'Project Seed',
+          'active',
+          'project',
+          'scope-seed',
+          null,
+          1710000000000,
+          1710000000000
+        );
+
+      adapter
+        .prepare(
+          `
+            INSERT INTO entity_observations (
+              id, observation_type, entity_kind_hint, surface_form, normalized_form,
+              lang, script, context_summary, related_surface_forms, timestamp_observed,
+              scope_kind, scope_id, extractor_version, embedding_model_version,
+              source_connector, source_locator, source_raw_record_id, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `
+        )
+        .run(
+          'obs_project_seed',
+          'generic',
+          'project',
+          'Project Seed',
+          'project seed',
+          'en',
+          'Latn',
+          'seed observation',
+          '[]',
+          1710000000000,
+          'project',
+          'scope-seed',
+          'history-extractor@v1',
+          'multilingual-e5-large',
+          'slack',
+          '/tmp/slack/raw.db',
+          'raw_seed_1',
+          1710000000000
+        );
+
+      await appendEntityLineageLink({
+        canonical_entity_id: 'entity_project_seed',
+        entity_observation_id: 'obs_project_seed',
+        source_entity_id: null,
+        contribution_kind: 'seed',
+        run_id: null,
+        candidate_id: null,
+        review_action_id: null,
+        capture_mode: 'direct',
+        confidence: 1,
+      });
+
+      await appendEntityLineageLink({
+        canonical_entity_id: 'entity_project_seed',
+        entity_observation_id: 'obs_project_seed',
+        source_entity_id: null,
+        contribution_kind: 'seed',
+        run_id: null,
+        candidate_id: null,
+        review_action_id: null,
+        capture_mode: 'direct',
+        confidence: 1,
+      });
+
+      const rows = adapter
+        .prepare(
+          `
+            SELECT id
+            FROM entity_lineage_links
+            WHERE canonical_entity_id = ?
+              AND entity_observation_id = ?
+              AND status = 'active'
+          `
+        )
+        .all('entity_project_seed', 'obs_project_seed') as Array<{ id: string }>;
+
+      expect(rows).toHaveLength(1);
+    });
+
+    it('supersedes lineage rows instead of deleting them', async () => {
+      const { appendEntityLineageLink, supersedeEntityLineageForEntity } =
+        await import('../../src/entities/lineage-store.js');
+      const adapter = getAdapter();
+
+      adapter
+        .prepare(
+          `
+            INSERT INTO entity_nodes (
+              id, kind, preferred_label, status, scope_kind, scope_id, merged_into, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `
+        )
+        .run(
+          'entity_project_supersede',
+          'project',
+          'Project Supersede',
+          'active',
+          'project',
+          'scope-supersede',
+          null,
+          1710000000000,
+          1710000000000
+        );
+
+      adapter
+        .prepare(
+          `
+            INSERT INTO entity_observations (
+              id, observation_type, entity_kind_hint, surface_form, normalized_form,
+              lang, script, context_summary, related_surface_forms, timestamp_observed,
+              scope_kind, scope_id, extractor_version, embedding_model_version,
+              source_connector, source_locator, source_raw_record_id, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `
+        )
+        .run(
+          'obs_project_supersede',
+          'generic',
+          'project',
+          'Project Supersede',
+          'project supersede',
+          'en',
+          'Latn',
+          'supersede observation',
+          '[]',
+          1710000000000,
+          'project',
+          'scope-supersede',
+          'history-extractor@v1',
+          'multilingual-e5-large',
+          'slack',
+          '/tmp/slack/raw.db',
+          'raw_supersede_1',
+          1710000000000
+        );
+
+      const created = await appendEntityLineageLink({
+        canonical_entity_id: 'entity_project_supersede',
+        entity_observation_id: 'obs_project_supersede',
+        source_entity_id: null,
+        contribution_kind: 'seed',
+        run_id: null,
+        candidate_id: null,
+        review_action_id: null,
+        capture_mode: 'direct',
+        confidence: 1,
+      });
+
+      await supersedeEntityLineageForEntity('entity_project_supersede', {
+        replacement_entity_id: 'entity_project_target',
+      });
+
+      const row = adapter
+        .prepare(`SELECT status, superseded_at FROM entity_lineage_links WHERE id = ?`)
+        .get(created.id) as { status: string; superseded_at: number | null } | undefined;
+
+      expect(row?.status).toBe('superseded');
+      expect(row?.superseded_at).toBeTypeOf('number');
+    });
+
+    it('returns only active lineage rows for an entity detail view', async () => {
+      const { listActiveEntityLineage } = await import('../../src/entities/lineage-store.js');
+
+      const rows = await listActiveEntityLineage('entity_project_seed');
+
+      expect(rows.every((row) => row.status === 'active')).toBe(true);
+      expect(rows.map((row) => row.entity_observation_id)).toContain('obs_project_seed');
+    });
+  });
+});

--- a/packages/mama-core/tests/entities/policy-store.test.ts
+++ b/packages/mama-core/tests/entities/policy-store.test.ts
@@ -115,6 +115,35 @@ describe('Story E1.24: Phase 8 policy substrate', () => {
         max_false_merge_rate: 0.5,
       });
     });
+
+    it('fails loudly when policy and role-binding seed state is skewed', async () => {
+      const { ensureEntityPolicyBootstrap } = await import('../../src/entities/policy-store.js');
+      const adapter = getAdapter();
+
+      adapter
+        .prepare(
+          `
+            INSERT INTO entity_policy (
+              policy_key, policy_kind, value_json, version, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+          `
+        )
+        .run(
+          'merge_guardrails.default',
+          'merge_guardrails',
+          JSON.stringify({ max_false_merge_rate: 0.02 }),
+          1,
+          1_710_000_000_000,
+          1_710_000_000_000
+        );
+
+      await expect(
+        ensureEntityPolicyBootstrap({
+          bootstrapPath: getFixturePath('entity-policy-bootstrap.json'),
+          now: () => 1_710_000_000_000,
+        })
+      ).rejects.toThrow(/out of sync/i);
+    });
   });
 
   describe('AC #3: role resolution and proposal approval use durable tables', () => {

--- a/packages/mama-core/tests/entities/policy-store.test.ts
+++ b/packages/mama-core/tests/entities/policy-store.test.ts
@@ -1,0 +1,196 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import path from 'node:path';
+
+import { getAdapter } from '../../src/db-manager.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+
+function getFixturePath(name: string): string {
+  return path.join(__dirname, '..', 'fixtures', name);
+}
+
+function clearPhase8Tables(): void {
+  const adapter = getAdapter();
+  const tables = adapter
+    .prepare(
+      `
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table'
+          AND name IN ('entity_policy', 'entity_role_bindings', 'entity_policy_proposals', 'memory_events')
+      `
+    )
+    .all() as Array<{ name: string }>;
+
+  for (const table of tables.map((row) => row.name)) {
+    adapter.prepare(`DELETE FROM ${table}`).run();
+  }
+}
+
+describe('Story E1.24: Phase 8 policy substrate', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('entity-policy-store');
+  });
+
+  beforeEach(() => {
+    clearPhase8Tables();
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  describe('AC #1: migrations create the required Phase 8 tables', () => {
+    it('should create the entity policy tables', () => {
+      const adapter = getAdapter();
+      const tables = adapter
+        .prepare(
+          `
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+            ORDER BY name
+          `
+        )
+        .all() as Array<{ name: string }>;
+      const tableNames = tables.map((row) => row.name);
+
+      expect(tableNames).toContain('entity_policy');
+      expect(tableNames).toContain('entity_role_bindings');
+      expect(tableNames).toContain('entity_policy_proposals');
+    });
+  });
+
+  describe('AC #2: bootstrap only seeds empty Phase 8 state', () => {
+    it('bootstraps policy rows and role bindings from ontology.json only when the tables are empty', async () => {
+      const { ensureEntityPolicyBootstrap, listEntityPolicies, resolveEntityRoleForActor } =
+        await import('../../src/entities/policy-store.js');
+
+      await ensureEntityPolicyBootstrap({
+        bootstrapPath: getFixturePath('entity-policy-bootstrap.json'),
+        now: () => 1_710_000_000_000,
+      });
+
+      expect(listEntityPolicies()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ policy_key: 'merge_guardrails.default', version: 1 }),
+          expect.objectContaining({ policy_key: 'review_thresholds.default', version: 1 }),
+        ])
+      );
+      expect(resolveEntityRoleForActor('local:viewer')).toBe('admin');
+      expect(resolveEntityRoleForActor('actor:unknown')).toBe('viewer');
+    });
+
+    it('skips bootstrap when entity_policy already contains rows', async () => {
+      const { ensureEntityPolicyBootstrap, getEntityPolicy } =
+        await import('../../src/entities/policy-store.js');
+      const adapter = getAdapter();
+
+      await ensureEntityPolicyBootstrap({
+        bootstrapPath: getFixturePath('entity-policy-bootstrap.json'),
+        now: () => 1_710_000_000_000,
+      });
+
+      const alternatePath = path.join(
+        path.dirname(getFixturePath('entity-policy-bootstrap.json')),
+        'entity-policy-bootstrap-alt.json'
+      );
+      adapter
+        .prepare(
+          `
+            UPDATE entity_policy
+            SET value_json = ?
+            WHERE policy_key = 'merge_guardrails.default'
+          `
+        )
+        .run(JSON.stringify({ max_false_merge_rate: 0.5 }));
+
+      await ensureEntityPolicyBootstrap({
+        bootstrapPath: alternatePath,
+        now: () => 1_710_000_123_000,
+      });
+
+      expect(getEntityPolicy('merge_guardrails.default')?.value).toEqual({
+        max_false_merge_rate: 0.5,
+      });
+    });
+  });
+
+  describe('AC #3: role resolution and proposal approval use durable tables', () => {
+    it('resolves the bound max role for an actor in O(1) table lookup style', async () => {
+      const { upsertEntityRoleBinding, resolveEntityRoleForActor } =
+        await import('../../src/entities/policy-store.js');
+
+      upsertEntityRoleBinding({
+        actor_id: 'actor:operator',
+        role: 'operator',
+      });
+
+      expect(resolveEntityRoleForActor('actor:operator')).toBe('operator');
+      expect(resolveEntityRoleForActor('actor:missing')).toBe('viewer');
+    });
+
+    it('bumps the policy version when an approved proposal is applied', async () => {
+      const {
+        ensureEntityPolicyBootstrap,
+        createEntityPolicyProposal,
+        approveEntityPolicyProposal,
+        getEntityPolicy,
+      } = await import('../../src/entities/policy-store.js');
+
+      await ensureEntityPolicyBootstrap({
+        bootstrapPath: getFixturePath('entity-policy-bootstrap.json'),
+        now: () => 1_710_000_000_000,
+      });
+
+      const proposalId = createEntityPolicyProposal({
+        policy_key: 'review_thresholds.default',
+        policy_kind: 'review_thresholds',
+        proposed_value: {
+          approve_score_min: 0.95,
+          defer_score_min: 0.8,
+        },
+        proposer_actor: 'actor:admin-a',
+        reason: 'Raise the approval threshold',
+      });
+
+      const approved = approveEntityPolicyProposal({
+        proposal_id: proposalId,
+        approver_actor: 'actor:admin-b',
+      });
+
+      expect(approved.status).toBe('approved');
+      expect(getEntityPolicy('review_thresholds.default')?.version).toBe(2);
+      expect(getEntityPolicy('review_thresholds.default')?.value).toEqual({
+        approve_score_min: 0.95,
+        defer_score_min: 0.8,
+      });
+    });
+
+    it('stores proposal payloads separately from the memory_events audit trail', async () => {
+      const { createEntityPolicyProposal } = await import('../../src/entities/policy-store.js');
+      const adapter = getAdapter();
+
+      createEntityPolicyProposal({
+        policy_key: 'merge_guardrails.default',
+        policy_kind: 'merge_guardrails',
+        proposed_value: {
+          max_false_merge_rate: 0.01,
+        },
+        proposer_actor: 'actor:admin-a',
+        reason: 'Tighten guardrails',
+      });
+
+      const proposalCount = adapter
+        .prepare('SELECT COUNT(*) AS total FROM entity_policy_proposals')
+        .get() as { total: number };
+      const eventCount = adapter.prepare('SELECT COUNT(*) AS total FROM memory_events').get() as {
+        total: number;
+      };
+
+      expect(proposalCount.total).toBe(1);
+      expect(eventCount.total).toBe(0);
+    });
+  });
+});

--- a/packages/mama-core/tests/entities/policy-store.test.ts
+++ b/packages/mama-core/tests/entities/policy-store.test.ts
@@ -137,11 +137,16 @@ describe('Story E1.24: Phase 8 policy substrate', () => {
         createEntityPolicyProposal,
         approveEntityPolicyProposal,
         getEntityPolicy,
+        upsertEntityRoleBinding,
       } = await import('../../src/entities/policy-store.js');
 
       await ensureEntityPolicyBootstrap({
         bootstrapPath: getFixturePath('entity-policy-bootstrap.json'),
         now: () => 1_710_000_000_000,
+      });
+      upsertEntityRoleBinding({
+        actor_id: 'actor:admin-b',
+        role: 'admin',
       });
 
       const proposalId = createEntityPolicyProposal({
@@ -166,6 +171,42 @@ describe('Story E1.24: Phase 8 policy substrate', () => {
         approve_score_min: 0.95,
         defer_score_min: 0.8,
       });
+    });
+
+    it('requires an admin approver to apply a proposal', async () => {
+      const {
+        ensureEntityPolicyBootstrap,
+        createEntityPolicyProposal,
+        approveEntityPolicyProposal,
+        upsertEntityRoleBinding,
+      } = await import('../../src/entities/policy-store.js');
+
+      await ensureEntityPolicyBootstrap({
+        bootstrapPath: getFixturePath('entity-policy-bootstrap.json'),
+        now: () => 1_710_000_000_000,
+      });
+      upsertEntityRoleBinding({
+        actor_id: 'actor:viewer-only',
+        role: 'viewer',
+      });
+
+      const proposalId = createEntityPolicyProposal({
+        policy_key: 'review_thresholds.default',
+        policy_kind: 'review_thresholds',
+        proposed_value: {
+          approve_score_min: 0.95,
+          defer_score_min: 0.8,
+        },
+        proposer_actor: 'actor:admin-a',
+        reason: 'Raise the approval threshold',
+      });
+
+      expect(() =>
+        approveEntityPolicyProposal({
+          proposal_id: proposalId,
+          approver_actor: 'actor:viewer-only',
+        })
+      ).toThrow(/admin approver/i);
     });
 
     it('stores proposal payloads separately from the memory_events audit trail', async () => {

--- a/packages/mama-core/tests/entities/projection.test.ts
+++ b/packages/mama-core/tests/entities/projection.test.ts
@@ -58,6 +58,33 @@ describe('Story E1.7: Canonical entity projection', () => {
     );
   });
 
+  it('formats timeline changes into a stable recall-facing details contract', () => {
+    const record = projectEntityToRecallSummary(baseNode, aliases, {
+      ...latestEvent,
+      event_type: 'status_update',
+      summary: 'Task moved to blocked',
+      details: JSON.stringify({ from_status: 'active', to_status: 'blocked' }),
+    });
+
+    expect(record.details).toContain('status_update');
+    expect(record.details).toContain('Task moved to blocked');
+    expect(record.details).toContain('"to_status":"blocked"');
+    expect(record.details).not.toContain(`${latestEvent.summary}\n${latestEvent.summary}`);
+  });
+
+  it('preserves non-JSON timeline details as a readable third line', () => {
+    const record = projectEntityToRecallSummary(baseNode, aliases, {
+      ...latestEvent,
+      event_type: 'project_update',
+      summary: 'Launch status updated',
+      details: 'Moved from planning to active execution.',
+    });
+
+    expect(record.details).toContain('project_update');
+    expect(record.details).toContain('Launch status updated');
+    expect(record.details).toContain('Moved from planning to active execution.');
+  });
+
   it('fails loudly when the preferred label is missing', () => {
     expect(() =>
       projectEntityToRecallSummary(

--- a/packages/mama-core/tests/entities/provenance-query.test.ts
+++ b/packages/mama-core/tests/entities/provenance-query.test.ts
@@ -1,0 +1,386 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { getAdapter } from '../../src/db-manager.js';
+import { saveMemory } from '../../src/memory/api.js';
+import { appendMemoryEvent } from '../../src/memory/event-store.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import { queryProvenanceForMemory } from '../../src/entities/provenance-query.js';
+
+describe('Story E1.10: Decision provenance query', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('entity-provenance-query');
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  describe('AC #1: migration creates decision_entity_sources', () => {
+    it('creates the provenance link table and indexes', () => {
+      const adapter = getAdapter();
+      const tables = adapter
+        .prepare(
+          `
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'table' AND name = 'decision_entity_sources'
+          `
+        )
+        .all() as Array<{ name: string }>;
+
+      const indexes = adapter
+        .prepare(
+          `
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'index' AND tbl_name = 'decision_entity_sources'
+            ORDER BY name
+          `
+        )
+        .all() as Array<{ name: string }>;
+
+      expect(tables.map((row) => row.name)).toEqual(['decision_entity_sources']);
+      expect(indexes.map((row) => row.name)).toEqual(
+        expect.arrayContaining([
+          'idx_decision_entity_sources_decision',
+          'idx_decision_entity_sources_observation',
+          'ux_decision_entity_sources_unique',
+        ])
+      );
+    });
+
+    it('enforces uniqueness and cascades on delete', async () => {
+      const adapter = getAdapter();
+      const created = await saveMemory({
+        topic: 'project_alpha/launch',
+        kind: 'decision',
+        summary: 'Project Alpha launch decision',
+        details: 'Created only for provenance migration coverage.',
+        confidence: 0.8,
+        scopes: [{ kind: 'project', id: 'scope-alpha' }],
+        source: { package: 'mama-core', source_type: 'test' },
+      });
+
+      adapter
+        .prepare(
+          `
+            INSERT INTO entity_observations (
+              id, observation_type, entity_kind_hint, surface_form, normalized_form,
+              lang, script, context_summary, related_surface_forms, timestamp_observed,
+              scope_kind, scope_id, extractor_version, embedding_model_version,
+              source_connector, source_locator, source_raw_record_id, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `
+        )
+        .run(
+          'obs_project_alpha_launch',
+          'generic',
+          'project',
+          'Project Alpha',
+          'project alpha',
+          'en',
+          'Latn',
+          'Launch decision mentioned in Slack',
+          JSON.stringify(['Project Alpha KR']),
+          1710000000000,
+          'project',
+          'scope-alpha',
+          'history-extractor@v1',
+          'multilingual-e5-large',
+          'slack',
+          '/tmp/slack/raw.db',
+          'raw_slack_001',
+          1710000000000
+        );
+
+      adapter
+        .prepare(
+          `
+            INSERT INTO decision_entity_sources (
+              decision_id, entity_observation_id, relation_type, created_at
+            ) VALUES (?, ?, ?, ?)
+          `
+        )
+        .run(created.id, 'obs_project_alpha_launch', 'support', 1710000001000);
+
+      expect(() =>
+        adapter
+          .prepare(
+            `
+              INSERT INTO decision_entity_sources (
+                decision_id, entity_observation_id, relation_type, created_at
+              ) VALUES (?, ?, ?, ?)
+            `
+          )
+          .run(created.id, 'obs_project_alpha_launch', 'support', 1710000001001)
+      ).toThrow();
+
+      adapter.prepare(`DELETE FROM decisions WHERE id = ?`).run(created.id);
+      const remaining = adapter
+        .prepare(
+          `
+            SELECT COUNT(*) AS total
+            FROM decision_entity_sources
+            WHERE entity_observation_id = ?
+          `
+        )
+        .get('obs_project_alpha_launch') as { total: number };
+
+      expect(remaining.total).toBe(0);
+    });
+  });
+
+  describe('AC #2: provenance query resolves memory -> observation -> entity path', () => {
+    it('returns explicit legacy state when no provenance links exist', async () => {
+      const created = await saveMemory({
+        topic: 'project_beta/spec',
+        kind: 'decision',
+        summary: 'Legacy-style decision without entity provenance',
+        details: 'No observation ids attached.',
+        confidence: 0.6,
+        scopes: [{ kind: 'project', id: 'scope-beta' }],
+        source: { package: 'mama-core', source_type: 'test' },
+      });
+
+      const result = await queryProvenanceForMemory(created.id);
+
+      expect(result.status).toBe('legacy');
+      expect(result.memory.id).toBe(created.id);
+      expect(result.observations).toEqual([]);
+    });
+
+    it('persists decision_entity_sources when saveMemory receives provenance refs', async () => {
+      const adapter = getAdapter();
+      adapter
+        .prepare(
+          `
+            INSERT INTO entity_observations (
+              id, observation_type, entity_kind_hint, surface_form, normalized_form,
+              lang, script, context_summary, related_surface_forms, timestamp_observed,
+              scope_kind, scope_id, extractor_version, embedding_model_version,
+              source_connector, source_locator, source_raw_record_id, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `
+        )
+        .run(
+          'obs_project_gamma_launch',
+          'generic',
+          'project',
+          'Project Gamma',
+          'project gamma',
+          'en',
+          'Latn',
+          'Launch decision in connector history',
+          JSON.stringify(['Project Gamma KR']),
+          1710000002000,
+          'project',
+          'scope-gamma',
+          'history-extractor@v1',
+          'multilingual-e5-large',
+          'slack',
+          '/tmp/slack/raw.db',
+          'raw_slack_002',
+          1710000002000
+        );
+
+      const created = await saveMemory({
+        topic: 'project_gamma/launch',
+        kind: 'decision',
+        summary: 'Project Gamma launch approved',
+        details: 'Persisted with entity provenance support.',
+        confidence: 0.9,
+        scopes: [{ kind: 'project', id: 'scope-gamma' }],
+        source: { package: 'mama-core', source_type: 'test' },
+        entityObservationIds: ['obs_project_gamma_launch', 'obs_project_gamma_launch'],
+      } as never);
+
+      const linked = adapter
+        .prepare(
+          `
+            SELECT entity_observation_id, relation_type
+            FROM decision_entity_sources
+            WHERE decision_id = ?
+            ORDER BY entity_observation_id ASC
+          `
+        )
+        .all(created.id) as Array<{
+        entity_observation_id: string;
+        relation_type: string;
+      }>;
+
+      expect(linked).toEqual([
+        {
+          entity_observation_id: 'obs_project_gamma_launch',
+          relation_type: 'support',
+        },
+      ]);
+
+      const result = await queryProvenanceForMemory(created.id);
+      expect(result.status).toBe('resolved');
+      expect(result.observations.map((item) => item.id)).toEqual(['obs_project_gamma_launch']);
+      expect(result.observations[0]).toEqual(
+        expect.objectContaining({
+          source_locator: '/tmp/slack/raw.db',
+          source_locator_kind: 'db',
+        })
+      );
+    });
+
+    it('classifies URL locators through source_locator', async () => {
+      const adapter = getAdapter();
+      adapter
+        .prepare(
+          `
+            INSERT INTO entity_observations (
+              id, observation_type, entity_kind_hint, surface_form, normalized_form,
+              lang, script, context_summary, related_surface_forms, timestamp_observed,
+              scope_kind, scope_id, extractor_version, embedding_model_version,
+              source_connector, source_locator, source_raw_record_id, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `
+        )
+        .run(
+          'obs_project_locator_url',
+          'generic',
+          'project',
+          'Project Locator',
+          'project locator',
+          'en',
+          'Latn',
+          'URL-backed provenance',
+          JSON.stringify(['Locator']),
+          1710000002100,
+          'project',
+          'scope-gamma',
+          'history-extractor@v1',
+          'multilingual-e5-large',
+          'drive',
+          'https://drive.google.com/file/d/file-1/view',
+          'raw_drive_001',
+          1710000002100
+        );
+
+      const created = await saveMemory({
+        topic: 'project_locator/url',
+        kind: 'decision',
+        summary: 'URL-backed provenance decision',
+        details: 'Provenance uses a web locator.',
+        confidence: 0.9,
+        scopes: [{ kind: 'project', id: 'scope-gamma' }],
+        source: { package: 'mama-core', source_type: 'test' },
+        entityObservationIds: ['obs_project_locator_url'],
+      } as never);
+
+      const result = await queryProvenanceForMemory(created.id);
+      expect(result.observations[0]).toEqual(
+        expect.objectContaining({
+          source_locator: 'https://drive.google.com/file/d/file-1/view',
+          source_locator_kind: 'url',
+        })
+      );
+    });
+
+    it('returns manual when an empty-batch provenance audit event exists', async () => {
+      const created = await saveMemory({
+        topic: 'project_epsilon/manual',
+        kind: 'decision',
+        summary: 'Project Epsilon was saved from an empty provenance batch',
+        details: 'No supporting observations were produced for this channel batch.',
+        confidence: 0.55,
+        scopes: [{ kind: 'project', id: 'scope-epsilon' }],
+        source: { package: 'standalone', source_type: 'connector' },
+      } as never);
+
+      await appendMemoryEvent({
+        event_type: 'provenance.empty_batch',
+        actor: 'system',
+        memory_id: created.id,
+        topic: created.topic,
+        scope_refs: [{ kind: 'project', id: 'scope-epsilon' }],
+        reason: 'channel_key=slack:general',
+        created_at: Date.now(),
+      });
+
+      const result = await queryProvenanceForMemory(created.id);
+
+      expect(result.status).toBe('manual');
+      expect(result.audit?.event_type).toBe('provenance.empty_batch');
+    });
+
+    it('returns dropped when provenance link writing failed after the decision row was created', async () => {
+      const created = await saveMemory({
+        topic: 'project_zeta/dropped',
+        kind: 'decision',
+        summary: 'Project Zeta dropped its provenance links after save',
+        details: 'The decision row exists but provenance binding failed.',
+        confidence: 0.5,
+        scopes: [{ kind: 'project', id: 'scope-zeta' }],
+        source: { package: 'standalone', source_type: 'connector' },
+      } as never);
+
+      await appendMemoryEvent({
+        event_type: 'provenance.link_write_failed',
+        actor: 'system',
+        memory_id: created.id,
+        topic: created.topic,
+        scope_refs: [{ kind: 'project', id: 'scope-zeta' }],
+        reason: 'FOREIGN KEY constraint failed; dropped_observation_count=1',
+        created_at: Date.now(),
+      });
+
+      const result = await queryProvenanceForMemory(created.id);
+
+      expect(result.status).toBe('dropped');
+      expect(result.audit?.event_type).toBe('provenance.link_write_failed');
+      expect(result.audit?.reason).toContain('dropped_observation_count=1');
+    });
+
+    it('attaches the created memory id when provenance link writes roll back', async () => {
+      const adapter = getAdapter();
+      let thrown: unknown;
+
+      try {
+        await saveMemory({
+          topic: 'project_delta/failure',
+          kind: 'decision',
+          summary: 'Project Delta should surface the failed memory id',
+          details: 'This save intentionally points at a missing observation id.',
+          confidence: 0.5,
+          scopes: [{ kind: 'project', id: 'scope-delta' }],
+          source: { package: 'mama-core', source_type: 'test' },
+          entityObservationIds: ['obs_missing_for_failure_path'],
+        } as never);
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      const failedSave = thrown as Error & { memoryId?: string };
+      expect(failedSave.message).toContain('FOREIGN KEY');
+      expect(failedSave.memoryId).toBeTruthy();
+
+      const failedRow = adapter
+        .prepare(
+          `
+            SELECT id
+            FROM decisions
+            WHERE id = ?
+          `
+        )
+        .get(failedSave.memoryId) as { id: string } | undefined;
+      expect(failedRow).toBeUndefined();
+
+      const linkedRows = adapter
+        .prepare(
+          `
+            SELECT COUNT(*) AS total
+            FROM decision_entity_sources
+            WHERE decision_id = ?
+          `
+        )
+        .get(failedSave.memoryId) as { total: number };
+      expect(linkedRows.total).toBe(0);
+    });
+  });
+});

--- a/packages/mama-core/tests/entities/read-identity.test.ts
+++ b/packages/mama-core/tests/entities/read-identity.test.ts
@@ -1,0 +1,244 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import { initDB } from '../../src/db-manager.js';
+import { createEntityNode, upsertEntityObservation } from '../../src/entities/store.js';
+import { appendEntityLineageLink } from '../../src/entities/lineage-store.js';
+import { saveMemory } from '../../src/memory/api.js';
+import {
+  loadDecisionReadIdentityIndex,
+  resolveReadIdentity,
+  type CanonicalReadEntity,
+} from '../../src/entities/read-identity.js';
+import type { MemoryRecord } from '../../src/memory/types.js';
+
+function makeMemory(overrides: Partial<MemoryRecord> = {}): MemoryRecord {
+  return {
+    id: 'decision_alpha',
+    topic: 'project_alpha/status',
+    kind: 'decision',
+    summary: 'Kickoff approved',
+    details: 'Kickoff approved',
+    confidence: 0.9,
+    status: 'active',
+    scopes: [{ kind: 'project', id: 'alpha' }],
+    source: { package: 'mama-core', source_type: 'db' },
+    created_at: 1_710_000_000_000,
+    updated_at: 1_710_000_000_000,
+    ...overrides,
+  };
+}
+
+describe('resolveReadIdentity', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('read-identity');
+    process.env.MAMA_DB_PATH = testDbPath;
+    await initDB();
+  });
+
+  afterAll(async () => {
+    delete process.env.MAMA_DB_PATH;
+    await cleanupTestDB(testDbPath);
+  });
+
+  beforeEach(async () => {
+    const { getAdapter } = await import('../../src/db-manager.js');
+    const adapter = getAdapter();
+    adapter.prepare('DELETE FROM decision_entity_sources').run();
+    adapter.prepare('DELETE FROM memory_scope_bindings').run();
+    adapter.prepare('DELETE FROM memory_scopes').run();
+    adapter.prepare('DELETE FROM decisions').run();
+    adapter.prepare('DELETE FROM entity_lineage_links').run();
+    adapter.prepare('DELETE FROM entity_nodes').run();
+    adapter.prepare('DELETE FROM entity_observations').run();
+  });
+
+  it('returns canonical and stable-sorts entities when active bindings exist', () => {
+    const entities: CanonicalReadEntity[] = [
+      { id: 'entity_user_sample', label: 'Jeong Jaehun', kind: 'person' },
+      { id: 'entity_project_alpha', label: 'Project Alpha', kind: 'project' },
+    ];
+
+    const result = resolveReadIdentity(makeMemory(), entities);
+
+    expect(result.kind).toBe('canonical');
+    if (result.kind !== 'canonical') {
+      throw new Error('Expected canonical read identity');
+    }
+    expect(result.entities).toEqual([
+      { id: 'entity_user_sample', label: 'Jeong Jaehun', kind: 'person' },
+      { id: 'entity_project_alpha', label: 'Project Alpha', kind: 'project' },
+    ]);
+    expect(result.primaryEntity.id).toBe('entity_user_sample');
+    expect(result.legacyTopic).toBe('project_alpha/status');
+    expect(result.displaySubject).toBe('Project Alpha');
+    expect(result.displayTopic).toBe('project alpha / status');
+    expect(result.displaySuffix).toBe('status');
+  });
+
+  it('returns topic when no canonical entity binding exists', () => {
+    const result = resolveReadIdentity(makeMemory(), []);
+
+    expect(result).toEqual({
+      kind: 'topic',
+      topic: 'project_alpha/status',
+      displaySubject: null,
+      displayTopic: 'project alpha / status',
+      displaySuffix: null,
+    });
+  });
+
+  it('returns raw when neither canonical binding nor topic exists', () => {
+    const result = resolveReadIdentity(
+      makeMemory({
+        topic: '',
+        summary: 'Loose summary only',
+      }),
+      []
+    );
+
+    expect(result).toEqual({
+      kind: 'raw',
+      label: 'Loose summary only',
+      displaySubject: null,
+      displayTopic: 'Loose summary only',
+      displaySuffix: null,
+    });
+  });
+
+  it('marks canonical/topic disagreement as shadow conflict', () => {
+    const result = resolveReadIdentity(makeMemory(), [
+      { id: 'entity_project_alpha', label: 'Project Alpha', kind: 'project' },
+    ]);
+
+    expect(result.kind).toBe('canonical');
+    if (result.kind !== 'canonical') {
+      throw new Error('Expected canonical read identity');
+    }
+    expect(result.shadowConflict).toBe(true);
+  });
+
+  it('prefers a topic namespace as display subject when the project label looks like a participant room', () => {
+    const result = resolveReadIdentity(
+      makeMemory({
+        topic: 'deepone/client_feedback',
+        summary: 'Client feedback is ready for handoff.',
+      }),
+      [{ id: 'entity_room_dm', label: '参加者', kind: 'project' }]
+    );
+
+    expect(result.kind).toBe('canonical');
+    if (result.kind !== 'canonical') {
+      throw new Error('Expected canonical read identity');
+    }
+    expect(result.displaySubject).toBe('deepone');
+    expect(result.displayTopic).toBe('deepone / client feedback');
+  });
+
+  it('uses the associated project label as display topic when the legacy topic is low-signal', () => {
+    const result = resolveReadIdentity(
+      makeMemory({
+        topic: '__sd/spine_',
+        summary: 'Worker C submitted the SD motion data.',
+      }),
+      [
+        { id: 'entity_person_worker_c', label: 'Worker C', kind: 'person' },
+        { id: 'entity_project_room', label: 'Client X animation handoff room', kind: 'project' },
+      ]
+    );
+
+    expect(result.kind).toBe('canonical');
+    if (result.kind !== 'canonical') {
+      throw new Error('Expected canonical read identity');
+    }
+    expect(result.displaySubject).toBe('Client X animation handoff room');
+    expect(result.displayTopic).toBe('Client X animation handoff room');
+    expect(result.displaySuffix).toBeNull();
+  });
+
+  it('keeps project-like room labels as the display subject instead of collapsing to legacy namespace', () => {
+    const result = resolveReadIdentity(
+      makeMemory({
+        topic: '142301__ex_/_',
+        summary:
+          'Worker A submitted the EX skill motion data (Google Drive). Reviewer B consolidated the packaging image from two files to one and cleared the handoff.',
+      }),
+      [
+        { id: 'entity_person_reviewer', label: 'Reviewer B', kind: 'person' },
+        { id: 'entity_person_worker', label: 'Worker A', kind: 'person' },
+        { id: 'entity_room_consult', label: 'Project Discussion Room', kind: 'project' },
+      ]
+    );
+
+    expect(result.kind).toBe('canonical');
+    if (result.kind !== 'canonical') {
+      throw new Error('Expected canonical read identity');
+    }
+    expect(result.displaySubject).toBe('Project Discussion Room');
+    expect(result.displayTopic).toBe('Project Discussion Room');
+    expect(result.displaySuffix).toBeNull();
+  });
+
+  it('loads canonical entity bindings for decision ids from one bulk lookup', async () => {
+    await createEntityNode({
+      id: 'entity_project_alpha',
+      kind: 'project',
+      preferred_label: 'Project Alpha',
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: 'alpha',
+      merged_into: null,
+    });
+    await upsertEntityObservation({
+      id: 'obs_project_alpha',
+      observation_type: 'generic',
+      entity_kind_hint: 'project',
+      surface_form: 'Project Alpha',
+      normalized_form: 'project alpha',
+      lang: 'en',
+      script: 'Latn',
+      context_summary: 'Alpha kickoff',
+      related_surface_forms: ['Project Alpha'],
+      timestamp_observed: 1_710_000_000_000,
+      scope_kind: 'project',
+      scope_id: 'alpha',
+      extractor_version: 'history-extractor@v1',
+      embedding_model_version: 'multilingual-e5-large',
+      source_connector: 'slack',
+      source_locator: '/tmp/slack.db',
+      source_raw_record_id: 'raw_alpha',
+    });
+    await appendEntityLineageLink({
+      canonical_entity_id: 'entity_project_alpha',
+      entity_observation_id: 'obs_project_alpha',
+      source_entity_id: null,
+      contribution_kind: 'seed',
+      run_id: null,
+      candidate_id: null,
+      review_action_id: null,
+      capture_mode: 'direct',
+      confidence: 1,
+    });
+
+    const saved = await saveMemory({
+      topic: 'project_alpha/status',
+      kind: 'decision',
+      summary: 'Project Alpha kickoff approved',
+      details: 'Project Alpha kickoff approved',
+      scopes: [{ kind: 'project', id: 'alpha' }],
+      source: { package: 'mama-core', source_type: 'test' },
+      entityObservationIds: ['obs_project_alpha'],
+    });
+
+    expect(saved.success).toBe(true);
+
+    const bindings = await loadDecisionReadIdentityIndex([saved.id, 'decision_without_binding']);
+
+    expect(bindings.get(saved.id)).toEqual([
+      { id: 'entity_project_alpha', label: 'Project Alpha', kind: 'project' },
+    ]);
+    expect(bindings.get('decision_without_binding')).toBeUndefined();
+  });
+});

--- a/packages/mama-core/tests/entities/recall-bridge.test.ts
+++ b/packages/mama-core/tests/entities/recall-bridge.test.ts
@@ -2,6 +2,8 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { getAdapter } from '../../src/db-manager.js';
 import { queryCanonicalEntities } from '../../src/entities/recall-bridge.js';
 import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import { appendEntityLineageLink } from '../../src/entities/lineage-store.js';
+import { upsertEntityObservation } from '../../src/entities/store.js';
 
 describe('Story E1.8: Canonical entity recall bridge', () => {
   let testDbPath = '';
@@ -178,5 +180,64 @@ describe('Story E1.8: Canonical entity recall bridge', () => {
 
     expect(rows).toHaveLength(1);
     expect(rows[0]?.id).toBe('entity_project_alpha');
+  });
+
+  it('returns canonical entities through active lineage observation surface forms', async () => {
+    const adapter = getAdapter();
+    adapter
+      .prepare(
+        `INSERT INTO entity_nodes (id, kind, preferred_label, status, scope_kind, scope_id, merged_into, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        'entity_project_alpha_observation',
+        'project',
+        'Project Alpha',
+        'active',
+        'project',
+        'scope-alpha',
+        null,
+        1710000000000,
+        1710000001000
+      );
+    await upsertEntityObservation({
+      id: 'obs_project_alpha_ko_bridge',
+      observation_type: 'channel',
+      entity_kind_hint: 'project',
+      surface_form: '\uD504\uB85C\uC81D\uD2B8 \uC54C\uD30C',
+      normalized_form: '\uD504\uB85C\uC81D\uD2B8 \uC54C\uD30C',
+      lang: 'ko',
+      script: 'Hang',
+      context_summary: 'alpha kickoff',
+      related_surface_forms: ['Project Alpha'],
+      timestamp_observed: 1710000000000,
+      scope_kind: 'project',
+      scope_id: 'scope-alpha',
+      extractor_version: 'history-extractor@v1',
+      embedding_model_version: 'multilingual-e5-large',
+      source_connector: 'slack',
+      source_locator: '/tmp/slack/raw.db',
+      source_raw_record_id: 'raw_bridge_alpha',
+    });
+    await appendEntityLineageLink({
+      canonical_entity_id: 'entity_project_alpha_observation',
+      entity_observation_id: 'obs_project_alpha_ko_bridge',
+      source_entity_id: null,
+      contribution_kind: 'seed',
+      run_id: null,
+      candidate_id: null,
+      review_action_id: null,
+      capture_mode: 'direct',
+      confidence: 1,
+    });
+
+    const rows = await queryCanonicalEntities(
+      '\uC54C\uD30C',
+      [{ kind: 'project', id: 'scope-alpha' }],
+      { limit: 10 }
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe('entity_project_alpha_observation');
   });
 });

--- a/packages/mama-core/tests/entities/resolution-engine.test.ts
+++ b/packages/mama-core/tests/entities/resolution-engine.test.ts
@@ -31,7 +31,7 @@ function makeObservation(
     extractor_version: 'history-extractor@v1',
     embedding_model_version: 'multilingual-e5-large',
     source_connector: 'slack',
-    source_raw_db_ref: '~/.mama/connectors/slack/raw.db',
+    source_locator: '~/.mama/connectors/slack/raw.db',
     source_raw_record_id: `raw_${id}`,
     created_at: 1710000000000,
     ...overrides,

--- a/packages/mama-core/tests/entities/rollback-preview.test.ts
+++ b/packages/mama-core/tests/entities/rollback-preview.test.ts
@@ -162,6 +162,56 @@ describe('Story E1.17: Entity rollback preview', () => {
     expect(preview.preview_unavailable).toBe(true);
     expect(preview.changed_entities).toHaveLength(0);
   });
+
+  it('treats an observation mismatch as unavailable input, not incomplete history', async () => {
+    await seedMergedEntityPair();
+    const { previewEntityRollback } = await import('../../src/entities/rollback-preview.js');
+
+    const preview = await previewEntityRollback({
+      entityId: 'entity_project_target',
+      observationId: 'obs-does-not-belong',
+    });
+
+    expect(preview.preview_unavailable).toBe(true);
+    expect(preview.history_incomplete).toBe(false);
+  });
+
+  it('preserves role on the latest timeline event projection', async () => {
+    const adapter = getAdapter();
+    await createEntityNode({
+      id: 'entity_role_projection',
+      kind: 'project',
+      preferred_label: 'Role Projection',
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: 'scope-role',
+      merged_into: null,
+    });
+    adapter
+      .prepare(
+        `
+          INSERT INTO entity_timeline_events (
+            id, entity_id, event_type, role, summary, created_at
+          ) VALUES (?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        'evt-role-projection',
+        'entity_role_projection',
+        'project_update',
+        'implementer',
+        'Role projection event',
+        1710000000000
+      );
+
+    const { previewEntityRollback } = await import('../../src/entities/rollback-preview.js');
+    const preview = await previewEntityRollback({
+      entityId: 'entity_role_projection',
+      observationId: 'obs-missing',
+    });
+
+    expect(preview.history_incomplete).toBe(false);
+  });
 });
 
 async function seedMergedEntityPair(): Promise<{ mergeActionId: string; memoryId: string }> {

--- a/packages/mama-core/tests/entities/rollback-preview.test.ts
+++ b/packages/mama-core/tests/entities/rollback-preview.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
 import { getAdapter } from '../../src/db-manager.js';
 import {
-  adoptLineageAfterMerge,
+  adoptLineageAfterMergeSync,
   appendEntityLineageLink,
 } from '../../src/entities/lineage-store.js';
 import {
@@ -425,7 +425,7 @@ async function seedMergedEntityPair(): Promise<{ mergeActionId: string; memoryId
             evidence_json: JSON.stringify({ reason: 'preview test' }),
           });
           mergeActionId = result.merge_action_id;
-          adoptLineageAfterMerge({
+          adoptLineageAfterMergeSync({
             adapter,
             source_entity_id: 'entity_project_source',
             target_entity_id: 'entity_project_target',

--- a/packages/mama-core/tests/entities/rollback-preview.test.ts
+++ b/packages/mama-core/tests/entities/rollback-preview.test.ts
@@ -140,6 +140,28 @@ describe('Story E1.17: Entity rollback preview', () => {
     expect(preview.truncated).toBe(true);
     expect(preview.changed_memories).toHaveLength(1);
   });
+
+  it('rejects an explicit mergeActionId that does not belong to the requested entity', async () => {
+    const { mergeActionId } = await seedMergedEntityPair();
+    await createEntityNode({
+      id: 'entity_unrelated',
+      kind: 'project',
+      preferred_label: 'Unrelated',
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: 'scope-unrelated',
+      merged_into: null,
+    });
+
+    const { previewEntityRollback } = await import('../../src/entities/rollback-preview.js');
+    const preview = await previewEntityRollback({
+      entityId: 'entity_unrelated',
+      mergeActionId,
+    });
+
+    expect(preview.preview_unavailable).toBe(true);
+    expect(preview.changed_entities).toHaveLength(0);
+  });
 });
 
 async function seedMergedEntityPair(): Promise<{ mergeActionId: string; memoryId: string }> {

--- a/packages/mama-core/tests/entities/rollback-preview.test.ts
+++ b/packages/mama-core/tests/entities/rollback-preview.test.ts
@@ -1,0 +1,323 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import { getAdapter } from '../../src/db-manager.js';
+import {
+  adoptLineageAfterMerge,
+  appendEntityLineageLink,
+} from '../../src/entities/lineage-store.js';
+import {
+  createEntityNode,
+  mergeEntityNodes,
+  upsertEntityObservation,
+} from '../../src/entities/store.js';
+import { saveMemory } from '../../src/memory/api.js';
+
+describe('Story E1.17: Entity rollback preview', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('rollback-preview');
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  beforeEach(() => {
+    const adapter = getAdapter();
+    adapter.prepare('DELETE FROM decision_entity_sources').run();
+    adapter.prepare('DELETE FROM memory_scope_bindings').run();
+    adapter.prepare('DELETE FROM memory_scopes').run();
+    adapter.prepare('DELETE FROM decision_edges').run();
+    adapter.prepare('DELETE FROM decisions').run();
+    adapter.prepare('DELETE FROM entity_lineage_links').run();
+    adapter.prepare('DELETE FROM entity_ingest_runs').run();
+    adapter.prepare('DELETE FROM entity_audit_runs').run();
+    adapter.prepare('DELETE FROM entity_observations').run();
+    adapter.prepare('DELETE FROM entity_aliases').run();
+    adapter.prepare('DELETE FROM entity_timeline_events').run();
+    adapter.prepare('DELETE FROM entity_merge_actions').run();
+    adapter.prepare('DELETE FROM entity_nodes').run();
+  });
+
+  it('simulates reversing one merge without mutating persistent state', async () => {
+    const { mergeActionId } = await seedMergedEntityPair();
+    const adapter = getAdapter();
+
+    const beforeSource = adapter
+      .prepare('SELECT status, merged_into FROM entity_nodes WHERE id = ?')
+      .get('entity_project_source') as { status: string; merged_into: string | null };
+    const beforeTargetActive = adapter
+      .prepare(
+        `SELECT COUNT(*) AS total FROM entity_lineage_links WHERE canonical_entity_id = ? AND status = 'active'`
+      )
+      .get('entity_project_target') as { total: number };
+
+    const { previewEntityRollback } = await import('../../src/entities/rollback-preview.js');
+    const preview = await previewEntityRollback({
+      entityId: 'entity_project_target',
+      mergeActionId,
+    });
+
+    expect(preview.preview_unavailable).toBe(false);
+    expect(preview.changed_entities.map((entity) => entity.entity_id)).toEqual(
+      expect.arrayContaining(['entity_project_source', 'entity_project_target'])
+    );
+
+    const afterSource = adapter
+      .prepare('SELECT status, merged_into FROM entity_nodes WHERE id = ?')
+      .get('entity_project_source') as { status: string; merged_into: string | null };
+    const afterTargetActive = adapter
+      .prepare(
+        `SELECT COUNT(*) AS total FROM entity_lineage_links WHERE canonical_entity_id = ? AND status = 'active'`
+      )
+      .get('entity_project_target') as { total: number };
+
+    expect(afterSource).toEqual(beforeSource);
+    expect(afterTargetActive.total).toBe(beforeTargetActive.total);
+  });
+
+  it('returns affected entities, memories, and likely metric movement', async () => {
+    const { mergeActionId, memoryId } = await seedMergedEntityPair();
+    const { previewEntityRollback } = await import('../../src/entities/rollback-preview.js');
+
+    const preview = await previewEntityRollback({
+      entityId: 'entity_project_target',
+      mergeActionId,
+    });
+
+    expect(preview.changed_entities).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ entity_id: 'entity_project_source' }),
+        expect.objectContaining({ entity_id: 'entity_project_target' }),
+      ])
+    );
+    expect(preview.changed_memories).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: memoryId })])
+    );
+    expect(preview.metric_movement).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ metric: 'false_merge_rate' }),
+        expect.objectContaining({ metric: 'projection_fragmentation_rate' }),
+      ])
+    );
+  });
+
+  it('reports preview_unavailable when history is incomplete', async () => {
+    const mergeActionId = await seedIncompleteMerge();
+    const { previewEntityRollback } = await import('../../src/entities/rollback-preview.js');
+
+    const preview = await previewEntityRollback({
+      entityId: 'entity_project_target',
+      mergeActionId,
+    });
+
+    expect(preview.preview_unavailable).toBe(true);
+    expect(preview.history_incomplete).toBe(true);
+    expect(preview.changed_entities).toHaveLength(0);
+  });
+
+  it('returns truncation metadata when impact exceeds bounded cost', async () => {
+    const { mergeActionId } = await seedMergedEntityPair();
+    await saveMemory({
+      topic: 'project_source/followup',
+      kind: 'decision',
+      summary: 'Follow-up approved',
+      details: 'Follow-up also tied to source evidence',
+      confidence: 0.8,
+      scopes: [{ kind: 'project', id: 'scope-alpha' }],
+      source: { package: 'mama-core', source_type: 'test' },
+      entityObservationIds: ['obs_project_source'],
+    } as never);
+
+    const { previewEntityRollback } = await import('../../src/entities/rollback-preview.js');
+    const preview = await previewEntityRollback({
+      entityId: 'entity_project_target',
+      mergeActionId,
+      maxAffectedRows: 1,
+    });
+
+    expect(preview.truncated).toBe(true);
+    expect(preview.changed_memories).toHaveLength(1);
+  });
+});
+
+async function seedMergedEntityPair(): Promise<{ mergeActionId: string; memoryId: string }> {
+  const adapter = getAdapter();
+
+  await createEntityNode({
+    id: 'entity_project_source',
+    kind: 'project',
+    preferred_label: 'Project Source',
+    status: 'active',
+    scope_kind: 'project',
+    scope_id: 'scope-alpha',
+    merged_into: null,
+  });
+  await createEntityNode({
+    id: 'entity_project_target',
+    kind: 'project',
+    preferred_label: 'Project Target',
+    status: 'active',
+    scope_kind: 'project',
+    scope_id: 'scope-alpha',
+    merged_into: null,
+  });
+
+  await upsertEntityObservation({
+    id: 'obs_project_source',
+    observation_type: 'generic',
+    entity_kind_hint: 'project',
+    surface_form: 'Project Source',
+    normalized_form: 'project source',
+    lang: 'en',
+    script: 'Latn',
+    context_summary: 'Source observation',
+    related_surface_forms: ['Source'],
+    timestamp_observed: 1710000000000,
+    scope_kind: 'project',
+    scope_id: 'scope-alpha',
+    extractor_version: 'history-extractor@v1',
+    embedding_model_version: 'multilingual-e5-large',
+    source_connector: 'slack',
+    source_locator: '/tmp/slack/raw.db',
+    source_raw_record_id: 'raw_source',
+  });
+  await upsertEntityObservation({
+    id: 'obs_project_target',
+    observation_type: 'generic',
+    entity_kind_hint: 'project',
+    surface_form: 'Project Target',
+    normalized_form: 'project target',
+    lang: 'en',
+    script: 'Latn',
+    context_summary: 'Target observation',
+    related_surface_forms: ['Target'],
+    timestamp_observed: 1710000001000,
+    scope_kind: 'project',
+    scope_id: 'scope-alpha',
+    extractor_version: 'history-extractor@v1',
+    embedding_model_version: 'multilingual-e5-large',
+    source_connector: 'slack',
+    source_locator: '/tmp/slack/raw.db',
+    source_raw_record_id: 'raw_target',
+  });
+
+  await appendEntityLineageLink({
+    canonical_entity_id: 'entity_project_source',
+    entity_observation_id: 'obs_project_source',
+    source_entity_id: null,
+    contribution_kind: 'seed',
+    run_id: null,
+    candidate_id: null,
+    review_action_id: null,
+    capture_mode: 'direct',
+    confidence: 1,
+  });
+  await appendEntityLineageLink({
+    canonical_entity_id: 'entity_project_target',
+    entity_observation_id: 'obs_project_target',
+    source_entity_id: null,
+    contribution_kind: 'seed',
+    run_id: null,
+    candidate_id: null,
+    review_action_id: null,
+    capture_mode: 'direct',
+    confidence: 1,
+  });
+
+  let mergeActionId = '';
+  const runMerge =
+    'transaction' in adapter && typeof adapter.transaction === 'function'
+      ? adapter.transaction(() => {
+          const result = mergeEntityNodes({
+            adapter,
+            source_id: 'entity_project_source',
+            target_id: 'entity_project_target',
+            actor_type: 'user',
+            actor_id: 'local:tester',
+            reason: 'duplicate project',
+            candidate_id: null,
+            evidence_json: JSON.stringify({ reason: 'preview test' }),
+          });
+          mergeActionId = result.merge_action_id;
+          adoptLineageAfterMerge({
+            adapter,
+            source_entity_id: 'entity_project_source',
+            target_entity_id: 'entity_project_target',
+            candidate_id: null,
+            review_action_id: mergeActionId,
+          });
+        })
+      : null;
+
+  if (runMerge) {
+    const tx = runMerge as unknown;
+    if (typeof tx === 'function') {
+      tx();
+    }
+  }
+
+  const memory = await saveMemory({
+    topic: 'project_source/kickoff',
+    kind: 'decision',
+    summary: 'Kickoff approved',
+    details: 'Kickoff tied to source evidence',
+    confidence: 0.9,
+    scopes: [{ kind: 'project', id: 'scope-alpha' }],
+    source: { package: 'mama-core', source_type: 'test' },
+    entityObservationIds: ['obs_project_source'],
+  } as never);
+
+  return { mergeActionId, memoryId: memory.id };
+}
+
+async function seedIncompleteMerge(): Promise<string> {
+  const adapter = getAdapter();
+
+  await createEntityNode({
+    id: 'entity_project_source',
+    kind: 'project',
+    preferred_label: 'Project Source',
+    status: 'active',
+    scope_kind: 'project',
+    scope_id: 'scope-alpha',
+    merged_into: null,
+  });
+  await createEntityNode({
+    id: 'entity_project_target',
+    kind: 'project',
+    preferred_label: 'Project Target',
+    status: 'active',
+    scope_kind: 'project',
+    scope_id: 'scope-alpha',
+    merged_into: null,
+  });
+
+  let mergeActionId = '';
+  const runMerge =
+    'transaction' in adapter && typeof adapter.transaction === 'function'
+      ? adapter.transaction(() => {
+          const result = mergeEntityNodes({
+            adapter,
+            source_id: 'entity_project_source',
+            target_id: 'entity_project_target',
+            actor_type: 'user',
+            actor_id: 'local:tester',
+            reason: 'history missing',
+            candidate_id: null,
+            evidence_json: JSON.stringify({ reason: 'preview incomplete test' }),
+          });
+          mergeActionId = result.merge_action_id;
+        })
+      : null;
+
+  if (runMerge) {
+    const tx = runMerge as unknown;
+    if (typeof tx === 'function') {
+      tx();
+    }
+  }
+
+  return mergeActionId;
+}

--- a/packages/mama-core/tests/entities/rollback-preview.test.ts
+++ b/packages/mama-core/tests/entities/rollback-preview.test.ts
@@ -141,6 +141,118 @@ describe('Story E1.17: Entity rollback preview', () => {
     expect(preview.changed_memories).toHaveLength(1);
   });
 
+  it('scopes restored and removed lineage rows to the selected mergeActionId', async () => {
+    const { mergeActionId, memoryId } = await seedMergedEntityPair();
+    const adapter = getAdapter();
+
+    await upsertEntityObservation({
+      id: 'obs_project_source_other',
+      observation_type: 'generic',
+      entity_kind_hint: 'project',
+      surface_form: 'Project Source Other',
+      normalized_form: 'project source other',
+      lang: 'en',
+      script: 'Latn',
+      context_summary: 'Other merge action observation',
+      related_surface_forms: ['Source Other'],
+      timestamp_observed: 1710000002000,
+      scope_kind: 'project',
+      scope_id: 'scope-alpha',
+      extractor_version: 'history-extractor@v1',
+      embedding_model_version: 'multilingual-e5-large',
+      source_connector: 'slack',
+      source_locator: '/tmp/slack/raw.db',
+      source_raw_record_id: 'raw_source_other',
+    });
+
+    adapter
+      .prepare(
+        `
+          INSERT INTO entity_merge_actions (
+            id, action_type, source_entity_id, target_entity_id, candidate_id,
+            actor_type, actor_id, reason, evidence_json, created_at
+          ) VALUES (?, 'merge', ?, ?, NULL, 'system', 'test', ?, ?, ?)
+        `
+      )
+      .run(
+        'mact_other',
+        'entity_project_source',
+        'entity_project_target',
+        'synthetic alternate merge action',
+        JSON.stringify({ reason: 'test setup' }),
+        1710000002050
+      );
+
+    adapter
+      .prepare(
+        `
+          INSERT INTO entity_lineage_links (
+            id, canonical_entity_id, entity_observation_id, source_entity_id,
+            contribution_kind, run_id, candidate_id, review_action_id,
+            status, capture_mode, confidence, created_at, superseded_at
+          ) VALUES (?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        'elin_source_other_superseded',
+        'entity_project_source',
+        'obs_project_source_other',
+        'entity_project_source',
+        'merge_adopt',
+        'mact_other',
+        'superseded',
+        'direct',
+        1,
+        1710000002000,
+        1710000002100
+      );
+    adapter
+      .prepare(
+        `
+          INSERT INTO entity_lineage_links (
+            id, canonical_entity_id, entity_observation_id, source_entity_id,
+            contribution_kind, run_id, candidate_id, review_action_id,
+            status, capture_mode, confidence, created_at, superseded_at
+          ) VALUES (?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?, ?, ?, NULL)
+        `
+      )
+      .run(
+        'elin_target_other_active',
+        'entity_project_target',
+        'obs_project_source_other',
+        'entity_project_source',
+        'merge_adopt',
+        'mact_other',
+        'active',
+        'direct',
+        1,
+        1710000002200
+      );
+
+    const extraMemory = await saveMemory({
+      topic: 'project_source/other-merge',
+      kind: 'decision',
+      summary: 'Other merge memory',
+      details: 'Should not appear for the selected merge action',
+      confidence: 0.7,
+      scopes: [{ kind: 'project', id: 'scope-alpha' }],
+      source: { package: 'mama-core', source_type: 'test' },
+      entityObservationIds: ['obs_project_source_other'],
+    } as never);
+
+    const { previewEntityRollback } = await import('../../src/entities/rollback-preview.js');
+    const preview = await previewEntityRollback({
+      entityId: 'entity_project_target',
+      mergeActionId,
+    });
+
+    expect(preview.preview_unavailable).toBe(false);
+    expect(preview.changed_memories).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: memoryId })])
+    );
+    expect(preview.changed_memories.map((memory) => memory.id)).not.toContain(extraMemory.id);
+  });
+
   it('rejects an explicit mergeActionId that does not belong to the requested entity', async () => {
     const { mergeActionId } = await seedMergedEntityPair();
     await createEntityNode({

--- a/packages/mama-core/tests/entities/store.test.ts
+++ b/packages/mama-core/tests/entities/store.test.ts
@@ -8,6 +8,7 @@ import {
   listEntityNodes,
   parseObservationRow,
   upsertEntityObservation,
+  upsertEntityObservations,
 } from '../../src/entities/store.js';
 import { getAdapter } from '../../src/db-manager.js';
 import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
@@ -256,6 +257,32 @@ describe('Story E1.3: Canonical entity persistence', () => {
         )
         .get('slack', 'raw_slack_002') as { total: number };
       expect(count.total).toBe(2);
+    });
+
+    it('should return one batch result per input under immediate transaction adapters', async () => {
+      const saved = await upsertEntityObservations([
+        {
+          id: 'obs_batch_single',
+          observation_type: 'generic',
+          entity_kind_hint: 'project',
+          surface_form: 'Project Batch',
+          normalized_form: 'project batch',
+          lang: 'en',
+          script: 'Latn',
+          context_summary: 'Batch insert',
+          related_surface_forms: [],
+          timestamp_observed: 1710000000000,
+          scope_kind: 'project',
+          scope_id: 'scope-batch',
+          extractor_version: 'history-extractor@v1',
+          embedding_model_version: 'multilingual-e5-large',
+          source_connector: 'slack',
+          source_locator: '~/.mama/connectors/slack/raw.db',
+          source_raw_record_id: 'raw_batch_single',
+        },
+      ]);
+
+      expect(saved).toEqual([{ id: 'obs_batch_single', created: true }]);
     });
 
     it('should append timeline events with observed provenance details', async () => {

--- a/packages/mama-core/tests/entities/store.test.ts
+++ b/packages/mama-core/tests/entities/store.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
+  appendEntityTimelineEvent,
   attachEntityAlias,
   createEntityNode,
   getEntityNode,
@@ -73,7 +74,8 @@ describe('Story E1.3: Canonical entity persistence', () => {
       expect(names).toContain('extractor_version');
       expect(names).toContain('embedding_model_version');
       expect(names).toContain('source_connector');
-      expect(names).toContain('source_raw_db_ref');
+      expect(names).toContain('source_locator');
+      expect(names).toContain('source_locator');
       expect(names).toContain('source_raw_record_id');
       expect(columns.find((column) => column.name === 'source_connector')?.notnull).toBe(1);
     });
@@ -113,6 +115,7 @@ describe('Story E1.3: Canonical entity persistence', () => {
       const names = indexes.map((index) => index.name);
 
       expect(names).toContain('idx_entity_observations_source_record');
+      expect(names).toContain('idx_entity_observations_source_locator_record');
     });
   });
 
@@ -173,7 +176,7 @@ describe('Story E1.3: Canonical entity persistence', () => {
         extractor_version: 'history-extractor@v1',
         embedding_model_version: 'multilingual-e5-large',
         source_connector: 'slack',
-        source_raw_db_ref: '~/.mama/connectors/slack/raw.db',
+        source_locator: '~/.mama/connectors/slack/raw.db',
         source_raw_record_id: 'raw_slack_001',
       });
 
@@ -193,7 +196,7 @@ describe('Story E1.3: Canonical entity persistence', () => {
         extractor_version: 'history-extractor@v1',
         embedding_model_version: 'multilingual-e5-large',
         source_connector: 'slack',
-        source_raw_db_ref: '~/.mama/connectors/slack/raw.db',
+        source_locator: '~/.mama/connectors/slack/raw.db',
         source_raw_record_id: 'raw_slack_001',
       });
 
@@ -218,7 +221,7 @@ describe('Story E1.3: Canonical entity persistence', () => {
         extractor_version: 'history-extractor@v1',
         embedding_model_version: 'multilingual-e5-large',
         source_connector: 'slack',
-        source_raw_db_ref: '~/.mama/connectors/slack/raw.db',
+        source_locator: '~/.mama/connectors/slack/raw.db',
         source_raw_record_id: 'raw_slack_002',
       });
 
@@ -238,7 +241,7 @@ describe('Story E1.3: Canonical entity persistence', () => {
         extractor_version: 'history-extractor@v1',
         embedding_model_version: 'multilingual-e5-large',
         source_connector: 'slack',
-        source_raw_db_ref: '~/.mama/connectors/slack/raw.db',
+        source_locator: '~/.mama/connectors/slack/raw.db',
         source_raw_record_id: 'raw_slack_002',
       });
 
@@ -253,6 +256,61 @@ describe('Story E1.3: Canonical entity persistence', () => {
         )
         .get('slack', 'raw_slack_002') as { total: number };
       expect(count.total).toBe(2);
+    });
+
+    it('should append timeline events with observed provenance details', async () => {
+      await createEntityNode({
+        id: 'entity_project_beta',
+        kind: 'project',
+        preferred_label: 'Project Beta',
+        status: 'active',
+        scope_kind: 'project',
+        scope_id: 'scope-project-beta',
+        merged_into: null,
+      });
+
+      const event = await appendEntityTimelineEvent({
+        event: {
+          entity_id: 'entity_project_beta',
+          event_type: 'status_update',
+          role: 'affected',
+          valid_from: null,
+          valid_to: null,
+          observed_at: 1710000001234,
+          source_ref: '~/.mama/connectors/slack/raw.db',
+          summary: 'Project Beta moved to blocked.',
+          details: JSON.stringify({ from_status: 'in_progress', to_status: 'blocked' }),
+        },
+      });
+
+      const row = getAdapter()
+        .prepare(
+          `
+            SELECT entity_id, event_type, role, observed_at, source_ref, summary, details
+            FROM entity_timeline_events
+            WHERE id = ?
+          `
+        )
+        .get(event.id) as {
+        entity_id: string;
+        event_type: string;
+        role: string | null;
+        observed_at: number;
+        source_ref: string | null;
+        summary: string;
+        details: string | null;
+      };
+
+      expect(event.role).toBe('affected');
+      expect(row).toEqual({
+        entity_id: 'entity_project_beta',
+        event_type: 'status_update',
+        role: 'affected',
+        observed_at: 1710000001234,
+        source_ref: '~/.mama/connectors/slack/raw.db',
+        summary: 'Project Beta moved to blocked.',
+        details: JSON.stringify({ from_status: 'in_progress', to_status: 'blocked' }),
+      });
     });
   });
 
@@ -274,7 +332,7 @@ describe('Story E1.3: Canonical entity persistence', () => {
           scope_id: 'C123',
           extractor_version: 'history-extractor@v1',
           embedding_model_version: null,
-          source_raw_db_ref: null,
+          source_locator: null,
           source_connector: 'slack',
           source_raw_record_id: 42,
           created_at: Date.now(),
@@ -300,7 +358,7 @@ describe('Story E1.3: Canonical entity persistence', () => {
           extractor_version: 'history-extractor@v1',
           embedding_model_version: null,
           source_connector: 'slack',
-          source_raw_db_ref: null,
+          source_locator: null,
           source_raw_record_id: 'raw_slack_003',
           created_at: Date.now(),
         })
@@ -328,7 +386,7 @@ describe('Story E1.3: Canonical entity persistence', () => {
           source_raw_record_id: 'raw_slack_004',
           created_at: Date.now(),
         })
-      ).toThrow(/source_raw_db_ref must be present/i);
+      ).toThrow(/source_locator must be present/i);
     });
   });
 });

--- a/packages/mama-core/tests/entities/types.test.ts
+++ b/packages/mama-core/tests/entities/types.test.ts
@@ -65,12 +65,12 @@ describe('Story E1.1: Canonical entity domain contracts', () => {
   });
 
   describe('AC #3: Type contracts preserve required provenance and scope fields', () => {
-    it('should require scope binding on entity nodes', () => {
+    it('should preserve nullable scope binding on entity nodes', () => {
       expectTypeOf<EntityNode>().toMatchTypeOf<{
         id: string;
         kind: EntityKind;
         preferred_label: string;
-        scope_kind: EntityScopeKind;
+        scope_kind: EntityScopeKind | null;
         scope_id: string | null;
       }>();
     });

--- a/packages/mama-core/tests/entities/types.test.ts
+++ b/packages/mama-core/tests/entities/types.test.ts
@@ -87,7 +87,7 @@ describe('Story E1.1: Canonical entity domain contracts', () => {
         extractor_version: string;
         embedding_model_version: string | null;
         source_connector: string;
-        source_raw_db_ref: string | null;
+        source_locator: string | null;
         source_raw_record_id: string;
       }>();
     });

--- a/packages/mama-core/tests/fixtures/entity-policy-bootstrap-alt.json
+++ b/packages/mama-core/tests/fixtures/entity-policy-bootstrap-alt.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "policies": [
+    {
+      "policy_key": "merge_guardrails.default",
+      "policy_kind": "merge_guardrails",
+      "value": {
+        "max_false_merge_rate": 0.01,
+        "require_review_for_cross_scope": false
+      }
+    }
+  ],
+  "role_bindings": [
+    {
+      "actor_id": "actor:alternate-admin",
+      "role": "admin"
+    }
+  ]
+}

--- a/packages/mama-core/tests/fixtures/entity-policy-bootstrap.json
+++ b/packages/mama-core/tests/fixtures/entity-policy-bootstrap.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "policies": [
+    {
+      "policy_key": "merge_guardrails.default",
+      "policy_kind": "merge_guardrails",
+      "value": {
+        "max_false_merge_rate": 0.02,
+        "require_review_for_cross_scope": true
+      }
+    },
+    {
+      "policy_key": "review_thresholds.default",
+      "policy_kind": "review_thresholds",
+      "value": {
+        "approve_score_min": 0.92,
+        "defer_score_min": 0.78
+      }
+    }
+  ],
+  "role_bindings": [
+    {
+      "actor_id": "local:viewer",
+      "role": "admin"
+    }
+  ]
+}

--- a/packages/mama-core/tests/search/feedback-store.test.ts
+++ b/packages/mama-core/tests/search/feedback-store.test.ts
@@ -1,0 +1,185 @@
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  getFeedbackRetentionDays,
+  hashQuery,
+  listSearchFeedback,
+  recordSearchFeedback,
+  type FeedbackStoreAdapter,
+  type SearchFeedbackInput,
+} from '../../src/search/feedback-store.js';
+
+import { applyMigrationsThrough } from '../../src/test-utils.js';
+function setRetention(db: Database.Database, days: number): void {
+  db.prepare(
+    `
+      INSERT INTO search_ranker_settings (key, value_json, updated_at)
+      VALUES ('search_feedback_retention_days', ?, '2026-04-18T00:00:00.000Z')
+      ON CONFLICT(key) DO UPDATE SET value_json = excluded.value_json
+    `
+  ).run(JSON.stringify(days));
+}
+
+function input(overrides: Partial<SearchFeedbackInput> = {}): SearchFeedbackInput {
+  return {
+    result_id: overrides.result_id ?? `feedback-${Math.random().toString(16).slice(2)}`,
+    session_id: overrides.session_id ?? 'session-1',
+    query: overrides.query ?? 'current status',
+    result_source_type: overrides.result_source_type ?? 'case',
+    result_source_id: overrides.result_source_id ?? 'case-1',
+    feedback_kind: overrides.feedback_kind ?? 'shown',
+    question_type: overrides.question_type ?? 'status',
+    shown_index: overrides.shown_index ?? 0,
+    result_case_id: overrides.result_case_id ?? null,
+    clicked_result_rank: overrides.clicked_result_rank,
+    created_at: overrides.created_at,
+  };
+}
+
+describe('Phase 3 Task 10: search feedback store', () => {
+  let db: Database.Database;
+  let adapter: FeedbackStoreAdapter;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+    adapter = db as unknown as FeedbackStoreAdapter;
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('hashes normalized queries to 16 hex chars for external identity', () => {
+    expect(hashQuery('  Current Status  ')).toBe(hashQuery('current status'));
+    expect(hashQuery('current status')).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('dedupes shown feedback with latest shown winning', () => {
+    recordSearchFeedback(
+      adapter,
+      input({
+        result_id: 'shown-old',
+        shown_index: 1,
+        created_at: '2026-04-18T00:00:00.000Z',
+      })
+    );
+    const result = recordSearchFeedback(
+      adapter,
+      input({
+        result_id: 'shown-new',
+        shown_index: 4,
+        created_at: '2026-04-18T00:01:00.000Z',
+      })
+    );
+
+    const rows = listSearchFeedback(adapter, {
+      since: '2026-04-18T00:00:00.000Z',
+      until: '2026-04-18T00:02:00.000Z',
+    });
+
+    expect(result.deduped).toBe(true);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      feedback_id: 'shown-new',
+      rank_position: 4,
+      session_id: 'session-1',
+    });
+  });
+
+  it('compacts old shown rows but preserves explicit labels', () => {
+    setRetention(db, 1);
+    recordSearchFeedback(
+      adapter,
+      input({
+        result_id: 'old-shown',
+        result_source_id: 'case-old-shown',
+        created_at: '2026-01-01T00:00:00.000Z',
+      })
+    );
+    recordSearchFeedback(
+      adapter,
+      input({
+        result_id: 'old-accept',
+        result_source_id: 'case-old-accept',
+        feedback_kind: 'accept',
+        created_at: '2026-01-01T00:00:00.000Z',
+      })
+    );
+    recordSearchFeedback(
+      adapter,
+      input({
+        result_id: 'new-shown',
+        result_source_id: 'case-new-shown',
+      })
+    );
+
+    const allRows = db
+      .prepare('SELECT feedback_id, feedback_kind FROM search_feedback ORDER BY feedback_id')
+      .all() as Array<{ feedback_id: string; feedback_kind: string }>;
+
+    expect(allRows).toEqual([
+      { feedback_id: 'new-shown', feedback_kind: 'shown' },
+      { feedback_id: 'old-accept', feedback_kind: 'accept' },
+    ]);
+  });
+
+  it('uses the default retention window when listing feedback', () => {
+    recordSearchFeedback(
+      adapter,
+      input({
+        result_id: 'recent',
+        result_source_id: 'case-recent',
+      })
+    );
+    recordSearchFeedback(
+      adapter,
+      input({
+        result_id: 'old',
+        result_source_id: 'case-old',
+        feedback_kind: 'accept',
+        created_at: '2025-01-01T00:00:00.000Z',
+      })
+    );
+
+    const rows = listSearchFeedback(adapter);
+
+    expect(rows.map((row) => row.feedback_id)).toContain('recent');
+    expect(rows.map((row) => row.feedback_id)).not.toContain('old');
+  });
+
+  it('uses explicit since and until windows', () => {
+    recordSearchFeedback(
+      adapter,
+      input({
+        result_id: 'inside',
+        result_source_id: 'case-inside',
+        created_at: '2026-04-18T00:30:00.000Z',
+      })
+    );
+    recordSearchFeedback(
+      adapter,
+      input({
+        result_id: 'outside',
+        result_source_id: 'case-outside',
+        created_at: '2026-04-18T02:30:00.000Z',
+      })
+    );
+
+    const rows = listSearchFeedback(adapter, {
+      since: '2026-04-18T00:00:00.000Z',
+      until: '2026-04-18T01:00:00.000Z',
+    });
+
+    expect(rows.map((row) => row.feedback_id)).toEqual(['inside']);
+  });
+
+  it('reads search_feedback_retention_days from settings', () => {
+    setRetention(db, 14);
+
+    expect(getFeedbackRetentionDays(adapter)).toBe(14);
+  });
+});

--- a/packages/mama-core/tests/search/feedback-store.test.ts
+++ b/packages/mama-core/tests/search/feedback-store.test.ts
@@ -214,4 +214,41 @@ describe('Phase 3 Task 10: search feedback store', () => {
 
     expect(getFeedbackRetentionDays(adapter)).toBe(14);
   });
+
+  it('classifies question_type when the caller omits it', () => {
+    const result = recordSearchFeedback(
+      adapter,
+      {
+        result_id: 'classified-on-write',
+        session_id: 'session-1',
+        query: 'how to configure the ranker',
+        result_source_type: 'case',
+        result_source_id: 'case-1',
+        feedback_kind: 'shown',
+        shown_index: 0,
+      } as SearchFeedbackInput
+    );
+
+    const row = db
+      .prepare(`SELECT question_type FROM search_feedback WHERE feedback_id = ?`)
+      .get(result.feedback_id) as { question_type: string };
+
+    expect(row.question_type).toBe('how_to');
+  });
+
+  it('fails fast when adapter.transaction is missing', () => {
+    const noTxAdapter = {
+      prepare: adapter.prepare.bind(adapter),
+    } as unknown as FeedbackStoreAdapter;
+
+    expect(() =>
+      recordSearchFeedback(
+        noTxAdapter,
+        input({
+          result_id: 'no-transaction',
+          result_source_id: 'case-no-transaction',
+        })
+      )
+    ).toThrow(/adapter\.transaction/i);
+  });
 });

--- a/packages/mama-core/tests/search/feedback-store.test.ts
+++ b/packages/mama-core/tests/search/feedback-store.test.ts
@@ -1,4 +1,3 @@
-
 import Database from 'better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -84,10 +83,10 @@ describe('Phase 3 Task 10: search feedback store', () => {
     expect(result.deduped).toBe(true);
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({
-      feedback_id: 'shown-new',
       rank_position: 4,
       session_id: 'session-1',
     });
+    expect(rows[0]?.feedback_id).toBe(result.feedback_id);
   });
 
   it('compacts old shown rows but preserves explicit labels', () => {
@@ -121,10 +120,42 @@ describe('Phase 3 Task 10: search feedback store', () => {
       .prepare('SELECT feedback_id, feedback_kind FROM search_feedback ORDER BY feedback_id')
       .all() as Array<{ feedback_id: string; feedback_kind: string }>;
 
-    expect(allRows).toEqual([
-      { feedback_id: 'new-shown', feedback_kind: 'shown' },
-      { feedback_id: 'old-accept', feedback_kind: 'accept' },
-    ]);
+    expect(allRows).toHaveLength(2);
+    expect(allRows.map((row) => row.feedback_kind).sort()).toEqual(['accept', 'shown']);
+  });
+
+  it('allows multiple feedback events for the same result_id', () => {
+    const shown = recordSearchFeedback(
+      adapter,
+      input({
+        result_id: 'same-result-id',
+        result_source_id: 'case-shared',
+        feedback_kind: 'shown',
+      })
+    );
+    const accepted = recordSearchFeedback(
+      adapter,
+      input({
+        result_id: 'same-result-id',
+        result_source_id: 'case-shared',
+        feedback_kind: 'accept',
+      })
+    );
+
+    const rows = db
+      .prepare(
+        `
+          SELECT feedback_id, feedback_kind
+          FROM search_feedback
+          WHERE result_source_id = 'case-shared'
+          ORDER BY created_at ASC, feedback_id ASC
+        `
+      )
+      .all() as Array<{ feedback_id: string; feedback_kind: string }>;
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.feedback_kind).sort()).toEqual(['accept', 'shown']);
+    expect(shown.feedback_id).not.toBe(accepted.feedback_id);
   });
 
   it('uses the default retention window when listing feedback', () => {
@@ -147,8 +178,8 @@ describe('Phase 3 Task 10: search feedback store', () => {
 
     const rows = listSearchFeedback(adapter);
 
-    expect(rows.map((row) => row.feedback_id)).toContain('recent');
-    expect(rows.map((row) => row.feedback_id)).not.toContain('old');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.feedback_kind).toBe('shown');
   });
 
   it('uses explicit since and until windows', () => {
@@ -174,7 +205,8 @@ describe('Phase 3 Task 10: search feedback store', () => {
       until: '2026-04-18T01:00:00.000Z',
     });
 
-    expect(rows.map((row) => row.feedback_id)).toEqual(['inside']);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.feedback_kind).toBe('shown');
   });
 
   it('reads search_feedback_retention_days from settings', () => {

--- a/packages/mama-core/tests/search/question-type.test.ts
+++ b/packages/mama-core/tests/search/question-type.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifyQuestionType } from '../../src/search/question-type.js';
+
+describe('Phase 3 Task 10: question type classifier', () => {
+  it('classifies correction questions', () => {
+    expect(classifyQuestionType('fix the stale case status')).toBe('correction');
+  });
+
+  it('classifies artifact questions', () => {
+    expect(classifyQuestionType('find the Obsidian doc for this case')).toBe('artifact');
+  });
+
+  it('classifies timeline questions', () => {
+    expect(classifyQuestionType('when did this happen before 2026-04-18')).toBe('timeline');
+  });
+
+  it('classifies status questions', () => {
+    expect(classifyQuestionType('what is the current progress now')).toBe('status');
+  });
+
+  it('classifies decision-reason questions', () => {
+    expect(classifyQuestionType('why did we choose this because the reason matters')).toBe(
+      'decision_reason'
+    );
+  });
+
+  it('classifies how-to questions', () => {
+    expect(classifyQuestionType('how to configure the ranker')).toBe('how_to');
+  });
+
+  it('falls back to unknown', () => {
+    expect(classifyQuestionType('banana window silver')).toBe('unknown');
+  });
+
+  it('prioritizes correction over how-to', () => {
+    expect(classifyQuestionType('how to fix the wrong case merge')).toBe('correction');
+  });
+});

--- a/packages/mama-core/tests/search/ranker-quality-fixtures.test.ts
+++ b/packages/mama-core/tests/search/ranker-quality-fixtures.test.ts
@@ -1,0 +1,68 @@
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  evaluateAgainstBaselines,
+  RANKER_QUALITY_FIXTURES,
+  seedQualityFixtureFeedback,
+  trainOfflineRanker,
+  type RankerTrainerAdapter,
+} from '../../src/search/ranker-trainer.js';
+
+import { applyMigrationsThrough } from '../../src/test-utils.js';
+describe('Phase 3 Task 12: ranker quality fixtures', () => {
+  let db: Database.Database;
+  let adapter: RankerTrainerAdapter;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+    adapter = db as unknown as RankerTrainerAdapter;
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('trains on seeded fixtures and beats baselines by the activation margin', async () => {
+    seedQualityFixtureFeedback(adapter);
+
+    const training = await trainOfflineRanker({
+      adapter,
+      minFeedbackRows: 8,
+      minDistinctQueries: 8,
+      since: '2026-04-17T00:00:00.000Z',
+      until: '2026-04-19T00:00:00.000Z',
+    });
+
+    expect(training.status).toBe('trained');
+    expect(RANKER_QUALITY_FIXTURES).toHaveLength(8);
+
+    const evaluation = await evaluateAgainstBaselines(
+      {
+        adapter,
+        minFeedbackRows: 8,
+        minDistinctQueries: 8,
+      },
+      training.model!
+    );
+
+    const baselines = [evaluation.bm25, evaluation.vector, evaluation.rrf, evaluation.logistic];
+    const bestAggregateNdcg = Math.max(...baselines.map((metric) => metric.ndcg));
+    const bestAggregateMrr = Math.max(...baselines.map((metric) => metric.mrr));
+
+    for (const fixture of RANKER_QUALITY_FIXTURES) {
+      const learned = evaluation.learned.per_query[fixture.query];
+      const bestBaseline = Math.max(
+        ...baselines.map((metric) => metric.per_query[fixture.query].ndcg)
+      );
+      expect(learned.ndcg).toBeGreaterThanOrEqual(bestBaseline - 0.0001);
+    }
+
+    expect(evaluation.learned.ndcg).toBeGreaterThanOrEqual(bestAggregateNdcg + 0.01);
+    expect(evaluation.learned.mrr).toBeGreaterThanOrEqual(bestAggregateMrr + 0.01);
+    expect(evaluation.passes).toBe(true);
+  });
+});

--- a/packages/mama-core/tests/search/ranker-rescore.test.ts
+++ b/packages/mama-core/tests/search/ranker-rescore.test.ts
@@ -1,0 +1,165 @@
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { SEARCH_RANKER_FEATURE_SET_VERSION } from '../../src/search/ranker-features.js';
+import {
+  rescoreSearchResults,
+  type RankerRescoreAdapter,
+} from '../../src/search/ranker-rescore.js';
+
+import { applyMigrationsThrough } from '../../src/test-utils.js';
+function insertModel(
+  db: Database.Database,
+  overrides: Partial<{
+    feature_set_version: string;
+    quality_gate_status: string;
+    active: number;
+  }> = {}
+): void {
+  const coefficients = {
+    coefficients: [0, 0, 0, 0, 0, 4, -4, -4, -4, -4, 0, 0, 0, 0, 0, 0, 0],
+    intercept: 0,
+    question_type_weights: {
+      correction: [0, 0, 0, 0, 0, 4, -4, -4, -4, -4, 0, 0, 0, 0, 0, 0, 0],
+      artifact: [0, 0, 0, 0, 0, -4, -4, -4, 4, -4, 0, 0, 0, 0, 0, 0, 0],
+      timeline: [0, 0, 0, 0, 0, -4, -4, -4, -4, 4, 0, 0, 0, 0, 0, 0, 0],
+      status: [0, 0, 0, 0, 0, -4, -4, 4, -4, -4, 0, 0, 0, 0, 0, 0, 0],
+      decision_reason: [0, 0, 0, 0, 0, 4, -4, -4, -4, -4, 0, 0, 0, 0, 0, 0, 0],
+      how_to: [0, 0, 0, 0, 0, 4, -4, -4, -4, -4, 0, 0, 0, 0, 0, 0, 0],
+      unknown: [0, 0, 0, 0, 0, 4, -4, -4, -4, -4, 0, 0, 0, 0, 0, 0, 0],
+    },
+    training_rows_count: 10,
+  };
+
+  db.prepare(
+    `
+      INSERT INTO ranker_model_versions (
+        model_id, model_version, feature_set_version, coefficients_json, metrics_json,
+        training_window_json, baseline_metrics_json, quality_gate_status, trained_at,
+        trained_by, active
+      )
+      VALUES (
+        'ranker-active', 'v1', ?, ?, '{}', '{}', '{}', ?,
+        '2026-04-18T00:00:00.000Z', 'test', ?
+      )
+    `
+  ).run(
+    overrides.feature_set_version ?? SEARCH_RANKER_FEATURE_SET_VERSION,
+    JSON.stringify(coefficients),
+    overrides.quality_gate_status ?? 'passed',
+    overrides.active ?? 1
+  );
+}
+
+describe('Phase 3 Task 12: ranker rescoring', () => {
+  let db: Database.Database;
+  let adapter: RankerRescoreAdapter;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+    adapter = db as unknown as RankerRescoreAdapter;
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('preserves order when no active model exists', () => {
+    const result = rescoreSearchResults(adapter, {
+      query: 'fix wrong decision',
+      results: [
+        { id: 'a', source_type: 'wiki_page', final_score: 0.9 },
+        { id: 'b', source_type: 'decision', final_score: 0.1 },
+      ],
+    });
+
+    expect(result.skipped_reason).toBe('no_active_model');
+    expect(result.results.map((row) => row.id)).toEqual(['a', 'b']);
+  });
+
+  it('skips one-result inputs before model loading', () => {
+    const result = rescoreSearchResults(adapter, {
+      query: 'fix wrong decision',
+      results: [{ id: 'a', source_type: 'decision', final_score: 0.9 }],
+    });
+
+    expect(result.skipped_reason).toBe('insufficient_result_count');
+  });
+
+  // Codex test bug: the 0.80*base + 0.20*ranker blend can't overcome a base
+  // score delta of 0.6 (wiki=0.9 vs decision=0.3) since ranker_score is
+  // Final score combines base and ranker as finalScore = 0.8 * base + 0.2 * ranker.
+  // Any test that expects the ranker to flip order must start from base scores
+  // within ~0.2 of each other, otherwise the 0.8 weight on the base dominates.
+  it('reranks deterministically with an active model and preserves base score', () => {
+    insertModel(db);
+
+    const result = rescoreSearchResults(adapter, {
+      query: 'fix wrong decision',
+      results: [
+        // Base scores intentionally tight; the ranker's source-type coefficients
+        // (decision=+4, wiki_page=-4 for correction question type) are what
+        // reorder them, not the base delta.
+        { id: 'wiki', source_type: 'wiki_page', final_score: 0.55 },
+        { id: 'decision', source_type: 'decision', final_score: 0.5 },
+      ],
+    });
+
+    expect(result.model_id).toBe('ranker-active');
+    expect(result.skipped_reason).toBeUndefined();
+    // Decision wins despite starting below wiki, because its ranker_score
+    // approaches 1 while wiki's approaches 0 for the correction question type.
+    expect(result.results[0].id).toBe('decision');
+    expect(result.results[0].ranker_score).toBeGreaterThan(0.9);
+    expect(result.results[0].score_before_ranker).toBe(0.5);
+    // wiki's ranker_score is strongly negative → close to 0 after logistic.
+    expect(result.results[1].id).toBe('wiki');
+    expect(result.results[1].ranker_score).toBeLessThan(0.1);
+  });
+
+  it('skips mismatched feature-set models', () => {
+    insertModel(db, { feature_set_version: 'bad-version' });
+
+    const result = rescoreSearchResults(adapter, {
+      query: 'fix wrong decision',
+      results: [
+        { id: 'a', source_type: 'wiki_page', final_score: 0.9 },
+        { id: 'b', source_type: 'decision', final_score: 0.1 },
+      ],
+    });
+
+    expect(result.skipped_reason).toBe('feature_set_mismatch');
+  });
+
+  it('skips when legacy LLM reranking is requested', () => {
+    insertModel(db);
+
+    const result = rescoreSearchResults(adapter, {
+      query: 'fix wrong decision',
+      useReranking: true,
+      results: [
+        { id: 'a', source_type: 'decision', final_score: 0.9 },
+        { id: 'b', source_type: 'wiki_page', final_score: 0.1 },
+      ],
+    });
+
+    expect(result.skipped_reason).toBe('llm_reranking_requested');
+  });
+
+  it('preserves original order when final scores tie', () => {
+    insertModel(db);
+
+    const result = rescoreSearchResults(adapter, {
+      query: 'fix wrong decision',
+      results: [
+        { id: 'first', source_type: 'decision', final_score: 0.5 },
+        { id: 'second', source_type: 'decision', final_score: 0.5 },
+      ],
+    });
+
+    expect(result.results.map((row) => row.id)).toEqual(['first', 'second']);
+  });
+});

--- a/packages/mama-core/tests/search/ranker-trainer.test.ts
+++ b/packages/mama-core/tests/search/ranker-trainer.test.ts
@@ -7,6 +7,7 @@ import {
   type FeedbackStoreAdapter,
 } from '../../src/search/feedback-store.js';
 import {
+  RANKER_QUALITY_FIXTURES,
   activateRankerModel,
   evaluateAgainstBaselines,
   insertRankerModelVersion,
@@ -96,6 +97,20 @@ describe('Phase 3 Task 11: offline ranker trainer', () => {
     expect(result.model?.feature_set_version).toBe(SEARCH_RANKER_FEATURE_SET_VERSION);
   });
 
+  it('returns insufficient_data when examples only contain one label', async () => {
+    insertFeedback(adapter, 'query-positive-a', 'case-1', 'accept');
+    insertFeedback(adapter, 'query-positive-b', 'case-2', 'accept');
+
+    const result = await trainOfflineRanker({
+      adapter,
+      minFeedbackRows: 2,
+      minDistinctQueries: 2,
+    });
+
+    expect(result.status).toBe('insufficient_data');
+    expect(result.model).toBeUndefined();
+  });
+
   it('caps neutral shown rows to 3x explicit labels per query', async () => {
     for (let index = 0; index < 100; index += 1) {
       insertFeedback(adapter, 'query-neutral', `shown-${index}`, 'shown');
@@ -162,6 +177,40 @@ describe('Phase 3 Task 11: offline ranker trainer', () => {
       retention_warning: true,
       retention_days_at_train_time: 1,
     });
+  });
+
+  it('builds collision-resistant model ids even when metadata is identical', async () => {
+    insertFeedback(adapter, 'query-a', 'case-1', 'accept');
+    insertFeedback(adapter, 'query-a', 'case-2', 'reject');
+    insertFeedback(adapter, 'query-b', 'case-3', 'accept');
+    insertFeedback(adapter, 'query-b', 'case-4', 'reject');
+
+    const now = new Date('2026-04-18T12:00:00.000Z');
+    const first = await trainOfflineRanker({
+      adapter,
+      minFeedbackRows: 4,
+      minDistinctQueries: 2,
+      now,
+    });
+    const second = await trainOfflineRanker({
+      adapter,
+      minFeedbackRows: 4,
+      minDistinctQueries: 2,
+      now,
+    });
+
+    expect(first.status).toBe('trained');
+    expect(second.status).toBe('trained');
+    expect(first.model?.model_id).not.toBe(second.model?.model_id);
+  });
+
+  it('uses varied fixture ordering so ties cannot rely on the same first item', () => {
+    const leadingRelevances = RANKER_QUALITY_FIXTURES.map(
+      (fixture) => fixture.candidates[0]?.relevance
+    );
+
+    expect(leadingRelevances).toContain(0);
+    expect(new Set(leadingRelevances).size).toBeGreaterThan(1);
   });
 
   it('rejects activation for mismatched feature sets', async () => {

--- a/packages/mama-core/tests/search/ranker-trainer.test.ts
+++ b/packages/mama-core/tests/search/ranker-trainer.test.ts
@@ -1,0 +1,184 @@
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  recordSearchFeedback,
+  type FeedbackStoreAdapter,
+} from '../../src/search/feedback-store.js';
+import {
+  activateRankerModel,
+  evaluateAgainstBaselines,
+  insertRankerModelVersion,
+  SEARCH_RANKER_FEATURE_SET_VERSION,
+  trainOfflineRanker,
+  type RankerTrainerAdapter,
+} from '../../src/search/ranker-trainer.js';
+
+import { applyMigrationsThrough } from '../../src/test-utils.js';
+function setRetention(db: Database.Database, days: number): void {
+  db.prepare(
+    `
+      UPDATE search_ranker_settings
+      SET value_json = ?
+      WHERE key = 'search_feedback_retention_days'
+    `
+  ).run(JSON.stringify(days));
+}
+
+function insertFeedback(
+  adapter: FeedbackStoreAdapter,
+  query: string,
+  resultId: string,
+  kind: 'shown' | 'accept' | 'reject' | 'hide' | 'click',
+  createdAt = '2026-04-18T00:00:00.000Z'
+): void {
+  recordSearchFeedback(adapter, {
+    result_id: `${kind}-${query}-${resultId}`,
+    session_id: `session-${query}`,
+    query,
+    result_source_type: 'case',
+    result_source_id: resultId,
+    feedback_kind: kind,
+    question_type: 'status',
+    shown_index: Number(resultId.replace(/\D/g, '')) || 0,
+    created_at: createdAt,
+  });
+}
+
+describe('Phase 3 Task 11: offline ranker trainer', () => {
+  let db: Database.Database;
+  let adapter: FeedbackStoreAdapter & RankerTrainerAdapter;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+    adapter = db as unknown as FeedbackStoreAdapter & RankerTrainerAdapter;
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('returns insufficient_data when feedback is empty', async () => {
+    const result = await trainOfflineRanker({ adapter });
+
+    expect(result.status).toBe('insufficient_data');
+    expect(result.counts).toEqual({ feedbackRows: 0, distinctQueries: 0 });
+  });
+
+  it('requires 1000 rows and 10 distinct queries by default', async () => {
+    for (let index = 0; index < 20; index += 1) {
+      insertFeedback(adapter, `query-${index % 10}`, `case-${index}`, 'accept');
+    }
+
+    const result = await trainOfflineRanker({ adapter });
+
+    expect(result.status).toBe('insufficient_data');
+    expect(result.counts.distinctQueries).toBe(10);
+    expect(result.counts.feedbackRows).toBe(20);
+  });
+
+  it('allows seeded tests to lower training thresholds', async () => {
+    insertFeedback(adapter, 'query-a', 'case-1', 'accept');
+    insertFeedback(adapter, 'query-a', 'case-2', 'reject');
+    insertFeedback(adapter, 'query-b', 'case-3', 'accept');
+    insertFeedback(adapter, 'query-b', 'case-4', 'reject');
+
+    const result = await trainOfflineRanker({
+      adapter,
+      minFeedbackRows: 4,
+      minDistinctQueries: 2,
+    });
+
+    expect(result.status).toBe('trained');
+    expect(result.model?.feature_set_version).toBe(SEARCH_RANKER_FEATURE_SET_VERSION);
+  });
+
+  it('caps neutral shown rows to 3x explicit labels per query', async () => {
+    for (let index = 0; index < 100; index += 1) {
+      insertFeedback(adapter, 'query-neutral', `shown-${index}`, 'shown');
+    }
+    insertFeedback(adapter, 'query-neutral', 'positive-1', 'accept');
+    insertFeedback(adapter, 'query-neutral', 'positive-2', 'click');
+    insertFeedback(adapter, 'query-neutral', 'negative-1', 'reject');
+
+    const result = await trainOfflineRanker({
+      adapter,
+      minFeedbackRows: 1,
+      minDistinctQueries: 1,
+    });
+
+    expect(result.status).toBe('trained');
+    expect(result.model?.training_rows_count).toBe(12);
+    expect(result.counts.feedbackRows).toBe(12);
+  });
+
+  it('uses retention as the default training window', async () => {
+    setRetention(db, 1);
+    insertFeedback(adapter, 'query-retention', 'case-old', 'accept', '2026-04-16T00:00:00.000Z');
+    insertFeedback(adapter, 'query-retention', 'case-new', 'reject', '2026-04-18T00:00:00.000Z');
+
+    const result = await trainOfflineRanker({
+      adapter,
+      minFeedbackRows: 1,
+      minDistinctQueries: 1,
+      now: new Date('2026-04-18T12:00:00.000Z'),
+    });
+
+    expect(result.counts.feedbackRows).toBe(1);
+    expect(result.effectiveWindow.since).toBe('2026-04-17T12:00:00.000Z');
+  });
+
+  it('warns and persists a retention flag when explicit since exceeds retention', async () => {
+    setRetention(db, 1);
+    insertFeedback(adapter, 'query-warning', 'case-1', 'accept', '2026-04-16T00:00:00.000Z');
+    insertFeedback(adapter, 'query-warning', 'case-2', 'reject', '2026-04-18T00:00:00.000Z');
+
+    const result = await trainOfflineRanker({
+      adapter,
+      since: '2026-04-16T00:00:00.000Z',
+      until: '2026-04-18T12:00:00.000Z',
+      minFeedbackRows: 2,
+      minDistinctQueries: 1,
+      now: new Date('2026-04-18T12:00:00.000Z'),
+    });
+
+    expect(result.status).toBe('trained');
+    expect(result.effectiveWindow.retention_warning).toBe(true);
+
+    const evaluation = await evaluateAgainstBaselines(
+      { adapter, minFeedbackRows: 1, minDistinctQueries: 1 },
+      result.model!
+    );
+    await insertRankerModelVersion(adapter, result.model!, evaluation);
+
+    const row = db
+      .prepare('SELECT training_window_json FROM ranker_model_versions WHERE model_id = ?')
+      .get(result.model!.model_id) as { training_window_json: string };
+
+    expect(JSON.parse(row.training_window_json)).toMatchObject({
+      retention_warning: true,
+      retention_days_at_train_time: 1,
+    });
+  });
+
+  it('rejects activation for mismatched feature sets', async () => {
+    db.prepare(
+      `
+        INSERT INTO ranker_model_versions (
+          model_id, model_version, feature_set_version, coefficients_json, metrics_json,
+          training_window_json, baseline_metrics_json, quality_gate_status, trained_at,
+          trained_by, active
+        )
+        VALUES (
+          'bad-version', 'v1', 'bad-version', '{"coefficients":[],"intercept":0}',
+          '{}', '{}', '{}', 'passed', '2026-04-18T00:00:00.000Z', 'test', 0
+        )
+      `
+    ).run();
+
+    await expect(activateRankerModel(adapter, 'bad-version')).resolves.toBe('feature_set_mismatch');
+  });
+});

--- a/packages/mama-core/tests/search/search-feedback-schema.test.ts
+++ b/packages/mama-core/tests/search/search-feedback-schema.test.ts
@@ -1,0 +1,270 @@
+
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+
+import { applyMigrationsThrough } from '../../src/test-utils.js';
+function insertFeedback(
+  db: Database.Database,
+  overrides: Partial<{
+    feedback_id: string;
+    query: string;
+    query_hash: Buffer;
+    question_type: string;
+    result_source_type: string;
+    result_source_id: string;
+    feedback_kind: string;
+    rank_position: number;
+    session_id: string | null;
+  }> = {}
+): void {
+  const id = overrides.feedback_id ?? `fb-${Math.random().toString(16).slice(2)}`;
+  db.prepare(
+    `
+      INSERT INTO search_feedback (
+        feedback_id, query, query_hash, question_type, result_source_type, result_source_id,
+        case_id, feedback_kind, rank_position, score_before, score_after, session_id,
+        actor, metadata_json, created_at, updated_at
+      )
+      VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, 0.5, 0.7, ?, 'actor:test', '{}',
+              '2026-04-18T00:00:00.000Z', NULL)
+    `
+  ).run(
+    id,
+    overrides.query ?? 'what is blocked',
+    overrides.query_hash ?? Buffer.alloc(32, 2),
+    overrides.question_type ?? 'status',
+    overrides.result_source_type ?? 'case',
+    overrides.result_source_id ?? `case-${id}`,
+    overrides.feedback_kind ?? 'shown',
+    overrides.rank_position ?? 0,
+    overrides.session_id ?? 'session-1'
+  );
+}
+
+function insertRankerModel(
+  db: Database.Database,
+  overrides: Partial<{
+    model_id: string;
+    quality_gate_status: string;
+    active: number;
+  }> = {}
+): void {
+  const id = overrides.model_id ?? `ranker-${Math.random().toString(16).slice(2)}`;
+  db.prepare(
+    `
+      INSERT INTO ranker_model_versions (
+        model_id, model_version, feature_set_version, coefficients_json, metrics_json,
+        training_window_json, baseline_metrics_json, quality_gate_status, trained_at,
+        trained_by, active
+      )
+      VALUES (?, 'v1', 'features-v1', '{"bias":0}', '{"ndcg":0.42}',
+              '{"from":"2026-01-01","to":"2026-04-18"}', '{"bm25":{"ndcg":0.40}}',
+              ?, '2026-04-18T00:00:00.000Z', 'test', ?)
+    `
+  ).run(id, overrides.quality_gate_status ?? 'passed', overrides.active ?? 0);
+}
+
+describe('case-first substrate — search feedback and ranker schema', () => {
+  it('accepts every valid feedback kind', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    for (const kind of ['shown', 'click', 'accept', 'reject', 'hide']) {
+      expect(() =>
+        insertFeedback(db, {
+          feedback_id: `fb-${kind}`,
+          feedback_kind: kind,
+          result_source_id: `result-${kind}`,
+        })
+      ).not.toThrow();
+    }
+
+    db.close();
+  });
+
+  it('rejects invalid question_type and feedback_kind values', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    expect(() =>
+      insertFeedback(db, {
+        feedback_id: 'fb-invalid-question',
+        question_type: 'not-a-question-type',
+      })
+    ).toThrow(/CHECK constraint/i);
+
+    expect(() =>
+      insertFeedback(db, {
+        feedback_id: 'fb-invalid-kind',
+        feedback_kind: 'bookmark',
+      })
+    ).toThrow(/CHECK constraint/i);
+
+    db.close();
+  });
+
+  it('enforces 32-byte query_hash values', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    expect(() =>
+      insertFeedback(db, {
+        feedback_id: 'fb-short-hash',
+        query_hash: Buffer.from('short'),
+      })
+    ).toThrow(/CHECK constraint/i);
+
+    expect(() =>
+      insertFeedback(db, {
+        feedback_id: 'fb-valid-hash',
+        query_hash: Buffer.alloc(32, 3),
+      })
+    ).not.toThrow();
+
+    db.close();
+  });
+
+  it('dedupes shown feedback per session, query hash, result type, and result id', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    const queryHash = Buffer.alloc(32, 4);
+    insertFeedback(db, {
+      feedback_id: 'fb-shown-1',
+      query_hash: queryHash,
+      result_source_type: 'case',
+      result_source_id: 'case-1',
+      feedback_kind: 'shown',
+      session_id: 'session-a',
+    });
+
+    expect(() =>
+      insertFeedback(db, {
+        feedback_id: 'fb-shown-2',
+        query_hash: queryHash,
+        result_source_type: 'case',
+        result_source_id: 'case-1',
+        feedback_kind: 'shown',
+        session_id: 'session-a',
+      })
+    ).toThrow(/UNIQUE constraint/i);
+
+    expect(() =>
+      insertFeedback(db, {
+        feedback_id: 'fb-shown-3',
+        query_hash: queryHash,
+        result_source_type: 'case',
+        result_source_id: 'case-1',
+        feedback_kind: 'shown',
+        session_id: null,
+      })
+    ).not.toThrow();
+
+    db.close();
+  });
+
+  it('allows explicit accept and reject rows to coexist with shown feedback', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    const queryHash = Buffer.alloc(32, 5);
+    insertFeedback(db, {
+      feedback_id: 'fb-coexist-shown',
+      query_hash: queryHash,
+      result_source_id: 'case-coexist',
+      feedback_kind: 'shown',
+    });
+
+    expect(() =>
+      insertFeedback(db, {
+        feedback_id: 'fb-coexist-accept',
+        query_hash: queryHash,
+        result_source_id: 'case-coexist',
+        feedback_kind: 'accept',
+      })
+    ).not.toThrow();
+
+    expect(() =>
+      insertFeedback(db, {
+        feedback_id: 'fb-coexist-reject',
+        query_hash: queryHash,
+        result_source_id: 'case-coexist',
+        feedback_kind: 'reject',
+      })
+    ).not.toThrow();
+
+    const row = db.prepare('SELECT COUNT(*) AS count FROM search_feedback').get() as {
+      count: number;
+    };
+    expect(row.count).toBe(3);
+
+    db.close();
+  });
+
+  it('seeds search_feedback_retention_days as 180', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    const row = db
+      .prepare(
+        "SELECT value_json FROM search_ranker_settings WHERE key = 'search_feedback_retention_days'"
+      )
+      .get() as { value_json: string } | undefined;
+
+    expect(row?.value_json).toBe('180');
+
+    db.close();
+  });
+
+  it('allows only one active ranker model', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    insertRankerModel(db, { model_id: 'ranker-active-1', active: 1 });
+    expect(() => insertRankerModel(db, { model_id: 'ranker-active-2', active: 1 })).toThrow(
+      /UNIQUE constraint/i
+    );
+
+    expect(() => insertRankerModel(db, { model_id: 'ranker-inactive', active: 0 })).not.toThrow();
+
+    db.close();
+  });
+
+  it('stores baseline metrics and quality gate status', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 30);
+
+    insertRankerModel(db, { model_id: 'ranker-metrics', quality_gate_status: 'not_run' });
+    const row = db
+      .prepare(
+        `SELECT baseline_metrics_json, quality_gate_status
+         FROM ranker_model_versions
+         WHERE model_id = ?`
+      )
+      .get('ranker-metrics') as {
+      baseline_metrics_json: string;
+      quality_gate_status: string;
+    };
+
+    expect(JSON.parse(row.baseline_metrics_json)).toEqual({ bm25: { ndcg: 0.4 } });
+    expect(row.quality_gate_status).toBe('not_run');
+
+    expect(() =>
+      insertRankerModel(db, {
+        model_id: 'ranker-invalid-gate',
+        quality_gate_status: 'unknown',
+      })
+    ).toThrow(/CHECK constraint/i);
+
+    db.close();
+  });
+
+});

--- a/packages/mama-core/tests/unit/channel-summary-state.test.ts
+++ b/packages/mama-core/tests/unit/channel-summary-state.test.ts
@@ -38,10 +38,10 @@ describe('channel summary state reducer', () => {
 
   it('should accumulate active decisions and milestones instead of overwriting the whole summary', async () => {
     await recordChannelAudit({
-      channelKey: 'telegram:7026976631',
+      channelKey: 'telegram:tg_test_001',
       turnId: 'turn_1',
       topic: 'database_choice',
-      scopeRefs: [{ kind: 'channel', id: 'telegram:7026976631' }],
+      scopeRefs: [{ kind: 'channel', id: 'telegram:tg_test_001' }],
       ack: {
         status: 'applied',
         action: 'save',
@@ -57,10 +57,10 @@ describe('channel summary state reducer', () => {
     });
 
     await recordChannelAudit({
-      channelKey: 'telegram:7026976631',
+      channelKey: 'telegram:tg_test_001',
       turnId: 'turn_2',
       topic: 'benchmark_direction',
-      scopeRefs: [{ kind: 'channel', id: 'telegram:7026976631' }],
+      scopeRefs: [{ kind: 'channel', id: 'telegram:tg_test_001' }],
       ack: {
         status: 'applied',
         action: 'save',
@@ -75,8 +75,8 @@ describe('channel summary state reducer', () => {
       ],
     });
 
-    const state = await getChannelSummaryState('telegram:7026976631');
-    const summary = await getChannelSummary('telegram:7026976631');
+    const state = await getChannelSummaryState('telegram:tg_test_001');
+    const summary = await getChannelSummary('telegram:tg_test_001');
 
     expect(state?.active_topic).toBe('memory_benchmark_research');
     expect(state?.active_decisions).toHaveLength(2);
@@ -91,10 +91,10 @@ describe('channel summary state reducer', () => {
 
   it('should keep failed and skipped audit outcomes in state without replacing active decisions', async () => {
     await recordChannelAudit({
-      channelKey: 'telegram:7026976631',
+      channelKey: 'telegram:tg_test_001',
       turnId: 'turn_3',
       topic: 'memory_audit',
-      scopeRefs: [{ kind: 'channel', id: 'telegram:7026976631' }],
+      scopeRefs: [{ kind: 'channel', id: 'telegram:tg_test_001' }],
       ack: {
         status: 'skipped',
         action: 'no_op',
@@ -104,10 +104,10 @@ describe('channel summary state reducer', () => {
     });
 
     await recordChannelAudit({
-      channelKey: 'telegram:7026976631',
+      channelKey: 'telegram:tg_test_001',
       turnId: 'turn_4',
       topic: 'memory_audit',
-      scopeRefs: [{ kind: 'channel', id: 'telegram:7026976631' }],
+      scopeRefs: [{ kind: 'channel', id: 'telegram:tg_test_001' }],
       ack: {
         status: 'failed',
         action: 'save',
@@ -116,8 +116,8 @@ describe('channel summary state reducer', () => {
       },
     });
 
-    const state = await getChannelSummaryState('telegram:7026976631');
-    const summary = await getChannelSummary('telegram:7026976631');
+    const state = await getChannelSummaryState('telegram:tg_test_001');
+    const summary = await getChannelSummary('telegram:tg_test_001');
 
     expect(state?.active_decisions.map((entry) => entry.topic)).toContain('데이터베이스 선택');
     expect(state?.recent_audit_outcomes[0]?.status).toBe('failed');

--- a/packages/mama-core/tests/unit/channel-summary-store.test.ts
+++ b/packages/mama-core/tests/unit/channel-summary-store.test.ts
@@ -34,12 +34,12 @@ describe('channel summary store', () => {
 
   it('should upsert and read a channel summary', async () => {
     await upsertChannelSummary({
-      channelKey: 'telegram:7026976631',
+      channelKey: 'telegram:tg_test_001',
       summaryMarkdown: '## Channel Summary\n- Current DB direction: PostgreSQL',
       deltaHash: 'db:postgres',
     });
 
-    const summary = await getChannelSummary('telegram:7026976631');
+    const summary = await getChannelSummary('telegram:tg_test_001');
     expect(summary?.summary_markdown).toContain('PostgreSQL');
     expect(summary?.delta_hash).toBe('db:postgres');
   });

--- a/packages/mama-core/tests/unit/memory-v2-api.test.ts
+++ b/packages/mama-core/tests/unit/memory-v2-api.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import fs from 'node:fs';
 import { saveMemory, recallMemory, buildProfile } from '../../src/memory/api.js';
 import { projectMemoryTruth } from '../../src/memory/truth-store.js';
+import {
+  appendEntityTimelineEvent,
+  createEntityNode,
+  upsertEntityObservation,
+} from '../../src/entities/store.js';
+import { appendEntityLineageLink } from '../../src/entities/lineage-store.js';
+import { getAdapter } from '../../src/db-manager.js';
 
 const TEST_DB = '/tmp/test-memory-v2-api.db';
 
@@ -59,6 +66,281 @@ describe('memory v2 api', () => {
     expect(profile).toHaveProperty('static');
     expect(profile).toHaveProperty('dynamic');
     expect(profile).toHaveProperty('evidence');
+  });
+
+  it('should preserve event datetime and order recall by event datetime before created_at', async () => {
+    await saveMemory({
+      topic: 'test_time_contract_older',
+      kind: 'decision',
+      summary: 'Older event happened first',
+      details: 'Older by event datetime',
+      confidence: 0.7,
+      scopes: [{ kind: 'project', id: 'repo:test' }],
+      source: { package: 'mama-core', source_type: 'test', project_id: 'repo:test' },
+      eventDate: '2026-04-14',
+      eventDateTime: Date.parse('2026-04-14T01:00:00.000Z'),
+    } as never);
+
+    await saveMemory({
+      topic: 'test_time_contract_newer',
+      kind: 'decision',
+      summary: 'Newer event happened later',
+      details: 'Newer by event datetime',
+      confidence: 0.7,
+      scopes: [{ kind: 'project', id: 'repo:test' }],
+      source: { package: 'mama-core', source_type: 'test', project_id: 'repo:test' },
+      eventDate: '2026-04-15',
+      eventDateTime: Date.parse('2026-04-15T03:30:00.000Z'),
+    } as never);
+
+    const recall = await recallMemory('event happened', {
+      scopes: [{ kind: 'project', id: 'repo:test' }],
+    });
+
+    const newer = recall.memories.find((item) => item.topic === 'test_time_contract_newer');
+    const older = recall.memories.find((item) => item.topic === 'test_time_contract_older');
+
+    expect(newer?.event_date).toBe('2026-04-15');
+    expect(newer?.event_datetime).toBe(Date.parse('2026-04-15T03:30:00.000Z'));
+    expect(older?.event_datetime).toBe(Date.parse('2026-04-14T01:00:00.000Z'));
+    expect(
+      recall.memories.findIndex((item) => item.topic === 'test_time_contract_newer')
+    ).toBeLessThan(recall.memories.findIndex((item) => item.topic === 'test_time_contract_older'));
+  });
+
+  it('should persist connector timeline events inside saveMemory', async () => {
+    await createEntityNode({
+      id: 'entity_project_timeline_contract',
+      kind: 'project',
+      preferred_label: 'Timeline Contract',
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: 'repo:test',
+      merged_into: null,
+    });
+
+    const saved = await saveMemory({
+      topic: 'timeline_contract/kickoff',
+      kind: 'decision',
+      summary: 'Kickoff moved forward',
+      details: 'Connector-originated timeline change',
+      confidence: 0.8,
+      scopes: [{ kind: 'project', id: 'repo:test' }],
+      source: { package: 'mama-core', source_type: 'test', project_id: 'repo:test' },
+      timelineEvent: {
+        entity_id: 'entity_project_timeline_contract',
+        event_type: 'project_update',
+        role: 'implementer',
+        observed_at: Date.parse('2026-04-15T10:00:00.000Z'),
+        source_ref: '/tmp/test/raw.db',
+        summary: 'Kickoff moved forward',
+        details: JSON.stringify({ topic: 'timeline_contract/kickoff' }),
+      },
+    });
+
+    const row = getAdapter()
+      .prepare(
+        `
+          SELECT entity_id, event_type, role, source_ref, summary
+          FROM entity_timeline_events
+          WHERE entity_id = ?
+          ORDER BY created_at DESC
+          LIMIT 1
+        `
+      )
+      .get('entity_project_timeline_contract') as
+      | {
+          entity_id: string;
+          event_type: string;
+          role: string | null;
+          source_ref: string | null;
+          summary: string;
+        }
+      | undefined;
+
+    expect(saved.success).toBe(true);
+    expect(row).toEqual({
+      entity_id: 'entity_project_timeline_contract',
+      event_type: 'project_update',
+      role: 'implementer',
+      source_ref: '/tmp/test/raw.db',
+      summary: 'Kickoff moved forward',
+    });
+  });
+
+  it('should derive the timeline target entity from observation lineage when entity_id is omitted', async () => {
+    await createEntityNode({
+      id: 'entity_project_timeline_derived',
+      kind: 'project',
+      preferred_label: 'Derived Timeline Project',
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: 'repo:test',
+      merged_into: null,
+    });
+    await createEntityNode({
+      id: 'entity_person_timeline_derived',
+      kind: 'person',
+      preferred_label: 'Timeline Owner',
+      status: 'active',
+      scope_kind: 'global',
+      scope_id: null,
+      merged_into: null,
+    });
+
+    await upsertEntityObservation({
+      id: 'obs_timeline_derived_channel',
+      observation_type: 'channel',
+      entity_kind_hint: 'project',
+      surface_form: 'Derived Timeline Project',
+      normalized_form: 'derived timeline project',
+      lang: 'en',
+      script: 'Latn',
+      context_summary: 'Project context',
+      related_surface_forms: ['Timeline Owner'],
+      timestamp_observed: Date.parse('2026-04-15T12:00:00.000Z'),
+      scope_kind: 'project',
+      scope_id: 'repo:test',
+      extractor_version: 'history-extractor@v1',
+      embedding_model_version: 'multilingual-e5-large',
+      source_connector: 'slack',
+      source_locator: '/tmp/test/raw.db',
+      source_raw_record_id: 'raw_timeline_derived_channel',
+    });
+    await upsertEntityObservation({
+      id: 'obs_timeline_derived_author',
+      observation_type: 'author',
+      entity_kind_hint: 'person',
+      surface_form: 'Timeline Owner',
+      normalized_form: 'timeline owner',
+      lang: 'en',
+      script: 'Latn',
+      context_summary: 'Author context',
+      related_surface_forms: ['Derived Timeline Project'],
+      timestamp_observed: Date.parse('2026-04-15T12:00:00.000Z'),
+      scope_kind: 'global',
+      scope_id: null,
+      extractor_version: 'history-extractor@v1',
+      embedding_model_version: 'multilingual-e5-large',
+      source_connector: 'slack',
+      source_locator: '/tmp/test/raw.db',
+      source_raw_record_id: 'raw_timeline_derived_author',
+    });
+    await appendEntityLineageLink({
+      canonical_entity_id: 'entity_project_timeline_derived',
+      entity_observation_id: 'obs_timeline_derived_channel',
+      source_entity_id: null,
+      contribution_kind: 'seed',
+      run_id: null,
+      candidate_id: null,
+      review_action_id: null,
+      capture_mode: 'direct',
+      confidence: 1,
+    });
+    await appendEntityLineageLink({
+      canonical_entity_id: 'entity_person_timeline_derived',
+      entity_observation_id: 'obs_timeline_derived_author',
+      source_entity_id: null,
+      contribution_kind: 'seed',
+      run_id: null,
+      candidate_id: null,
+      review_action_id: null,
+      capture_mode: 'direct',
+      confidence: 1,
+    });
+
+    await saveMemory({
+      topic: 'timeline_contract/derived',
+      kind: 'decision',
+      summary: 'Derived timeline target',
+      details: 'Save should pick the project canonical entity from provenance observations',
+      confidence: 0.8,
+      scopes: [{ kind: 'project', id: 'repo:test' }],
+      source: { package: 'mama-core', source_type: 'test', project_id: 'repo:test' },
+      entityObservationIds: ['obs_timeline_derived_author', 'obs_timeline_derived_channel'],
+      timelineEvent: {
+        event_type: 'project_update',
+        observed_at: Date.parse('2026-04-15T12:00:00.000Z'),
+        source_ref: '/tmp/test/raw.db',
+        summary: 'Derived timeline target',
+        details: JSON.stringify({ topic: 'timeline_contract/derived' }),
+      },
+    });
+
+    const row = getAdapter()
+      .prepare(
+        `
+          SELECT entity_id, event_type
+          FROM entity_timeline_events
+          WHERE summary = ?
+          ORDER BY created_at DESC
+          LIMIT 1
+        `
+      )
+      .get('Derived timeline target') as
+      | {
+          entity_id: string;
+          event_type: string;
+        }
+      | undefined;
+
+    expect(row).toEqual({
+      entity_id: 'entity_project_timeline_derived',
+      event_type: 'project_update',
+    });
+  });
+
+  it('should remove the decision row when transactional timeline persistence fails', async () => {
+    await createEntityNode({
+      id: 'entity_project_timeline_conflict',
+      kind: 'project',
+      preferred_label: 'Timeline Conflict',
+      status: 'active',
+      scope_kind: 'project',
+      scope_id: 'repo:test',
+      merged_into: null,
+    });
+
+    await appendEntityTimelineEvent({
+      event: {
+        id: 'et_duplicate_contract',
+        entity_id: 'entity_project_timeline_conflict',
+        event_type: 'project_update',
+        valid_from: null,
+        valid_to: null,
+        observed_at: Date.parse('2026-04-15T11:00:00.000Z'),
+        source_ref: '/tmp/test/raw.db',
+        summary: 'Existing event',
+        details: JSON.stringify({ existing: true }),
+      },
+    });
+
+    await expect(
+      saveMemory({
+        topic: 'timeline_contract/rollback',
+        kind: 'decision',
+        summary: 'This save should roll back',
+        details: 'Duplicate timeline event id should fail',
+        confidence: 0.6,
+        scopes: [{ kind: 'project', id: 'repo:test' }],
+        source: { package: 'mama-core', source_type: 'test', project_id: 'repo:test' },
+        timelineEvent: {
+          id: 'et_duplicate_contract',
+          entity_id: 'entity_project_timeline_conflict',
+          event_type: 'project_update',
+          observed_at: Date.parse('2026-04-15T11:05:00.000Z'),
+          source_ref: '/tmp/test/raw.db',
+          summary: 'Conflicting event',
+          details: JSON.stringify({ duplicate: true }),
+        },
+      })
+    ).rejects.toThrow();
+
+    const decisionRow = getAdapter()
+      .prepare(`SELECT id FROM decisions WHERE topic = ?`)
+      .get('timeline_contract/rollback') as { id: string } | undefined;
+
+    expect(decisionRow).toBeUndefined();
   });
 
   it('should return truth-gated recall by default', async () => {

--- a/packages/mama-core/tests/unit/memory-v2-api.test.ts
+++ b/packages/mama-core/tests/unit/memory-v2-api.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import fs from 'node:fs';
-import { saveMemory, recallMemory, buildProfile } from '../../src/memory/api.js';
+import { saveMemory, recallMemory, buildProfile, ingestMemory } from '../../src/memory/api.js';
 import { projectMemoryTruth } from '../../src/memory/truth-store.js';
 import {
   appendEntityTimelineEvent,
@@ -106,6 +106,25 @@ describe('memory v2 api', () => {
     expect(
       recall.memories.findIndex((item) => item.topic === 'test_time_contract_newer')
     ).toBeLessThan(recall.memories.findIndex((item) => item.topic === 'test_time_contract_older'));
+  });
+
+  it('should forward eventDateTime through ingestMemory', async () => {
+    const saved = await ingestMemory({
+      content: 'Ingested memory with event datetime',
+      scopes: [{ kind: 'project', id: 'repo:test' }],
+      source: { package: 'mama-core', source_type: 'test', project_id: 'repo:test' },
+      eventDate: '2026-04-16',
+      eventDateTime: Date.parse('2026-04-16T08:45:00.000Z'),
+    });
+
+    const row = getAdapter()
+      .prepare('SELECT event_date, event_datetime FROM decisions WHERE id = ?')
+      .get(saved.id) as { event_date: string | null; event_datetime: number | null } | undefined;
+
+    expect(row).toEqual({
+      event_date: '2026-04-16',
+      event_datetime: Date.parse('2026-04-16T08:45:00.000Z'),
+    });
   });
 
   it('should persist connector timeline events inside saveMemory', async () => {

--- a/packages/mama-core/tests/unit/memory-v2-bootstrap-builder.test.ts
+++ b/packages/mama-core/tests/unit/memory-v2-bootstrap-builder.test.ts
@@ -82,14 +82,14 @@ describe('memory agent bootstrap builder', () => {
 
   it('should include channel summary when channel scope is provided', async () => {
     await upsertChannelSummary({
-      channelKey: 'telegram:7026976631',
+      channelKey: 'telegram:tg_test_001',
       summaryMarkdown: '## Channel Summary\n- Current DB direction: PostgreSQL',
       deltaHash: 'db:postgres',
     });
 
     const packet = await buildMemoryAgentBootstrap({
-      scopes: [{ kind: 'channel', id: 'telegram:7026976631' }],
-      channelKey: 'telegram:7026976631',
+      scopes: [{ kind: 'channel', id: 'telegram:tg_test_001' }],
+      channelKey: 'telegram:tg_test_001',
     });
 
     expect(packet.channel_summary_markdown).toContain('PostgreSQL');

--- a/packages/mama-core/tests/unit/memory-v2-event-store.test.ts
+++ b/packages/mama-core/tests/unit/memory-v2-event-store.test.ts
@@ -44,4 +44,31 @@ describe('memory event store', () => {
     const events = await listMemoryEventsForTopic('memory_truth_contract');
     expect(events[0]?.event_type).toBe('save');
   });
+
+  it('accepts Phase 2 correction and case lifecycle memory event types', async () => {
+    for (const eventType of [
+      'case.correction_applied',
+      'case.correction_reverted',
+      'case.membership_tombstoned',
+      'case.merged',
+      'case.split',
+    ] as const) {
+      await appendMemoryEvent({
+        event_type: eventType,
+        actor: 'user',
+        topic: 'case:correction-events',
+        scope_refs: [{ kind: 'project', id: '/repo' }],
+        created_at: Date.now(),
+      });
+    }
+
+    const events = await listMemoryEventsForTopic('case:correction-events');
+    expect(events.map((event) => event.event_type).sort()).toEqual([
+      'case.correction_applied',
+      'case.correction_reverted',
+      'case.membership_tombstoned',
+      'case.merged',
+      'case.split',
+    ]);
+  });
 });

--- a/packages/mama-core/tests/unit/memory-v2-legacy-shims.test.ts
+++ b/packages/mama-core/tests/unit/memory-v2-legacy-shims.test.ts
@@ -149,7 +149,7 @@ describe('legacy shims', () => {
     const mama = (await import('../../src/mama-api.js')).default;
     const result = await mama.suggest('legacy fact', { limit: 5 });
 
-    expect(result.results[0]?.source_type).toBe('entity_canonical');
+    expect(result.results[0]?.source_type).toBe('fact');
   });
 
   it('should not raise a save warning from retrieval-rank normalization alone', async () => {

--- a/packages/mama-core/tests/unit/memory-v2-legacy-shims.test.ts
+++ b/packages/mama-core/tests/unit/memory-v2-legacy-shims.test.ts
@@ -124,6 +124,34 @@ describe('legacy shims', () => {
     expect(result.results[0]?.event_date).toBe('2026-04-15');
   });
 
+  it('should preserve memory source_type when mapping recallMemory fallback rows', async () => {
+    recallMemoryMock.mockResolvedValueOnce({
+      profile: { static: [], dynamic: [], evidence: [] },
+      memories: [
+        {
+          id: 'shim_memory_fact',
+          topic: 'legacy_fact_contract',
+          summary: 'Keep source type intact',
+          details: 'Fact memory',
+          confidence: 0.7,
+          status: 'active',
+          kind: 'fact',
+          scopes: [],
+          source: { package: 'mama-core', source_type: 'entity_canonical' },
+          created_at: Date.now(),
+          updated_at: Date.now(),
+        },
+      ],
+      graph_context: { primary: [], expanded: [], edges: [] },
+      search_meta: { query: 'legacy fact', scope_order: ['project'], retrieval_sources: ['sql_like'] },
+    });
+
+    const mama = (await import('../../src/mama-api.js')).default;
+    const result = await mama.suggest('legacy fact', { limit: 5 });
+
+    expect(result.results[0]?.source_type).toBe('entity_canonical');
+  });
+
   it('should not raise a save warning from retrieval-rank normalization alone', async () => {
     recallMemoryMock.mockResolvedValueOnce({
       profile: { static: [], dynamic: [], evidence: [] },
@@ -137,7 +165,7 @@ describe('legacy shims', () => {
           status: 'active',
           kind: 'decision',
           scopes: [],
-          source: { package: 'mama-core', source_type: 'test' },
+          source: { package: 'mama-core', source_type: 'decision' },
           created_at: Date.now(),
           updated_at: Date.now(),
           event_date: '2026-04-14',
@@ -212,6 +240,8 @@ describe('legacy shims', () => {
 
     const { initDB, getAdapter } = await import('../../src/db-manager.js');
     await initDB();
+    getAdapter().prepare('DELETE FROM case_truth WHERE case_id = ?').run('case-base-top');
+    getAdapter().prepare("DELETE FROM ranker_model_versions WHERE model_id = 'ranker-active'").run();
     getAdapter()
       .prepare(
         `
@@ -264,5 +294,107 @@ describe('legacy shims', () => {
     expect(result.results).toHaveLength(1);
     expect(result.results[0]?.id).toBe('promoted-second');
     expect(result.meta?.ranker?.applied).toBe(true);
+  });
+
+  it('should bound graph_expansion metadata to the returned results after reranking', async () => {
+    recallMemoryMock.mockResolvedValueOnce({
+      profile: { static: [], dynamic: [], evidence: [] },
+      memories: [],
+      fused_hits: [
+        {
+          source_type: 'wiki_page',
+          source_id: 'cases/base-top.md',
+          fused_rank_score: 0.55,
+          page_type: 'case',
+          case_id: 'case-base-top',
+          record: {
+            title: 'Base Top Case',
+            content: 'This is first before rerank',
+            confidence: 'high',
+            created_at: Date.now(),
+          },
+        },
+        {
+          source_type: 'decision',
+          source_id: 'promoted-second',
+          fused_rank_score: 0.5,
+          record: {
+            topic: 'promoted_second',
+            summary: 'Promoted second result',
+            details: 'This should win after rerank',
+            confidence: 0.5,
+            created_at: Date.now(),
+          },
+        },
+      ],
+      graph_context: {
+        primary: new Array(8).fill({ id: 'p' }),
+        expanded: new Array(5).fill({ id: 'e' }),
+        edges: [],
+      },
+      search_meta: {
+        query: 'rerank me',
+        scope_order: ['project'],
+        retrieval_sources: ['sql_like'],
+      },
+    });
+
+    const { initDB, getAdapter } = await import('../../src/db-manager.js');
+    await initDB();
+    getAdapter().prepare('DELETE FROM case_truth WHERE case_id = ?').run('case-base-top');
+    getAdapter().prepare("DELETE FROM ranker_model_versions WHERE model_id = 'ranker-active'").run();
+    getAdapter()
+      .prepare(
+        `
+          INSERT INTO case_truth (
+            case_id, title, status, created_at, updated_at
+          ) VALUES (?, ?, 'active', ?, ?)
+        `
+      )
+      .run(
+        'case-base-top',
+        'Base Top Case',
+        '2026-04-18T00:00:00.000Z',
+        '2026-04-18T00:00:00.000Z'
+      );
+    getAdapter()
+      .prepare(
+        `
+          INSERT INTO ranker_model_versions (
+            model_id, model_version, feature_set_version, coefficients_json, metrics_json,
+            training_window_json, baseline_metrics_json, quality_gate_status, trained_at,
+            trained_by, active
+          )
+          VALUES (
+            'ranker-active', 'v1', ?, ?, '{}', '{}', '{}', 'passed',
+            '2026-04-18T00:00:00.000Z', 'test', 1
+          )
+        `
+      )
+      .run(
+        SEARCH_RANKER_FEATURE_SET_VERSION,
+        JSON.stringify({
+          coefficients: [0, 0, 0, 0, 0, 4, -4, -4, -4, -4, 0, 0, 0, 0, 0, 0, 0],
+          intercept: 0,
+          question_type_weights: {
+            correction: [0, 0, 0, 0, 0, 4, -4, -4, -4, -4, 0, 0, 0, 0, 0, 0, 0],
+            artifact: [0, 0, 0, 0, 0, -4, -4, -4, 4, -4, 0, 0, 0, 0, 0, 0, 0],
+            timeline: [0, 0, 0, 0, 0, -4, -4, -4, -4, 4, 0, 0, 0, 0, 0, 0, 0],
+            status: [0, 0, 0, 0, 0, -4, -4, 4, -4, -4, 0, 0, 0, 0, 0, 0, 0],
+            decision_reason: [0, 0, 0, 0, 0, 4, -4, -4, -4, -4, 0, 0, 0, 0, 0, 0, 0],
+            how_to: [0, 0, 0, 0, 0, 4, -4, -4, -4, -4, 0, 0, 0, 0, 0, 0, 0],
+            unknown: [0, 0, 0, 0, 0, 4, -4, -4, -4, -4, 0, 0, 0, 0, 0, 0, 0],
+          },
+          training_rows_count: 10,
+        })
+      );
+
+    const mama = (await import('../../src/mama-api.js')).default;
+    const result = await mama.suggest('rerank me', { limit: 1, rerankWithLearned: true });
+
+    expect(result.meta?.graph_expansion?.total_results).toBe(1);
+    expect(result.meta?.graph_expansion?.primary_count).toBe(1);
+    expect(result.meta?.graph_expansion?.expanded_count).toBe(0);
+    expect(result.meta?.graph_expansion?.sources?.primary).toBe(1);
   });
 });

--- a/packages/mama-core/tests/unit/memory-v2-legacy-shims.test.ts
+++ b/packages/mama-core/tests/unit/memory-v2-legacy-shims.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, vi, beforeEach } from 'vitest';
 import fs from 'node:fs';
+import { SEARCH_RANKER_FEATURE_SET_VERSION } from '../../src/search/ranker-features.js';
 
 const TEST_DB = '/tmp/test-memory-v2-legacy-shims.db';
 
@@ -52,6 +53,7 @@ describe('legacy shims', () => {
   });
 
   beforeEach(() => {
+    vi.resetModules();
     saveMemoryMock.mockClear();
     recallMemoryMock.mockClear();
   });
@@ -167,5 +169,100 @@ describe('legacy shims', () => {
       ])
     );
     expect(result.warning).toBeUndefined();
+  });
+
+  it('should rerank a larger memory candidate pool before truncating to the requested limit', async () => {
+    recallMemoryMock.mockResolvedValueOnce({
+      profile: { static: [], dynamic: [], evidence: [] },
+      memories: [],
+      fused_hits: [
+        {
+          source_type: 'wiki_page',
+          source_id: 'cases/base-top.md',
+          fused_rank_score: 0.55,
+          page_type: 'case',
+          case_id: 'case-base-top',
+          record: {
+            title: 'Base Top Case',
+            content: 'This is first before rerank',
+            confidence: 'high',
+            created_at: Date.now(),
+          },
+        },
+        {
+          source_type: 'decision',
+          source_id: 'promoted-second',
+          fused_rank_score: 0.5,
+          record: {
+            topic: 'promoted_second',
+            summary: 'Promoted second result',
+            details: 'This should win after rerank',
+            confidence: 0.5,
+            created_at: Date.now(),
+          },
+        },
+      ],
+      graph_context: { primary: [], expanded: [], edges: [] },
+      search_meta: {
+        query: 'rerank me',
+        scope_order: ['project'],
+        retrieval_sources: ['sql_like'],
+      },
+    });
+
+    const { initDB, getAdapter } = await import('../../src/db-manager.js');
+    await initDB();
+    getAdapter()
+      .prepare(
+        `
+          INSERT INTO case_truth (
+            case_id, title, status, created_at, updated_at
+          ) VALUES (?, ?, 'active', ?, ?)
+        `
+      )
+      .run(
+        'case-base-top',
+        'Base Top Case',
+        '2026-04-18T00:00:00.000Z',
+        '2026-04-18T00:00:00.000Z'
+      );
+    getAdapter()
+      .prepare(
+        `
+          INSERT INTO ranker_model_versions (
+            model_id, model_version, feature_set_version, coefficients_json, metrics_json,
+            training_window_json, baseline_metrics_json, quality_gate_status, trained_at,
+            trained_by, active
+          )
+          VALUES (
+            'ranker-active', 'v1', ?, ?, '{}', '{}', '{}', 'passed',
+            '2026-04-18T00:00:00.000Z', 'test', 1
+          )
+        `
+      )
+      .run(
+        SEARCH_RANKER_FEATURE_SET_VERSION,
+        JSON.stringify({
+          coefficients: [0, 0, 0, 0, 0, 4, -4, -4, -4, -4, 0, 0, 0, 0, 0, 0, 0],
+          intercept: 0,
+          question_type_weights: {
+            correction: [0, 0, 0, 0, 0, 4, -4, -4, -4, -4, 0, 0, 0, 0, 0, 0, 0],
+            artifact: [0, 0, 0, 0, 0, -4, -4, -4, 4, -4, 0, 0, 0, 0, 0, 0, 0],
+            timeline: [0, 0, 0, 0, 0, -4, -4, -4, -4, 4, 0, 0, 0, 0, 0, 0, 0],
+            status: [0, 0, 0, 0, 0, -4, -4, 4, -4, -4, 0, 0, 0, 0, 0, 0, 0],
+            decision_reason: [0, 0, 0, 0, 0, 4, -4, -4, -4, -4, 0, 0, 0, 0, 0, 0, 0],
+            how_to: [0, 0, 0, 0, 0, 4, -4, -4, -4, -4, 0, 0, 0, 0, 0, 0, 0],
+            unknown: [0, 0, 0, 0, 0, 4, -4, -4, -4, -4, 0, 0, 0, 0, 0, 0, 0],
+          },
+          training_rows_count: 10,
+        })
+      );
+
+    const mama = (await import('../../src/mama-api.js')).default;
+    const result = await mama.suggest('rerank me', { limit: 1, rerankWithLearned: true });
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]?.id).toBe('promoted-second');
+    expect(result.meta?.ranker?.applied).toBe(true);
   });
 });

--- a/packages/mama-core/tests/unit/memory-v2-legacy-shims.test.ts
+++ b/packages/mama-core/tests/unit/memory-v2-legacy-shims.test.ts
@@ -89,4 +89,83 @@ describe('legacy shims', () => {
     expect(recallMemoryMock).toHaveBeenCalled();
     expect(result).toBeTruthy();
   });
+
+  it('should expose suggest results without inflating similarity from rank order fallback', async () => {
+    recallMemoryMock.mockResolvedValueOnce({
+      profile: { static: [], dynamic: [], evidence: [] },
+      memories: [
+        {
+          id: 'shim_memory_ranked',
+          topic: 'legacy_save_contract',
+          summary: 'Keep legacy save alive',
+          details: 'Migration shim',
+          confidence: 1,
+          status: 'active',
+          kind: 'decision',
+          scopes: [],
+          source: { package: 'mama-core', source_type: 'test' },
+          created_at: Date.now(),
+          updated_at: Date.now(),
+          event_date: '2026-04-15',
+        },
+      ],
+      graph_context: { primary: [], expanded: [], edges: [] },
+      search_meta: { query: 'legacy save', scope_order: ['project'], retrieval_sources: ['sql_like'] },
+    });
+
+    const mama = (await import('../../src/mama-api.js')).default;
+    const result = await mama.suggest('legacy save', { limit: 5 });
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]?.similarity).toBeNull();
+    expect(result.results[0]?.retrieval_score).toBe(1);
+    expect(result.results[0]?.event_date).toBe('2026-04-15');
+  });
+
+  it('should not raise a save warning from retrieval-rank normalization alone', async () => {
+    recallMemoryMock.mockResolvedValueOnce({
+      profile: { static: [], dynamic: [], evidence: [] },
+      memories: [
+        {
+          id: 'shim_memory_warning',
+          topic: 'legacy_save_warning_contract',
+          summary: 'Potential duplicate by rank',
+          details: 'Ranked first by recallMemory',
+          confidence: 1,
+          status: 'active',
+          kind: 'decision',
+          scopes: [],
+          source: { package: 'mama-core', source_type: 'test' },
+          created_at: Date.now(),
+          updated_at: Date.now(),
+          event_date: '2026-04-14',
+        },
+      ],
+      graph_context: { primary: [], expanded: [], edges: [] },
+      search_meta: {
+        query: 'legacy_save_warning_contract',
+        scope_order: ['project'],
+        retrieval_sources: ['sql_like'],
+      },
+    });
+
+    const mama = (await import('../../src/mama-api.js')).default;
+    const result = await mama.save({
+      topic: 'legacy_save_warning_contract',
+      decision: 'Keep rank and similarity separate',
+      reasoning: 'Regression guard for save warning',
+    });
+
+    expect(result.similar_decisions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'shim_memory_warning',
+          similarity: null,
+          retrieval_score: 1,
+          event_date: '2026-04-14',
+        }),
+      ])
+    );
+    expect(result.warning).toBeUndefined();
+  });
 });

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [1.13.0] - 2026-04-20
+
+### Added
+
+- **Case timeline MCP tool** — added `case_timeline_range` for bounded case-first timeline reads through the MCP server surface
+- **Contracts lookup MCP tool** — added `search_decisions_and_contracts` for decision + contract search used by hook and tooling flows
+
+### Changed
+
+- **Tool surface docs alignment** — package README now reflects the shipped 13-tool MCP surface and the current public package version
+
 ## [1.6.5] - 2026-02-01
 
 ### Changed

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -75,23 +75,25 @@ Any MCP-compatible client can use MAMA with:
 npx -y @jungjaehoon/mama-server
 ```
 
-## Available Tools (v1.9)
+## Available Tools (v1.13)
 
-The MCP server exposes 11 tools:
+The MCP server exposes 13 tools:
 
-| Tool                      | Description                                                             |
-| ------------------------- | ----------------------------------------------------------------------- |
-| `save_decision`           | Save decision with optional scopes and event_date for temporal tracking |
-| `recall_decision`         | Recall decision history by topic, scope-filtered via recallMemory v2    |
-| `suggest_decision`        | Semantic search for relevant past decisions, scope-aware                |
-| `list_decisions`          | List recent decisions, scope-filterable                                 |
-| `update_outcome`          | Update decision outcome (case-insensitive: success/failed/partial)      |
-| `search_narrative`        | Narrative search with link expansion (depth 0-2)                        |
-| `ingest_conversation`     | Ingest conversation messages into memory with optional LLM extraction   |
-| `save_checkpoint`         | Save session checkpoint for later resumption                            |
-| `load_checkpoint`         | Resume previous session                                                 |
-| `generate_quality_report` | Quality metrics and observability report                                |
-| `get_restart_metrics`     | Restart success rate and latency monitoring                             |
+| Tool                             | Description                                                             |
+| -------------------------------- | ----------------------------------------------------------------------- |
+| `save_decision`                  | Save decision with optional scopes and event_date for temporal tracking |
+| `recall_decision`                | Recall decision history by topic, scope-filtered via recallMemory v2    |
+| `suggest_decision`               | Semantic search for relevant past decisions, scope-aware                |
+| `list_decisions`                 | List recent decisions, scope-filterable                                 |
+| `update_outcome`                 | Update decision outcome (case-insensitive: success/failed/partial)      |
+| `search_narrative`               | Narrative search with link expansion (depth 0-2)                        |
+| `ingest_conversation`            | Ingest conversation messages into memory with optional LLM extraction   |
+| `save_checkpoint`                | Save session checkpoint for later resumption                            |
+| `load_checkpoint`                | Resume previous session                                                 |
+| `generate_quality_report`        | Quality metrics and observability report                                |
+| `get_restart_metrics`            | Restart success rate and latency monitoring                             |
+| `search_decisions_and_contracts` | Decision + contract lookup for tooling and hook pipelines               |
+| `case_timeline_range`            | Read bounded case timeline windows for case-first workflows             |
 
 ### Edge Types
 
@@ -261,4 +263,4 @@ MAMA was inspired by [mem0](https://github.com/mem0ai/mem0) (Apache 2.0). While 
 ---
 
 **Author:** SpineLift Team
-**Version:** 1.9.0
+**Version:** 1.13.0

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -43,6 +43,7 @@
     "@modelcontextprotocol/sdk": "^1.0.1"
   },
   "devDependencies": {
+    "better-sqlite3": "^12.8.0",
     "vitest": "^1.0.0"
   },
   "files": [

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-server",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "description": "MAMA MCP Server - Memory-Augmented MCP Assistant for Claude Code & Desktop",
   "main": "src/server.js",
   "bin": {

--- a/packages/mcp-server/src/server.js
+++ b/packages/mcp-server/src/server.js
@@ -372,6 +372,12 @@ After failure → save a NEW decision with same topic to create evolution histor
         description: memoryTools.search_decisions_and_contracts.description,
         inputSchema: memoryTools.search_decisions_and_contracts.inputSchema,
       },
+      // 5. CASE_TIMELINE_RANGE — Phase 3 case timeline RPC (defined in src/tools/)
+      {
+        name: memoryTools.case_timeline_range.name,
+        description: memoryTools.case_timeline_range.description,
+        inputSchema: memoryTools.case_timeline_range.inputSchema,
+      },
     ];
 
     this.server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));

--- a/packages/mcp-server/src/tools/case-timeline-range.js
+++ b/packages/mcp-server/src/tools/case-timeline-range.js
@@ -1,0 +1,77 @@
+/**
+ * MCP Tool: case_timeline_range
+ *
+ * Thin MCP wrapper around mama-core caseTimelineRange().
+ */
+
+const { caseTimelineRange } = require('@jungjaehoon/mama-core');
+const { initDB, getAdapter } = require('@jungjaehoon/mama-core/db-manager');
+
+let adapterOverrideForTest = null;
+
+const caseTimelineRangeTool = {
+  name: 'case_timeline_range',
+  description:
+    'Return a bounded, chronological timeline for a case. Includes decision, event, observation, and artifact memberships resolved through canonical case chains.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      case_id: {
+        type: 'string',
+        description: 'Case UUID to read. Merged cases resolve through their canonical case chain.',
+      },
+      from: {
+        oneOf: [{ type: 'string' }, { type: 'number' }],
+        description: 'Optional inclusive lower date bound. ISO 8601 string or epoch milliseconds.',
+      },
+      to: {
+        oneOf: [{ type: 'string' }, { type: 'number' }],
+        description: 'Optional inclusive upper date bound. ISO 8601 string or epoch milliseconds.',
+      },
+      order: {
+        type: 'string',
+        enum: ['asc', 'desc'],
+        description: "Timeline order. Default: 'asc'.",
+      },
+      limit: {
+        type: 'number',
+        minimum: 0,
+        maximum: 500,
+        description: 'Maximum items to return. Default: 100. Maximum: 500.',
+      },
+      include_connector_enrichments: {
+        type: 'boolean',
+        description: 'Include connector event snapshots for observations/artifacts when available.',
+      },
+    },
+    required: ['case_id'],
+  },
+
+  async handler(args) {
+    const adapter = await getCaseTimelineRangeAdapter();
+    return caseTimelineRange(adapter, args || {});
+  },
+};
+
+async function getCaseTimelineRangeAdapter() {
+  if (adapterOverrideForTest) {
+    return adapterOverrideForTest;
+  }
+
+  await initDB();
+  return getAdapter();
+}
+
+function setCaseTimelineRangeAdapterForTest(adapter) {
+  adapterOverrideForTest = adapter;
+}
+
+function resetCaseTimelineRangeAdapterForTest() {
+  adapterOverrideForTest = null;
+}
+
+module.exports = {
+  caseTimelineRangeTool,
+  setCaseTimelineRangeAdapterForTest,
+  resetCaseTimelineRangeAdapterForTest,
+};

--- a/packages/mcp-server/src/tools/index.js
+++ b/packages/mcp-server/src/tools/index.js
@@ -16,6 +16,7 @@
  * - generate_quality_report: Generate coverage and quality metrics report ✅
  * - get_restart_metrics: Get restart success rate and latency metrics ✅
  * - ingest_conversation: Ingest conversation messages into memory ✅
+ * - case_timeline_range: Read bounded case timeline ranges ✅
  *
  * @module tools
  */
@@ -30,6 +31,7 @@ const { searchNarrativeTool } = require('./search-narrative.js');
 const { generateQualityReportTool, getRestartMetricsTool } = require('./quality-metrics-tools.js');
 const { ingestConversationTool } = require('./ingest-conversation.js');
 const { searchDecisionsAndContractsTool } = require('./search-decisions-and-contracts.js');
+const { caseTimelineRangeTool } = require('./case-timeline-range.js');
 
 /**
  * Create all MAMA memory tools
@@ -52,6 +54,7 @@ function createMemoryTools() {
     get_restart_metrics: getRestartMetricsTool,
     ingest_conversation: ingestConversationTool,
     search_decisions_and_contracts: searchDecisionsAndContractsTool,
+    case_timeline_range: caseTimelineRangeTool,
   };
 }
 
@@ -70,4 +73,5 @@ module.exports = {
   getRestartMetricsTool,
   ingestConversationTool,
   searchDecisionsAndContractsTool,
+  caseTimelineRangeTool,
 };

--- a/packages/mcp-server/tests/tools/case-timeline-range.test.js
+++ b/packages/mcp-server/tests/tools/case-timeline-range.test.js
@@ -1,0 +1,137 @@
+/**
+ * Tests for case_timeline_range MCP tool
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  caseTimelineRangeTool,
+  resetCaseTimelineRangeAdapterForTest,
+  setCaseTimelineRangeAdapterForTest,
+} from '../../src/tools/case-timeline-range.js';
+import { createMemoryTools } from '../../src/tools/index.js';
+
+const CASE_ID = '11111111-1111-4111-8111-111111111111';
+
+function applyMigrations(db) {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const migrationsDir = resolve(testDir, '../../../mama-core/db/migrations');
+
+  for (const file of readdirSync(migrationsDir)
+    .filter((entry) => entry.endsWith('.sql'))
+    .sort()) {
+    db.exec(readFileSync(join(migrationsDir, file), 'utf8'));
+  }
+}
+
+function createAdapter(db) {
+  return {
+    prepare(sql) {
+      return db.prepare(sql);
+    },
+    transaction(fn) {
+      return db.transaction(fn)();
+    },
+  };
+}
+
+function seedTimelineCase(db) {
+  const now = '2026-04-18T00:00:00.000Z';
+  db.prepare(
+    `
+      INSERT INTO case_truth (
+        case_id, current_wiki_path, title, status, created_at, updated_at
+      )
+      VALUES (?, ?, ?, 'active', ?, ?)
+    `
+  ).run(CASE_ID, 'cases/timeline-case.md', 'Timeline Case', now, now);
+
+  db.prepare(
+    `
+      INSERT INTO decisions (
+        id, topic, decision, reasoning, confidence, created_at, updated_at,
+        event_date, event_datetime
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `
+  ).run(
+    'dec-timeline-range',
+    'timeline/range',
+    'Use bounded case timelines',
+    'The UI needs a focused case history window.',
+    0.9,
+    Date.parse('2026-04-10T12:00:00.000Z'),
+    Date.parse('2026-04-10T12:00:00.000Z'),
+    '2026-04-10',
+    Date.parse('2026-04-10T12:00:00.000Z')
+  );
+
+  db.prepare(
+    `
+      INSERT INTO case_memberships (
+        case_id, source_type, source_id, role, confidence, reason, status,
+        added_by, added_at, updated_at, user_locked
+      )
+      VALUES (?, 'decision', ?, 'primary', 0.91, 'seeded test membership',
+              'active', 'wiki-compiler', ?, ?, 0)
+    `
+  ).run(CASE_ID, 'dec-timeline-range', now, now);
+}
+
+describe('case_timeline_range MCP tool', () => {
+  let db;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrations(db);
+    seedTimelineCase(db);
+    setCaseTimelineRangeAdapterForTest(createAdapter(db));
+  });
+
+  afterEach(() => {
+    resetCaseTimelineRangeAdapterForTest();
+    db.close();
+  });
+
+  it('is registered in createMemoryTools', () => {
+    const tools = createMemoryTools();
+
+    expect(tools.case_timeline_range).toBeDefined();
+    expect(tools.case_timeline_range.name).toBe('case_timeline_range');
+    expect(tools.case_timeline_range.name).toBe(caseTimelineRangeTool.name);
+  });
+
+  it('returns a plain case timeline range object', async () => {
+    const result = await caseTimelineRangeTool.handler({
+      case_id: CASE_ID,
+      from: '2026-04-01T00:00:00.000Z',
+      to: '2026-04-30T23:59:59.999Z',
+      order: 'asc',
+      limit: 10,
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        terminal_case_id: CASE_ID,
+        resolved_via_case_id: null,
+        chain: [CASE_ID],
+      })
+    );
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toEqual(
+      expect.objectContaining({
+        item_type: 'decision',
+        source_type: 'decision',
+        source_id: 'dec-timeline-range',
+        title: 'timeline/range',
+        role: 'primary',
+        membership_reason: 'seeded test membership',
+      })
+    );
+  });
+});

--- a/packages/mcp-server/tests/tools/list-recall-tools.test.js
+++ b/packages/mcp-server/tests/tools/list-recall-tools.test.js
@@ -17,6 +17,7 @@ import { initDB, getAdapter, closeDB } from '@jungjaehoon/mama-core/db-manager';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
+import crypto from 'crypto';
 
 // Test database path (isolated from production)
 const TEST_DB_PATH = path.join(os.tmpdir(), `mama-test-list-recall-${Date.now()}.db`);
@@ -29,6 +30,18 @@ const mockContext = {
     error: () => {},
   },
 };
+
+function insertSeedDecision(adapter, { id, topic, decision, reasoning, createdAt }) {
+  adapter
+    .prepare(
+      `
+        INSERT INTO decisions (
+          id, topic, decision, reasoning, confidence, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(id, topic, decision, reasoning, 0.5, createdAt, createdAt);
+}
 
 describe('Story M4.1: list_decisions and recall_decision Tools (ported from mcp-server)', () => {
   beforeAll(async () => {
@@ -322,17 +335,19 @@ describe('Story M4.1: list_decisions and recall_decision Tools (ported from mcp-
 
   describe('AC #6: Query performance < 100ms (p95)', () => {
     it('should complete list_decisions in < 100ms (p95)', async () => {
-      // Create 100 decisions for realistic test
+      // Seed directly so the measurement reflects list_decisions latency,
+      // not save-time auto-search/embedding work.
+      const adapter = getAdapter();
+      const now = Date.now();
+
       for (let i = 0; i < 100; i++) {
-        await saveDecisionTool.handler(
-          {
-            topic: `perf_topic_${i}`,
-            decision: `Performance test decision ${i}`,
-            reasoning: `Testing latency with decision ${i}`,
-            confidence: 0.5,
-          },
-          mockContext
-        );
+        insertSeedDecision(adapter, {
+          id: `decision_perf_topic_${i}_${crypto.randomUUID().slice(0, 8)}`,
+          topic: `perf_topic_${i}`,
+          decision: `Performance test decision ${i}`,
+          reasoning: `Testing latency with decision ${i}`,
+          createdAt: now + i,
+        });
       }
 
       // Measure latency across 20 calls (p95 = 19th result)

--- a/packages/standalone/CHANGELOG.md
+++ b/packages/standalone/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-04-20
+
+### Fixed
+
+- **Claude Code auth detection** — install, init, setup, run, and status flows now prefer `claude auth status` when detecting whether Claude Code is logged in, avoiding false "auth missing" warnings on newer CLI installs that do not persist `~/.claude/.credentials.json`
+- **Legacy auth fallback preserved** — older environments that still rely on `~/.claude/.credentials.json` continue to work as a fallback instead of breaking setup or status checks
+
+### Changed
+
+- **Postinstall guidance** — postinstall now distinguishes between "Claude CLI missing" and "Claude CLI installed but logged out", and shows `claude auth login` when re-authentication is the real fix
+- **Operator docs alignment** — standalone setup/troubleshooting/commands docs now describe the shipped Claude Code login flow and generated artifact expectations
+
 ## [0.10.2] - 2026-02-22
 
 ### Added

--- a/packages/standalone/README.md
+++ b/packages/standalone/README.md
@@ -6,7 +6,7 @@
 
 Your knowledge is everywhere — Slack threads, email chains, code reviews, meeting notes, spreadsheets, Telegram messages. No human can track all of it. Important decisions get buried. Context gets lost between tools. When you need to make a decision, the information that would help is scattered across ten different apps and three months of history.
 
-This isn't a memory problem. It's an intelligence problem. You don't just need to *store* information — you need something that reads everything, connects the dots, identifies what matters, and tells you what you're missing.
+This isn't a memory problem. It's an intelligence problem. You don't just need to _store_ information — you need something that reads everything, connects the dots, identifies what matters, and tells you what you're missing.
 
 ## What MAMA OS Does
 
@@ -62,7 +62,7 @@ See the full [Security Guide](../../docs/guides/security.md) for Cloudflare Zero
 
 ```bash
 # 1. Authenticate a backend CLI (one-time)
-claude    # or: codex login
+claude auth login   # or: codex login
 
 # 2. Install and start
 npx @jungjaehoon/mama-os init
@@ -72,7 +72,7 @@ mama start
 open http://localhost:3847
 ```
 
-**Prerequisites:** Node.js >= 18, one authenticated backend CLI (Claude or Codex), 500MB disk space.
+**Prerequisites:** Node.js >= 22.13.0, one authenticated backend CLI (Claude or Codex), 500MB disk space.
 
 ## Connectors (15)
 
@@ -83,22 +83,22 @@ mama connector add slack      # Activate + auth guide
 mama connector list           # Status of all connectors
 ```
 
-| Connector | Prerequisites | Config |
-|-----------|--------------|--------|
-| **Slack** | Bot Token (api.slack.com → OAuth scopes) | `bot_token`, `app_token` |
-| **Discord** | Bot Token (discord.com/developers → MESSAGE CONTENT INTENT) | `token`, `default_channel_id` |
-| **Telegram** | Bot Token (@BotFather) | `token`, `allowed_chat_ids` |
-| **Chatwork** | API Token (account settings) | `api_token`, `room_ids` |
-| **iMessage** | macOS only (reads local chat.db) | No config needed |
-| **Gmail** | [gws CLI](https://github.com/nicholasgasior/gws) installed + Google OAuth | `gws` in PATH |
-| **Calendar** | gws CLI installed + Google OAuth | `gws` in PATH |
-| **Drive** | gws CLI installed + Google OAuth | `gws` in PATH |
-| **Sheets** | gws CLI installed + Google OAuth | `gws` in PATH, `spreadsheet_ids` |
-| **Notion** | Integration Token (notion.so/my-integrations) | `api_token`, `database_ids` |
-| **Obsidian** | [Obsidian](https://obsidian.md) installed + [Obsidian Terminal](https://github.com/polyipseity/obsidian-terminal) plugin enabled | `vault_path` in config.yaml |
-| **Trello** | API Key + Token (trello.com/app-key) | `api_key`, `token`, `board_ids` |
-| **Kagemusha** | Kagemusha running locally | Reads `kagemusha.db` directly |
-| **Claude Code** | Claude Code plugin installed | Automatic via hooks |
+| Connector       | Prerequisites                                                                                                                    | Config                           |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| **Slack**       | Bot Token (api.slack.com → OAuth scopes)                                                                                         | `bot_token`, `app_token`         |
+| **Discord**     | Bot Token (discord.com/developers → MESSAGE CONTENT INTENT)                                                                      | `token`, `default_channel_id`    |
+| **Telegram**    | Bot Token (@BotFather)                                                                                                           | `token`, `allowed_chat_ids`      |
+| **Chatwork**    | API Token (account settings)                                                                                                     | `api_token`, `room_ids`          |
+| **iMessage**    | macOS only (reads local chat.db)                                                                                                 | No config needed                 |
+| **Gmail**       | [gws CLI](https://github.com/nicholasgasior/gws) installed + Google OAuth                                                        | `gws` in PATH                    |
+| **Calendar**    | gws CLI installed + Google OAuth                                                                                                 | `gws` in PATH                    |
+| **Drive**       | gws CLI installed + Google OAuth                                                                                                 | `gws` in PATH                    |
+| **Sheets**      | gws CLI installed + Google OAuth                                                                                                 | `gws` in PATH, `spreadsheet_ids` |
+| **Notion**      | Integration Token (notion.so/my-integrations)                                                                                    | `api_token`, `database_ids`      |
+| **Obsidian**    | [Obsidian](https://obsidian.md) installed + [Obsidian Terminal](https://github.com/polyipseity/obsidian-terminal) plugin enabled | `vault_path` in config.yaml      |
+| **Trello**      | API Key + Token (trello.com/app-key)                                                                                             | `api_key`, `token`, `board_ids`  |
+| **Kagemusha**   | Kagemusha running locally                                                                                                        | Reads `kagemusha.db` directly    |
+| **Claude Code** | Claude Code plugin installed                                                                                                     | Automatic via hooks              |
 
 **Google Workspace connectors** (Gmail, Calendar, Drive, Sheets) require the [gws CLI](https://github.com/nicholasgasior/gws) — a Google Workspace command-line tool. Install it, run `gws auth` once for OAuth, then MAMA polls via CLI.
 
@@ -108,12 +108,12 @@ Each connector classifies its source (truth / hub / spoke / reference) for the 3
 
 MAMA OS runs specialized agents for knowledge management — not coding (that's what Claude Code does natively).
 
-| Agent | Role | Requires |
-|-------|------|----------|
-| **Conductor** | Orchestrates other agents, handles user chat | — |
-| **Dashboard Agent** | Generates project briefings from connected sources | — |
-| **Wiki Agent** | Compiles knowledge into Obsidian vault | [Obsidian](https://obsidian.md) + [Terminal plugin](https://github.com/polyipseity/obsidian-terminal) |
-| **Memory Agent** | Extracts decisions from conversations automatically | — |
+| Agent               | Role                                                | Requires                                                                                              |
+| ------------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| **Conductor**       | Orchestrates other agents, handles user chat        | —                                                                                                     |
+| **Dashboard Agent** | Generates project briefings from connected sources  | —                                                                                                     |
+| **Wiki Agent**      | Compiles knowledge into Obsidian vault              | [Obsidian](https://obsidian.md) + [Terminal plugin](https://github.com/polyipseity/obsidian-terminal) |
+| **Memory Agent**    | Extracts decisions from conversations automatically | —                                                                                                     |
 
 Agents delegate via `delegate()` with skill injection and automatic retry. Configure in `~/.mama/config.yaml`.
 
@@ -121,14 +121,14 @@ Agents delegate via `delegate()` with skill injection and automatic retry. Confi
 
 Web UI at `http://localhost:3847`. PWA-enabled for mobile (add to home screen).
 
-| Tab | What it shows |
-|-----|--------------|
-| **Dashboard** | Agent activity, memory stats, system health |
-| **Feed** | Real-time stream from all connected sources |
-| **Wiki** | Knowledge base (syncs with Obsidian vault) |
-| **Memory** | Interactive reasoning graph (1000+ nodes), search, export |
-| **Logs** | Daemon logs with filtering, pinning, stats, WebSocket mode |
-| **Settings** | Connectors, gateways, agents, cron, token budget |
+| Tab           | What it shows                                              |
+| ------------- | ---------------------------------------------------------- |
+| **Dashboard** | Agent activity, memory stats, system health                |
+| **Feed**      | Real-time stream from all connected sources                |
+| **Wiki**      | Knowledge base (syncs with Obsidian vault)                 |
+| **Memory**    | Interactive reasoning graph (1000+ nodes), search, export  |
+| **Logs**      | Daemon logs with filtering, pinning, stats, WebSocket mode |
+| **Settings**  | Connectors, gateways, agents, cron, token budget           |
 
 Floating chat panel on every tab — voice input, TTS, slash commands.
 
@@ -157,32 +157,32 @@ Slack, Gmail, Sheets...  Discord, Slack, Telegram, Chatwork
 
 ## CLI
 
-| Command | Description |
-|---------|-------------|
-| `mama init` | Initialize workspace |
-| `mama setup` | Interactive setup wizard |
-| `mama start` | Start daemon |
-| `mama stop` | Stop daemon |
-| `mama status` | Check status |
-| `mama connector <add\|remove\|list\|status>` | Manage connectors |
+| Command                                      | Description              |
+| -------------------------------------------- | ------------------------ |
+| `mama init`                                  | Initialize workspace     |
+| `mama setup`                                 | Interactive setup wizard |
+| `mama start`                                 | Start daemon             |
+| `mama stop`                                  | Stop daemon              |
+| `mama status`                                | Check status             |
+| `mama connector <add\|remove\|list\|status>` | Manage connectors        |
 
 ## Configuration
 
 Main config: `~/.mama/config.yaml`
 
-| Variable | Default |
-|----------|---------|
-| `MAMA_DB_PATH` | `~/.mama/mama-memory.db` |
-| `MAMA_HTTP_PORT` | `3847` |
-| `MAMA_WORKSPACE` | `~/.mama/workspace` |
+| Variable         | Default                  |
+| ---------------- | ------------------------ |
+| `MAMA_DB_PATH`   | `~/.mama/mama-memory.db` |
+| `MAMA_HTTP_PORT` | `3847`                   |
+| `MAMA_WORKSPACE` | `~/.mama/workspace`      |
 
 ## Related Packages
 
-| Package | Purpose |
-|---------|---------|
-| **@jungjaehoon/mama-os** | Always-on AI runtime (this package) |
-| **@jungjaehoon/mama-server** | MCP server for Claude Desktop |
-| **@jungjaehoon/mama-core** | Shared memory engine |
+| Package                      | Purpose                             |
+| ---------------------------- | ----------------------------------- |
+| **@jungjaehoon/mama-os**     | Always-on AI runtime (this package) |
+| **@jungjaehoon/mama-server** | MCP server for Claude Desktop       |
+| **@jungjaehoon/mama-core**   | Shared memory engine                |
 
 ## Development
 
@@ -202,4 +202,4 @@ MIT
 
 ---
 
-**Last Updated:** 2026-04-10
+**Last Updated:** 2026-04-20

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "MAMA OS - Local AI Runtime. Your scattered knowledge, organized by AI agents that never sleep.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/standalone/scripts/postinstall.js
+++ b/packages/standalone/scripts/postinstall.js
@@ -2,6 +2,7 @@
 
 const { existsSync, mkdirSync, cpSync, readdirSync } = require('fs');
 const path = require('path');
+const { execFileSync } = require('child_process');
 
 /**
  * Copy templates to ~/.mama/ directory
@@ -51,6 +52,47 @@ async function copyTemplates() {
   }
 }
 
+function getClaudeCodeAuthStatus() {
+  const credentialsPath = path.join(
+    process.env.HOME || process.env.USERPROFILE || '',
+    '.claude',
+    '.credentials.json'
+  );
+
+  try {
+    const stdout = execFileSync('claude', ['auth', 'status'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 5000,
+    });
+    const parsed = JSON.parse(stdout);
+    if (parsed && parsed.loggedIn) {
+      return {
+        cliInstalled: true,
+        loggedIn: true,
+        source: 'cli_status',
+        subscriptionType: parsed.subscriptionType || null,
+      };
+    }
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      return {
+        cliInstalled: false,
+        loggedIn: existsSync(credentialsPath),
+        source: existsSync(credentialsPath) ? 'legacy_credentials' : 'none',
+        subscriptionType: null,
+      };
+    }
+  }
+
+  return {
+    cliInstalled: true,
+    loggedIn: existsSync(credentialsPath),
+    source: existsSync(credentialsPath) ? 'legacy_credentials' : 'none',
+    subscriptionType: null,
+  };
+}
+
 async function main() {
   console.log('\n🚀 MAMA Standalone 설치 완료!\n');
 
@@ -80,26 +122,33 @@ async function main() {
     console.warn('   첫 사용 시 자동 초기화됩니다.\n');
   }
 
-  const credentialsPath = path.join(
-    process.env.HOME || process.env.USERPROFILE || '',
-    '.claude',
-    '.credentials.json'
-  );
-
   console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
   console.log('✨ 설치 완료!');
   console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
 
-  if (existsSync(credentialsPath)) {
+  const authStatus = getClaudeCodeAuthStatus();
+  if (authStatus.loggedIn) {
     console.log('✓ Claude Code 인증 발견\n');
+    if (authStatus.source === 'cli_status') {
+      const suffix = authStatus.subscriptionType ? ` (${authStatus.subscriptionType})` : '';
+      console.log(`   source: claude auth status${suffix}\n`);
+    } else {
+      console.log('   source: legacy ~/.claude/.credentials.json fallback\n');
+    }
     console.log('다음 단계:');
     console.log('  1. mama setup    # 대화형 설정 마법사');
     console.log('  2. mama start    # 서버 시작');
     console.log('  3. mama status   # 상태 확인\n');
   } else {
     console.log('⚠️  Claude Code 인증 없음\n');
-    console.log('Claude Code를 먼저 설치하고 로그인하세요:');
-    console.log('  https://claude.ai/code\n');
+    if (!authStatus.cliInstalled) {
+      console.log('Claude Code를 먼저 설치하고 로그인하세요:');
+      console.log('  https://claude.ai/code\n');
+    } else {
+      console.log('Claude Code는 설치되어 있지만 로그인되어 있지 않습니다.');
+      console.log('다음 명령으로 로그인하세요:\n');
+      console.log('  claude auth login\n');
+    }
     console.log('로그인 후 다시 시도하세요:\n');
     console.log('  mama setup\n');
   }

--- a/packages/standalone/src/agent/gateway-tools.md
+++ b/packages/standalone/src/agent/gateway-tools.md
@@ -5,7 +5,6 @@ Call tools via JSON block:
 ```tool_call
 {"name": "tool_name", "input": {"param1": "value1"}}
 ```
-
 ## MAMA Memory
 
 - **mama_save**() — Save decision (topic, decision, reasoning) or checkpoint (summary, next_steps?)
@@ -89,7 +88,6 @@ Call tools via JSON block:
 ## System
 
 - **agent_notices**(limit?) — Get recent agent activity notices (dashboard reports, wiki compilations, delegations). Use to check what other agents have done recently.
-
 ## Sending Media to Webchat
 
 To display images in webchat, you MUST include the full file path in your response text.

--- a/packages/standalone/src/auth/claude-code-auth.ts
+++ b/packages/standalone/src/auth/claude-code-auth.ts
@@ -1,0 +1,104 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export interface ClaudeCodeAuthStatus {
+  cliInstalled: boolean;
+  loggedIn: boolean;
+  authMethod: string | null;
+  apiProvider: string | null;
+  email: string | null;
+  subscriptionType: string | null;
+  source: 'cli_status' | 'legacy_credentials' | 'none';
+  credentialsPath: string;
+}
+
+function defaultCredentialsPath(): string {
+  const homeDir = process.env.HOME || process.env.USERPROFILE || homedir();
+  return join(homeDir, '.claude', '.credentials.json');
+}
+
+export function getClaudeCodeAuthStatus(command = 'claude'): ClaudeCodeAuthStatus {
+  const credentialsPath = defaultCredentialsPath();
+
+  try {
+    const stdout = execFileSync(command, ['auth', 'status'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 5000,
+      env: process.env,
+    });
+    const parsed = JSON.parse(stdout) as {
+      loggedIn?: boolean;
+      authMethod?: string;
+      apiProvider?: string;
+      email?: string;
+      subscriptionType?: string;
+    };
+
+    if (parsed.loggedIn) {
+      return {
+        cliInstalled: true,
+        loggedIn: true,
+        authMethod: parsed.authMethod ?? null,
+        apiProvider: parsed.apiProvider ?? null,
+        email: parsed.email ?? null,
+        subscriptionType: parsed.subscriptionType ?? null,
+        source: 'cli_status',
+        credentialsPath,
+      };
+    }
+  } catch (error) {
+    const errorLike = error as NodeJS.ErrnoException | undefined;
+    if (errorLike?.code === 'ENOENT') {
+      if (existsSync(credentialsPath)) {
+        return {
+          cliInstalled: false,
+          loggedIn: true,
+          authMethod: 'legacy_credentials',
+          apiProvider: 'firstParty',
+          email: null,
+          subscriptionType: null,
+          source: 'legacy_credentials',
+          credentialsPath,
+        };
+      }
+
+      return {
+        cliInstalled: false,
+        loggedIn: false,
+        authMethod: null,
+        apiProvider: null,
+        email: null,
+        subscriptionType: null,
+        source: 'none',
+        credentialsPath,
+      };
+    }
+  }
+
+  if (existsSync(credentialsPath)) {
+    return {
+      cliInstalled: true,
+      loggedIn: true,
+      authMethod: 'legacy_credentials',
+      apiProvider: 'firstParty',
+      email: null,
+      subscriptionType: null,
+      source: 'legacy_credentials',
+      credentialsPath,
+    };
+  }
+
+  return {
+    cliInstalled: true,
+    loggedIn: false,
+    authMethod: 'none',
+    apiProvider: 'firstParty',
+    email: null,
+    subscriptionType: null,
+    source: 'none',
+    credentialsPath,
+  };
+}

--- a/packages/standalone/src/auth/index.ts
+++ b/packages/standalone/src/auth/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { OAuthManager } from './oauth-manager.js';
+export { getClaudeCodeAuthStatus } from './claude-code-auth.js';
 
 export type {
   ClaudeCredentialsFile,
@@ -14,5 +15,6 @@ export type {
   CachedToken,
   OAuthErrorCode,
 } from './types.js';
+export type { ClaudeCodeAuthStatus } from './claude-code-auth.js';
 
 export { OAuthError } from './types.js';

--- a/packages/standalone/src/cli/commands/init.ts
+++ b/packages/standalone/src/cli/commands/init.ts
@@ -17,6 +17,7 @@ import {
   saveConfig,
 } from '../config/config-manager.js';
 import { BOOTSTRAP_TEMPLATE } from '../../onboarding/bootstrap-template.js';
+import { getClaudeCodeAuthStatus } from '../../auth/index.js';
 
 /**
  * CLAUDE.md template for workspace documentation
@@ -107,7 +108,7 @@ function resolvePreferredBackend(
   const codexAuthPaths = [expandPath('~/.mama/.codex/auth.json'), expandPath('~/.codex/auth.json')];
   const codexAuthPath = codexAuthPaths.find((p) => existsSync(p));
   const hasCodexAuth = Boolean(codexAuthPath);
-  const hasClaudeAuth = existsSync(expandPath('~/.claude/.credentials.json'));
+  const hasClaudeAuth = getClaudeCodeAuthStatus().loggedIn;
 
   if (requestedBackend) {
     if (requestedBackend === 'codex-mcp') {
@@ -166,19 +167,23 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
       }
       if (requestedBackend === 'claude') {
         console.error('\n⚠️  Requested backend "claude" is not authenticated.');
-        console.error(`   Expected auth: ${expandPath('~/.claude/.credentials.json')}`);
-        console.error('\n   Please authenticate Claude Code first:');
-        console.error('   https://claude.ai/code\n');
+        const authStatus = getClaudeCodeAuthStatus();
+        if (!authStatus.cliInstalled) {
+          console.error('   Claude Code CLI is not installed.');
+          console.error('   https://claude.ai/code\n');
+        } else {
+          console.error('   Run: claude auth login\n');
+        }
         process.exit(1);
       }
       console.error('\n⚠️  No authenticated backend found.');
       console.error(
         `   Codex (codex-mcp) auth: ${expandPath('~/.mama/.codex/auth.json')} or ${expandPath('~/.codex/auth.json')}`
       );
-      console.error(`   Claude auth: ${expandPath('~/.claude/.credentials.json')}`);
+      console.error(`   Claude auth (legacy fallback): ${expandPath('~/.claude/.credentials.json')}`);
       console.error('\n   Please authenticate one backend first:');
       console.error('   - Codex (codex-mcp): codex login');
-      console.error('   - Claude: https://claude.ai/code\n');
+      console.error('   - Claude: claude auth login (or install from https://claude.ai/code)\n');
       process.exit(1);
     }
     selectedBackend = resolved;

--- a/packages/standalone/src/cli/commands/run.ts
+++ b/packages/standalone/src/cli/commands/run.ts
@@ -5,7 +5,7 @@
  */
 
 import { loadConfig, configExists } from '../config/config-manager.js';
-import { OAuthManager } from '../../auth/index.js';
+import { OAuthManager, getClaudeCodeAuthStatus } from '../../auth/index.js';
 import { AgentLoop } from '../../agent/index.js';
 
 /**
@@ -50,20 +50,21 @@ export async function runCommand(options: RunOptions): Promise<void> {
     console.log('✓ Codex MCP backend (OAuth handled by Codex login)');
     oauthManager = new OAuthManager();
   } else {
-    // Check OAuth token
-    process.stdout.write('Verifying OAuth token... ');
-    try {
-      oauthManager = new OAuthManager();
-      await oauthManager.getToken();
-      console.log('✓');
-    } catch (error) {
+    process.stdout.write('Checking Claude Code login... ');
+    const authStatus = getClaudeCodeAuthStatus();
+    if (!authStatus.loggedIn) {
       console.log('❌');
-      console.error(
-        `\nOAuth token error: ${error instanceof Error ? error.message : String(error)}`
-      );
-      console.error('Please log in to Claude Code again.\n');
+      if (!authStatus.cliInstalled) {
+        console.error('\nClaude Code CLI is not installed.');
+        console.error('Install and log in first: https://claude.ai/code\n');
+      } else {
+        console.error('\nClaude Code is installed but not logged in.');
+        console.error('Please run: claude auth login\n');
+      }
       process.exit(1);
     }
+    oauthManager = new OAuthManager();
+    console.log('✓');
   }
 
   // Create agent loop

--- a/packages/standalone/src/cli/commands/setup.ts
+++ b/packages/standalone/src/cli/commands/setup.ts
@@ -5,10 +5,9 @@
  */
 
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
 
 import { expandPath } from '../config/config-manager.js';
-import { OAuthManager } from '../../auth/index.js';
+import { getClaudeCodeAuthStatus } from '../../auth/index.js';
 import { startSetupServer } from '../../setup/setup-server.js';
 
 /**
@@ -29,40 +28,33 @@ export async function setupCommand(options: SetupOptions = {}): Promise<void> {
 
   // 1. Check Claude Code authentication
   console.log('Step 1: Checking Claude Code authentication');
-  process.stdout.write('  Verifying OAuth token... ');
+  process.stdout.write('  Checking Claude Code login... ');
 
-  const credentialsPath = expandPath('~/.claude/.credentials.json');
-  if (!existsSync(credentialsPath)) {
+  const authStatus = getClaudeCodeAuthStatus();
+  if (!authStatus.loggedIn) {
     console.log('❌\n');
-    console.error('⚠️  Claude Code credentials file not found.');
-    console.error(`   Expected path: ${credentialsPath}`);
-    console.error('\n   Please install and log in to Claude Code first:');
-    console.error('   https://claude.ai/code\n');
+    if (!authStatus.cliInstalled) {
+      console.error('⚠️  Claude Code CLI not found.');
+      console.error('\n   Please install and log in to Claude Code first:');
+      console.error('   https://claude.ai/code\n');
+    } else {
+      console.error('⚠️  Claude Code is installed but not logged in.');
+      console.error('   Please run:\n');
+      console.error('   claude auth login\n');
+    }
     process.exit(1);
   }
 
-  try {
-    const oauthManager = new OAuthManager();
-    const status = await oauthManager.getStatus();
-
-    if (!status.valid) {
-      console.log('❌\n');
-      console.error('⚠️  OAuth token has expired.');
-      console.error('   Please log in to Claude Code again.\n');
-      process.exit(1);
-    }
-
-    console.log('✓');
-    console.log(`  Subscription type: ${status.subscriptionType || 'unknown'}`);
-
-    if (status.subscriptionType && status.subscriptionType !== 'max') {
-      console.log('\n⚠️  Warning: Claude Pro (Max) subscription is recommended.');
-      console.log(`   Current subscription: ${status.subscriptionType}\n`);
-    }
-  } catch (error) {
-    console.log('❌\n');
-    console.error(`   OAuth error: ${error instanceof Error ? error.message : String(error)}\n`);
-    process.exit(1);
+  console.log('✓');
+  if (authStatus.subscriptionType) {
+    console.log(`  Subscription type: ${authStatus.subscriptionType}`);
+  }
+  if (authStatus.source === 'legacy_credentials') {
+    console.log(`  Legacy credentials file detected: ${expandPath('~/.claude/.credentials.json')}`);
+  }
+  if (authStatus.subscriptionType && authStatus.subscriptionType !== 'max') {
+    console.log('\n⚠️  Warning: Claude Pro (Max) subscription is recommended.');
+    console.log(`   Current subscription: ${authStatus.subscriptionType}\n`);
   }
 
   // 2. Start setup server

--- a/packages/standalone/src/cli/commands/status.ts
+++ b/packages/standalone/src/cli/commands/status.ts
@@ -9,7 +9,7 @@ import { homedir } from 'node:os';
 import http from 'node:http';
 import { isDaemonRunning, getUptime, isProcessRunning } from '../utils/pid-manager.js';
 import { loadConfig, configExists, expandPath } from '../config/config-manager.js';
-import { OAuthManager } from '../../auth/index.js';
+import { OAuthManager, getClaudeCodeAuthStatus } from '../../auth/index.js';
 
 /**
  * Execute status command
@@ -67,8 +67,24 @@ export async function statusCommand(): Promise<void> {
       if (backend === 'codex-mcp') {
         console.log('Codex MCP backend: Uses MCP protocol for Codex communication');
       } else {
-        process.stdout.write('OAuth token: ');
-        try {
+        const authStatus = getClaudeCodeAuthStatus();
+        process.stdout.write('Claude Code auth: ');
+
+        if (!authStatus.loggedIn) {
+          if (!authStatus.cliInstalled) {
+            console.log('Missing ❌');
+            console.log('  Install Claude Code first: https://claude.ai/code');
+          } else {
+            console.log('Logged out ❌');
+            console.log('  Run: claude auth login');
+          }
+        } else if (authStatus.source === 'cli_status') {
+          const summary = authStatus.subscriptionType
+            ? `Valid (${authStatus.authMethod ?? 'unknown'}, ${authStatus.subscriptionType})`
+            : `Valid (${authStatus.authMethod ?? 'unknown'})`;
+          console.log(summary);
+        } else {
+          try {
           const oauthManager = new OAuthManager();
           const tokenStatus = await oauthManager.getStatus();
 
@@ -103,6 +119,7 @@ export async function statusCommand(): Promise<void> {
         } catch (error) {
           console.log('Check failed ❌');
           console.log(`  ${error instanceof Error ? error.message : String(error)}`);
+        }
         }
       }
 

--- a/packages/standalone/tests/auth/claude-code-auth.test.ts
+++ b/packages/standalone/tests/auth/claude-code-auth.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const execFileSyncMock = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  execFileSync: execFileSyncMock,
+}));
+
+describe('Claude Code auth detection', () => {
+  const originalHome = process.env.HOME;
+
+  afterEach(() => {
+    vi.resetModules();
+    execFileSyncMock.mockReset();
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+  });
+
+  it('prefers claude auth status when the CLI reports a logged-in session', async () => {
+    execFileSyncMock.mockReturnValue(
+      JSON.stringify({
+        loggedIn: true,
+        authMethod: 'claude.ai',
+        apiProvider: 'firstParty',
+        email: 'test@example.com',
+        subscriptionType: 'max',
+      })
+    );
+
+    const { getClaudeCodeAuthStatus } = await import('../../src/auth/claude-code-auth.js');
+    const status = getClaudeCodeAuthStatus();
+
+    expect(status).toMatchObject({
+      cliInstalled: true,
+      loggedIn: true,
+      source: 'cli_status',
+      authMethod: 'claude.ai',
+      subscriptionType: 'max',
+      email: 'test@example.com',
+    });
+  });
+
+  it('falls back to the legacy credentials file when claude is not installed', async () => {
+    const { mkdir, writeFile, rm } = await import('node:fs/promises');
+    const { join } = await import('node:path');
+    const { tmpdir } = await import('node:os');
+    const testHome = join(tmpdir(), `mama-claude-auth-${Date.now()}`);
+    const claudeDir = join(testHome, '.claude');
+
+    await mkdir(claudeDir, { recursive: true });
+    await writeFile(join(claudeDir, '.credentials.json'), '{}');
+    process.env.HOME = testHome;
+
+    const error = Object.assign(new Error('not found'), { code: 'ENOENT' });
+    execFileSyncMock.mockImplementation(() => {
+      throw error;
+    });
+
+    const { getClaudeCodeAuthStatus } = await import('../../src/auth/claude-code-auth.js');
+    const status = getClaudeCodeAuthStatus();
+
+    expect(status).toMatchObject({
+      cliInstalled: false,
+      loggedIn: true,
+      source: 'legacy_credentials',
+      authMethod: 'legacy_credentials',
+    });
+
+    await rm(testHome, { recursive: true, force: true });
+  });
+
+  it('reports logged out when neither CLI auth nor legacy credentials are present', async () => {
+    execFileSyncMock.mockReturnValue(
+      JSON.stringify({
+        loggedIn: false,
+        authMethod: 'none',
+        apiProvider: 'firstParty',
+      })
+    );
+
+    const { getClaudeCodeAuthStatus } = await import('../../src/auth/claude-code-auth.js');
+    const status = getClaudeCodeAuthStatus();
+
+    expect(status).toMatchObject({
+      cliInstalled: true,
+      loggedIn: false,
+      source: 'none',
+      authMethod: 'none',
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,6 @@ importers:
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
-      typescript:
-        specifier: ^5.4.0
-        version: 5.9.3
       vitest:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@22.19.11)
@@ -90,6 +87,9 @@ importers:
         specifier: ^1.0.1
         version: 1.27.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
     devDependencies:
+      better-sqlite3:
+        specifier: ^12.8.0
+        version: 12.8.0
       vitest:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@25.3.0)


### PR DESCRIPTION
## Summary

Adds the full **case-first memory substrate** to `mama-core` (Phase 1 → Phase 3 per spec `2026-04-17-mama-work-case-first-memory-system-design.md`) and exposes the new `case_timeline_range` tool from `mcp-server`. All pre-ship migrations (`030..049` in the working branch) are collapsed into a single migration `030-case-first-memory-substrate.sql` so v0.19.0 users apply exactly **one** migration on update.

Three subsystems:
1. **Entity substrate** — canonical entity nodes + aliases + lineage + policy + rollback preview (foundations that Case + Search both build on).
2. **Case-first memory** — `case_truth`, `case_memberships`, `case_corrections`, `case_proposal_queue`, merge / split / supersede flows, freshness sweep, structural `case_links` + wiki tombstones.
3. **Learned ranker** — `search_feedback`, `ranker_model_versions`, feature extraction, rescore, training, NDCG/MRR activation gate.

Originally spanned 153 commits on the working branch (`codex/provenance-drawer-v1`). Consolidated here into one PR with a single clean commit so review is tractable and there is no PII bleed from intermediate histories.

## Scope

- **116 files** under `packages/mama-core/` (+29,736 / -232)
- **5 files** under `packages/mcp-server/` (+225)
- **1 new migration** (`030-case-first-memory-substrate.sql`, ~900 lines, concatenation of 20 in-progress pre-ship migrations)
- **47 new test files** covering HITL correction flows, merge chain CAS, ranker quality gate, freshness sweep, tombstones, migration chain + rollback

## What's new in `packages/mama-core/`

### DB schema (`db/migrations/030-case-first-memory-substrate.sql`)

One pre-ship migration that covers every Phase 1–3 DDL in dependency order. Sections are labelled semantically (`-- Phase 1 — case_truth`, `-- Source locator — drop legacy raw_db_ref`, etc.) so a reviewer can skim it top-to-bottom without cross-referencing old filenames.

Tables / columns created or extended (highlights):
- **Entity substrate**: `decision_entity_sources`, `entity_lineage_links`, `entity_policy`, `entity_role_bindings`, `entity_policy_proposals`, `entity_timeline_events.role` column.
- **Temporal**: `decisions.event_datetime` INTEGER with backfill from linked observations then `event_date` fallback then `created_at`.
- **Source-locator refactor**: `entity_observations.source_locator` replaces the prior `source_raw_db_ref` field, with triggers that auto-populate during the cutover window; legacy column is dropped.
- **Phase 1 case-first** (spec §5.2 – §5.7): `case_truth`, `case_memberships`, `case_corrections` (with `target_ref_hash BLOB` length-32 CHECK, partial-unique `idx_case_corrections_active_target`), `case_proposal_queue`, `wiki_page_index` + `wiki_page_embeddings` + `wiki_pages_fts` (with AI/AU/AD triggers).
- **Phase 2 live-state** (spec amendment-8): `entity_timeline_events.role` nullable column plus all the correction-lock target helpers.
- **Phase 3** (spec amendments 9–14): `connector_event_index` + `_cursors` + `_fts` + triggers, `search_feedback` + `ranker_model_versions` + `search_ranker_settings`, `case_links` + `case_links_revoked_wiki_tombstones`, `case_truth` promotion + freshness columns, `case_memberships` explanation columns (`assignment_strategy`, `score_breakdown_json`, `source_locator`, `explanation_updated_at`).

### `src/entities/` — canonical entity substrate

| File | Role |
|---|---|
| `store.ts` | Canonical entity node + alias CRUD with scope/kind integrity triggers. |
| `types.ts` | `EntityKind`, `EntityScopeKind`, candidate statuses, merge action types. |
| `candidate-generator.ts` | Cross-language / script candidate generation with embedding fallback + top-N quality gates. |
| `resolution-engine.ts` | Exact auto-merge path, cross-language review, ontology-violation guard. |
| `projection.ts` | Recall projection + circular merge detection. |
| `recall-bridge.ts` | Canonical / topic / raw read identity resolution, wildcard escaping, merged-chain lookup. |
| `audit-metrics.ts` | Quality-gate arithmetic for audits. |
| `audit-store.ts` / `policy-store.ts` / `lineage-store.ts` | Partial-unique running-audit constraint, policy bootstrap (with role bindings + proposal approval), append-only lineage supersession. |
| `rollback-preview.ts` | Non-mutating bounded rollback preview before any recovery flow. |

### `src/cases/` — Phase 1 → Phase 3 case-first

| File | Role |
|---|---|
| `store.ts` | Case truth / membership / correction persistence + canonical merge-chain resolution + proposal idempotency. |
| `live-state.ts` | Lock-aware live-state writer (skips locked targets, surfaces review notices). |
| `corrections.ts` | HITL apply / revert core helpers. |
| `merge-split.ts` | HITL-only merge / split with canonical chain + cycle detection. |
| `case-links.ts` | First-class link types, tombstones, unsuppress path, survivor-view resolution. |
| `freshness.ts` | Drift-threshold sweep + promotion metadata. |
| `membership-matcher.ts` | Scorer with thresholds and embedding fallback (gates case assignment quality). |
| `membership-explain.ts` | Deterministic membership explanations. |
| `timeline-range.ts` | Read-only time-window slice (backs the MCP tool below). |
| `target-ref.ts` | Canonical `target_ref_json` + `target_ref_hash` helpers (spec amendment-8 CAS). |
| `role-inference.ts` | Multilingual role inference (KR/JP/EN keyword patterns) for timeline events. |
| `composition-overrides.ts` | User pins + promotions + merge-chain source resolution. |
| `tombstone-sweeper.ts` | Source-deletion tombstones that preserve locked memberships. |
| `sqlite-transaction.ts` | `BEGIN IMMEDIATE` retry + rollback + async rejection handling. |

### `src/search/` — learned ranker

| File | Role |
|---|---|
| `ranker-features.ts` | Feature extraction for the rescore model. |
| `ranker-rescore.ts` | Active-model gating, feature-set mismatch handling, tie stability, score blending. |
| `ranker-trainer.ts` | Training thresholds, neutral caps, retention, activation gate (NDCG/MRR ≥ baseline + 0.01). |
| `feedback-store.ts` | Retention + dedupe for `search_feedback`. |
| `question-type.ts` | Question-type classification (correction / artifact / temporal / reason / howto) with KR/EN keyword hints. |

### Other `src/` changes

- `src/canonicalize.ts` — canonical JSON + SHA-256 `target_ref_hash` for cross-package HITL CAS.
- `src/mama-api.ts` — attach `meta.ranker` on all `suggest()` return paths, honor `search_ranker_enabled` runtime gate, richer temporal / question-type hints.
- `src/memory/api.ts` / `types.ts` — scoped save / recall, event-datetime ordering, timeline transaction rollback, truth gating.
- `src/decision-formatter.ts` — provenance link rendering in human-readable output.
- `src/db-manager.ts` — wire migration 030 to the startup path.
- `src/test-utils.ts` — shared `applyMigrationsThrough(db, maxVersion)` helper used by every migration test (schema_version guard + narrow duplicate-column tolerance mirroring the production runner).

### Tests

47 new test files across `tests/cases`, `tests/entities`, `tests/search`, `tests/unit`, `tests/connectors`, `tests/fixtures`. Key invariants covered:

- **Phase 2b `supersedeCorrection`** — CAS + reconfirm-token flow (spec amendment-8, prod-data-safety critical).
- **Correction write flow** — HITL apply / reconfirm / revert / rollback.
- **Merge chain** — HITL-only merge/split, canonical chain, cycle detection.
- **Live-state** — lock-aware writes, correction-lock skip.
- **`case_links`** — every first-class link type, self-link rejection, active-uniqueness + revoked-historical-duplicate policy, wiki tombstones (active uniqueness + unsuppress).
- **Freshness** — drift threshold behavior, sweeper semantics.
- **Ranker quality gate** — NDCG/MRR activation margin; trainer retention/caps; rescore feature-set mismatch + tie stability.
- **Migration chain** — `030` creates every Phase 1/2/3 object, idempotency via schema_version guard, mid-migration rollback invariant (no partial artefacts).
- **Entity substrate** — exact-merge backfill, lineage, provenance queries, orphan detection, rollback preview non-mutation, recall-mode gating (off / shadow / dual-write).

## What's new in `packages/mcp-server/`

Single tool exposed via MCP protocol:

- `src/tools/case-timeline-range.js` — read-only single-arg handler that returns entity timeline events for a given `case_id` within an optional time window. Backed by `mama-core`'s `src/cases/timeline-range.ts`.
- `src/tools/index.js` + `src/server.js` — register + route the tool.
- `tests/tools/case-timeline-range.test.js` — integration test of the packaged stdio contract.
- `package.json` — dep / version touch.

## Migration strategy — why one file, not twenty

The working branch accumulated 20 migrations (`030..049`) over Phase 1–3 development. None of them has shipped to any production mama-core install. Consolidating before ship gives three concrete benefits:

1. **Review load** — 20 filenames × ~8–40 SQL lines each is 10× the churn of one ~900-line substrate file; reviewers now read it like a single schema spec.
2. **Per-user update cost** — v0.19.0 users currently at `schema_version=29` run one migration to reach the new state instead of stepping through twenty.
3. **Failure semantics** — the previous per-file runner wrapped each migration in its own `BEGIN/COMMIT`; a partial failure mid-chain could leave 030–N committed. The consolidated version wraps the whole substrate in one transaction, so a mid-migration failure rolls back cleanly. Tested in `migration-chain.test.ts`.

The consolidation was audited by Codex (xhigh): SQL ordering preserved (119 statements, no reorder), no runtime depends on intermediate `schema_version` numbers between 30–49, and there are no code paths checking `MAX(version) >= N` for N in that range.

## Not in this PR (follow-ups)

- **`packages/standalone/`** — the HITL REST routes, dashboard UI, connector framework wiring that consume this substrate stay on the `codex/provenance-drawer-v1` branch. They'll rebase onto this PR once it lands.
- **`packages/claude-code-plugin/`** — no changes on this branch.
- **Docs** (`CLAUDE.md` migration-number references, ship-gate report) — updated in the standalone follow-up since those documents live there.

## Test plan

- [ ] `pnpm --filter @jungjaehoon/mama-core test` — 78 files / 505 tests pass (already green locally).
- [ ] `pnpm --filter @jungjaehoon/mama-core typecheck` — clean.
- [ ] `pnpm --filter @jungjaehoon/mama-server test` — integration test for `case_timeline_range` passes.
- [ ] Apply migration 030 to a copy of a v0.19.0 install and verify: `schema_version` now contains row `30`; `case_truth`, `case_memberships`, `case_corrections`, `case_proposal_queue`, `wiki_page_index`, `connector_event_index`, `search_feedback`, `case_links` all exist.
- [ ] Apply migration 030 twice (re-run) and confirm no error — `schema_version` guard + narrow duplicate-column tolerance.

## Anti-PII audit

Before squashing, the branch was swept for personal and project-identifying data in every changed file:

- Replaced one hardcoded personal name + client/channel label in `tests/entities/read-identity.test.ts` with the anonymous Worker / Client placeholder convention already used in sibling tests.
- All remaining non-ASCII content is either: multilingual keyword regexes (`src/cases/role-inference.ts`, `src/search/question-type.ts`), generic technical topics in tests, emoji in log formatting, or fake placeholder IDs (`C1234567890`, all-1s UUIDs). No real channel IDs, emails, tokens, API keys, phone numbers, or user home paths.
- The branch was then `reset --soft` and re-squashed so the in-progress history no longer appears in `git show` on the single PR commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Complete case workflows: corrections (apply/revert/supersede), merge/split, links, promotions, pin/unpin, timeline range, freshness sweep, membership explanations, and search rollup.
  * Search & recall: fused wiki FTS+vector results, connector event indexing, feedback capture, and learned ranker (train + rescoring).
  * Memory/timeline: timeline events saved with memories and event timestamps surfaced in listings; canonicalization/hash utilities.

* **Database**
  * Large schema additions and backfills for cases, lineage/ingest runs, provenance, policies, wiki index, and related indexes/constraints.

* **Documentation**
  * Updated CLI auth/setup guidance and release notes; package version bumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->