### PR TITLE
feat(m1r): complete reactive envelope runtime and audit contract

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -76,13 +76,16 @@ Use this focused suite when changing Reactive envelope issuance, gateway tool
 execution, `agent_activity` audit rows, or envelope health/status APIs:
 
 ```bash
-pnpm -C packages/standalone exec vitest run tests/contract/m1r-envelope-completion-matrix.test.ts tests/contract/envelope-callsite-matrix.test.ts tests/agent/delegation-executor.test.ts tests/envelope/executor-pipeline.test.ts tests/envelope/agent-loop-internal-tool-context.test.ts tests/envelope/code-act-context.test.ts tests/cli/runtime/agent-loop-init-envelope-options.test.ts tests/cli/runtime/envelope-bootstrap.test.ts tests/envelope/reactive-config.test.ts tests/envelope/memory-scope-mismatch-logging.test.ts tests/envelope/executor-audit.test.ts tests/db/agent-activity.test.ts tests/api/health-envelope.test.ts tests/api/envelope-status-auth.test.ts tests/envelope/executor-integration.test.ts tests/contract/reactive-envelope.test.ts tests/contract/reactive-envelope-tool-path.test.ts tests/contract/envelope-drift-sentinel.test.ts tests/contract/code-task-delegation-empty-scopes.test.ts
+MAMA_FORCE_TIER_3=true pnpm -C packages/standalone exec vitest run tests/contract/m1r-envelope-completion-matrix.test.ts tests/contract/envelope-callsite-matrix.test.ts tests/agent/delegation-executor.test.ts tests/envelope/executor-pipeline.test.ts tests/envelope/agent-loop-internal-tool-context.test.ts tests/envelope/code-act-context.test.ts tests/cli/runtime/agent-loop-init-envelope-options.test.ts tests/cli/runtime/envelope-bootstrap.test.ts tests/envelope/reactive-config.test.ts tests/envelope/memory-scope-mismatch-logging.test.ts tests/envelope/executor-audit.test.ts tests/db/agent-activity.test.ts tests/api/health-envelope.test.ts tests/api/envelope-status-auth.test.ts tests/envelope/executor-integration.test.ts tests/contract/reactive-envelope.test.ts tests/contract/reactive-envelope-tool-path.test.ts tests/contract/envelope-drift-sentinel.test.ts tests/contract/code-task-delegation-empty-scopes.test.ts
 pnpm -C packages/standalone typecheck
 pnpm -C packages/standalone test
 pnpm test
 pnpm build
 git diff --check
 ```
+
+`MAMA_FORCE_TIER_3=true` skips embedding work during focused verification, which
+keeps local and CI runs faster and less sensitive to embedding runtime latency.
 
 `/health` must stay public and envelope-free. Envelope runtime metadata and the
 24-hour scope-mismatch count are verified through authenticated

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -70,6 +70,25 @@ npm test -- --watch
 # Tests re-run on file changes
 ```
 
+### M1R Envelope Runtime Verification
+
+Use this focused suite when changing Reactive envelope issuance, gateway tool
+execution, `agent_activity` audit rows, or envelope health/status APIs:
+
+```bash
+pnpm -C packages/standalone exec vitest run tests/contract/m1r-envelope-completion-matrix.test.ts tests/contract/envelope-callsite-matrix.test.ts tests/agent/delegation-executor.test.ts tests/envelope/executor-pipeline.test.ts tests/envelope/agent-loop-internal-tool-context.test.ts tests/envelope/code-act-context.test.ts tests/cli/runtime/agent-loop-init-envelope-options.test.ts tests/cli/runtime/envelope-bootstrap.test.ts tests/envelope/reactive-config.test.ts tests/envelope/memory-scope-mismatch-logging.test.ts tests/envelope/executor-audit.test.ts tests/db/agent-activity.test.ts tests/api/health-envelope.test.ts tests/api/envelope-status-auth.test.ts tests/envelope/executor-integration.test.ts tests/contract/reactive-envelope.test.ts tests/contract/reactive-envelope-tool-path.test.ts tests/contract/envelope-drift-sentinel.test.ts tests/contract/code-task-delegation-empty-scopes.test.ts
+pnpm -C packages/standalone typecheck
+pnpm -C packages/standalone test
+pnpm test
+pnpm build
+git diff --check
+```
+
+`/health` must stay public and envelope-free. Envelope runtime metadata and the
+24-hour scope-mismatch count are verified through authenticated
+`/api/envelope/status`, with the count sourced from `agent_activity`, not
+best-effort metrics.
+
 ---
 
 ## Test Coverage

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -1061,9 +1061,9 @@ MAMA OS includes a **Code-Act sandbox** — a JavaScript execution environment p
 ### Security Model
 
 ```
-User Code → QuickJS WASM Sandbox → Host Bridge → Gateway Tools (Tier 3 only)
+User Code → QuickJS WASM Sandbox → Host Bridge → Gateway Tools (Tier 2)
              ↑                      ↑
-             No Node.js APIs        Read-only tools only
+             No Node.js APIs        Read + memory-write tools
              No file system         No Bash, no Write
              No network access      No communication tools
 ```
@@ -1074,13 +1074,19 @@ User Code → QuickJS WASM Sandbox → Host Bridge → Gateway Tools (Tier 3 onl
 - **No network access** — No `fetch()`, no `XMLHttpRequest`, no sockets
 - **Execution timeout** — Default 30s, max 60s, enforced at engine level
 - **Memory limit** — QuickJS WASM heap is bounded (default ~256 MB, set by `quickjs-emscripten` WASM allocation)
-- **Tier 3 tools only** — Only read-only gateway tools are exposed via the host bridge
+- **Tier 2 tools for `/api/code-act`** — The HTTP endpoint injects the host
+  bridge with tier 2 in `start.ts`, exposing read tools plus bounded memory-write
+  tools. `Bash`, `Write`, and communication tools remain unavailable.
 
 ### Available Tools in Sandbox
 
-Only Tier 3 (read-only) tools are injected:
+`POST /api/code-act` injects Tier 2 tools:
 
 - `mama_search`, `mama_load_checkpoint` — Memory read
+- `mama_save`, `mama_update`, `mama_add`, `mama_ingest` — Memory write, audited
+  through gateway envelope context when envelope issuance is enabled
+- `report_publish`, `wiki_publish` — Dashboard/wiki publish helpers with
+  autosave audit behavior
 - `Read` — File read
 - `browser_get_text`, `browser_screenshot` — Browser read
 - `os_list_bots`, `os_get_config` — Status read
@@ -1091,8 +1097,11 @@ Only Tier 3 (read-only) tools are injected:
 The Code-Act sandbox is accessible via `POST /api/code-act`. This endpoint:
 
 - Requires `MAMA_AUTH_TOKEN` if set
-- Uses Tier 3 (read-only) tools exclusively
+- Uses Tier 2 tools via `HostBridge.injectInto(sandbox, 2)` in `start.ts`
 - Has no access to agent persona or conversation context
+- Must be treated as write-capable for memory surfaces; expose it only behind
+  localhost, token auth, and the same network controls used for other `/api`
+  routes.
 
 ### Risk Assessment
 
@@ -1100,7 +1109,8 @@ The Code-Act sandbox is accessible via `POST /api/code-act`. This endpoint:
 | ------------------- | -------------------------------------------- |
 | Code injection      | QuickJS WASM isolation, no eval of host code |
 | File system access  | Only via `Read` tool (read-only)             |
-| Command execution   | `Bash` tool not available in Tier 3          |
+| Command execution   | `Bash` tool not available in Tier 2          |
+| Memory mutation     | Tier 2 memory writes are envelope-audited    |
 | Data exfiltration   | No network access, no communication tools    |
 | Resource exhaustion | Timeout + WASM memory bounds                 |
 

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -1076,7 +1076,9 @@ User Code → QuickJS WASM Sandbox → Host Bridge → Gateway Tools (Tier 2)
 - **Memory limit** — QuickJS WASM heap is bounded (default ~256 MB, set by `quickjs-emscripten` WASM allocation)
 - **Tier 2 tools for `/api/code-act`** — The HTTP endpoint injects the host
   bridge with tier 2 in `start.ts`, exposing read tools plus bounded memory-write
-  tools. `Bash`, `Write`, and communication tools remain unavailable.
+  tools. `Bash`, `Write`, and communication tools remain unavailable. Set
+  `MAMA_CODE_ACT_READ_ONLY=1` to force the endpoint to inject tier 3 read-only
+  tools only.
 
 ### Available Tools in Sandbox
 
@@ -1084,7 +1086,10 @@ User Code → QuickJS WASM Sandbox → Host Bridge → Gateway Tools (Tier 2)
 
 - `mama_search`, `mama_load_checkpoint` — Memory read
 - `mama_save`, `mama_update`, `mama_add`, `mama_ingest` — Memory write, audited
-  through gateway envelope context when envelope issuance is enabled
+  through gateway envelope context when envelope issuance is enabled. Automated
+  coverage verifies Code-Act context propagation and memory-scope mismatch rows
+  in `tests/envelope/code-act-context.test.ts` and
+  `tests/envelope/memory-scope-mismatch-logging.test.ts`.
 - `report_publish`, `wiki_publish` — Dashboard/wiki publish helpers with
   autosave audit behavior
 - `Read` — File read
@@ -1096,12 +1101,24 @@ User Code → QuickJS WASM Sandbox → Host Bridge → Gateway Tools (Tier 2)
 
 The Code-Act sandbox is accessible via `POST /api/code-act`. This endpoint:
 
-- Requires `MAMA_AUTH_TOKEN` if set
-- Uses Tier 2 tools via `HostBridge.injectInto(sandbox, 2)` in `start.ts`
+- Is write-capable for memory surfaces by default via
+  `HostBridge.injectInto(sandbox, 2)`
+- Requires strong perimeter controls before any non-local exposure. Production
+  deployments must use Zero Trust access or mTLS/IP allowlisting plus bearer
+  token auth; token auth alone is not sufficient for internet exposure.
+- Remains localhost-only when no `MAMA_AUTH_TOKEN` is configured
+- Can be forced read-only with `MAMA_CODE_ACT_READ_ONLY=1`, which injects
+  tier 3 tools instead
 - Has no access to agent persona or conversation context
-- Must be treated as write-capable for memory surfaces; expose it only behind
-  localhost, token auth, and the same network controls used for other `/api`
-  routes.
+- Applies a per-client rate limit (`MAMA_CODE_ACT_RATE_LIMIT_PER_MINUTE`,
+  default 30) and structured logs for memory mutation attempts
+- Trusts forwarded client IP headers only when the socket peer is a configured
+  trusted proxy (`MAMA_TRUSTED_PROXY_IPS`, plus loopback defaults); otherwise
+  the socket peer is the rate-limit identity
+- Records gateway audit rows with envelope hash, requested scopes, envelope
+  scope snapshots, and `scope_mismatch`. The signed envelope/audit row gives
+  durable request provenance; independent tamper-evidence for the memory row
+  itself remains future work.
 
 ### Risk Assessment
 

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -1102,13 +1102,16 @@ User Code → QuickJS WASM Sandbox → Host Bridge → Gateway Tools (Tier 2)
 The Code-Act sandbox is accessible via `POST /api/code-act`. This endpoint:
 
 - Is write-capable for memory surfaces by default via
-  `HostBridge.injectInto(sandbox, 2)`
+  `HostBridge.injectInto(sandbox, 2)` only after the request passes token auth
+  (`MAMA_AUTH_TOKEN`) or trusted Cloudflare Access
+  (`MAMA_TRUST_CLOUDFLARE_ACCESS`)
 - Requires strong perimeter controls before any non-local exposure. Production
   deployments must use Zero Trust access or mTLS/IP allowlisting plus bearer
   token auth; token auth alone is not sufficient for internet exposure.
-- Remains localhost-only when no `MAMA_AUTH_TOKEN` is configured
+- Remains localhost-only when neither token auth (`MAMA_AUTH_TOKEN`) nor trusted
+  Cloudflare Access (`MAMA_TRUST_CLOUDFLARE_ACCESS`) is configured
 - Can be forced read-only with `MAMA_CODE_ACT_READ_ONLY=1`, which injects
-  tier 3 tools instead
+  tier 3 tools instead after the same token-or-Cloudflare perimeter check
 - Has no access to agent persona or conversation context
 - Applies a per-client rate limit (`MAMA_CODE_ACT_RATE_LIMIT_PER_MINUTE`,
   default 30) and structured logs for memory mutation attempts

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -7,6 +7,7 @@
 ## Table of Contents
 
 - [Security Model](#security-model)
+- [Envelope Threat Model and Posture](#envelope-threat-model-and-posture)
 - [Built-in Detection and Response](#built-in-detection-and-response)
 - [Localhost-Only Mode (Default)](#localhost-only-mode-default)
 - [External Access via Tunnels](#external-access-via-tunnels)
@@ -60,6 +61,63 @@ To route alerts to chat, set:
 ```bash
 export MAMA_SECURITY_ALERT_CHANNELS="discord:CHANNEL_ID,slack:C123456"
 ```
+
+## Envelope Threat Model and Posture
+
+M1R covers Reactive runtime issuance, gateway audit logging, and memory-scope
+mismatch visibility. It does not cover delegated memory workers or Autonomous
+Standing agents; those belong to M7 and M8. Code-task delegation is outside the
+memory-twin worker scope and must not gain memory mutation scope.
+
+### Covered Threats
+
+- Agent fabrication: gateway tools receive a signed envelope from the runtime,
+  not from model-authored text.
+- Durable audit tamper evidence: gateway tool calls record `envelope_hash`,
+  requested scopes, envelope scope snapshots, and `scope_mismatch` in
+  `agent_activity`.
+- Irreversible exfiltration: destination sends, raw connector reads, and tiered
+  write paths fail closed when the signed envelope does not authorize them.
+
+### Not Covered
+
+- Key extraction through process dumps, host compromise, or shell access.
+- Supply-chain compromise of runtime dependencies or local plugins.
+- Multi-tenant isolation. MAMA OS remains a localhost-first personal runtime.
+- Delegated memory-worker envelopes and Autonomous Standing envelopes.
+
+### Hybrid Enforcement
+
+M1R deliberately uses a hybrid posture:
+
+- Fail closed for destination, `raw_connector`, and tier violations because a
+  wrong send or cross-boundary raw read cannot be unsent.
+- Log and alarm for memory-scope mismatch because memory writes are recoverable,
+  and hard denial can amplify hallucinated scope retries. The evidence is kept
+  for operator review instead.
+
+Industry pattern mapping:
+
+- Macaroons: caveat-style narrowing maps to M1R's scoped envelope fields.
+- Biscuit: decentralized capability tokens map to a possible future asymmetric
+  worker-envelope design.
+- Microsoft "Auditable Security Layer for Agentic AI": audit-first enforcement
+  maps to M1R's durable ledger plus fail-closed irreversible boundaries.
+
+### Mismatch Investigation
+
+Find memory-scope mismatches in these places:
+
+- `agent_activity` rows where `scope_mismatch=1`
+- `agent_activity.requested_scopes` and `envelope_scopes_snapshot`
+- `MetricsStore` counter `envelope_scope_mismatch`
+- `securityLogger.warn` lines containing envelope scope mismatch context
+- Authenticated `/api/envelope/status` field `recent_mismatch_count_24h`
+
+When mismatches spike, compare `requested_scopes` with
+`envelope_scopes_snapshot` for the same `envelope_hash`. Classify the cause as
+prompt injection, agent hallucination, or a legitimate caller-side scope
+derivation bug before changing policy.
 
 ---
 

--- a/docs/guides/standalone-setup.md
+++ b/docs/guides/standalone-setup.md
@@ -233,6 +233,7 @@ mama start
 Check public health and authenticated envelope status separately:
 
 ```bash
+export MAMA_AUTH_TOKEN="replace-with-strong-token"
 curl http://localhost:3847/health
 curl -H "Authorization: Bearer $MAMA_AUTH_TOKEN" \
   http://localhost:3847/api/envelope/status

--- a/docs/guides/standalone-setup.md
+++ b/docs/guides/standalone-setup.md
@@ -210,6 +210,50 @@ mama start
 
 Use `MAMA_AUTH_TOKEN` instead for temporary tunnels that do not provide Cloudflare Access identity headers.
 
+### Reactive Envelope Runtime (M1R)
+
+M1R adds signed Reactive envelopes for gateway turns. The envelope records runtime
+provenance and gives irreversible side-effect tools a verifiable boundary.
+
+For local operator testing, enable issuance with env-managed HMAC key material:
+
+```bash
+export MAMA_ENVELOPE_ISSUANCE=enabled
+export MAMA_ENVELOPE_HMAC_KEY_BASE64="$(openssl rand -base64 32)"
+export MAMA_ENVELOPE_HMAC_KEY_ID="local-2026-04"
+export MAMA_ENVELOPE_HMAC_KEY_VERSION=1
+```
+
+Then start MAMA:
+
+```bash
+mama start
+```
+
+Check public health and authenticated envelope status separately:
+
+```bash
+curl http://localhost:3847/health
+curl -H "Authorization: Bearer $MAMA_AUTH_TOKEN" \
+  http://localhost:3847/api/envelope/status
+```
+
+`/health` intentionally returns only `{ "status": "ok", "timestamp": ... }`.
+Envelope metadata lives behind `/api/envelope/status`, which reports `issuance`,
+`key_id`, `key_version`, and `recent_mismatch_count_24h`.
+
+Production notes:
+
+- Store envelope keys in environment variables or a secret manager. Never commit
+  them to git.
+- Use `MAMA_ENVELOPE_ISSUANCE=required` only after an authenticated status check
+  confirms the expected key metadata.
+- Current verification uses a single active key unless multi-key rotation support
+  is added. Old envelopes may not verify after key material rotation.
+- The M1R HMAC model is symmetric. Future delegated memory workers would need
+  shared verifier access to the issuer secret unless M7/M8 move to an asymmetric
+  capability format such as Biscuit-style tokens.
+
 ---
 
 ## Configuration

--- a/packages/mama-core/tests/cases/case-correction-supersede.test.ts
+++ b/packages/mama-core/tests/cases/case-correction-supersede.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import { getAdapter } from '../../src/db-manager.js';
@@ -459,7 +460,7 @@ describe('Phase 2b Task — supersedeCorrection (spec amendment-8 unblocked)', (
         correctionId,
         CASE_ID,
         targetRefJson,
-        require('node:crypto').createHash('sha256').update(targetRefJson).digest(),
+        createHash('sha256').update(targetRefJson).digest(),
         JSON.stringify('old narrative'),
         JSON.stringify('new narrative'),
         NOW

--- a/packages/memorybench/src/benchmarks/longmemeval/index.ts
+++ b/packages/memorybench/src/benchmarks/longmemeval/index.ts
@@ -13,6 +13,46 @@ import { logger } from "../../utils/logger"
 const DEFAULT_DATA_PATH = "./data/benchmarks/longmemeval/datasets"
 const HF_DATASET_URL =
   "https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/resolve/main/longmemeval_s_cleaned.json"
+const BENCHMARK_DATA_LOAD_ERROR = "Failed to load benchmark data"
+
+function sanitizeBenchmarkDataError(error: unknown): Error {
+  logger.warn(
+    `LongMemEval data load failed: ${error instanceof Error ? error.message : String(error)}`
+  )
+  return new Error(BENCHMARK_DATA_LOAD_ERROR)
+}
+
+function safeReadFileSync(path: string): string {
+  try {
+    return readFileSync(path, "utf8")
+  } catch (error) {
+    throw sanitizeBenchmarkDataError(error)
+  }
+}
+
+function safeReadDirSync(path: string): string[] {
+  try {
+    return readdirSync(path)
+  } catch (error) {
+    throw sanitizeBenchmarkDataError(error)
+  }
+}
+
+function safeMkdirSync(path: string): void {
+  try {
+    mkdirSync(path, { recursive: true })
+  } catch (error) {
+    throw sanitizeBenchmarkDataError(error)
+  }
+}
+
+function safeWriteFileSync(path: string, data: string): void {
+  try {
+    writeFileSync(path, data)
+  } catch (error) {
+    throw sanitizeBenchmarkDataError(error)
+  }
+}
 
 function parseLongMemEvalDate(dateStr: string): { iso: string; formatted: string } | null {
   const match = dateStr.match(/(\d{4})\/(\d{2})\/(\d{2})\s*\([^)]*\)\s*(\d{2}):(\d{2})/)
@@ -102,7 +142,7 @@ export class LongMemEvalBenchmark implements Benchmark {
       await this.downloadDataset(rawDataPath)
     }
 
-    if (!existsSync(questionsDir) || readdirSync(questionsDir).length === 0) {
+    if (!existsSync(questionsDir) || safeReadDirSync(questionsDir).length === 0) {
       logger.info("Splitting questions into individual files...")
       await this.splitQuestions(rawDataPath, questionsDir)
     }
@@ -113,7 +153,7 @@ export class LongMemEvalBenchmark implements Benchmark {
   private async downloadDataset(destPath: string): Promise<void> {
     const dir = join(destPath, "..")
     if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true })
+      safeMkdirSync(dir)
     }
 
     logger.info(`Fetching from ${HF_DATASET_URL}...`)
@@ -159,16 +199,16 @@ export class LongMemEvalBenchmark implements Benchmark {
     }
 
     const data = new TextDecoder().decode(allChunks)
-    writeFileSync(destPath, data)
+    safeWriteFileSync(destPath, data)
     logger.success(`Downloaded LongMemEval dataset to ${destPath}`)
   }
 
   private async splitQuestions(rawPath: string, questionsDir: string): Promise<void> {
     if (!existsSync(questionsDir)) {
-      mkdirSync(questionsDir, { recursive: true })
+      safeMkdirSync(questionsDir)
     }
 
-    const dataset: LongMemEvalItem[] = JSON.parse(readFileSync(rawPath, "utf8"))
+    const dataset: LongMemEvalItem[] = JSON.parse(safeReadFileSync(rawPath))
 
     for (const item of dataset) {
       if (!item.question_id) continue
@@ -183,19 +223,22 @@ export class LongMemEvalBenchmark implements Benchmark {
         })
       }
 
-      writeFileSync(join(questionsDir, `${item.question_id}.json`), JSON.stringify(item, null, 2))
+      safeWriteFileSync(
+        join(questionsDir, `${item.question_id}.json`),
+        JSON.stringify(item, null, 2)
+      )
     }
 
     logger.success(`Split ${dataset.length} questions`)
   }
 
   private loadQuestions(questionsDir: string): void {
-    const files = readdirSync(questionsDir)
+    const files = safeReadDirSync(questionsDir)
       .filter((f) => f.endsWith(".json"))
       .sort()
 
     for (const file of files) {
-      const item: LongMemEvalItem = JSON.parse(readFileSync(join(questionsDir, file), "utf8"))
+      const item: LongMemEvalItem = JSON.parse(safeReadFileSync(join(questionsDir, file)))
       this.data.push(item)
 
       const sessions = this.extractSessions(item)

--- a/packages/memorybench/src/cli/commands/list-questions.ts
+++ b/packages/memorybench/src/cli/commands/list-questions.ts
@@ -70,8 +70,9 @@ export async function listQuestionsCommand(args: string[]): Promise<void> {
 
   try {
     await benchmark.load()
-  } catch (e: any) {
-    console.error(`Failed to load benchmark: ${e.message}`)
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e)
+    console.error(`Failed to load benchmark: ${message}`)
     return
   }
 

--- a/packages/memorybench/src/cli/index.ts
+++ b/packages/memorybench/src/cli/index.ts
@@ -6,8 +6,6 @@ import { testQuestionCommand } from "./commands/test-question"
 import { statusCommand } from "./commands/status"
 import { listQuestionsCommand } from "./commands/list-questions"
 import { showFailuresCommand } from "./commands/show-failures"
-import { getAvailableProviders } from "../providers"
-import { getAvailableBenchmarks } from "../benchmarks"
 import { listModelsByProvider, MODEL_ALIASES, DEFAULT_ANSWERING_MODEL } from "../utils/models"
 
 function printHelp(): void {
@@ -193,7 +191,7 @@ export async function cli(args: string[]): Promise<void> {
     }
     case "help":
     case "--help":
-    case "-h":
+    case "-h": {
       const topic = commandArgs[0]
       if (topic === "providers") {
         printProvidersHelp()
@@ -205,6 +203,7 @@ export async function cli(args: string[]): Promise<void> {
         printHelp()
       }
       break
+    }
     default:
       printHelp()
       break

--- a/packages/memorybench/src/judges/base.ts
+++ b/packages/memorybench/src/judges/base.ts
@@ -2,7 +2,7 @@ import type { JudgeInput, JudgeResult } from "../types/judge"
 import type { ProviderPrompts } from "../types/prompts"
 import { getJudgePromptForType } from "../prompts/defaults"
 
-export function getJudgePrompt(questionType: string, providerPrompts?: ProviderPrompts): string {
+export function getJudgePrompt(questionType: string, _providerPrompts?: ProviderPrompts): string {
   return getJudgePromptForType(questionType)
 }
 

--- a/packages/memorybench/src/orchestrator/checkpoint.ts
+++ b/packages/memorybench/src/orchestrator/checkpoint.ts
@@ -24,6 +24,14 @@ import { logger } from "../utils/logger"
 
 const RUNS_DIR = "./data/runs"
 
+function getErrorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null || !("code" in error)) {
+    return undefined
+  }
+  const code = (error as { code?: unknown }).code
+  return typeof code === "string" ? code : undefined
+}
+
 export class CheckpointManager {
   private basePath: string
   private saveLock = new Map<string, Promise<void>>()
@@ -84,7 +92,7 @@ export class CheckpointManager {
 
     checkpoint.updatedAt = new Date().toISOString()
 
-    let lastError: any
+    let lastError: Error = new Error("Failed to save checkpoint")
 
     // Windows often locks files briefly (EPERM/EBUSY), so we retry a few times
     for (let attempt = 0; attempt < 5; attempt++) {
@@ -92,9 +100,10 @@ export class CheckpointManager {
         writeFileSync(tempPath, JSON.stringify(checkpoint, null, 2))
         renameSync(tempPath, path)
         return // Success
-      } catch (e: any) {
-        lastError = e
-        if (e.code !== "EPERM" && e.code !== "EBUSY") {
+      } catch (e: unknown) {
+        lastError = e instanceof Error ? e : new Error(String(e))
+        const code = getErrorCode(e)
+        if (code !== "EPERM" && code !== "EBUSY") {
           break // Don't retry other errors
         }
         // Wait with exponential backoff: 50, 100, 200, 400, 800ms
@@ -105,7 +114,9 @@ export class CheckpointManager {
     // If we get here, all retries failed or it was a non-retriable error
     try {
       unlinkSync(tempPath)
-    } catch { }
+    } catch {
+      // Ignore cleanup errors; the original save error is more useful.
+    }
     throw lastError
   }
 
@@ -284,12 +295,12 @@ export class CheckpointManager {
       evaluated: questions.filter((q) => q.phases.evaluate.status === "completed").length,
       ...(episodesTotal > 0
         ? {
-          indexingEpisodes: {
-            total: episodesTotal,
-            completed: episodesCompleted,
-            failed: episodesFailed,
-          },
-        }
+            indexingEpisodes: {
+              total: episodesTotal,
+              completed: episodesCompleted,
+              failed: episodesFailed,
+            },
+          }
         : {}),
     }
   }

--- a/packages/memorybench/src/orchestrator/phases/evaluate.ts
+++ b/packages/memorybench/src/orchestrator/phases/evaluate.ts
@@ -7,7 +7,6 @@ import { logger } from "../../utils/logger"
 import { ConcurrentExecutor } from "../concurrent"
 import { resolveConcurrency } from "../../types/concurrency"
 import { calculateRetrievalMetrics } from "./retrieval-eval"
-import { getModelConfig } from "../../utils/models"
 import { ClaudeSession } from "../../utils/claude-session"
 import { CodexSession } from "../../utils/codex-session"
 import type { AnthropicJudge } from "../../judges/anthropic"
@@ -49,13 +48,21 @@ export async function runEvaluatePhase(
     await claudeSession.start()
     ;(judge as AnthropicJudge).setClaudeSession(claudeSession)
     concurrency = 1
-    logger.info(`[evaluate] Using persistent Claude session (model: ${judgeModelConfig.id}, concurrency forced to 1)`)
+    logger.info(
+      `[evaluate] Using persistent Claude session (model: ${judgeModelConfig.id}, concurrency forced to 1)`
+    )
   } else if (judgeModelConfig.execution === "codex-cli" && "setCodexSession" in judge) {
-    codexSession = new CodexSession({ model: judgeModelConfig.id, timeoutMs: 120_000, sandbox: "read-only" })
+    codexSession = new CodexSession({
+      model: judgeModelConfig.id,
+      timeoutMs: 120_000,
+      sandbox: "read-only",
+    })
     await codexSession.start()
     ;(judge as OpenAIJudge).setCodexSession(codexSession)
     concurrency = 1
-    logger.info(`[evaluate] Using persistent Codex session (model: ${judgeModelConfig.id}, concurrency forced to 1)`)
+    logger.info(
+      `[evaluate] Using persistent Codex session (model: ${judgeModelConfig.id}, concurrency forced to 1)`
+    )
   }
 
   logger.info(
@@ -137,7 +144,9 @@ export async function runEvaluatePhase(
   }
   if (codexSession) {
     const stats = codexSession.tokenStats
-    logger.info(`[evaluate] Codex session closed after ${codexSession.messageCount} messages (${stats.input} in, ${stats.output} out, ${stats.cached} cached)`)
+    logger.info(
+      `[evaluate] Codex session closed after ${codexSession.messageCount} messages (${stats.input} in, ${stats.output} out, ${stats.cached} cached)`
+    )
     codexSession.close()
   }
 

--- a/packages/memorybench/src/orchestrator/phases/report.ts
+++ b/packages/memorybench/src/orchestrator/phases/report.ts
@@ -198,12 +198,15 @@ export function generateReport(benchmark: Benchmark, checkpoint: RunCheckpoint):
     // Only consider questions that were evaluated (same filter as the quality/latency loop above)
     if (qCheckpoint.phases.evaluate.status !== "completed") continue
     const answerPhase = qCheckpoint.phases.answer
-    if (answerPhase.promptTokens !== null && answerPhase.promptTokens !== undefined)
+    if (answerPhase.promptTokens !== null && answerPhase.promptTokens !== undefined) {
       allPromptTokens.push(answerPhase.promptTokens)
-    if (answerPhase.basePromptTokens !== null && answerPhase.basePromptTokens !== undefined)
+    }
+    if (answerPhase.basePromptTokens !== null && answerPhase.basePromptTokens !== undefined) {
       allBasePromptTokens.push(answerPhase.basePromptTokens)
-    if (answerPhase.contextTokens !== null && answerPhase.contextTokens !== undefined)
+    }
+    if (answerPhase.contextTokens !== null && answerPhase.contextTokens !== undefined) {
       allContextTokens.push(answerPhase.contextTokens)
+    }
   }
 
   if (allPromptTokens.length > 0) {

--- a/packages/memorybench/src/orchestrator/phases/report.ts
+++ b/packages/memorybench/src/orchestrator/phases/report.ts
@@ -198,10 +198,12 @@ export function generateReport(benchmark: Benchmark, checkpoint: RunCheckpoint):
     // Only consider questions that were evaluated (same filter as the quality/latency loop above)
     if (qCheckpoint.phases.evaluate.status !== "completed") continue
     const answerPhase = qCheckpoint.phases.answer
-    if (answerPhase.promptTokens != null) allPromptTokens.push(answerPhase.promptTokens)
-    if (answerPhase.basePromptTokens != null)
+    if (answerPhase.promptTokens !== null && answerPhase.promptTokens !== undefined)
+      allPromptTokens.push(answerPhase.promptTokens)
+    if (answerPhase.basePromptTokens !== null && answerPhase.basePromptTokens !== undefined)
       allBasePromptTokens.push(answerPhase.basePromptTokens)
-    if (answerPhase.contextTokens != null) allContextTokens.push(answerPhase.contextTokens)
+    if (answerPhase.contextTokens !== null && answerPhase.contextTokens !== undefined)
+      allContextTokens.push(answerPhase.contextTokens)
   }
 
   if (allPromptTokens.length > 0) {

--- a/packages/memorybench/src/server/index.ts
+++ b/packages/memorybench/src/server/index.ts
@@ -25,7 +25,7 @@ export const wsManager = new WebSocketManager()
 export async function startServer(options: ServerOptions): Promise<void> {
   const { port, open = true } = options
 
-  const server = Bun.serve({
+  const _server = Bun.serve({
     port,
 
     async fetch(req, server) {
@@ -138,7 +138,7 @@ export async function startServer(options: ServerOptions): Promise<void> {
     let foundPort = false
 
     const readOutput = async () => {
-      while (true) {
+      for (;;) {
         const { done, value } = await reader.read()
         if (done) break
 

--- a/packages/memorybench/src/server/routes/benchmarks.ts
+++ b/packages/memorybench/src/server/routes/benchmarks.ts
@@ -2,6 +2,7 @@ import { existsSync } from "fs"
 import { join } from "path"
 import { getAvailableProviders, getProviderInfo } from "../../providers"
 import { getAvailableBenchmarks, createBenchmark } from "../../benchmarks"
+import type { BenchmarkName } from "../../types/benchmark"
 import { MODEL_ALIASES, listModelsByProvider } from "../../utils/models"
 import { getActiveRunsWithBenchmarks } from "../runState"
 
@@ -86,7 +87,11 @@ export async function handleBenchmarksRoutes(req: Request, url: URL): Promise<Re
     const benchmarkName = questionsMatch[1]
 
     try {
-      const benchmark = createBenchmark(benchmarkName as any)
+      if (!getAvailableBenchmarks().includes(benchmarkName as BenchmarkName)) {
+        return json({ error: `Benchmark not found: ${benchmarkName}` }, 404)
+      }
+
+      const benchmark = createBenchmark(benchmarkName as BenchmarkName)
       await benchmark.load()
       const questions = benchmark.getQuestions()
 
@@ -123,7 +128,7 @@ export async function handleBenchmarksRoutes(req: Request, url: URL): Promise<Re
           totalPages: Math.ceil(total / limit),
         },
       })
-    } catch (e) {
+    } catch {
       return json({ error: `Benchmark not found: ${benchmarkName}` }, 404)
     }
   }

--- a/packages/memorybench/src/server/routes/benchmarks.ts
+++ b/packages/memorybench/src/server/routes/benchmarks.ts
@@ -86,11 +86,11 @@ export async function handleBenchmarksRoutes(req: Request, url: URL): Promise<Re
   if (method === "GET" && questionsMatch) {
     const benchmarkName = questionsMatch[1]
 
-    try {
-      if (!getAvailableBenchmarks().includes(benchmarkName as BenchmarkName)) {
-        return json({ error: `Benchmark not found: ${benchmarkName}` }, 404)
-      }
+    if (!getAvailableBenchmarks().includes(benchmarkName as BenchmarkName)) {
+      return json({ error: `Benchmark not found: ${benchmarkName}` }, 404)
+    }
 
+    try {
       const benchmark = createBenchmark(benchmarkName as BenchmarkName)
       await benchmark.load()
       const questions = benchmark.getQuestions()
@@ -128,8 +128,14 @@ export async function handleBenchmarksRoutes(req: Request, url: URL): Promise<Re
           totalPages: Math.ceil(total / limit),
         },
       })
-    } catch {
-      return json({ error: `Benchmark not found: ${benchmarkName}` }, 404)
+    } catch (error) {
+      return json(
+        {
+          error: `Failed to load benchmark: ${benchmarkName}`,
+          message: error instanceof Error ? error.message : String(error),
+        },
+        500
+      )
     }
   }
 

--- a/packages/memorybench/src/server/routes/compare.ts
+++ b/packages/memorybench/src/server/routes/compare.ts
@@ -1,13 +1,11 @@
 import { existsSync, readdirSync } from "fs"
-import { join } from "path"
 import { CheckpointManager } from "../../orchestrator/checkpoint"
 import { batchManager } from "../../orchestrator/batch"
-import type { CompareManifest } from "../../orchestrator/batch"
 import { wsManager } from "../index"
 import { getRunState } from "../runState"
 import type { ProviderName } from "../../types/provider"
 import type { BenchmarkName } from "../../types/benchmark"
-import type { SamplingConfig } from "../../types/checkpoint"
+import type { QuestionCheckpoint, RunCheckpoint, SamplingConfig } from "../../types/checkpoint"
 
 const checkpointManager = new CheckpointManager()
 
@@ -23,16 +21,17 @@ export type CompareState = {
 
 const activeCompares = new Map<string, CompareState>()
 
+type RunSummary = ReturnType<CheckpointManager["getSummary"]>
+
+function isPresent<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined
+}
+
 function json(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
     status,
     headers: { "Content-Type": "application/json" },
   })
-}
-
-function shouldStop(compareId: string): boolean {
-  const state = activeCompares.get(compareId)
-  return state?.status === "stopping"
 }
 
 function requestStop(compareId: string): boolean {
@@ -136,8 +135,8 @@ export async function handleCompareRoutes(req: Request, url: URL): Promise<Respo
           runProgress,
         }
       })
-      .filter(Boolean)
-      .sort((a: any, b: any) => (b.createdAt || "").localeCompare(a.createdAt || ""))
+      .filter(isPresent)
+      .sort((a, b) => (b.createdAt || "").localeCompare(a.createdAt || ""))
 
     return json(compareDetails)
   }
@@ -200,12 +199,8 @@ export async function handleCompareRoutes(req: Request, url: URL): Promise<Respo
 
       // Calculate accuracy from checkpoint questions
       const questions = Object.values(checkpoint.questions)
-      const evaluatedQuestions = questions.filter(
-        (q: any) => q.phases?.evaluate?.status === "completed"
-      )
-      const correctCount = evaluatedQuestions.filter(
-        (q: any) => q.phases?.evaluate?.score === 1
-      ).length
+      const evaluatedQuestions = questions.filter((q) => q.phases.evaluate.status === "completed")
+      const correctCount = evaluatedQuestions.filter((q) => q.phases.evaluate.score === 1).length
       const accuracy =
         evaluatedQuestions.length > 0 ? correctCount / evaluatedQuestions.length : null
 
@@ -330,7 +325,7 @@ export async function handleCompareRoutes(req: Request, url: URL): Promise<Respo
   return null
 }
 
-function getRunStatus(checkpoint: any, summary: any): string {
+function getRunStatus(checkpoint: RunCheckpoint, summary: RunSummary): string {
   // Active process takes priority
   const runState = getRunState(checkpoint.runId)
   if (runState) {
@@ -346,9 +341,9 @@ function getRunStatus(checkpoint: any, summary: any): string {
   }
 
   // Check if any question has a failed phase
-  const questions = Object.values(checkpoint.questions || {}) as any[]
-  const hasFailed = questions.some((q: any) => {
-    const phases = q.phases || {}
+  const questions: QuestionCheckpoint[] = Object.values(checkpoint.questions || {})
+  const hasFailed = questions.some((q) => {
+    const phases = q.phases
     return (
       phases.ingest?.status === "failed" ||
       phases.indexing?.status === "failed" ||

--- a/packages/memorybench/src/server/routes/compare.ts
+++ b/packages/memorybench/src/server/routes/compare.ts
@@ -198,9 +198,12 @@ export async function handleCompareRoutes(req: Request, url: URL): Promise<Respo
       const status = getRunStatus(checkpoint, summary)
 
       // Calculate accuracy from checkpoint questions
-      const questions = Object.values(checkpoint.questions)
-      const evaluatedQuestions = questions.filter((q) => q.phases.evaluate.status === "completed")
-      const correctCount = evaluatedQuestions.filter((q) => q.phases.evaluate.score === 1).length
+      const questions =
+        checkpoint.questions && typeof checkpoint.questions === "object"
+          ? Object.values(checkpoint.questions)
+          : []
+      const evaluatedQuestions = questions.filter((q) => q.phases?.evaluate?.status === "completed")
+      const correctCount = evaluatedQuestions.filter((q) => q.phases?.evaluate?.score === 1).length
       const accuracy =
         evaluatedQuestions.length > 0 ? correctCount / evaluatedQuestions.length : null
 

--- a/packages/memorybench/src/server/routes/leaderboard.ts
+++ b/packages/memorybench/src/server/routes/leaderboard.ts
@@ -5,12 +5,14 @@ import { db, schema } from "../db"
 import { CheckpointManager } from "../../orchestrator/checkpoint"
 import { createBenchmark } from "../../benchmarks"
 import type { BenchmarkName } from "../../types/benchmark"
+import type { QuestionCheckpoint } from "../../types/checkpoint"
+import type { BenchmarkResult, QuestionTypeRegistry } from "../../types/unified"
 
 const checkpointManager = new CheckpointManager()
 
-const benchmarkRegistryCache: Record<string, any> = {}
+const benchmarkRegistryCache: Record<string, QuestionTypeRegistry> = {}
 
-function getQuestionTypeRegistry(benchmarkName: string) {
+function getQuestionTypeRegistry(benchmarkName: string): QuestionTypeRegistry {
   if (!benchmarkRegistryCache[benchmarkName]) {
     const benchmark = createBenchmark(benchmarkName as BenchmarkName)
     benchmarkRegistryCache[benchmarkName] = benchmark.getQuestionTypes()
@@ -122,14 +124,14 @@ export async function handleLeaderboardRoutes(req: Request, url: URL): Promise<R
 
       // Load report for accuracy stats
       const reportPath = join(checkpointManager.getRunPath(runId), "report.json")
-      let report: any = null
+      let report: BenchmarkResult | null = null
       if (existsSync(reportPath)) {
-        report = JSON.parse(readFileSync(reportPath, "utf8"))
+        report = JSON.parse(readFileSync(reportPath, "utf8")) as BenchmarkResult
       }
 
       // Calculate accuracy from checkpoint if no report
-      const questions = Object.values(checkpoint.questions)
-      const correctCount = questions.filter((q: any) => q.phases?.evaluate?.score === 1).length
+      const questions: QuestionCheckpoint[] = Object.values(checkpoint.questions)
+      const correctCount = questions.filter((q) => q.phases.evaluate.score === 1).length
       const accuracy = report?.summary?.accuracy ?? correctCount / summary.total
 
       // Get provider code
@@ -142,13 +144,12 @@ export async function handleLeaderboardRoutes(req: Request, url: URL): Promise<R
       const byQuestionType: Record<string, { total: number; correct: number; accuracy: number }> =
         {}
       for (const q of questions) {
-        const qData = q as any
-        const type = qData.questionType || "unknown"
+        const type = q.questionType || "unknown"
         if (!byQuestionType[type]) {
           byQuestionType[type] = { total: 0, correct: 0, accuracy: 0 }
         }
         byQuestionType[type].total++
-        if (qData.phases?.evaluate?.score === 1) {
+        if (q.phases.evaluate.score === 1) {
           byQuestionType[type].correct++
         }
       }
@@ -157,18 +158,18 @@ export async function handleLeaderboardRoutes(req: Request, url: URL): Promise<R
       }
 
       // Build evaluations from checkpoint if no report
-      let evaluations = report?.evaluations || []
+      let evaluations: unknown[] = report?.evaluations || []
       if (!report?.evaluations) {
-        evaluations = questions.map((q: any) => ({
+        evaluations = questions.map((q) => ({
           questionId: q.questionId,
           questionType: q.questionType,
           question: q.question,
           groundTruth: q.groundTruth,
-          hypothesis: q.phases?.answer?.hypothesis || "",
-          score: q.phases?.evaluate?.score || 0,
-          label: q.phases?.evaluate?.label || "incorrect",
-          explanation: q.phases?.evaluate?.explanation || "",
-          searchResults: q.phases?.search?.results || [],
+          hypothesis: q.phases.answer.hypothesis || "",
+          score: q.phases.evaluate.score || 0,
+          label: q.phases.evaluate.label || "incorrect",
+          explanation: q.phases.evaluate.explanation || "",
+          searchResults: q.phases.search.results || [],
         }))
       }
 

--- a/packages/memorybench/src/server/routes/leaderboard.ts
+++ b/packages/memorybench/src/server/routes/leaderboard.ts
@@ -7,6 +7,7 @@ import { createBenchmark } from "../../benchmarks"
 import type { BenchmarkName } from "../../types/benchmark"
 import type { QuestionCheckpoint } from "../../types/checkpoint"
 import type { BenchmarkResult, QuestionTypeRegistry } from "../../types/unified"
+import { logger } from "../../utils/logger"
 
 const checkpointManager = new CheckpointManager()
 
@@ -126,13 +127,26 @@ export async function handleLeaderboardRoutes(req: Request, url: URL): Promise<R
       const reportPath = join(checkpointManager.getRunPath(runId), "report.json")
       let report: BenchmarkResult | null = null
       if (existsSync(reportPath)) {
-        report = JSON.parse(readFileSync(reportPath, "utf8")) as BenchmarkResult
+        try {
+          report = JSON.parse(readFileSync(reportPath, "utf8")) as BenchmarkResult
+        } catch (error) {
+          logger.warn(
+            `Failed to read leaderboard report cache: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          )
+          report = null
+        }
       }
 
       // Calculate accuracy from checkpoint if no report
-      const questions: QuestionCheckpoint[] = Object.values(checkpoint.questions)
-      const correctCount = questions.filter((q) => q.phases.evaluate.score === 1).length
-      const accuracy = report?.summary?.accuracy ?? correctCount / summary.total
+      const questions: QuestionCheckpoint[] =
+        checkpoint.questions && typeof checkpoint.questions === "object"
+          ? Object.values(checkpoint.questions)
+          : []
+      const correctCount = questions.filter((q) => q.phases?.evaluate?.score === 1).length
+      const accuracy =
+        report?.summary?.accuracy ?? (summary.total > 0 ? correctCount / summary.total : null)
 
       // Get provider code
       const providerCode = getProviderCode(checkpoint.provider)
@@ -149,7 +163,7 @@ export async function handleLeaderboardRoutes(req: Request, url: URL): Promise<R
           byQuestionType[type] = { total: 0, correct: 0, accuracy: 0 }
         }
         byQuestionType[type].total++
-        if (q.phases.evaluate.score === 1) {
+        if (q.phases?.evaluate?.score === 1) {
           byQuestionType[type].correct++
         }
       }
@@ -162,14 +176,14 @@ export async function handleLeaderboardRoutes(req: Request, url: URL): Promise<R
       if (!report?.evaluations) {
         evaluations = questions.map((q) => ({
           questionId: q.questionId,
-          questionType: q.questionType,
-          question: q.question,
-          groundTruth: q.groundTruth,
-          hypothesis: q.phases.answer.hypothesis || "",
-          score: q.phases.evaluate.score || 0,
-          label: q.phases.evaluate.label || "incorrect",
-          explanation: q.phases.evaluate.explanation || "",
-          searchResults: q.phases.search.results || [],
+          questionType: q.questionType || "unknown",
+          question: q.question || "",
+          groundTruth: q.groundTruth || "",
+          hypothesis: q.phases?.answer?.hypothesis || "",
+          score: q.phases?.evaluate?.score || 0,
+          label: q.phases?.evaluate?.label || "incorrect",
+          explanation: q.phases?.evaluate?.explanation || "",
+          searchResults: q.phases?.search?.results || [],
         }))
       }
 

--- a/packages/memorybench/src/server/routes/runs.ts
+++ b/packages/memorybench/src/server/routes/runs.ts
@@ -56,9 +56,16 @@ export async function handleRunsRoutes(req: Request, url: URL): Promise<Response
         const summary = checkpointManager.getSummary(checkpoint)
 
         // Calculate accuracy from checkpoint questions
-        const questions = Object.values(checkpoint.questions)
-        const evaluatedQuestions = questions.filter((q) => q.phases.evaluate.status === "completed")
-        const correctCount = evaluatedQuestions.filter((q) => q.phases.evaluate.score === 1).length
+        const questions =
+          checkpoint.questions && typeof checkpoint.questions === "object"
+            ? Object.values(checkpoint.questions)
+            : []
+        const evaluatedQuestions = questions.filter(
+          (q) => q.phases?.evaluate?.status === "completed"
+        )
+        const correctCount = evaluatedQuestions.filter(
+          (q) => q.phases?.evaluate?.score === 1
+        ).length
         const accuracy =
           evaluatedQuestions.length > 0 ? correctCount / evaluatedQuestions.length : null
 

--- a/packages/memorybench/src/server/routes/runs.ts
+++ b/packages/memorybench/src/server/routes/runs.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync } from "fs"
+import { existsSync, readFileSync } from "fs"
 import { join } from "path"
 import { CheckpointManager } from "../../orchestrator/checkpoint"
 import { orchestrator } from "../../orchestrator"
@@ -7,15 +7,27 @@ import { activeRuns, startRun, endRun, requestStop, isRunActive, getRunState } f
 import { createBenchmark } from "../../benchmarks"
 import type { ProviderName } from "../../types/provider"
 import type { BenchmarkName } from "../../types/benchmark"
-import type { PhaseId, SamplingConfig } from "../../types/checkpoint"
+import type {
+  PhaseId,
+  QuestionCheckpoint,
+  RunCheckpoint,
+  SamplingConfig,
+} from "../../types/checkpoint"
 import type { ConcurrencyConfig } from "../../types/concurrency"
 import { getPhasesFromPhase, PHASE_ORDER } from "../../types/checkpoint"
+import type { QuestionTypeRegistry } from "../../types/unified"
 
 const checkpointManager = new CheckpointManager()
 
-const benchmarkRegistryCache: Record<string, any> = {}
+const benchmarkRegistryCache: Record<string, QuestionTypeRegistry> = {}
 
-function getQuestionTypeRegistry(benchmarkName: string) {
+type RunSummary = ReturnType<CheckpointManager["getSummary"]>
+
+function isPresent<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined
+}
+
+function getQuestionTypeRegistry(benchmarkName: string): QuestionTypeRegistry {
   if (!benchmarkRegistryCache[benchmarkName]) {
     const benchmark = createBenchmark(benchmarkName as BenchmarkName)
     benchmarkRegistryCache[benchmarkName] = benchmark.getQuestionTypes()
@@ -45,12 +57,8 @@ export async function handleRunsRoutes(req: Request, url: URL): Promise<Response
 
         // Calculate accuracy from checkpoint questions
         const questions = Object.values(checkpoint.questions)
-        const evaluatedQuestions = questions.filter(
-          (q: any) => q.phases?.evaluate?.status === "completed"
-        )
-        const correctCount = evaluatedQuestions.filter(
-          (q: any) => q.phases?.evaluate?.score === 1
-        ).length
+        const evaluatedQuestions = questions.filter((q) => q.phases.evaluate.status === "completed")
+        const correctCount = evaluatedQuestions.filter((q) => q.phases.evaluate.score === 1).length
         const accuracy =
           evaluatedQuestions.length > 0 ? correctCount / evaluatedQuestions.length : null
 
@@ -67,8 +75,8 @@ export async function handleRunsRoutes(req: Request, url: URL): Promise<Response
           accuracy,
         }
       })
-      .filter(Boolean)
-      .sort((a: any, b: any) => (b.createdAt || "").localeCompare(a.createdAt || ""))
+      .filter(isPresent)
+      .sort((a, b) => (b.createdAt || "").localeCompare(a.createdAt || ""))
 
     return json(runDetails)
   }
@@ -317,7 +325,7 @@ export async function handleRunsRoutes(req: Request, url: URL): Promise<Response
   return null
 }
 
-function getRunStatus(checkpoint: any, summary: any): string {
+function getRunStatus(checkpoint: RunCheckpoint, summary: RunSummary): string {
   const runState = getRunState(checkpoint.runId)
   if (runState) {
     return runState.status
@@ -331,9 +339,9 @@ function getRunStatus(checkpoint: any, summary: any): string {
   }
 
   // Check if any question has a failed phase
-  const questions = Object.values(checkpoint.questions || {}) as any[]
-  const hasFailed = questions.some((q: any) => {
-    const phases = q.phases || {}
+  const questions: QuestionCheckpoint[] = Object.values(checkpoint.questions || {})
+  const hasFailed = questions.some((q) => {
+    const phases = q.phases
     return (
       phases.ingest?.status === "failed" ||
       phases.indexing?.status === "failed" ||

--- a/packages/memorybench/src/server/websocket.ts
+++ b/packages/memorybench/src/server/websocket.ts
@@ -50,8 +50,8 @@ export class WebSocketManager {
           ws.send(JSON.stringify({ type: "pong" }))
           break
       }
-    } catch (e) {
-      // Ignore invalid messages
+    } catch {
+      // Ignore invalid messages.
     }
   }
 
@@ -62,8 +62,8 @@ export class WebSocketManager {
       if (client.subscribedRuns.has(runId)) {
         try {
           ws.send(payload)
-        } catch (e) {
-          // Client disconnected, will be cleaned up
+        } catch {
+          // Client disconnected, will be cleaned up.
         }
       }
     }
@@ -75,8 +75,8 @@ export class WebSocketManager {
     for (const [ws] of this.clients) {
       try {
         ws.send(payload)
-      } catch (e) {
-        // Client disconnected
+      } catch {
+        // Client disconnected.
       }
     }
   }

--- a/packages/memorybench/src/utils/codex-session.ts
+++ b/packages/memorybench/src/utils/codex-session.ts
@@ -249,13 +249,15 @@ export class CodexSession {
         }
       }
       // Ignore notifications (codex/event) for simplicity
-    } catch {}
+    } catch {
+      // Ignore malformed JSON-RPC lines from the subprocess.
+    }
   }
 
   private handleClose(code: number | null): void {
     logger.info(`[CodexSession] Process closed (code: ${code})`)
     this.state = "dead"
-    for (const [id, pending] of this.pendingRequests) {
+    for (const pending of this.pendingRequests.values()) {
       if (pending.timeout) clearTimeout(pending.timeout)
       pending.reject(new Error(`Process exited with code ${code}`))
     }
@@ -263,7 +265,7 @@ export class CodexSession {
   }
 
   private handleError(err: Error): void {
-    for (const [id, pending] of this.pendingRequests) {
+    for (const pending of this.pendingRequests.values()) {
       if (pending.timeout) clearTimeout(pending.timeout)
       pending.reject(err)
     }

--- a/packages/memorybench/src/utils/tokens.ts
+++ b/packages/memorybench/src/utils/tokens.ts
@@ -45,7 +45,7 @@ function countOpenAITokens(text: string, modelId: string): number {
     const encoding = getEncoder(modelId)
     const tokens = encoding.encode(text)
     return tokens.length
-  } catch (error) {
+  } catch {
     return Math.ceil(text.length / 4)
   }
 }

--- a/packages/standalone/src/agent/agent-loop.ts
+++ b/packages/standalone/src/agent/agent-loop.ts
@@ -50,13 +50,14 @@ import type {
   StreamCallbacks,
   AgentContext,
   PromptFinalResponse,
+  GatewayExecutionSurface,
+  GatewayToolExecutionContext,
 } from './types.js';
 import { AgentError } from './types.js';
 import { buildMinimalContext } from './context-prompt-builder.js';
 import { PostToolHandler } from './post-tool-handler.js';
 import { StopContinuationHandler } from './stop-continuation-handler.js';
 import { PreCompactHandler } from './pre-compact-handler.js';
-import type { Envelope } from '../envelope/types.js';
 import * as debugLogger from '@jungjaehoon/mama-core/debug-logger';
 
 const { DebugLogger } = debugLogger as {
@@ -263,13 +264,7 @@ export function getGatewayToolsPrompt(disallowed?: string[]): string {
   return filtered;
 }
 
-export type AgentToolExecutionContext = {
-  agentContext: AgentContext | undefined;
-  agentId?: string;
-  source?: string;
-  channelId?: string;
-  envelope?: Envelope;
-};
+export type AgentToolExecutionContext = GatewayToolExecutionContext;
 
 export function buildAgentToolExecutionContext(
   options?: AgentLoopOptions
@@ -294,6 +289,23 @@ export function buildAgentToolExecutionContext(
     source: options.source,
     channelId: options.channelId,
     envelope: options.envelope,
+    executionSurface: 'model_tool',
+  };
+}
+
+function withExecutionSurface(
+  executionContext: AgentToolExecutionContext | null,
+  executionSurface: GatewayExecutionSurface
+): AgentToolExecutionContext | null {
+  if (!executionContext) {
+    return null;
+  }
+  if (executionContext.executionSurface === executionSurface) {
+    return executionContext;
+  }
+  return {
+    ...executionContext,
+    executionSurface,
   };
 }
 
@@ -556,7 +568,8 @@ export class AgentLoop {
     // Initialize PostToolHandler (fire-and-forget after tool execution)
     if (options.postToolUse?.enabled) {
       this.postToolHandler = new PostToolHandler(
-        (name, input) => this.mcpExecutor.execute(name, input as GatewayToolInput),
+        (name, input, executionContext) =>
+          this.mcpExecutor.execute(name, input as GatewayToolInput, executionContext ?? undefined),
         { enabled: true, contractSaveLimit: options.postToolUse.contractSaveLimit }
       );
       console.log('[AgentLoop] PostToolHandler enabled');
@@ -567,7 +580,8 @@ export class AgentLoop {
     // Initialize PreCompactHandler (unsaved decision detection)
     if (options.preCompact?.enabled) {
       this.preCompactHandler = new PreCompactHandler(
-        (name, input) => this.mcpExecutor.execute(name, input as GatewayToolInput),
+        (name, input, executionContext) =>
+          this.mcpExecutor.execute(name, input as GatewayToolInput, executionContext ?? undefined),
         { enabled: true, maxDecisionsToDetect: options.preCompact.maxDecisionsToDetect }
       );
       console.log('[AgentLoop] PreCompactHandler enabled');
@@ -1177,7 +1191,10 @@ export class AgentLoop {
                 .map((b) => b.text)
                 .join('\n');
             });
-            const compactResult = await this.preCompactHandler.process(historyText);
+            const compactResult = await this.preCompactHandler.process(
+              historyText,
+              withExecutionSurface(toolExecutionContext, 'reactive_internal')
+            );
             if (compactResult.compactionPrompt) {
               history.push({
                 role: 'user',
@@ -1338,6 +1355,8 @@ export class AgentLoop {
     stopAfterSuccessfulTools: string[] = [],
     executionContext: AgentToolExecutionContext | null = null
   ): Promise<ToolResultBlock[]> {
+    const modelToolContext = withExecutionSurface(executionContext, 'model_tool');
+    const reactiveInternalContext = withExecutionSurface(executionContext, 'reactive_internal');
     const toolUseBlocks = content.filter(
       (block): block is ToolUseBlock => block.type === 'tool_use'
     );
@@ -1362,7 +1381,7 @@ export class AgentLoop {
           const codeInput = toolUse.input as Record<string, unknown> | undefined;
           const code = typeof codeInput?.code === 'string' ? codeInput.code : '';
           const codeActResult = code
-            ? await this.executeCodeAct(code, this.currentTier)
+            ? await this.executeCodeAct(code, this.currentTier, modelToolContext)
             : {
                 success: false,
                 error: {
@@ -1385,14 +1404,14 @@ export class AgentLoop {
             contractContext = await this.searchContractsForTool(
               toolUse.name,
               toolUse.input as GatewayToolInput,
-              executionContext
+              reactiveInternalContext
             );
           }
 
           const toolResult = await this.mcpExecutor.execute(
             toolUse.name,
             toolUse.input as GatewayToolInput,
-            executionContext ?? undefined
+            modelToolContext ?? undefined
           );
           result = JSON.stringify(toolResult, null, 2);
 
@@ -1411,7 +1430,12 @@ export class AgentLoop {
           this.onToolUse?.(toolUse.name, toolUse.input, toolResult);
 
           // PostToolUse: auto-extract contracts (fire-and-forget)
-          this.postToolHandler?.processInBackground(toolUse.name, toolUse.input, toolResult);
+          this.postToolHandler?.processInBackground(
+            toolUse.name,
+            toolUse.input,
+            toolResult,
+            reactiveInternalContext
+          );
 
           // Notify stream: tool completed (check actual status)
           this.currentStreamCallbacks?.onToolComplete?.(toolUse.name, toolUse.id, isError);
@@ -1563,10 +1587,15 @@ export class AgentLoop {
   /**
    * Execute Code-Act JS code in a sandboxed QuickJS environment
    */
-  private async executeCodeAct(code: string, tier: 1 | 2 | 3 = 1): Promise<ExecutionResult> {
+  private async executeCodeAct(
+    code: string,
+    tier: 1 | 2 | 3 = 1,
+    executionContext: AgentToolExecutionContext | null = null
+  ): Promise<ExecutionResult> {
     try {
       const sandbox = new CodeActSandbox();
-      const bridge = new HostBridge(this.mcpExecutor);
+      const bridgeContext = withExecutionSurface(executionContext, 'code_act');
+      const bridge = new HostBridge(this.mcpExecutor, undefined, bridgeContext);
       bridge.onToolUse = (toolName, input, result) => {
         if (result === undefined) {
           // Tool starting — surface to stream

--- a/packages/standalone/src/agent/code-act/host-bridge.ts
+++ b/packages/standalone/src/agent/code-act/host-bridge.ts
@@ -1,5 +1,5 @@
 import type { GatewayToolExecutor } from '../gateway-tool-executor.js';
-import type { GatewayToolInput, GatewayToolResult } from '../types.js';
+import type { GatewayToolExecutionContext, GatewayToolInput, GatewayToolResult } from '../types.js';
 import type { CodeActSandbox } from './sandbox.js';
 import type { FunctionDescriptor } from './types.js';
 import type { RoleConfig } from '../../cli/config/types.js';
@@ -607,7 +607,8 @@ export class HostBridge {
 
   constructor(
     private executor: GatewayToolExecutor,
-    private roleManager?: RoleManager
+    private roleManager?: RoleManager,
+    private executionContext?: GatewayToolExecutionContext | null
   ) {}
 
   /** Inject all allowed functions into sandbox based on tier */
@@ -638,7 +639,9 @@ export class HostBridge {
         }
 
         this.onToolUse?.(desc.name, input, undefined);
-        const result = await this.executor.execute(desc.name, input as GatewayToolInput);
+        const result = this.executionContext
+          ? await this.executor.execute(desc.name, input as GatewayToolInput, this.executionContext)
+          : await this.executor.execute(desc.name, input as GatewayToolInput);
         this.onToolUse?.(desc.name, input, result);
 
         if (!result.success) {

--- a/packages/standalone/src/agent/code-act/host-bridge.ts
+++ b/packages/standalone/src/agent/code-act/host-bridge.ts
@@ -600,7 +600,14 @@ export const READ_ONLY_TOOLS = new Set([
 ]);
 
 /** Memory-write tools additionally allowed for Tier 2 */
-const MEMORY_WRITE_TOOLS = new Set(['mama_save', 'mama_update']);
+const MEMORY_WRITE_TOOLS = new Set([
+  'mama_save',
+  'mama_update',
+  'mama_add',
+  'mama_ingest',
+  'report_publish',
+  'wiki_publish',
+]);
 
 export class HostBridge {
   onToolUse?: (toolName: string, input: Record<string, unknown>, result: unknown) => void;

--- a/packages/standalone/src/agent/delegation-executor.ts
+++ b/packages/standalone/src/agent/delegation-executor.ts
@@ -17,6 +17,8 @@ const { DebugLogger } = debugLogger as unknown as {
   };
 };
 const securityLogger = new DebugLogger('SecurityAudit');
+const AGENT_TEST_WORKER_LIMIT = 3;
+const DELEGATE_MAX_RETRIES = 3;
 
 export type DelegationRoutingContext = {
   agentId: string;
@@ -293,7 +295,7 @@ export class DelegationExecutor {
     }
 
     const results: Array<{ input: string; output?: string; error?: string }> = [];
-    const workerCount = Math.min(3, items.length);
+    const workerCount = Math.min(AGENT_TEST_WORKER_LIMIT, items.length);
     let nextIndex = 0;
     const workers = Array.from({ length: workerCount }, async () => {
       for (;;) {
@@ -414,7 +416,8 @@ export class DelegationExecutor {
     input: DelegateInput,
     routing: DelegationRoutingContext
   ): Promise<GatewayToolResult> {
-    const { agentId, task, background } = input;
+    const { task, background } = input;
+    const agentId = this.deps.resolveManagedAgentId(input.agentId);
     const processManager = this.deps.agentProcessManager;
     const delegationManager = this.deps.delegationManagerRef;
     if (!processManager || !delegationManager) {
@@ -614,10 +617,9 @@ export class DelegationExecutor {
       );
     }
 
-    const MAX_RETRIES = 3;
     let lastError: Error | null = null;
 
-    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    for (let attempt = 0; attempt < DELEGATE_MAX_RETRIES; attempt++) {
       try {
         const process = await processManager.getProcess(source, channelId, agentId);
         let delegationPrompt = delegationManager.buildDelegationPrompt(sourceAgentId, task);
@@ -697,7 +699,7 @@ export class DelegationExecutor {
           processManager.stopProcess(source, channelId, agentId);
         }
 
-        if (attempt < MAX_RETRIES - 1 && (isBusy || isCrash)) {
+        if (attempt < DELEGATE_MAX_RETRIES - 1 && (isBusy || isCrash)) {
           await new Promise((r) => setTimeout(r, this.deps.retryDelayMs * (attempt + 1)));
           continue;
         }
@@ -744,7 +746,7 @@ export class DelegationExecutor {
 
     return {
       success: false,
-      error: `Delegation to ${agentId} failed after ${MAX_RETRIES} attempts: ${lastError?.message}`,
+      error: `Delegation to ${agentId} failed after ${DELEGATE_MAX_RETRIES} attempts: ${lastError?.message}`,
     } as GatewayToolResult;
   }
 }

--- a/packages/standalone/src/agent/delegation-executor.ts
+++ b/packages/standalone/src/agent/delegation-executor.ts
@@ -1,0 +1,750 @@
+import { existsSync, readFileSync } from 'fs';
+import { homedir } from 'os';
+import { join, resolve } from 'path';
+import * as debugLogger from '@jungjaehoon/mama-core/debug-logger';
+import type { AgentProcessManager } from '../multi-agent/agent-process-manager.js';
+import type { DelegationManager } from '../multi-agent/delegation-manager.js';
+import type { RawStore } from '../connectors/framework/raw-store.js';
+import type { SQLiteDatabase } from '../sqlite.js';
+import type { ValidationSessionService } from '../validation/session-service.js';
+import type { ValidationSessionRow } from '../validation/types.js';
+import { getLatestVersion, logActivity, updateActivityScore } from '../db/agent-store.js';
+import type { GatewayToolResult } from './types.js';
+
+const { DebugLogger } = debugLogger as unknown as {
+  DebugLogger: new (context?: string) => {
+    warn: (...args: unknown[]) => void;
+  };
+};
+const securityLogger = new DebugLogger('SecurityAudit');
+
+export type DelegationRoutingContext = {
+  agentId: string;
+  source: string;
+  channelId: string;
+};
+
+export type AgentTestInput = {
+  agent_id: string;
+  sample_count?: number;
+  test_data?: Array<{ input: string; expected?: string }>;
+};
+
+export type DelegateInput = {
+  agentId: string;
+  task: string;
+  background?: boolean;
+  skill?: string;
+};
+
+export type DelegationExecutorDeps = {
+  agentProcessManager: AgentProcessManager | null;
+  delegationManagerRef: DelegationManager | null;
+  rawStore?: RawStore | null;
+  sessionsDb?: SQLiteDatabase | null;
+  validationService?: ValidationSessionService | null;
+  retryDelayMs: number;
+  resolveManagedAgentId: (id: string) => string;
+  checkViewerOnly: () => string | null;
+};
+
+function summarizeActivityOutput(output: unknown): string | undefined {
+  if (output === undefined || output === null) {
+    return undefined;
+  }
+  if (typeof output === 'string') {
+    return output.slice(0, 500);
+  }
+  try {
+    return JSON.stringify(output).slice(0, 500);
+  } catch {
+    return String(output).slice(0, 500);
+  }
+}
+
+function resolveSkillPath(skillName: string): string | null {
+  if (!/^[a-zA-Z0-9_-]+$/.test(skillName)) {
+    return null;
+  }
+  const skillsDir = join(homedir(), '.mama', 'skills');
+  const resolved = resolve(skillsDir, `${skillName}.md`);
+  if (!resolved.startsWith(skillsDir)) {
+    return null;
+  }
+  return resolved;
+}
+
+function normalizeRouting(routing: DelegationRoutingContext): DelegationRoutingContext {
+  return {
+    agentId: routing.agentId || 'conductor',
+    source: routing.source || 'viewer',
+    channelId: routing.channelId || 'default',
+  };
+}
+
+export class DelegationExecutor {
+  private readonly testInFlight = new Map<string, Promise<GatewayToolResult>>();
+
+  constructor(private readonly deps: DelegationExecutorDeps) {}
+
+  async runAgentTest(
+    input: AgentTestInput,
+    routing: DelegationRoutingContext
+  ): Promise<GatewayToolResult> {
+    const permError = this.deps.checkViewerOnly();
+    if (permError) {
+      return { success: false, error: permError } as GatewayToolResult;
+    }
+
+    const { agent_id } = input;
+    const sample_count = Number.parseInt(String(input.sample_count ?? 2), 10);
+    const resolvedAgentId = this.deps.resolveManagedAgentId(agent_id);
+    if (!Number.isFinite(sample_count) || sample_count < 1) {
+      securityLogger.warn('[Agent test] Invalid sample_count received', {
+        agent_id: resolvedAgentId,
+        sample_count: input.sample_count ?? null,
+      });
+      return {
+        success: false,
+        error: `Invalid sample_count for '${resolvedAgentId}': ${String(input.sample_count)}. Must be >= 1.`,
+      } as GatewayToolResult;
+    }
+
+    if (this.testInFlight.has(resolvedAgentId)) {
+      return { success: false, error: 'test_already_running' } as GatewayToolResult;
+    }
+
+    const promise = this.runAgentTestInternal(
+      resolvedAgentId,
+      sample_count,
+      routing,
+      input.test_data
+    );
+    this.testInFlight.set(resolvedAgentId, promise);
+    try {
+      return await promise;
+    } finally {
+      this.testInFlight.delete(resolvedAgentId);
+    }
+  }
+
+  async runDelegate(
+    input: DelegateInput,
+    routing: DelegationRoutingContext
+  ): Promise<GatewayToolResult> {
+    return this.runDelegateInternal(input, routing);
+  }
+
+  private cleanupValidationSessionOnTelemetryFailure(
+    session: ValidationSessionRow | null,
+    error: unknown,
+    label: string
+  ): null {
+    if (!session || !this.deps.validationService) {
+      return null;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    try {
+      this.deps.validationService.finalizeSession(session.id, {
+        execution_status: 'failed',
+        error_message: `${label}: ${message}`,
+      });
+    } catch (cleanupErr) {
+      securityLogger.warn(
+        `[Delegation telemetry] Failed to clean up validation session ${session.id}`,
+        cleanupErr
+      );
+    }
+    return null;
+  }
+
+  private async runAgentTestInternal(
+    agentId: string,
+    sampleCount: number,
+    routing: DelegationRoutingContext,
+    testData?: Array<{ input: string; expected?: string }>
+  ): Promise<GatewayToolResult> {
+    const processManager = this.deps.agentProcessManager;
+    const delegationManager = this.deps.delegationManagerRef;
+    if (!processManager || !delegationManager) {
+      return {
+        success: false,
+        error: 'agent_timeout: multi-agent not configured',
+      } as GatewayToolResult;
+    }
+
+    const startTime = Date.now();
+
+    let items: Array<{ input: string; expected?: string }>;
+    if (testData && testData.length > 0) {
+      const normalizedItems: Array<{ input: string; expected?: string }> = [];
+      for (let index = 0; index < testData.length; index++) {
+        const rawItem = testData[index] as unknown as Record<string, unknown>;
+        if (typeof rawItem.input !== 'string') {
+          return {
+            success: false,
+            error: `Invalid test_data[${index}].input: expected string`,
+          } as GatewayToolResult;
+        }
+        if (rawItem.expected !== undefined && typeof rawItem.expected !== 'string') {
+          return {
+            success: false,
+            error: `Invalid test_data[${index}].expected: expected string`,
+          } as GatewayToolResult;
+        }
+        normalizedItems.push({
+          input: rawItem.input,
+          ...(typeof rawItem.expected === 'string' ? { expected: rawItem.expected } : {}),
+        });
+      }
+      items = normalizedItems;
+    } else if (this.deps.rawStore) {
+      const agentConfig = delegationManager.getAgentConfig(agentId);
+      const connectors: string[] = (agentConfig?.connectors as string[]) ?? [];
+      if (connectors.length === 0) {
+        return {
+          success: false,
+          error: 'connector_unavailable: no connectors configured',
+        } as GatewayToolResult;
+      }
+      const allItems: Array<{ input: string }> = [];
+      const missingConnectors: string[] = [];
+      for (const conn of connectors) {
+        if (!this.deps.rawStore.hasConnector(conn)) {
+          missingConnectors.push(conn);
+          continue;
+        }
+        const recent = this.deps.rawStore.getRecent(conn, sampleCount);
+        for (const item of recent) {
+          allItems.push({ input: `[${item.type}] ${item.content}` });
+        }
+        if (allItems.length >= sampleCount) {
+          break;
+        }
+      }
+      if (allItems.length === 0) {
+        const detail =
+          missingConnectors.length > 0
+            ? `connector(s) not found: ${missingConnectors.join(', ')}`
+            : 'no recent data';
+        return {
+          success: false,
+          error: `connector_unavailable: ${detail}`,
+        } as GatewayToolResult;
+      }
+      items = allItems.slice(0, sampleCount);
+    } else {
+      return {
+        success: false,
+        error: 'connector_unavailable: rawStore not available',
+      } as GatewayToolResult;
+    }
+
+    const testVer = this.deps.sessionsDb ? getLatestVersion(this.deps.sessionsDb, agentId) : null;
+    const testAgentVersion = testVer?.version ?? 0;
+    let testValSession: ValidationSessionRow | null = null;
+    try {
+      testValSession =
+        this.deps.validationService?.startSession(agentId, testAgentVersion, 'agent_test', {
+          goal: `Test with ${items.length} items`,
+          customBeforeSnapshot: JSON.stringify({
+            schema_version: 1,
+            test_input_summary: items.map((i) => i.input.slice(0, 80)).join('; '),
+            sample_count: items.length,
+          }),
+        }) ?? null;
+    } catch (telemetryErr) {
+      securityLogger.warn('[Agent test telemetry] Failed to start validation session', {
+        agentId,
+        testAgentVersion,
+        error: telemetryErr instanceof Error ? telemetryErr.message : String(telemetryErr),
+      });
+    }
+
+    let testRunId: number | null = null;
+    if (this.deps.sessionsDb) {
+      try {
+        const row = logActivity(this.deps.sessionsDb, {
+          agent_id: agentId,
+          agent_version: testAgentVersion,
+          type: 'test_run',
+          input_summary: `Testing with ${items.length} items`,
+          run_id: testValSession?.id,
+          execution_status: 'started',
+          trigger_reason: 'agent_test',
+        });
+        testRunId = row.id;
+        if (testValSession && this.deps.validationService) {
+          this.deps.validationService.recordRun(testValSession.id, { activityId: row.id });
+        }
+      } catch (telemetryErr) {
+        securityLogger.warn('[Agent test telemetry] Failed to persist startup activity', {
+          agentId,
+          testValSessionId: testValSession?.id ?? null,
+          error: telemetryErr instanceof Error ? telemetryErr.message : String(telemetryErr),
+        });
+        testValSession = this.cleanupValidationSessionOnTelemetryFailure(
+          testValSession,
+          telemetryErr,
+          'agent_test startup telemetry failed'
+        );
+        testRunId = null;
+      }
+    }
+
+    const results: Array<{ input: string; output?: string; error?: string }> = [];
+    const workerCount = Math.min(3, items.length);
+    let nextIndex = 0;
+    const workers = Array.from({ length: workerCount }, async () => {
+      for (;;) {
+        const currentIndex = nextIndex;
+        nextIndex++;
+        if (currentIndex >= items.length) {
+          return;
+        }
+        const item = items[currentIndex];
+        try {
+          const r = await this.runDelegateInternal(
+            {
+              agentId,
+              task: `Process this data:\n${item.input}`,
+            },
+            routing
+          );
+          const rAny = r as Record<string, unknown>;
+          const output = r.success
+            ? String((rAny.data as Record<string, unknown>)?.response ?? '')
+            : undefined;
+          results[currentIndex] = {
+            input: item.input,
+            output,
+            error: r.success ? undefined : String(rAny.error ?? 'unknown'),
+          };
+        } catch (err) {
+          results[currentIndex] = { input: item.input, error: String(err) };
+        }
+      }
+    });
+    await Promise.all(workers);
+
+    const passed = results.filter((r, index) => {
+      if (r.error) {
+        return false;
+      }
+      const expected = items[index]?.expected;
+      if (expected === undefined) {
+        return true;
+      }
+      return (r.output ?? '').trim() === expected.trim();
+    }).length;
+    const failed = results.length - passed;
+    const autoScore = results.length > 0 ? Math.round((passed / results.length) * 100) : 0;
+
+    if (this.deps.sessionsDb && testRunId) {
+      try {
+        updateActivityScore(
+          this.deps.sessionsDb,
+          testRunId,
+          autoScore,
+          {
+            total: results.length,
+            passed,
+            failed,
+            items: results.map((r, index) => ({
+              input: r.input.slice(0, 100),
+              result:
+                r.error ||
+                (items[index]?.expected !== undefined &&
+                  (r.output ?? '').trim() !== items[index]!.expected!.trim())
+                  ? 'fail'
+                  : 'pass',
+            })),
+          },
+          'completed'
+        );
+      } catch (telemetryErr) {
+        securityLogger.warn('[Agent test telemetry] Failed to persist test score', {
+          agentId,
+          testRunId,
+          autoScore,
+          totalResults: results.length,
+          error: telemetryErr instanceof Error ? telemetryErr.message : String(telemetryErr),
+        });
+      }
+    }
+
+    const testDurationMs = Date.now() - startTime;
+    if (testValSession && this.deps.validationService) {
+      try {
+        this.deps.validationService.finalizeSession(testValSession.id, {
+          execution_status: 'completed',
+          metrics: {
+            duration_ms: testDurationMs,
+            completion_rate: results.length > 0 ? passed / results.length : 0,
+            auto_score: autoScore,
+          },
+          test_input_summary: items.map((i) => i.input.slice(0, 80)).join('; '),
+        });
+      } catch (telemetryErr) {
+        securityLogger.warn('[Agent test telemetry] Failed to finalize validation session', {
+          agentId,
+          testValSessionId: testValSession.id,
+          autoScore,
+          totalResults: results.length,
+          error: telemetryErr instanceof Error ? telemetryErr.message : String(telemetryErr),
+        });
+      }
+    }
+
+    return {
+      success: true,
+      data: {
+        test_run_id: testRunId,
+        agent_id: agentId,
+        results,
+        auto_score: autoScore,
+        duration_ms: testDurationMs,
+        validation_session_id: testValSession?.id ?? null,
+        ...(testRunId === null ? { warning: 'score_not_persisted' } : {}),
+      },
+    } as GatewayToolResult;
+  }
+
+  private async runDelegateInternal(
+    input: DelegateInput,
+    routing: DelegationRoutingContext
+  ): Promise<GatewayToolResult> {
+    const { agentId, task, background } = input;
+    const processManager = this.deps.agentProcessManager;
+    const delegationManager = this.deps.delegationManagerRef;
+    if (!processManager || !delegationManager) {
+      return { success: false, error: 'Multi-agent not configured' } as GatewayToolResult;
+    }
+
+    const {
+      agentId: activeAgentId,
+      source: activeSource,
+      channelId: activeChannelId,
+    } = normalizeRouting(routing);
+    const sourceAgentId = activeAgentId || 'conductor';
+    const check = delegationManager.isDelegationAllowed(sourceAgentId, agentId);
+    if (!check.allowed) {
+      return {
+        success: false,
+        error: `Delegation denied: ${check.reason}`,
+      } as GatewayToolResult;
+    }
+
+    if (background) {
+      const source = activeSource || 'viewer';
+      const channelId = activeChannelId || 'default';
+
+      let bgAgentVersion = 0;
+      let bgValSession: ValidationSessionRow | null = null;
+      try {
+        const bgVer = this.deps.sessionsDb ? getLatestVersion(this.deps.sessionsDb, agentId) : null;
+        bgAgentVersion = bgVer?.version ?? 0;
+        bgValSession =
+          this.deps.validationService?.startSession(agentId, bgAgentVersion, 'delegate_run') ??
+          null;
+
+        if (this.deps.sessionsDb) {
+          const row = logActivity(this.deps.sessionsDb, {
+            agent_id: agentId,
+            agent_version: bgAgentVersion,
+            type: 'task_start',
+            input_summary: task?.slice(0, 200),
+            run_id: bgValSession?.id,
+            execution_status: 'started',
+            trigger_reason: 'delegate_run',
+          });
+          if (bgValSession && this.deps.validationService) {
+            this.deps.validationService.recordRun(bgValSession.id, { activityId: row.id });
+          }
+        }
+      } catch (telemetryErr) {
+        securityLogger.warn('[Delegation telemetry] Background bootstrap failed', telemetryErr);
+        bgAgentVersion = 0;
+        bgValSession = this.cleanupValidationSessionOnTelemetryFailure(
+          bgValSession,
+          telemetryErr,
+          'background delegate bootstrap failed'
+        );
+      }
+
+      const bgStartTime = Date.now();
+      void (async () => {
+        try {
+          const process = await processManager.getProcess(source, channelId, agentId);
+          let delegationPrompt = delegationManager.buildDelegationPrompt(sourceAgentId, task);
+          if (input.skill) {
+            const skillPath = resolveSkillPath(input.skill);
+            if (skillPath && existsSync(skillPath)) {
+              const skillContent = readFileSync(skillPath, 'utf-8');
+              delegationPrompt = skillContent + '\n\n---\n\n' + delegationPrompt;
+            }
+          }
+          const result = await process.sendMessage(delegationPrompt);
+          const durationMs = Date.now() - bgStartTime;
+
+          try {
+            if (this.deps.sessionsDb) {
+              const row = logActivity(this.deps.sessionsDb, {
+                agent_id: agentId,
+                agent_version: bgAgentVersion,
+                type: 'task_complete',
+                input_summary: task?.slice(0, 200),
+                output_summary: summarizeActivityOutput(result?.response),
+                duration_ms: durationMs,
+                run_id: bgValSession?.id,
+                execution_status: 'completed',
+                trigger_reason: 'delegate_run',
+              });
+              if (bgValSession && this.deps.validationService) {
+                this.deps.validationService.recordRun(bgValSession.id, {
+                  activityId: row.id,
+                  duration_ms: durationMs,
+                });
+              }
+            }
+          } catch (telemetryErr) {
+            securityLogger.warn(
+              '[Delegation telemetry] Background completion activity failed',
+              telemetryErr
+            );
+          }
+
+          try {
+            if (bgValSession && this.deps.validationService) {
+              this.deps.validationService.finalizeSession(bgValSession.id, {
+                execution_status: 'completed',
+                metrics: { duration_ms: durationMs },
+              });
+            }
+          } catch (telemetryErr) {
+            securityLogger.warn(
+              '[Delegation telemetry] Background completion finalize failed',
+              telemetryErr
+            );
+          }
+        } catch (err) {
+          const durationMs = Date.now() - bgStartTime;
+          try {
+            if (this.deps.sessionsDb) {
+              const row = logActivity(this.deps.sessionsDb, {
+                agent_id: agentId,
+                agent_version: bgAgentVersion,
+                type: 'task_error',
+                input_summary: task?.slice(0, 200),
+                error_message: String(err),
+                duration_ms: durationMs,
+                run_id: bgValSession?.id,
+                execution_status: 'failed',
+                trigger_reason: 'delegate_run',
+              });
+              if (bgValSession && this.deps.validationService) {
+                this.deps.validationService.recordRun(bgValSession.id, {
+                  activityId: row.id,
+                  duration_ms: durationMs,
+                });
+              }
+            }
+          } catch (telemetryErr) {
+            securityLogger.warn(
+              '[Delegation telemetry] Background failure activity failed',
+              telemetryErr
+            );
+          }
+          try {
+            if (bgValSession && this.deps.validationService) {
+              this.deps.validationService.finalizeSession(bgValSession.id, {
+                execution_status: 'failed',
+                error_message: String(err),
+                metrics: { duration_ms: durationMs },
+              });
+            }
+          } catch (telemetryErr) {
+            securityLogger.warn(
+              '[Delegation telemetry] Background failure finalize failed',
+              telemetryErr
+            );
+          }
+        }
+      })();
+
+      return {
+        success: true,
+        data: { agentId, background: true, message: 'Background task submitted' },
+      } as GatewayToolResult;
+    }
+
+    const source = activeSource || 'viewer';
+    const channelId = activeChannelId || 'default';
+    const startTime = Date.now();
+
+    let agentVersion = 0;
+    let valSession: ValidationSessionRow | null = null;
+    try {
+      const ver = this.deps.sessionsDb ? getLatestVersion(this.deps.sessionsDb, agentId) : null;
+      agentVersion = ver?.version ?? 0;
+      valSession =
+        this.deps.validationService?.startSession(agentId, agentVersion, 'delegate_run') ?? null;
+
+      if (this.deps.sessionsDb) {
+        const row = logActivity(this.deps.sessionsDb, {
+          agent_id: agentId,
+          agent_version: agentVersion,
+          type: 'task_start',
+          input_summary: task?.slice(0, 200),
+          run_id: valSession?.id,
+          execution_status: 'started',
+          trigger_reason: 'delegate_run',
+        });
+        if (valSession && this.deps.validationService) {
+          this.deps.validationService.recordRun(valSession.id, { activityId: row.id });
+        }
+      }
+    } catch (telemetryErr) {
+      securityLogger.warn('[Delegation telemetry] Validation bootstrap failed', telemetryErr);
+      agentVersion = 0;
+      valSession = this.cleanupValidationSessionOnTelemetryFailure(
+        valSession,
+        telemetryErr,
+        'delegate bootstrap failed'
+      );
+    }
+
+    const MAX_RETRIES = 3;
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      try {
+        const process = await processManager.getProcess(source, channelId, agentId);
+        let delegationPrompt = delegationManager.buildDelegationPrompt(sourceAgentId, task);
+
+        if (input.skill) {
+          const skillPath = resolveSkillPath(input.skill);
+          if (skillPath && existsSync(skillPath)) {
+            const skillContent = readFileSync(skillPath, 'utf-8');
+            delegationPrompt = skillContent + '\n\n---\n\n' + delegationPrompt;
+          }
+        }
+
+        const sessionId = process.getSessionId?.();
+        if (!sessionId || attempt > 0) {
+          try {
+            const { getChannelHistory } = await import('../gateways/channel-history.js');
+            const channelHistory = getChannelHistory();
+            if (channelHistory) {
+              const historyContext = channelHistory.formatForContext(channelId, '', agentId);
+              if (historyContext) {
+                delegationPrompt = `${historyContext}\n\n${delegationPrompt}`;
+              }
+            }
+          } catch {
+            // Channel history injection is best-effort.
+          }
+        }
+
+        const result = await process.sendMessage(delegationPrompt);
+        const durationMs = Date.now() - startTime;
+
+        try {
+          if (this.deps.sessionsDb) {
+            const row = logActivity(this.deps.sessionsDb, {
+              agent_id: agentId,
+              agent_version: agentVersion,
+              type: 'task_complete',
+              input_summary: task?.slice(0, 200),
+              output_summary: summarizeActivityOutput(result.response),
+              duration_ms: durationMs,
+              run_id: valSession?.id,
+              execution_status: 'completed',
+              trigger_reason: 'delegate_run',
+            });
+            if (valSession && this.deps.validationService) {
+              this.deps.validationService.recordRun(valSession.id, {
+                activityId: row.id,
+                duration_ms: durationMs,
+              });
+            }
+          }
+        } catch (telemetryErr) {
+          securityLogger.warn('[Delegation telemetry] Completion activity failed', telemetryErr);
+        }
+
+        try {
+          if (valSession && this.deps.validationService) {
+            this.deps.validationService.finalizeSession(valSession.id, {
+              execution_status: 'completed',
+              metrics: { duration_ms: durationMs },
+            });
+          }
+        } catch (telemetryErr) {
+          securityLogger.warn('[Delegation telemetry] Completion finalize failed', telemetryErr);
+        }
+
+        return {
+          success: true,
+          data: { agentId, response: result.response, duration_ms: durationMs },
+        } as GatewayToolResult;
+      } catch (err) {
+        lastError = err instanceof Error ? err : new Error(String(err));
+        const isBusy = lastError.message.includes('busy');
+        const isCrash = lastError.message.includes('exited with code');
+
+        if (isCrash) {
+          processManager.stopProcess(source, channelId, agentId);
+        }
+
+        if (attempt < MAX_RETRIES - 1 && (isBusy || isCrash)) {
+          await new Promise((r) => setTimeout(r, this.deps.retryDelayMs * (attempt + 1)));
+          continue;
+        }
+        break;
+      }
+    }
+
+    const failedDurationMs = Date.now() - startTime;
+    try {
+      if (this.deps.sessionsDb) {
+        const row = logActivity(this.deps.sessionsDb, {
+          agent_id: agentId,
+          agent_version: agentVersion,
+          type: 'task_error',
+          input_summary: task?.slice(0, 200),
+          error_message: lastError?.message,
+          duration_ms: failedDurationMs,
+          run_id: valSession?.id,
+          execution_status: 'failed',
+          trigger_reason: 'delegate_run',
+        });
+        if (valSession && this.deps.validationService) {
+          this.deps.validationService.recordRun(valSession.id, {
+            activityId: row.id,
+            duration_ms: failedDurationMs,
+          });
+        }
+      }
+    } catch (telemetryErr) {
+      securityLogger.warn('[Delegation telemetry] Failure activity failed', telemetryErr);
+    }
+
+    try {
+      if (valSession && this.deps.validationService) {
+        this.deps.validationService.finalizeSession(valSession.id, {
+          execution_status: 'failed',
+          error_message: lastError?.message,
+          metrics: { duration_ms: failedDurationMs },
+        });
+      }
+    } catch (telemetryErr) {
+      securityLogger.warn('[Delegation telemetry] Failure finalize failed', telemetryErr);
+    }
+
+    return {
+      success: false,
+      error: `Delegation to ${agentId} failed after ${MAX_RETRIES} attempts: ${lastError?.message}`,
+    } as GatewayToolResult;
+  }
+}

--- a/packages/standalone/src/agent/delegation-executor.ts
+++ b/packages/standalone/src/agent/delegation-executor.ts
@@ -4,6 +4,7 @@ import { join, resolve } from 'path';
 import * as debugLogger from '@jungjaehoon/mama-core/debug-logger';
 import type { AgentProcessManager } from '../multi-agent/agent-process-manager.js';
 import type { DelegationManager } from '../multi-agent/delegation-manager.js';
+import type { AgentRuntimeProcess } from '../multi-agent/runtime-process.js';
 import type { RawStore } from '../connectors/framework/raw-store.js';
 import type { SQLiteDatabase } from '../sqlite.js';
 import type { ValidationSessionService } from '../validation/session-service.js';
@@ -76,11 +77,23 @@ function resolveSkillPath(skillName: string): string | null {
   return resolved;
 }
 
-function normalizeRouting(routing: DelegationRoutingContext): DelegationRoutingContext {
+function requireRoutingField(
+  routing: Partial<DelegationRoutingContext> | undefined,
+  field: keyof DelegationRoutingContext
+): string {
+  const value = routing?.[field];
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`[delegation] missing routing.${field}`);
+  }
+  return value;
+}
+
+function requireRouting(routing: DelegationRoutingContext): DelegationRoutingContext {
+  const input = routing as Partial<DelegationRoutingContext> | undefined;
   return {
-    agentId: routing.agentId || 'conductor',
-    source: routing.source || 'viewer',
-    channelId: routing.channelId || 'default',
+    agentId: requireRoutingField(input, 'agentId'),
+    source: requireRoutingField(input, 'source'),
+    channelId: requireRoutingField(input, 'channelId'),
   };
 }
 
@@ -424,12 +437,7 @@ export class DelegationExecutor {
       return { success: false, error: 'Multi-agent not configured' } as GatewayToolResult;
     }
 
-    const {
-      agentId: activeAgentId,
-      source: activeSource,
-      channelId: activeChannelId,
-    } = normalizeRouting(routing);
-    const sourceAgentId = activeAgentId || 'conductor';
+    const { agentId: sourceAgentId, source, channelId } = requireRouting(routing);
     const check = delegationManager.isDelegationAllowed(sourceAgentId, agentId);
     if (!check.allowed) {
       return {
@@ -439,9 +447,6 @@ export class DelegationExecutor {
     }
 
     if (background) {
-      const source = activeSource || 'viewer';
-      const channelId = activeChannelId || 'default';
-
       let bgAgentVersion = 0;
       let bgValSession: ValidationSessionRow | null = null;
       try {
@@ -478,16 +483,16 @@ export class DelegationExecutor {
       const bgStartTime = Date.now();
       void (async () => {
         try {
-          const process = await processManager.getProcess(source, channelId, agentId);
-          let delegationPrompt = delegationManager.buildDelegationPrompt(sourceAgentId, task);
-          if (input.skill) {
-            const skillPath = resolveSkillPath(input.skill);
-            if (skillPath && existsSync(skillPath)) {
-              const skillContent = readFileSync(skillPath, 'utf-8');
-              delegationPrompt = skillContent + '\n\n---\n\n' + delegationPrompt;
-            }
-          }
-          const result = await process.sendMessage(delegationPrompt);
+          const result = await this.sendDelegationMessageWithRetry({
+            processManager,
+            delegationManager,
+            source,
+            channelId,
+            agentId,
+            sourceAgentId,
+            task,
+            skill: input.skill,
+          });
           const durationMs = Date.now() - bgStartTime;
 
           try {
@@ -581,8 +586,6 @@ export class DelegationExecutor {
       } as GatewayToolResult;
     }
 
-    const source = activeSource || 'viewer';
-    const channelId = activeChannelId || 'default';
     const startTime = Date.now();
 
     let agentVersion = 0;
@@ -617,136 +620,194 @@ export class DelegationExecutor {
       );
     }
 
+    try {
+      const result = await this.sendDelegationMessageWithRetry({
+        processManager,
+        delegationManager,
+        source,
+        channelId,
+        agentId,
+        sourceAgentId,
+        task,
+        skill: input.skill,
+      });
+      const durationMs = Date.now() - startTime;
+
+      try {
+        if (this.deps.sessionsDb) {
+          const row = logActivity(this.deps.sessionsDb, {
+            agent_id: agentId,
+            agent_version: agentVersion,
+            type: 'task_complete',
+            input_summary: task?.slice(0, 200),
+            output_summary: summarizeActivityOutput(result.response),
+            duration_ms: durationMs,
+            run_id: valSession?.id,
+            execution_status: 'completed',
+            trigger_reason: 'delegate_run',
+          });
+          if (valSession && this.deps.validationService) {
+            this.deps.validationService.recordRun(valSession.id, {
+              activityId: row.id,
+              duration_ms: durationMs,
+            });
+          }
+        }
+      } catch (telemetryErr) {
+        securityLogger.warn('[Delegation telemetry] Completion activity failed', telemetryErr);
+      }
+
+      try {
+        if (valSession && this.deps.validationService) {
+          this.deps.validationService.finalizeSession(valSession.id, {
+            execution_status: 'completed',
+            metrics: { duration_ms: durationMs },
+          });
+        }
+      } catch (telemetryErr) {
+        securityLogger.warn('[Delegation telemetry] Completion finalize failed', telemetryErr);
+      }
+
+      return {
+        success: true,
+        data: { agentId, response: result.response, duration_ms: durationMs },
+      } as GatewayToolResult;
+    } catch (err) {
+      const lastError = err instanceof Error ? err : new Error(String(err));
+      const failedDurationMs = Date.now() - startTime;
+      try {
+        if (this.deps.sessionsDb) {
+          const row = logActivity(this.deps.sessionsDb, {
+            agent_id: agentId,
+            agent_version: agentVersion,
+            type: 'task_error',
+            input_summary: task?.slice(0, 200),
+            error_message: lastError.message,
+            duration_ms: failedDurationMs,
+            run_id: valSession?.id,
+            execution_status: 'failed',
+            trigger_reason: 'delegate_run',
+          });
+          if (valSession && this.deps.validationService) {
+            this.deps.validationService.recordRun(valSession.id, {
+              activityId: row.id,
+              duration_ms: failedDurationMs,
+            });
+          }
+        }
+      } catch (telemetryErr) {
+        securityLogger.warn('[Delegation telemetry] Failure activity failed', telemetryErr);
+      }
+
+      try {
+        if (valSession && this.deps.validationService) {
+          this.deps.validationService.finalizeSession(valSession.id, {
+            execution_status: 'failed',
+            error_message: lastError.message,
+            metrics: { duration_ms: failedDurationMs },
+          });
+        }
+      } catch (telemetryErr) {
+        securityLogger.warn('[Delegation telemetry] Failure finalize failed', telemetryErr);
+      }
+
+      return {
+        success: false,
+        error: `Delegation to ${agentId} failed after ${DELEGATE_MAX_RETRIES} attempts: ${lastError.message}`,
+      } as GatewayToolResult;
+    }
+  }
+
+  private async sendDelegationMessageWithRetry(args: {
+    processManager: AgentProcessManager;
+    delegationManager: DelegationManager;
+    source: string;
+    channelId: string;
+    agentId: string;
+    sourceAgentId: string;
+    task: string;
+    skill?: string;
+  }): Promise<Awaited<ReturnType<AgentRuntimeProcess['sendMessage']>>> {
     let lastError: Error | null = null;
 
     for (let attempt = 0; attempt < DELEGATE_MAX_RETRIES; attempt++) {
       try {
-        const process = await processManager.getProcess(source, channelId, agentId);
-        let delegationPrompt = delegationManager.buildDelegationPrompt(sourceAgentId, task);
-
-        if (input.skill) {
-          const skillPath = resolveSkillPath(input.skill);
-          if (skillPath && existsSync(skillPath)) {
-            const skillContent = readFileSync(skillPath, 'utf-8');
-            delegationPrompt = skillContent + '\n\n---\n\n' + delegationPrompt;
-          }
-        }
+        const process = await args.processManager.getProcess(
+          args.source,
+          args.channelId,
+          args.agentId
+        );
+        let delegationPrompt = this.buildDelegationPrompt(args);
 
         const sessionId = process.getSessionId?.();
         if (!sessionId || attempt > 0) {
-          try {
-            const { getChannelHistory } = await import('../gateways/channel-history.js');
-            const channelHistory = getChannelHistory();
-            if (channelHistory) {
-              const historyContext = channelHistory.formatForContext(channelId, '', agentId);
-              if (historyContext) {
-                delegationPrompt = `${historyContext}\n\n${delegationPrompt}`;
-              }
-            }
-          } catch {
-            // Channel history injection is best-effort.
-          }
+          delegationPrompt = await this.withChannelHistory(
+            delegationPrompt,
+            args.channelId,
+            args.agentId
+          );
         }
 
-        const result = await process.sendMessage(delegationPrompt);
-        const durationMs = Date.now() - startTime;
-
-        try {
-          if (this.deps.sessionsDb) {
-            const row = logActivity(this.deps.sessionsDb, {
-              agent_id: agentId,
-              agent_version: agentVersion,
-              type: 'task_complete',
-              input_summary: task?.slice(0, 200),
-              output_summary: summarizeActivityOutput(result.response),
-              duration_ms: durationMs,
-              run_id: valSession?.id,
-              execution_status: 'completed',
-              trigger_reason: 'delegate_run',
-            });
-            if (valSession && this.deps.validationService) {
-              this.deps.validationService.recordRun(valSession.id, {
-                activityId: row.id,
-                duration_ms: durationMs,
-              });
-            }
-          }
-        } catch (telemetryErr) {
-          securityLogger.warn('[Delegation telemetry] Completion activity failed', telemetryErr);
-        }
-
-        try {
-          if (valSession && this.deps.validationService) {
-            this.deps.validationService.finalizeSession(valSession.id, {
-              execution_status: 'completed',
-              metrics: { duration_ms: durationMs },
-            });
-          }
-        } catch (telemetryErr) {
-          securityLogger.warn('[Delegation telemetry] Completion finalize failed', telemetryErr);
-        }
-
-        return {
-          success: true,
-          data: { agentId, response: result.response, duration_ms: durationMs },
-        } as GatewayToolResult;
+        return await process.sendMessage(delegationPrompt);
       } catch (err) {
         lastError = err instanceof Error ? err : new Error(String(err));
         const isBusy = lastError.message.includes('busy');
         const isCrash = lastError.message.includes('exited with code');
 
         if (isCrash) {
-          processManager.stopProcess(source, channelId, agentId);
+          args.processManager.stopProcess(args.source, args.channelId, args.agentId);
         }
 
         if (attempt < DELEGATE_MAX_RETRIES - 1 && (isBusy || isCrash)) {
-          await new Promise((r) => setTimeout(r, this.deps.retryDelayMs * (attempt + 1)));
+          await new Promise((resolveDelay) =>
+            setTimeout(resolveDelay, this.deps.retryDelayMs * (attempt + 1))
+          );
           continue;
         }
         break;
       }
     }
 
-    const failedDurationMs = Date.now() - startTime;
+    throw lastError ?? new Error('unknown delegation failure');
+  }
+
+  private buildDelegationPrompt(args: {
+    delegationManager: DelegationManager;
+    sourceAgentId: string;
+    task: string;
+    skill?: string;
+  }): string {
+    let delegationPrompt = args.delegationManager.buildDelegationPrompt(
+      args.sourceAgentId,
+      args.task
+    );
+    if (args.skill) {
+      const skillPath = resolveSkillPath(args.skill);
+      if (skillPath && existsSync(skillPath)) {
+        const skillContent = readFileSync(skillPath, 'utf-8');
+        delegationPrompt = skillContent + '\n\n---\n\n' + delegationPrompt;
+      }
+    }
+    return delegationPrompt;
+  }
+
+  private async withChannelHistory(
+    prompt: string,
+    channelId: string,
+    agentId: string
+  ): Promise<string> {
     try {
-      if (this.deps.sessionsDb) {
-        const row = logActivity(this.deps.sessionsDb, {
-          agent_id: agentId,
-          agent_version: agentVersion,
-          type: 'task_error',
-          input_summary: task?.slice(0, 200),
-          error_message: lastError?.message,
-          duration_ms: failedDurationMs,
-          run_id: valSession?.id,
-          execution_status: 'failed',
-          trigger_reason: 'delegate_run',
-        });
-        if (valSession && this.deps.validationService) {
-          this.deps.validationService.recordRun(valSession.id, {
-            activityId: row.id,
-            duration_ms: failedDurationMs,
-          });
+      const { getChannelHistory } = await import('../gateways/channel-history.js');
+      const channelHistory = getChannelHistory();
+      if (channelHistory) {
+        const historyContext = channelHistory.formatForContext(channelId, '', agentId);
+        if (historyContext) {
+          return `${historyContext}\n\n${prompt}`;
         }
       }
-    } catch (telemetryErr) {
-      securityLogger.warn('[Delegation telemetry] Failure activity failed', telemetryErr);
+    } catch {
+      // Channel history injection is best-effort.
     }
-
-    try {
-      if (valSession && this.deps.validationService) {
-        this.deps.validationService.finalizeSession(valSession.id, {
-          execution_status: 'failed',
-          error_message: lastError?.message,
-          metrics: { duration_ms: failedDurationMs },
-        });
-      }
-    } catch (telemetryErr) {
-      securityLogger.warn('[Delegation telemetry] Failure finalize failed', telemetryErr);
-    }
-
-    return {
-      success: false,
-      error: `Delegation to ${agentId} failed after ${DELEGATE_MAX_RETRIES} attempts: ${lastError?.message}`,
-    } as GatewayToolResult;
+    return prompt;
   }
 }

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -757,8 +757,10 @@ export class GatewayToolExecutor {
 
     const executionSurface = ctx?.executionSurface;
     const requiresEnvelope =
-      ctx !== undefined &&
-      (executionSurface === undefined || ENVELOPE_REQUIRED_SURFACES.has(executionSurface));
+      executionSurface !== 'direct' &&
+      (ctx === undefined ||
+        executionSurface === undefined ||
+        ENVELOPE_REQUIRED_SURFACES.has(executionSurface));
     if (!requiresEnvelope) {
       return undefined;
     }

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -787,6 +787,13 @@ export class GatewayToolExecutor {
       return this.withExecutionContext(executionContext, () => this.execute(toolName, input));
     }
 
+    return this.executeWithEnvelopeAndPermissions(toolName, input);
+  }
+
+  private async executeWithEnvelopeAndPermissions(
+    toolName: string,
+    input: GatewayToolInput
+  ): Promise<GatewayToolResult> {
     if (!VALID_TOOLS.includes(toolName as GatewayToolName)) {
       throw new AgentError(
         `Unknown tool: ${toolName}. Valid tools: ${VALID_TOOLS.join(', ')}`,

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -121,6 +121,11 @@ const AGENT_DETAIL_TABS = new Set([
 ]);
 
 type GatewayExecutionContext = GatewayToolExecutionContext;
+type GatewayContextSnapshot = {
+  agentId: string;
+  source: string;
+  channelId: string;
+};
 
 type ActiveGatewayExecutionContext = {
   agentContext: AgentContext | null;
@@ -144,6 +149,11 @@ const MEMORY_SCOPE_AUDIT_TOOLS = new Set<string>([
   'mama_update',
   'mama_add',
   'mama_ingest',
+]);
+const ENVELOPE_REQUIRED_SURFACES = new Set<GatewayExecutionSurface>([
+  'model_tool',
+  'reactive_internal',
+  'code_act',
 ]);
 
 async function withManagedAgentMutationLock<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
@@ -340,7 +350,7 @@ export class GatewayToolExecutor {
   }
 
   private normalizeExecutionContext(
-    executionContext?: GatewayExecutionContext
+    executionContext?: Partial<GatewayExecutionContext>
   ): ActiveGatewayExecutionContext {
     const agentContext = executionContext?.agentContext ?? null;
     const source = executionContext?.source ?? agentContext?.source ?? '';
@@ -399,6 +409,18 @@ export class GatewayToolExecutor {
     this.currentAgentId = agentId;
     this.currentSource = source;
     this.currentChannelId = channelId;
+  }
+  getCurrentAgentRoutingContext(): GatewayContextSnapshot {
+    return {
+      agentId: this.currentAgentId,
+      source: this.currentSource,
+      channelId: this.currentChannelId,
+    };
+  }
+  restoreCurrentAgentRoutingContext(context: GatewayContextSnapshot): void {
+    this.currentAgentId = context.agentId;
+    this.currentSource = context.source;
+    this.currentChannelId = context.channelId;
   }
   clearCurrentAgentContext(): void {
     this.currentAgentId = '';
@@ -724,8 +746,17 @@ export class GatewayToolExecutor {
       return undefined;
     }
 
+    const executionSurface = ctx?.executionSurface;
+    const requiresEnvelope =
+      executionSurface !== undefined && ENVELOPE_REQUIRED_SURFACES.has(executionSurface);
+    if (!requiresEnvelope) {
+      return undefined;
+    }
+
     if (failLoudOnMissing) {
-      throw new Error(`[envelope] tool ${toolName} called without envelope (fail-loud mode)`);
+      throw new Error(
+        `[envelope] tool ${toolName} called without envelope on ${executionSurface} (fail-loud mode)`
+      );
     }
 
     if (allowLegacyBypass) {
@@ -735,6 +766,7 @@ export class GatewayToolExecutor {
           agentId: ctx.agentId,
           source: ctx.source,
           channelId: ctx.channelId,
+          executionSurface,
         });
         this.logEnvelopeActivity(ctx, 'envelope_missing_legacy', toolName);
       }
@@ -749,6 +781,7 @@ export class GatewayToolExecutor {
         agentId: ctx.agentId,
         source: ctx.source,
         channelId: ctx.channelId,
+        executionSurface,
       });
       this.logEnvelopeActivity(ctx, 'envelope_missing_denied', toolName, error);
     }
@@ -834,7 +867,7 @@ export class GatewayToolExecutor {
     }
 
     const envelopeScopesSnapshot = ctx?.envelope?.scope.memory_scopes ?? null;
-    const requestedScopes = this.resolveEffectiveMemoryScopes(toolName, input, ctx);
+    const requestedScopes = this.resolveAuditMemoryScopes(toolName, input, ctx);
 
     if (!ctx?.envelope || !envelopeScopesSnapshot) {
       return { requestedScopes, envelopeScopesSnapshot, mismatch: 0 };
@@ -860,7 +893,7 @@ export class GatewayToolExecutor {
     };
   }
 
-  private resolveEffectiveMemoryScopes(
+  private resolveAuditMemoryScopes(
     toolName: string,
     input: GatewayToolInput,
     ctx: ActiveGatewayExecutionContext | undefined
@@ -881,11 +914,7 @@ export class GatewayToolExecutor {
       const fallbackScopes = this.deriveMemoryScopesFromActiveContext(ctx) ?? [];
       const inputScopes = normalizeMemoryScopes((input as { scopes?: unknown }).scopes);
       if (inputScopes && inputScopes.length > 0) {
-        const fallbackScopeKeys = new Set(fallbackScopes.map(memoryScopeKey));
-        const allInFallback = inputScopes.every((scope) =>
-          fallbackScopeKeys.has(memoryScopeKey(scope))
-        );
-        return allInFallback ? inputScopes : fallbackScopes;
+        return inputScopes;
       }
       return fallbackScopes.length > 0 ? fallbackScopes : null;
     }

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -60,6 +60,8 @@ import type {
   BotStatus,
   BotPlatform,
   EnvelopeDenialResult,
+  GatewayExecutionSurface,
+  GatewayToolExecutionContext,
 } from './types.js';
 import { AgentError } from './types.js';
 import {
@@ -118,13 +120,7 @@ const AGENT_DETAIL_TABS = new Set([
   'history',
 ]);
 
-type GatewayExecutionContext = {
-  agentContext?: AgentContext | null;
-  agentId?: string;
-  source?: string;
-  channelId?: string;
-  envelope?: Envelope;
-};
+type GatewayExecutionContext = GatewayToolExecutionContext;
 
 type ActiveGatewayExecutionContext = {
   agentContext: AgentContext | null;
@@ -132,6 +128,7 @@ type ActiveGatewayExecutionContext = {
   source: string;
   channelId: string;
   envelope?: Envelope;
+  executionSurface?: GatewayExecutionSurface;
 };
 
 const managedAgentMutationTails = new Map<string, Promise<void>>();
@@ -342,6 +339,7 @@ export class GatewayToolExecutor {
       source,
       channelId,
       envelope: executionContext?.envelope,
+      executionSurface: executionContext?.executionSurface,
     };
   }
 
@@ -351,7 +349,7 @@ export class GatewayToolExecutor {
       return active;
     }
     return this.normalizeExecutionContext({
-      agentContext: this.currentContext,
+      agentContext: this.currentContext ?? undefined,
       agentId: this.currentAgentId,
       source: this.currentSource,
       channelId: this.currentChannelId,

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -102,7 +102,7 @@ import {
   type DelegationRoutingContext,
 } from './delegation-executor.js';
 import { EnvelopeEnforcer, EnvelopeViolation } from '../envelope/index.js';
-import type { Envelope } from '../envelope/index.js';
+import type { Envelope, MemoryScope } from '../envelope/index.js';
 
 const { DebugLogger } = debugLogger as unknown as {
   DebugLogger: new (context?: string) => {
@@ -129,9 +129,22 @@ type ActiveGatewayExecutionContext = {
   channelId: string;
   envelope?: Envelope;
   executionSurface?: GatewayExecutionSurface;
+  parentToolName?: string;
+};
+
+type ScopeAuditFields = {
+  requestedScopes: MemoryScope[] | null;
+  envelopeScopesSnapshot: MemoryScope[] | null;
+  mismatch: 0 | 1;
 };
 
 const managedAgentMutationTails = new Map<string, Promise<void>>();
+const MEMORY_SCOPE_AUDIT_TOOLS = new Set<string>([
+  'mama_save',
+  'mama_update',
+  'mama_add',
+  'mama_ingest',
+]);
 
 async function withManagedAgentMutationLock<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
   const previous = managedAgentMutationTails.get(agentId) ?? Promise.resolve();
@@ -244,6 +257,7 @@ export class GatewayToolExecutor {
   private readonly executionContextStorage = new AsyncLocalStorage<ActiveGatewayExecutionContext>();
   private readonly envelopeEnforcer = new EnvelopeEnforcer();
   private readonly envelopeIssuanceMode: 'off' | 'enabled' | 'required';
+  private readonly metricsStore: GatewayToolExecutorOptions['metricsStore'];
   private currentContext: AgentContext | null = null;
   private memoryAgentProcessManager: AgentProcessManager | null = null;
   private agentProcessManager: AgentProcessManager | null = null;
@@ -534,6 +548,7 @@ export class GatewayToolExecutor {
     this.mamaDbPath = options.mamaDbPath;
     this.sessionStore = options.sessionStore;
     this.envelopeIssuanceMode = options.envelopeIssuanceMode ?? 'enabled';
+    this.metricsStore = options.metricsStore ?? null;
     this.browserTool = getBrowserTool({
       screenshotDir: join(process.env.HOME || '', '.mama', 'workspace', 'media', 'outbound'),
     });
@@ -697,6 +712,7 @@ export class GatewayToolExecutor {
             error: err.message,
             code: err.code,
             envelope_hash: ctx.envelope.envelope_hash,
+            ...err.metadata,
           };
           return denial;
         }
@@ -788,7 +804,204 @@ export class GatewayToolExecutor {
       return this.withExecutionContext(executionContext, () => this.execute(toolName, input));
     }
 
-    return this.executeWithEnvelopeAndPermissions(toolName, input);
+    const startedAt = Date.now();
+    const ctx = this.executionContextStorage.getStore();
+    const scopeAudit = this.computeScopeAuditFields(toolName, input, ctx);
+
+    try {
+      const result = await this.executeWithEnvelopeAndPermissions(toolName, input);
+      this.logGatewayToolCall(ctx, toolName, result, Date.now() - startedAt, scopeAudit);
+      if (scopeAudit.mismatch) {
+        this.alarmScopeMismatch(ctx, toolName);
+      }
+      return result;
+    } catch (error) {
+      this.logGatewayToolCall(ctx, toolName, undefined, Date.now() - startedAt, scopeAudit, error);
+      if (scopeAudit.mismatch) {
+        this.alarmScopeMismatch(ctx, toolName);
+      }
+      throw error;
+    }
+  }
+
+  private computeScopeAuditFields(
+    toolName: string,
+    input: GatewayToolInput,
+    ctx: ActiveGatewayExecutionContext | undefined
+  ): ScopeAuditFields {
+    if (!MEMORY_SCOPE_AUDIT_TOOLS.has(toolName)) {
+      return { requestedScopes: null, envelopeScopesSnapshot: null, mismatch: 0 };
+    }
+
+    const envelopeScopesSnapshot = ctx?.envelope?.scope.memory_scopes ?? null;
+    const requestedScopes = this.resolveEffectiveMemoryScopes(toolName, input, ctx);
+
+    if (!ctx?.envelope || !envelopeScopesSnapshot) {
+      return { requestedScopes, envelopeScopesSnapshot, mismatch: 0 };
+    }
+
+    if (!requestedScopes || requestedScopes.length === 0) {
+      return {
+        requestedScopes,
+        envelopeScopesSnapshot,
+        mismatch: envelopeScopesSnapshot.length > 0 ? 1 : 0,
+      };
+    }
+
+    const envelopeScopeKeys = new Set(envelopeScopesSnapshot.map(memoryScopeKey));
+    const hasOutOfEnvelopeScope = requestedScopes.some(
+      (scope) => !envelopeScopeKeys.has(memoryScopeKey(scope))
+    );
+
+    return {
+      requestedScopes,
+      envelopeScopesSnapshot,
+      mismatch: hasOutOfEnvelopeScope ? 1 : 0,
+    };
+  }
+
+  private resolveEffectiveMemoryScopes(
+    toolName: string,
+    input: GatewayToolInput,
+    ctx: ActiveGatewayExecutionContext | undefined
+  ): MemoryScope[] | null {
+    if (toolName === 'mama_save') {
+      return normalizeMemoryScopes((input as { scopes?: unknown }).scopes);
+    }
+
+    if (toolName === 'mama_update') {
+      return null;
+    }
+
+    if (toolName === 'mama_add') {
+      return this.deriveMemoryScopesFromActiveContext(ctx);
+    }
+
+    if (toolName === 'mama_ingest') {
+      const fallbackScopes = this.deriveMemoryScopesFromActiveContext(ctx) ?? [];
+      const inputScopes = normalizeMemoryScopes((input as { scopes?: unknown }).scopes);
+      if (inputScopes && inputScopes.length > 0) {
+        const fallbackScopeKeys = new Set(fallbackScopes.map(memoryScopeKey));
+        const allInFallback = inputScopes.every((scope) =>
+          fallbackScopeKeys.has(memoryScopeKey(scope))
+        );
+        return allInFallback ? inputScopes : fallbackScopes;
+      }
+      return fallbackScopes.length > 0 ? fallbackScopes : null;
+    }
+
+    return null;
+  }
+
+  private deriveMemoryScopesFromActiveContext(
+    ctx: ActiveGatewayExecutionContext | undefined
+  ): MemoryScope[] | null {
+    const context = ctx?.agentContext;
+    if (!context) {
+      return null;
+    }
+    return deriveMemoryScopes({
+      source: context.source,
+      channelId: context.session.channelId,
+      userId: context.session.userId,
+      projectId: process.env.MAMA_WORKSPACE || process.cwd(),
+    });
+  }
+
+  private logGatewayToolCall(
+    ctx: ActiveGatewayExecutionContext | undefined,
+    toolName: string,
+    result: GatewayToolResult | undefined,
+    durationMs: number,
+    scopeAudit: ScopeAuditFields,
+    error?: unknown
+  ): void {
+    try {
+      if (!this.sessionsDb) {
+        return;
+      }
+
+      const errorMessage =
+        error instanceof Error ? error.message : error ? String(error) : getFailureMessage(result);
+      const resultCode = result && 'code' in result ? String(result.code) : undefined;
+      const executionStatus = error || result?.success === false ? 'failed' : 'completed';
+
+      logActivity(this.sessionsDb, {
+        agent_id: ctx?.agentId || 'unknown',
+        agent_version: 0,
+        type: 'gateway_tool_call',
+        input_summary: toolName,
+        duration_ms: durationMs,
+        execution_status: executionStatus,
+        trigger_reason: 'gateway_tool_executor',
+        error_message: errorMessage,
+        envelopeHash: ctx?.envelope?.envelope_hash ?? null,
+        requestedScopes: scopeAudit.requestedScopes,
+        envelopeScopesSnapshot: scopeAudit.envelopeScopesSnapshot,
+        scopeMismatch: scopeAudit.mismatch,
+        details: {
+          source: ctx?.source ?? 'unknown',
+          channel_id: ctx?.channelId ?? 'unknown',
+          tool: toolName,
+          ...(resultCode ? { code: resultCode } : {}),
+          ...(ctx?.parentToolName ? { parent: ctx.parentToolName } : {}),
+        },
+      });
+    } catch (logErr) {
+      securityLogger.warn('[envelope] gateway audit log failed (non-fatal)', logErr);
+    }
+  }
+
+  private alarmScopeMismatch(
+    ctx: ActiveGatewayExecutionContext | undefined,
+    toolName: string
+  ): void {
+    try {
+      this.metricsStore?.record({
+        name: 'envelope_scope_mismatch',
+        value: 1,
+        labels: {
+          source: ctx?.source ?? 'unknown',
+          channel_id: ctx?.channelId ?? 'unknown',
+          tool: toolName,
+        },
+      });
+    } catch {
+      // Metrics are best-effort; the agent_activity row is the durable ledger.
+    }
+
+    try {
+      securityLogger.warn('[envelope] scope mismatch', {
+        envelope_hash: ctx?.envelope?.envelope_hash ?? null,
+        source: ctx?.source ?? 'unknown',
+        channel_id: ctx?.channelId ?? 'unknown',
+        tool: toolName,
+        ...(ctx?.parentToolName ? { parent: ctx.parentToolName } : {}),
+      });
+    } catch {
+      // Audit warnings must never affect tool execution.
+    }
+  }
+
+  private auditedAutoSave(parentToolName: string, input: SaveInput): void {
+    const parentContext = this.executionContextStorage.getStore();
+    void (async () => {
+      try {
+        if (parentContext) {
+          const autosaveContext: ActiveGatewayExecutionContext = {
+            ...parentContext,
+            parentToolName,
+          };
+          await this.executionContextStorage.run(autosaveContext, () =>
+            this.execute('mama_save', input)
+          );
+          return;
+        }
+        await this.execute('mama_save', input);
+      } catch {
+        // Autosave is intentionally non-fatal for report/wiki publish tools.
+      }
+    })();
   }
 
   private async executeWithEnvelopeAndPermissions(
@@ -941,7 +1154,7 @@ export class GatewayToolExecutor {
           if (permError) {
             return { success: false, error: permError };
           }
-          const args = input as { agent_id: string; limit?: number };
+          const args = input as { agent_id: string; limit?: number; include_trace?: boolean };
           const agentId = this.resolveManagedAgentId(args.agent_id);
           const rawLimit = Number.parseInt(String(args.limit ?? 20), 10);
           const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(rawLimit, 100) : 20;
@@ -953,7 +1166,9 @@ export class GatewayToolExecutor {
           return {
             success: true,
             agent_id: agentId,
-            activity: getActivity(this.sessionsDb, agentId, limit),
+            activity: getActivity(this.sessionsDb, agentId, limit, {
+              includeTrace: args.include_trace === true,
+            }),
           };
         }
         case 'agent_update': {
@@ -1194,20 +1409,13 @@ export class GatewayToolExecutor {
               .trim();
             const truncated =
               textSummary.length > 1500 ? textSummary.substring(0, 1500) + '...' : textSummary;
-            void (async () => {
-              try {
-                const a = await getApi();
-                await handleSave(a, {
-                  type: 'decision' as const,
-                  topic: 'dashboard_briefing',
-                  decision: `Dashboard briefing (${new Date().toISOString().split('T')[0]}): ${truncated}`,
-                  reasoning: 'Auto-saved by dashboard agent after report_publish',
-                  scopes: [{ kind: 'global', id: 'system' }],
-                });
-              } catch {
-                /* non-fatal */
-              }
-            })();
+            this.auditedAutoSave('report_publish', {
+              type: 'decision' as const,
+              topic: 'dashboard_briefing',
+              decision: `Dashboard briefing (${new Date().toISOString().split('T')[0]}): ${truncated}`,
+              reasoning: 'Auto-saved by dashboard agent after report_publish',
+              scopes: [{ kind: 'global', id: 'system' }],
+            });
 
             return {
               success: true,
@@ -1258,20 +1466,13 @@ export class GatewayToolExecutor {
               )
               .join('\n');
             const wikiSummary = `Wiki compilation (${now.split('T')[0]}): ${pagesInput.length} pages\n${pageSummary}`;
-            void (async () => {
-              try {
-                const a = await getApi();
-                await handleSave(a, {
-                  type: 'decision' as const,
-                  topic: 'wiki_compilation',
-                  decision: wikiSummary,
-                  reasoning: 'Auto-saved by wiki agent after wiki_publish',
-                  scopes: [{ kind: 'global', id: 'system' }],
-                });
-              } catch {
-                /* non-fatal */
-              }
-            })();
+            this.auditedAutoSave('wiki_publish', {
+              type: 'decision' as const,
+              topic: 'wiki_compilation',
+              decision: wikiSummary,
+              reasoning: 'Auto-saved by wiki agent after wiki_publish',
+              scopes: [{ kind: 'global', id: 'system' }],
+            });
 
             return {
               success: true,
@@ -2904,4 +3105,45 @@ function isTruthyEnv(name: string): boolean {
     return false;
   }
   return TRUTHY_ENV_VALUES.has(value.trim().toLowerCase());
+}
+
+function normalizeMemoryScopes(value: unknown): MemoryScope[] | null {
+  if (!Array.isArray(value) || value.length === 0) {
+    return null;
+  }
+
+  const scopes: MemoryScope[] = [];
+  for (const item of value) {
+    if (!isMemoryScope(item)) {
+      return null;
+    }
+    scopes.push({ kind: item.kind, id: item.id });
+  }
+  return scopes;
+}
+
+function isMemoryScope(value: unknown): value is MemoryScope {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.kind === 'string' &&
+    ['global', 'user', 'channel', 'project'].includes(candidate.kind) &&
+    typeof candidate.id === 'string' &&
+    candidate.id.length > 0
+  );
+}
+
+function memoryScopeKey(scope: MemoryScope): string {
+  return `${scope.kind}:${scope.id}`;
+}
+
+function getFailureMessage(result: GatewayToolResult | undefined): string | undefined {
+  if (!result || result.success !== false) {
+    return undefined;
+  }
+  const record = result as Record<string, unknown>;
+  const message = record.error ?? record.message ?? 'Tool returned success:false';
+  return String(message);
 }

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -82,7 +82,6 @@ import {
   compareVersionMetrics,
   getActivity,
   logActivity,
-  updateActivityScore,
 } from '../db/agent-store.js';
 import type { RoleConfig } from '../cli/config/types.js';
 import { DEFAULT_ROLES } from '../cli/config/types.js';
@@ -94,7 +93,12 @@ import {
   validateManagedAgentCreateInput,
   validateManagedAgentChanges,
 } from './managed-agent-validation.js';
-import type { ValidationSessionRow } from '../validation/types.js';
+import {
+  DelegationExecutor,
+  type AgentTestInput,
+  type DelegateInput,
+  type DelegationRoutingContext,
+} from './delegation-executor.js';
 import { EnvelopeEnforcer, EnvelopeViolation } from '../envelope/index.js';
 import type { Envelope } from '../envelope/index.js';
 
@@ -163,20 +167,6 @@ function sanitizeCommandForAudit(command: string): { commandHash: string; comman
     .slice(0, 200);
 
   return { commandHash, commandPreview };
-}
-
-function summarizeActivityOutput(output: unknown): string | undefined {
-  if (output === undefined || output === null) {
-    return undefined;
-  }
-  if (typeof output === 'string') {
-    return output.slice(0, 500);
-  }
-  try {
-    return JSON.stringify(output).slice(0, 500);
-  } catch {
-    return String(output).slice(0, 500);
-  }
 }
 
 /**
@@ -292,12 +282,14 @@ export class GatewayToolExecutor {
   private sessionsDb: SQLiteDatabase | null = null;
   setSessionsDb(db: SQLiteDatabase): void {
     this.sessionsDb = db;
+    this.refreshDelegationExecutor();
   }
   private rawStore: import('../connectors/framework/raw-store.js').RawStore | null = null;
   setRawStore(store: import('../connectors/framework/raw-store.js').RawStore): void {
     this.rawStore = store;
+    this.refreshDelegationExecutor();
   }
-  private testInFlight = new Map<string, Promise<GatewayToolResult>>();
+  private delegationExecutor: DelegationExecutor | null = null;
   private uiCommandQueue: UICommandQueue | null = null;
   setUICommandQueue(queue: UICommandQueue): void {
     this.uiCommandQueue = queue;
@@ -317,15 +309,18 @@ export class GatewayToolExecutor {
     svc: import('../validation/session-service.js').ValidationSessionService
   ): void {
     this.validationService = svc;
+    this.refreshDelegationExecutor();
   }
   setMemoryAgent(processManager: AgentProcessManager): void {
     this.memoryAgentProcessManager = processManager;
   }
   setAgentProcessManager(pm: AgentProcessManager): void {
     this.agentProcessManager = pm;
+    this.refreshDelegationExecutor();
   }
   setDelegationManager(dm: DelegationManager): void {
     this.delegationManagerRef = dm;
+    this.refreshDelegationExecutor();
   }
   /** Get AgentProcessManager (for cron/event triggers that need direct process access) */
   getAgentProcessManager(): AgentProcessManager | null {
@@ -367,7 +362,7 @@ export class GatewayToolExecutor {
     return this.getExecutionState().agentContext;
   }
 
-  private getActiveRouting(): { agentId: string; source: string; channelId: string } {
+  private getActiveRouting(): DelegationRoutingContext {
     const state = this.getExecutionState();
     return {
       agentId: state.agentId,
@@ -399,29 +394,6 @@ export class GatewayToolExecutor {
   }
   setDisallowedGatewayTools(tools: string[]): void {
     this.disallowedGatewayTools = new Set(tools);
-  }
-
-  private cleanupValidationSessionOnTelemetryFailure(
-    session: ValidationSessionRow | null,
-    error: unknown,
-    label: string
-  ): null {
-    if (!session || !this.validationService) {
-      return null;
-    }
-    const message = error instanceof Error ? error.message : String(error);
-    try {
-      this.validationService.finalizeSession(session.id, {
-        execution_status: 'failed',
-        error_message: `${label}: ${message}`,
-      });
-    } catch (cleanupErr) {
-      securityLogger.warn(
-        `[Delegation telemetry] Failed to clean up validation session ${session.id}`,
-        cleanupErr
-      );
-    }
-    return null;
   }
 
   private getPreferredViewerAgentTab(): string {
@@ -535,6 +507,30 @@ export class GatewayToolExecutor {
   /** Retry delay (ms) for delegate backoff. Initialized from config in constructor. */
   private _retryDelayMs: number = 1000;
 
+  private createDelegationExecutor(): DelegationExecutor {
+    return new DelegationExecutor({
+      agentProcessManager: this.agentProcessManager,
+      delegationManagerRef: this.delegationManagerRef,
+      rawStore: this.rawStore,
+      sessionsDb: this.sessionsDb,
+      validationService: this.validationService,
+      retryDelayMs: this._retryDelayMs,
+      resolveManagedAgentId: (id) => this.resolveManagedAgentId(id),
+      checkViewerOnly: () => this.checkViewerOnly(),
+    });
+  }
+
+  private refreshDelegationExecutor(): void {
+    this.delegationExecutor = this.createDelegationExecutor();
+  }
+
+  private getDelegationExecutor(): DelegationExecutor {
+    if (!this.delegationExecutor) {
+      this.refreshDelegationExecutor();
+    }
+    return this.delegationExecutor!;
+  }
+
   constructor(options: GatewayToolExecutorOptions = {}) {
     this.mamaDbPath = options.mamaDbPath;
     this.sessionStore = options.sessionStore;
@@ -556,6 +552,7 @@ export class GatewayToolExecutor {
     } catch {
       // Config not initialized yet — keep default 1000ms
     }
+    this.refreshDelegationExecutor();
   }
 
   /**
@@ -903,12 +900,9 @@ export class GatewayToolExecutor {
           );
         // Agent lifecycle tools
         case 'agent_test':
-          return await this.executeAgentTest(
-            input as {
-              agent_id: string;
-              sample_count?: number;
-              test_data?: Array<{ input: string; expected?: string }>;
-            }
+          return await this.getDelegationExecutor().runAgentTest(
+            input as AgentTestInput,
+            this.getActiveRouting()
           );
         // Agent management tools (Managed Agents pattern)
         case 'agent_get': {
@@ -1144,8 +1138,9 @@ export class GatewayToolExecutor {
         }
         // Multi-Agent delegation
         case 'delegate':
-          return await this.executeDelegate(
-            input as { agentId: string; task: string; background?: boolean }
+          return await this.getDelegationExecutor().runDelegate(
+            input as DelegateInput,
+            this.getActiveRouting()
           );
       }
 
@@ -2672,672 +2667,6 @@ export class GatewayToolExecutor {
         error: `Failed to send to webchat: ${err instanceof Error ? err.message : String(err)}`,
       };
     }
-  }
-
-  // ============================================================================
-  // Multi-Agent Delegation
-  // ============================================================================
-
-  /**
-   * Execute delegate tool — dispatch a task to another agent
-   */
-  // ── Agent Test ─────────────────────────────────────────────────────────────
-
-  private async executeAgentTest(input: {
-    agent_id: string;
-    sample_count?: number;
-    test_data?: Array<{ input: string; expected?: string }>;
-  }): Promise<GatewayToolResult> {
-    const permError = this.checkViewerOnly();
-    if (permError) {
-      return { success: false, error: permError } as GatewayToolResult;
-    }
-
-    const { agent_id } = input;
-    const sample_count = Number.parseInt(String(input.sample_count ?? 2), 10);
-    const resolvedAgentId = this.resolveManagedAgentId(agent_id);
-    if (!Number.isFinite(sample_count) || sample_count < 1) {
-      securityLogger.warn('[Agent test] Invalid sample_count received', {
-        agent_id: resolvedAgentId,
-        sample_count: input.sample_count ?? null,
-      });
-      return {
-        success: false,
-        error: `Invalid sample_count for '${resolvedAgentId}': ${String(input.sample_count)}. Must be >= 1.`,
-      } as GatewayToolResult;
-    }
-
-    // Concurrency guard
-    if (this.testInFlight.has(resolvedAgentId)) {
-      return { success: false, error: 'test_already_running' } as GatewayToolResult;
-    }
-
-    const promise = this._runAgentTest(resolvedAgentId, sample_count, input.test_data);
-    this.testInFlight.set(resolvedAgentId, promise);
-    try {
-      return await promise;
-    } finally {
-      this.testInFlight.delete(resolvedAgentId);
-    }
-  }
-
-  private async _runAgentTest(
-    agentId: string,
-    sampleCount: number,
-    testData?: Array<{ input: string; expected?: string }>
-  ): Promise<GatewayToolResult> {
-    if (!this.agentProcessManager || !this.delegationManagerRef) {
-      return {
-        success: false,
-        error: 'agent_timeout: multi-agent not configured',
-      } as GatewayToolResult;
-    }
-
-    const startTime = Date.now();
-
-    // 1. Collect test data
-    let items: Array<{ input: string; expected?: string }>;
-    if (testData && testData.length > 0) {
-      const normalizedItems: Array<{ input: string; expected?: string }> = [];
-      for (let index = 0; index < testData.length; index++) {
-        const rawItem = testData[index] as unknown as Record<string, unknown>;
-        if (typeof rawItem.input !== 'string') {
-          return {
-            success: false,
-            error: `Invalid test_data[${index}].input: expected string`,
-          } as GatewayToolResult;
-        }
-        if (rawItem.expected !== undefined && typeof rawItem.expected !== 'string') {
-          return {
-            success: false,
-            error: `Invalid test_data[${index}].expected: expected string`,
-          } as GatewayToolResult;
-        }
-        normalizedItems.push({
-          input: rawItem.input,
-          ...(typeof rawItem.expected === 'string' ? { expected: rawItem.expected } : {}),
-        });
-      }
-      items = normalizedItems;
-    } else if (this.rawStore) {
-      const agentConfig = this.delegationManagerRef.getAgentConfig(agentId);
-      const connectors: string[] = (agentConfig?.connectors as string[]) ?? [];
-      if (connectors.length === 0) {
-        return {
-          success: false,
-          error: 'connector_unavailable: no connectors configured',
-        } as GatewayToolResult;
-      }
-      const allItems: Array<{ input: string }> = [];
-      const missingConnectors: string[] = [];
-      for (const conn of connectors) {
-        if (!this.rawStore.hasConnector(conn)) {
-          missingConnectors.push(conn);
-          continue;
-        }
-        const recent = this.rawStore.getRecent(conn, sampleCount);
-        for (const item of recent) {
-          allItems.push({ input: `[${item.type}] ${item.content}` });
-        }
-        if (allItems.length >= sampleCount) {
-          break;
-        }
-      }
-      if (allItems.length === 0) {
-        const detail =
-          missingConnectors.length > 0
-            ? `connector(s) not found: ${missingConnectors.join(', ')}`
-            : 'no recent data';
-        return {
-          success: false,
-          error: `connector_unavailable: ${detail}`,
-        } as GatewayToolResult;
-      }
-      items = allItems.slice(0, sampleCount);
-    } else {
-      return {
-        success: false,
-        error: 'connector_unavailable: rawStore not available',
-      } as GatewayToolResult;
-    }
-
-    // 2. Start validation session for agent_test
-    const testVer = this.sessionsDb ? getLatestVersion(this.sessionsDb, agentId) : null;
-    const testAgentVersion = testVer?.version ?? 0;
-    let testValSession: ValidationSessionRow | null = null;
-    try {
-      testValSession =
-        this.validationService?.startSession(agentId, testAgentVersion, 'agent_test', {
-          goal: `Test with ${items.length} items`,
-          customBeforeSnapshot: JSON.stringify({
-            schema_version: 1,
-            test_input_summary: items.map((i) => i.input.slice(0, 80)).join('; '),
-            sample_count: items.length,
-          }),
-        }) ?? null;
-    } catch (telemetryErr) {
-      securityLogger.warn('[Agent test telemetry] Failed to start validation session', {
-        agentId,
-        testAgentVersion,
-        error: telemetryErr instanceof Error ? telemetryErr.message : String(telemetryErr),
-      });
-    }
-
-    // 3. Log test_run start
-    let testRunId: number | null = null;
-    if (this.sessionsDb) {
-      try {
-        const row = logActivity(this.sessionsDb, {
-          agent_id: agentId,
-          agent_version: testAgentVersion,
-          type: 'test_run',
-          input_summary: `Testing with ${items.length} items`,
-          run_id: testValSession?.id,
-          execution_status: 'started',
-          trigger_reason: 'agent_test',
-        });
-        testRunId = row.id;
-        if (testValSession && this.validationService) {
-          this.validationService.recordRun(testValSession.id, { activityId: row.id });
-        }
-      } catch (telemetryErr) {
-        securityLogger.warn('[Agent test telemetry] Failed to persist startup activity', {
-          agentId,
-          testValSessionId: testValSession?.id ?? null,
-          error: telemetryErr instanceof Error ? telemetryErr.message : String(telemetryErr),
-        });
-        testValSession = this.cleanupValidationSessionOnTelemetryFailure(
-          testValSession,
-          telemetryErr,
-          'agent_test startup telemetry failed'
-        );
-        testRunId = null;
-      }
-    }
-
-    // 4. Delegate with a small concurrency limit to keep tests responsive
-    const results: Array<{ input: string; output?: string; error?: string }> = [];
-    const workerCount = Math.min(3, items.length);
-    let nextIndex = 0;
-    const workers = Array.from({ length: workerCount }, async () => {
-      for (;;) {
-        const currentIndex = nextIndex;
-        nextIndex++;
-        if (currentIndex >= items.length) {
-          return;
-        }
-        const item = items[currentIndex];
-        try {
-          const r = await this.executeDelegate({
-            agentId,
-            task: `Process this data:\n${item.input}`,
-          });
-          const rAny = r as Record<string, unknown>;
-          const output = r.success
-            ? String((rAny.data as Record<string, unknown>)?.response ?? '')
-            : undefined;
-          results[currentIndex] = {
-            input: item.input,
-            output,
-            error: r.success ? undefined : String(rAny.error ?? 'unknown'),
-          };
-        } catch (err) {
-          results[currentIndex] = { input: item.input, error: String(err) };
-        }
-      }
-    });
-    await Promise.all(workers);
-
-    // 5. Auto-score: pass/fail ratio
-    const passed = results.filter((r, index) => {
-      if (r.error) {
-        return false;
-      }
-      const expected = items[index]?.expected;
-      if (expected === undefined) {
-        return true;
-      }
-      return (r.output ?? '').trim() === expected.trim();
-    }).length;
-    const failed = results.length - passed;
-    const autoScore = results.length > 0 ? Math.round((passed / results.length) * 100) : 0;
-
-    if (this.sessionsDb && testRunId) {
-      try {
-        updateActivityScore(
-          this.sessionsDb,
-          testRunId,
-          autoScore,
-          {
-            total: results.length,
-            passed,
-            failed,
-            items: results.map((r, index) => ({
-              input: r.input.slice(0, 100),
-              result:
-                r.error ||
-                (items[index]?.expected !== undefined &&
-                  (r.output ?? '').trim() !== items[index]!.expected!.trim())
-                  ? 'fail'
-                  : 'pass',
-            })),
-          },
-          'completed'
-        );
-      } catch (telemetryErr) {
-        securityLogger.warn('[Agent test telemetry] Failed to persist test score', {
-          agentId,
-          testRunId,
-          autoScore,
-          totalResults: results.length,
-          error: telemetryErr instanceof Error ? telemetryErr.message : String(telemetryErr),
-        });
-      }
-    }
-
-    // 6. Finalize validation session with test metrics
-    const testDurationMs = Date.now() - startTime;
-    if (testValSession && this.validationService) {
-      try {
-        this.validationService.finalizeSession(testValSession.id, {
-          execution_status: 'completed',
-          metrics: {
-            duration_ms: testDurationMs,
-            completion_rate: results.length > 0 ? passed / results.length : 0,
-            auto_score: autoScore,
-          },
-          test_input_summary: items.map((i) => i.input.slice(0, 80)).join('; '),
-        });
-      } catch (telemetryErr) {
-        securityLogger.warn('[Agent test telemetry] Failed to finalize validation session', {
-          agentId,
-          testValSessionId: testValSession.id,
-          autoScore,
-          totalResults: results.length,
-          error: telemetryErr instanceof Error ? telemetryErr.message : String(telemetryErr),
-        });
-      }
-    }
-
-    return {
-      success: true,
-      data: {
-        test_run_id: testRunId,
-        agent_id: agentId,
-        results,
-        auto_score: autoScore,
-        duration_ms: testDurationMs,
-        validation_session_id: testValSession?.id ?? null,
-        ...(testRunId === null ? { warning: 'score_not_persisted' } : {}),
-      },
-    } as GatewayToolResult;
-  }
-
-  // ── Delegation ────────────────────────────────────────────────────────────
-
-  private async executeDelegate(input: {
-    agentId: string;
-    task: string;
-    background?: boolean;
-    skill?: string;
-  }): Promise<GatewayToolResult> {
-    const { agentId, task, background } = input;
-
-    // Resolve skill path safely — reject path traversal attempts
-    const resolveSkillPath = (skillName: string): string | null => {
-      if (!/^[a-zA-Z0-9_-]+$/.test(skillName)) {
-        return null;
-      }
-      const skillsDir = join(homedir(), '.mama', 'skills');
-      const resolved = resolve(skillsDir, `${skillName}.md`);
-      if (!resolved.startsWith(skillsDir)) {
-        return null;
-      }
-      return resolved;
-    };
-
-    if (!this.agentProcessManager || !this.delegationManagerRef) {
-      return { success: false, error: 'Multi-agent not configured' } as GatewayToolResult;
-    }
-
-    // Permission check using existing DelegationManager
-    // Default to 'conductor' when no agent context is set (e.g., MessageRouter path, audit cron)
-    // Conductor is the default agent and the only tier-1 agent that should delegate
-    const {
-      agentId: activeAgentId,
-      source: activeSource,
-      channelId: activeChannelId,
-    } = this.getActiveRouting();
-    const sourceAgentId = activeAgentId || 'conductor';
-    const check = this.delegationManagerRef.isDelegationAllowed(sourceAgentId, agentId);
-    if (!check.allowed) {
-      return {
-        success: false,
-        error: `Delegation denied: ${check.reason}`,
-      } as GatewayToolResult;
-    }
-
-    // Background delegation: fire-and-forget with async validation finalize
-    if (background) {
-      const source = activeSource || 'viewer';
-      const channelId = activeChannelId || 'default';
-
-      // Start validation session for background delegation
-      let bgAgentVersion = 0;
-      let bgValSession: ValidationSessionRow | null = null;
-      try {
-        const bgVer = this.sessionsDb ? getLatestVersion(this.sessionsDb, agentId) : null;
-        bgAgentVersion = bgVer?.version ?? 0;
-        bgValSession =
-          this.validationService?.startSession(agentId, bgAgentVersion, 'delegate_run') ?? null;
-
-        if (this.sessionsDb) {
-          const row = logActivity(this.sessionsDb, {
-            agent_id: agentId,
-            agent_version: bgAgentVersion,
-            type: 'task_start',
-            input_summary: task?.slice(0, 200),
-            run_id: bgValSession?.id,
-            execution_status: 'started',
-            trigger_reason: 'delegate_run',
-          });
-          if (bgValSession && this.validationService) {
-            this.validationService.recordRun(bgValSession.id, { activityId: row.id });
-          }
-        }
-      } catch (telemetryErr) {
-        securityLogger.warn('[Delegation telemetry] Background bootstrap failed', telemetryErr);
-        bgAgentVersion = 0;
-        bgValSession = this.cleanupValidationSessionOnTelemetryFailure(
-          bgValSession,
-          telemetryErr,
-          'background delegate bootstrap failed'
-        );
-      }
-
-      // Fire-and-forget: finalize validation when complete
-      const bgStartTime = Date.now();
-      void (async () => {
-        try {
-          const process = await this.agentProcessManager!.getProcess(source, channelId, agentId);
-          let delegationPrompt = this.delegationManagerRef!.buildDelegationPrompt(
-            sourceAgentId,
-            task
-          );
-          if (input.skill) {
-            const skillPath = resolveSkillPath(input.skill);
-            if (skillPath && existsSync(skillPath)) {
-              const skillContent = readFileSync(skillPath, 'utf-8');
-              delegationPrompt = skillContent + '\n\n---\n\n' + delegationPrompt;
-            }
-          }
-          const result = await process.sendMessage(delegationPrompt);
-          const durationMs = Date.now() - bgStartTime;
-
-          try {
-            if (this.sessionsDb) {
-              const row = logActivity(this.sessionsDb, {
-                agent_id: agentId,
-                agent_version: bgAgentVersion,
-                type: 'task_complete',
-                input_summary: task?.slice(0, 200),
-                output_summary: summarizeActivityOutput(result?.response),
-                duration_ms: durationMs,
-                run_id: bgValSession?.id,
-                execution_status: 'completed',
-                trigger_reason: 'delegate_run',
-              });
-              if (bgValSession && this.validationService) {
-                this.validationService.recordRun(bgValSession.id, {
-                  activityId: row.id,
-                  duration_ms: durationMs,
-                });
-              }
-            }
-          } catch (telemetryErr) {
-            securityLogger.warn(
-              '[Delegation telemetry] Background completion activity failed',
-              telemetryErr
-            );
-          }
-
-          try {
-            if (bgValSession && this.validationService) {
-              this.validationService.finalizeSession(bgValSession.id, {
-                execution_status: 'completed',
-                metrics: { duration_ms: durationMs },
-              });
-            }
-          } catch (telemetryErr) {
-            securityLogger.warn(
-              '[Delegation telemetry] Background completion finalize failed',
-              telemetryErr
-            );
-          }
-        } catch (err) {
-          const durationMs = Date.now() - bgStartTime;
-          try {
-            if (this.sessionsDb) {
-              const row = logActivity(this.sessionsDb, {
-                agent_id: agentId,
-                agent_version: bgAgentVersion,
-                type: 'task_error',
-                input_summary: task?.slice(0, 200),
-                error_message: String(err),
-                duration_ms: durationMs,
-                run_id: bgValSession?.id,
-                execution_status: 'failed',
-                trigger_reason: 'delegate_run',
-              });
-              if (bgValSession && this.validationService) {
-                this.validationService.recordRun(bgValSession.id, {
-                  activityId: row.id,
-                  duration_ms: durationMs,
-                });
-              }
-            }
-          } catch (telemetryErr) {
-            securityLogger.warn(
-              '[Delegation telemetry] Background failure activity failed',
-              telemetryErr
-            );
-          }
-          try {
-            if (bgValSession && this.validationService) {
-              this.validationService.finalizeSession(bgValSession.id, {
-                execution_status: 'failed',
-                error_message: String(err),
-                metrics: { duration_ms: durationMs },
-              });
-            }
-          } catch (telemetryErr) {
-            securityLogger.warn(
-              '[Delegation telemetry] Background failure finalize failed',
-              telemetryErr
-            );
-          }
-        }
-      })();
-
-      return {
-        success: true,
-        data: { agentId, background: true, message: 'Background task submitted' },
-      } as GatewayToolResult;
-    }
-
-    // Synchronous delegation with retry + backoff for resilience
-    const source = activeSource || 'viewer';
-    const channelId = activeChannelId || 'default';
-    const startTime = Date.now();
-
-    // Start validation session for this delegation
-    let agentVersion = 0;
-    let valSession: ValidationSessionRow | null = null;
-    try {
-      const ver = this.sessionsDb ? getLatestVersion(this.sessionsDb, agentId) : null;
-      agentVersion = ver?.version ?? 0;
-      valSession =
-        this.validationService?.startSession(agentId, agentVersion, 'delegate_run') ?? null;
-
-      if (this.sessionsDb) {
-        const row = logActivity(this.sessionsDb, {
-          agent_id: agentId,
-          agent_version: agentVersion,
-          type: 'task_start',
-          input_summary: task?.slice(0, 200),
-          run_id: valSession?.id,
-          execution_status: 'started',
-          trigger_reason: 'delegate_run',
-        });
-        if (valSession && this.validationService) {
-          this.validationService.recordRun(valSession.id, { activityId: row.id });
-        }
-      }
-    } catch (telemetryErr) {
-      securityLogger.warn('[Delegation telemetry] Validation bootstrap failed', telemetryErr);
-      agentVersion = 0;
-      valSession = this.cleanupValidationSessionOnTelemetryFailure(
-        valSession,
-        telemetryErr,
-        'delegate bootstrap failed'
-      );
-    }
-
-    const MAX_RETRIES = 3;
-    let lastError: Error | null = null;
-
-    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-      try {
-        const process = await this.agentProcessManager.getProcess(source, channelId, agentId);
-
-        let delegationPrompt = this.delegationManagerRef.buildDelegationPrompt(sourceAgentId, task);
-
-        // Inject skill content if specified
-        if (input.skill) {
-          const skillPath = resolveSkillPath(input.skill);
-          if (skillPath && existsSync(skillPath)) {
-            const skillContent = readFileSync(skillPath, 'utf-8');
-            delegationPrompt = skillContent + '\n\n---\n\n' + delegationPrompt;
-          }
-        }
-
-        // Inject channel history for fresh processes (no prior context)
-        const sessionId = process.getSessionId?.();
-        if (!sessionId || attempt > 0) {
-          try {
-            const { getChannelHistory } = await import('../gateways/channel-history.js');
-            const channelHistory = getChannelHistory();
-            if (channelHistory) {
-              const historyContext = channelHistory.formatForContext(channelId, '', agentId);
-              if (historyContext) {
-                delegationPrompt = `${historyContext}\n\n${delegationPrompt}`;
-              }
-            }
-          } catch {
-            // Channel history injection is best-effort
-          }
-        }
-
-        const result = await process.sendMessage(delegationPrompt);
-        const durationMs = Date.now() - startTime;
-
-        try {
-          if (this.sessionsDb) {
-            const row = logActivity(this.sessionsDb, {
-              agent_id: agentId,
-              agent_version: agentVersion,
-              type: 'task_complete',
-              input_summary: task?.slice(0, 200),
-              output_summary: summarizeActivityOutput(result.response),
-              duration_ms: durationMs,
-              run_id: valSession?.id,
-              execution_status: 'completed',
-              trigger_reason: 'delegate_run',
-            });
-            if (valSession && this.validationService) {
-              this.validationService.recordRun(valSession.id, {
-                activityId: row.id,
-                duration_ms: durationMs,
-              });
-            }
-          }
-        } catch (telemetryErr) {
-          securityLogger.warn('[Delegation telemetry] Completion activity failed', telemetryErr);
-        }
-
-        try {
-          if (valSession && this.validationService) {
-            this.validationService.finalizeSession(valSession.id, {
-              execution_status: 'completed',
-              metrics: { duration_ms: durationMs },
-            });
-          }
-        } catch (telemetryErr) {
-          securityLogger.warn('[Delegation telemetry] Completion finalize failed', telemetryErr);
-        }
-
-        return {
-          success: true,
-          data: { agentId, response: result.response, duration_ms: durationMs },
-        } as GatewayToolResult;
-      } catch (err) {
-        lastError = err instanceof Error ? err : new Error(String(err));
-        const isBusy = lastError.message.includes('busy');
-        const isCrash = lastError.message.includes('exited with code');
-
-        if (isCrash) {
-          this.agentProcessManager.stopProcess(source, channelId, agentId);
-        }
-
-        if (attempt < MAX_RETRIES - 1 && (isBusy || isCrash)) {
-          await new Promise((r) => setTimeout(r, this._retryDelayMs * (attempt + 1)));
-          continue;
-        }
-        break;
-      }
-    }
-
-    const failedDurationMs = Date.now() - startTime;
-    try {
-      if (this.sessionsDb) {
-        const row = logActivity(this.sessionsDb, {
-          agent_id: agentId,
-          agent_version: agentVersion,
-          type: 'task_error',
-          input_summary: task?.slice(0, 200),
-          error_message: lastError?.message,
-          duration_ms: failedDurationMs,
-          run_id: valSession?.id,
-          execution_status: 'failed',
-          trigger_reason: 'delegate_run',
-        });
-        if (valSession && this.validationService) {
-          this.validationService.recordRun(valSession.id, {
-            activityId: row.id,
-            duration_ms: failedDurationMs,
-          });
-        }
-      }
-    } catch (telemetryErr) {
-      securityLogger.warn('[Delegation telemetry] Failure activity failed', telemetryErr);
-    }
-
-    try {
-      if (valSession && this.validationService) {
-        this.validationService.finalizeSession(valSession.id, {
-          execution_status: 'failed',
-          error_message: lastError?.message,
-          metrics: { duration_ms: failedDurationMs },
-        });
-      }
-    } catch (telemetryErr) {
-      securityLogger.warn('[Delegation telemetry] Failure finalize failed', telemetryErr);
-    }
-
-    return {
-      success: false,
-      error: `Delegation to ${agentId} failed after ${MAX_RETRIES} attempts: ${lastError?.message}`,
-    } as GatewayToolResult;
   }
 
   /**

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -394,6 +394,15 @@ export class GatewayToolExecutor {
     };
   }
 
+  private getActiveDelegationRouting(): DelegationRoutingContext {
+    const routing = this.getActiveRouting();
+    return {
+      agentId: routing.agentId || 'conductor',
+      source: routing.source || 'viewer',
+      channelId: routing.channelId || 'default',
+    };
+  }
+
   async withExecutionContext<T>(
     executionContext: GatewayExecutionContext | undefined,
     fn: () => Promise<T>
@@ -748,14 +757,16 @@ export class GatewayToolExecutor {
 
     const executionSurface = ctx?.executionSurface;
     const requiresEnvelope =
-      executionSurface !== undefined && ENVELOPE_REQUIRED_SURFACES.has(executionSurface);
+      ctx !== undefined &&
+      (executionSurface === undefined || ENVELOPE_REQUIRED_SURFACES.has(executionSurface));
     if (!requiresEnvelope) {
       return undefined;
     }
 
+    const surfaceLabel = executionSurface ?? 'unknown';
     if (failLoudOnMissing) {
       throw new Error(
-        `[envelope] tool ${toolName} called without envelope on ${executionSurface} (fail-loud mode)`
+        `[envelope] tool ${toolName} called without envelope on ${surfaceLabel} (fail-loud mode)`
       );
     }
 
@@ -1148,7 +1159,7 @@ export class GatewayToolExecutor {
         case 'agent_test':
           return await this.getDelegationExecutor().runAgentTest(
             input as AgentTestInput,
-            this.getActiveRouting()
+            this.getActiveDelegationRouting()
           );
         // Agent management tools (Managed Agents pattern)
         case 'agent_get': {
@@ -1388,7 +1399,7 @@ export class GatewayToolExecutor {
         case 'delegate':
           return await this.getDelegationExecutor().runDelegate(
             input as DelegateInput,
-            this.getActiveRouting()
+            this.getActiveDelegationRouting()
           );
       }
 

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -243,6 +243,7 @@ export class GatewayToolExecutor {
   private roleManager: RoleManager;
   private readonly executionContextStorage = new AsyncLocalStorage<ActiveGatewayExecutionContext>();
   private readonly envelopeEnforcer = new EnvelopeEnforcer();
+  private readonly envelopeIssuanceMode: 'off' | 'enabled' | 'required';
   private currentContext: AgentContext | null = null;
   private memoryAgentProcessManager: AgentProcessManager | null = null;
   private agentProcessManager: AgentProcessManager | null = null;
@@ -532,6 +533,7 @@ export class GatewayToolExecutor {
   constructor(options: GatewayToolExecutorOptions = {}) {
     this.mamaDbPath = options.mamaDbPath;
     this.sessionStore = options.sessionStore;
+    this.envelopeIssuanceMode = options.envelopeIssuanceMode ?? 'enabled';
     this.browserTool = getBrowserTool({
       screenshotDir: join(process.env.HOME || '', '.mama', 'workspace', 'media', 'outbound'),
     });
@@ -700,6 +702,10 @@ export class GatewayToolExecutor {
         }
         throw err;
       }
+    }
+
+    if (this.envelopeIssuanceMode === 'off') {
+      return undefined;
     }
 
     if (failLoudOnMissing) {

--- a/packages/standalone/src/agent/post-tool-handler.ts
+++ b/packages/standalone/src/agent/post-tool-handler.ts
@@ -5,8 +5,13 @@ import {
   CONTRACT_SAVE_LIMIT,
   type ExtractedContract,
 } from './contract-extractor.js';
+import type { GatewayToolExecutionContext } from './types.js';
 
-type ExecuteToolFn = (name: string, input: Record<string, unknown>) => Promise<unknown>;
+type ExecuteToolFn = (
+  name: string,
+  input: Record<string, unknown>,
+  executionContext?: GatewayToolExecutionContext | null
+) => Promise<unknown>;
 
 interface PostToolHandlerConfig {
   enabled: boolean;
@@ -38,15 +43,25 @@ export class PostToolHandler {
    * Synchronous entry point — fires background processing without blocking.
    * MUST NOT be async. MUST NOT return a Promise. MUST NOT throw.
    */
-  processInBackground(toolName: string, input: unknown, result: unknown): void {
+  processInBackground(
+    toolName: string,
+    input: unknown,
+    result: unknown,
+    executionContext?: GatewayToolExecutionContext | null
+  ): void {
     if (!this.enabled) {
       return;
     }
 
-    this.processAsync(toolName, input, result).catch(() => {});
+    this.processAsync(toolName, input, result, executionContext).catch(() => {});
   }
 
-  private async processAsync(toolName: string, input: unknown, result: unknown): Promise<void> {
+  private async processAsync(
+    toolName: string,
+    input: unknown,
+    result: unknown,
+    executionContext?: GatewayToolExecutionContext | null
+  ): Promise<void> {
     if (!this.isEditTool(toolName)) {
       return;
     }
@@ -79,12 +94,12 @@ export class PostToolHandler {
         continue;
       }
 
-      const isDupe = await this.isDuplicate(formatted.topic, formatted.decision);
+      const isDupe = await this.isDuplicate(formatted.topic, formatted.decision, executionContext);
       if (isDupe) {
         continue;
       }
 
-      await this.saveContract(formatted);
+      await this.saveContract(formatted, executionContext);
     }
   }
 
@@ -215,13 +230,20 @@ export class PostToolHandler {
     return undefined;
   }
 
-  private async isDuplicate(topic: string, decision: string): Promise<boolean> {
+  private async isDuplicate(
+    topic: string,
+    decision: string,
+    executionContext?: GatewayToolExecutionContext | null
+  ): Promise<boolean> {
     try {
-      const response = (await this.executeTool('mama_search', {
+      const input = {
         query: topic,
         type: 'decision',
         limit: 3,
-      })) as SearchResponse | undefined;
+      };
+      const response = (await (executionContext
+        ? this.executeTool('mama_search', input, executionContext)
+        : this.executeTool('mama_search', input))) as SearchResponse | undefined;
 
       if (!response?.results || response.results.length === 0) {
         return false;
@@ -233,20 +255,28 @@ export class PostToolHandler {
     }
   }
 
-  private async saveContract(formatted: {
-    topic: string;
-    decision: string;
-    reasoning: string;
-    confidence: number;
-  }): Promise<void> {
+  private async saveContract(
+    formatted: {
+      topic: string;
+      decision: string;
+      reasoning: string;
+      confidence: number;
+    },
+    executionContext?: GatewayToolExecutionContext | null
+  ): Promise<void> {
     try {
-      await this.executeTool('mama_save', {
+      const input = {
         type: 'decision',
         topic: formatted.topic,
         decision: formatted.decision,
         reasoning: formatted.reasoning,
         confidence: formatted.confidence,
-      });
+      };
+      if (executionContext) {
+        await this.executeTool('mama_save', input, executionContext);
+      } else {
+        await this.executeTool('mama_save', input);
+      }
     } catch {
       // intentionally empty
     }

--- a/packages/standalone/src/agent/pre-compact-handler.ts
+++ b/packages/standalone/src/agent/pre-compact-handler.ts
@@ -5,6 +5,7 @@
  * Uses executeTool callback to interact with MAMA memory (mama_search)
  * without importing mama-core directly.
  */
+import type { GatewayToolExecutionContext } from './types.js';
 
 // ============================================================================
 // Types
@@ -21,7 +22,11 @@ export interface PreCompactHandlerConfig {
   maxDecisionsToDetect?: number;
 }
 
-type ExecuteToolFn = (name: string, input: Record<string, unknown>) => Promise<unknown>;
+type ExecuteToolFn = (
+  name: string,
+  input: Record<string, unknown>,
+  executionContext?: GatewayToolExecutionContext | null
+) => Promise<unknown>;
 
 interface SearchResultItem {
   topic?: string;
@@ -62,7 +67,10 @@ export class PreCompactHandler {
     };
   }
 
-  async process(conversationHistory: string[]): Promise<CompactionResult> {
+  async process(
+    conversationHistory: string[],
+    executionContext?: GatewayToolExecutionContext | null
+  ): Promise<CompactionResult> {
     const emptyResult: CompactionResult = {
       unsavedDecisions: [],
       compactionPrompt: '',
@@ -84,7 +92,7 @@ export class PreCompactHandler {
         };
       }
 
-      const savedTopics = await this.getSavedTopics();
+      const savedTopics = await this.getSavedTopics(executionContext);
       const unsavedDecisions = this.filterUnsaved(candidates, savedTopics);
       const warningMessage = this.buildWarningMessage(unsavedDecisions);
       const compactionPrompt = this.buildCompactionPrompt(fullText, unsavedDecisions);
@@ -116,14 +124,19 @@ export class PreCompactHandler {
     return unique.slice(-this.config.maxDecisionsToDetect);
   }
 
-  private async getSavedTopics(): Promise<Set<string>> {
+  private async getSavedTopics(
+    executionContext?: GatewayToolExecutionContext | null
+  ): Promise<Set<string>> {
     const topics = new Set<string>();
 
     try {
-      const response = (await this.executeTool('mama_search', {
+      const input = {
         type: 'decision',
         limit: 20,
-      })) as SearchResponse | undefined;
+      };
+      const response = (await (executionContext
+        ? this.executeTool('mama_search', input, executionContext)
+        : this.executeTool('mama_search', input))) as SearchResponse | undefined;
 
       if (response?.results && Array.isArray(response.results)) {
         for (const item of response.results) {

--- a/packages/standalone/src/agent/types.ts
+++ b/packages/standalone/src/agent/types.ts
@@ -802,6 +802,8 @@ export interface EnvelopeDenialResult {
   error: string;
   code: string;
   envelope_hash?: string;
+  allowed?: unknown;
+  tier_required?: number;
 }
 
 /**

--- a/packages/standalone/src/agent/types.ts
+++ b/packages/standalone/src/agent/types.ts
@@ -102,7 +102,7 @@ export type GatewayToolExecutionContext = {
   source?: string;
   channelId?: string;
   envelope?: Envelope;
-  executionSurface?: GatewayExecutionSurface;
+  executionSurface: GatewayExecutionSurface;
 };
 
 // ============================================================================

--- a/packages/standalone/src/agent/types.ts
+++ b/packages/standalone/src/agent/types.ts
@@ -94,7 +94,7 @@ export interface AgentContext {
   backend?: 'claude' | 'codex-mcp';
 }
 
-export type GatewayExecutionSurface = 'model_tool' | 'reactive_internal' | 'code_act';
+export type GatewayExecutionSurface = 'model_tool' | 'reactive_internal' | 'code_act' | 'direct';
 
 export type GatewayToolExecutionContext = {
   agentContext?: AgentContext;

--- a/packages/standalone/src/agent/types.ts
+++ b/packages/standalone/src/agent/types.ts
@@ -94,6 +94,17 @@ export interface AgentContext {
   backend?: 'claude' | 'codex-mcp';
 }
 
+export type GatewayExecutionSurface = 'model_tool' | 'reactive_internal' | 'code_act';
+
+export type GatewayToolExecutionContext = {
+  agentContext?: AgentContext;
+  agentId?: string;
+  source?: string;
+  channelId?: string;
+  envelope?: Envelope;
+  executionSurface?: GatewayExecutionSurface;
+};
+
 // ============================================================================
 // Claude API Types
 // ============================================================================

--- a/packages/standalone/src/agent/types.ts
+++ b/packages/standalone/src/agent/types.ts
@@ -1101,6 +1101,10 @@ export interface GatewayToolExecutorOptions {
   mamaApi?: MAMAApiInterface;
   /** Roles configuration from config.yaml */
   rolesConfig?: import('../cli/config/types.js').RolesConfig;
+  /** Runtime envelope issuance mode (off disables missing-envelope enforcement). */
+  envelopeIssuanceMode?: 'off' | 'enabled' | 'required';
+  /** Optional metrics store for envelope/audit counters. */
+  metricsStore?: import('../observability/metrics-store.js').MetricsStore | null;
 }
 
 /**

--- a/packages/standalone/src/api/graph-api.ts
+++ b/packages/standalone/src/api/graph-api.ts
@@ -12,6 +12,7 @@ import os from 'os';
 import yaml from 'js-yaml';
 import type { IncomingMessage, ServerResponse } from 'http';
 import { isAuthenticated, logUnauthorizedAttempt } from './auth-middleware.js';
+import { getForwardedClientAddress } from '../security/trusted-proxy.js';
 import {
   handleGetAgents,
   handleGetAgent,
@@ -104,6 +105,13 @@ const DEFAULT_GRAPH_LIMIT = 300;
 const MAX_GRAPH_LIMIT = 2000;
 const GRAPH_PREVIEW_CHARS = 220;
 const SIMILAR_QUERY_DECISION_CHARS = 400;
+const CODE_ACT_RATE_LIMIT_WINDOW_MS = 60_000;
+const CODE_ACT_RATE_LIMIT_TTL_MS = CODE_ACT_RATE_LIMIT_WINDOW_MS * 5;
+const CODE_ACT_RATE_LIMIT_DEFAULT_MAX = 30;
+const codeActRateBuckets = new Map<
+  string,
+  { windowStartMs: number; count: number; lastSeenMs: number }
+>();
 
 // Model pattern helpers (used in multiple validation functions)
 const isClaudeModel = (model: string): boolean => /^claude-/i.test(model);
@@ -120,6 +128,60 @@ const VALIDATION_TRIGGER_TYPES = new Set<ValidationTriggerType>([
 const isOpus46Model = (model: string): boolean =>
   /^claude-opus-4-6(?:$|-)/i.test(model) || model.toLowerCase() === 'claude-opus-4-latest';
 const VALID_EFFORT_LEVELS = new Set(['low', 'medium', 'high', 'max']);
+
+function getCodeActRateLimitMax(): number {
+  const raw = process.env.MAMA_CODE_ACT_RATE_LIMIT_PER_MINUTE;
+  if (!raw) {
+    return CODE_ACT_RATE_LIMIT_DEFAULT_MAX;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : CODE_ACT_RATE_LIMIT_DEFAULT_MAX;
+}
+
+function getCodeActClientKey(req: IncomingMessage): string {
+  return getForwardedClientAddress(req);
+}
+
+function pruneCodeActRateBuckets(now: number): void {
+  for (const [clientKey, bucket] of codeActRateBuckets.entries()) {
+    if (now - bucket.lastSeenMs > CODE_ACT_RATE_LIMIT_TTL_MS) {
+      codeActRateBuckets.delete(clientKey);
+    }
+  }
+}
+
+function checkCodeActRateLimit(req: IncomingMessage): {
+  allowed: boolean;
+  clientKey: string;
+  retryAfterSeconds?: number;
+} {
+  const now = Date.now();
+  pruneCodeActRateBuckets(now);
+  const clientKey = getCodeActClientKey(req);
+  const limit = getCodeActRateLimitMax();
+  const existing = codeActRateBuckets.get(clientKey);
+
+  if (!existing || now - existing.windowStartMs >= CODE_ACT_RATE_LIMIT_WINDOW_MS) {
+    codeActRateBuckets.set(clientKey, { windowStartMs: now, count: 1, lastSeenMs: now });
+    return { allowed: true, clientKey };
+  }
+
+  existing.lastSeenMs = now;
+
+  if (existing.count >= limit) {
+    return {
+      allowed: false,
+      clientKey,
+      retryAfterSeconds: Math.max(
+        1,
+        Math.ceil((CODE_ACT_RATE_LIMIT_WINDOW_MS - (now - existing.windowStartMs)) / 1000)
+      ),
+    };
+  }
+
+  existing.count++;
+  return { allowed: true, clientKey };
+}
 
 // Allowed directories for persona files (security: prevent arbitrary file read)
 const ALLOWED_PERSONA_DIRS = [
@@ -3900,11 +3962,32 @@ async function handleCodeActRequest(
   try {
     // Security: require authentication for code execution endpoint
     if (!isAuthenticated(req)) {
+      logUnauthorizedAttempt(req);
       res.writeHead(401, { 'Content-Type': 'application/json' });
       res.end(
         JSON.stringify({
           error: true,
           message: 'Authentication required. Set Authorization header with valid token.',
+        })
+      );
+      return;
+    }
+
+    const rateLimit = checkCodeActRateLimit(req);
+    if (!rateLimit.allowed) {
+      logger.warn('Code-Act rate limit exceeded', {
+        client: rateLimit.clientKey,
+        retryAfterSeconds: rateLimit.retryAfterSeconds,
+      });
+      res.writeHead(429, {
+        'Content-Type': 'application/json',
+        'Retry-After': String(rateLimit.retryAfterSeconds ?? 60),
+      });
+      res.end(
+        JSON.stringify({
+          error: true,
+          message: 'Code-Act rate limit exceeded. Retry later.',
+          retry_after_seconds: rateLimit.retryAfterSeconds ?? 60,
         })
       );
       return;

--- a/packages/standalone/src/api/index.ts
+++ b/packages/standalone/src/api/index.ts
@@ -276,7 +276,7 @@ export function createApiServer(options: ApiServerOptions): ApiServer {
     res.json({ status: 'ok', timestamp: Date.now() });
   });
 
-  app.get('/api/envelope/status', requireAuth, (_req, res) => {
+  app.get('/api/envelope/status', (_req, res) => {
     if (!db) {
       res.status(503).json({
         error: true,

--- a/packages/standalone/src/api/index.ts
+++ b/packages/standalone/src/api/index.ts
@@ -15,7 +15,7 @@ import {
   type HeartbeatTracker,
 } from './heartbeat-handler.js';
 import { createTokenRouter, initTokenUsageTable } from './token-handler.js';
-import { initAgentTables } from '../db/agent-store.js';
+import { countScopeMismatches, initAgentTables } from '../db/agent-store.js';
 import { applyTokenUsageAgentVersionMigration } from '../db/migrations/token-usage-agent-version.js';
 import { createSkillsRouter } from './skills-handler.js';
 import { errorHandler, notFoundHandler } from './error-handler.js';
@@ -83,7 +83,15 @@ export interface ApiServerOptions {
       limit: number
     ): Array<{ agent: string; action: string; target: string; timestamp: number }>;
   };
+  /** Runtime envelope bootstrap metadata for authenticated status reporting */
+  envelope?: ApiEnvelopeMetadata;
 }
+
+export type ApiEnvelopeMetadata = {
+  issuance: 'off' | 'enabled' | 'required';
+  key_id?: string;
+  key_version?: number;
+};
 
 /**
  * API server instance
@@ -124,6 +132,7 @@ export function createApiServer(options: ApiServerOptions): ApiServer {
     rawStore,
     enabledConnectors,
     eventBus,
+    envelope = { issuance: 'off' },
   } = options;
 
   const app = express();
@@ -265,6 +274,30 @@ export function createApiServer(options: ApiServerOptions): ApiServer {
   // Health check endpoint (watchdog)
   app.get('/health', (_req, res) => {
     res.json({ status: 'ok', timestamp: Date.now() });
+  });
+
+  app.get('/api/envelope/status', requireAuth, (_req, res) => {
+    if (!db) {
+      res.status(503).json({
+        error: true,
+        code: 'audit_db_unavailable',
+        message: 'Envelope audit database is unavailable.',
+      });
+      return;
+    }
+
+    const since = new Date(Date.now() - 24 * 60 * 60_000)
+      .toISOString()
+      .slice(0, 19)
+      .replace('T', ' ');
+    const recentMismatchCount = countScopeMismatches(db, { since });
+
+    res.json({
+      issuance: envelope.issuance,
+      key_id: envelope.key_id,
+      key_version: envelope.key_version,
+      recent_mismatch_count_24h: recentMismatchCount,
+    });
   });
 
   // Metrics health endpoint (observability)

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -58,6 +58,27 @@ import { buildRuntimeEnvelopeBootstrap } from '../runtime/envelope-bootstrap.js'
 import { resolveReactiveProjectRoot } from '../../envelope/reactive-config.js';
 import { deriveMemoryScopes } from '../../memory/scope-context.js';
 import { randomUUID } from 'node:crypto';
+import * as debugLogger from '@jungjaehoon/mama-core/debug-logger';
+
+const { DebugLogger } = debugLogger as unknown as {
+  DebugLogger: new (context?: string) => {
+    warn: (...args: unknown[]) => void;
+  };
+};
+const codeActLogger = new DebugLogger('CodeAct');
+const TRUTHY_ENV_VALUES = new Set(['1', 'true', 'yes', 'on']);
+const CODE_ACT_MUTATION_TOOLS = new Set([
+  'mama_save',
+  'mama_update',
+  'mama_add',
+  'mama_ingest',
+  'report_publish',
+  'wiki_publish',
+]);
+
+function isTruthyEnvValue(value: string | undefined): boolean {
+  return value !== undefined && TRUTHY_ENV_VALUES.has(value.trim().toLowerCase());
+}
 
 /**
  * Options for start command
@@ -391,10 +412,19 @@ export async function runAgentLoop(
         };
       }
       const bridge = new HostBridge(toolExecutor, undefined, executionContext);
+      const codeActReadOnly = isTruthyEnvValue(process.env.MAMA_CODE_ACT_READ_ONLY);
       const toolCalls: { name: string; input: Record<string, unknown> }[] = [];
       bridge.onToolUse = (toolName, input, result) => {
         if (result !== undefined) {
           toolCalls.push({ name: toolName, input });
+          if (CODE_ACT_MUTATION_TOOLS.has(toolName)) {
+            codeActLogger.warn('[CodeAct] mutation tool call', {
+              toolName,
+              success: Boolean((result as { success?: unknown }).success),
+              readOnly: codeActReadOnly,
+              envelopeHash: executionContext?.envelope?.envelope_hash ?? null,
+            });
+          }
         }
       };
       const previousRoutingContext = toolExecutor.getCurrentAgentRoutingContext();
@@ -402,7 +432,7 @@ export async function runAgentLoop(
         // Set default agent context for /api/code-act calls (Conductor, tier 2 sandbox).
         // Per-request executionContext carries envelope data; this routing context is legacy fallback.
         toolExecutor.setCurrentAgentContext(codeActAgentId, 'api', 'code-act');
-        bridge.injectInto(sandbox, 2);
+        bridge.injectInto(sandbox, codeActReadOnly ? 3 : 2);
         const result = await sandbox.execute(code);
         return {
           success: result.success,

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -397,19 +397,24 @@ export async function runAgentLoop(
           toolCalls.push({ name: toolName, input });
         }
       };
-      // Set default agent context for /api/code-act calls (Conductor, tier 2 sandbox)
-      // In normal agent loop execution, this is set per-request by the handler
-      toolExecutor.setCurrentAgentContext(codeActAgentId, 'api', 'code-act');
-      bridge.injectInto(sandbox, 2);
-      const result = await sandbox.execute(code);
-      return {
-        success: result.success,
-        value: result.value,
-        logs: result.logs,
-        error: result.error?.message,
-        metrics: result.metrics,
-        toolCalls,
-      };
+      const previousRoutingContext = toolExecutor.getCurrentAgentRoutingContext();
+      try {
+        // Set default agent context for /api/code-act calls (Conductor, tier 2 sandbox).
+        // Per-request executionContext carries envelope data; this routing context is legacy fallback.
+        toolExecutor.setCurrentAgentContext(codeActAgentId, 'api', 'code-act');
+        bridge.injectInto(sandbox, 2);
+        const result = await sandbox.execute(code);
+        return {
+          success: result.success,
+          value: result.value,
+          logs: result.logs,
+          error: result.error?.message,
+          metrics: result.metrics,
+          toolCalls,
+        };
+      } finally {
+        toolExecutor.restoreCurrentAgentRoutingContext(previousRoutingContext);
+      }
     };
 
     // Pre-warm Code-Act WASM module for fast first execution

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -20,6 +20,7 @@ import { writePid, isDaemonRunning } from '../utils/pid-manager.js';
 import { killProcessesOnPorts, killAllMamaDaemons, killAllMamaWatchdogs } from './stop.js';
 import { OAuthManager } from '../../auth/index.js';
 import { GatewayToolExecutor } from '../../agent/gateway-tool-executor.js';
+import type { GatewayToolExecutionContext } from '../../agent/types.js';
 import { SessionStore, MessageRouter, initChannelHistory } from '../../gateways/index.js';
 import { createGraphHandler } from '../../api/graph-api.js';
 import type { GraphHandlerOptions } from '../../api/graph-api-types.js';
@@ -53,6 +54,10 @@ import { initApiServer } from '../runtime/api-server-init.js';
 import { registerApiRoutes } from '../runtime/api-routes-init.js';
 import { startServer } from '../runtime/server-start.js';
 import { installShutdownHandlers } from '../runtime/shutdown.js';
+import { buildRuntimeEnvelopeBootstrap } from '../runtime/envelope-bootstrap.js';
+import { resolveReactiveProjectRoot } from '../../envelope/reactive-config.js';
+import { deriveMemoryScopes } from '../../memory/scope-context.js';
+import { randomUUID } from 'node:crypto';
 
 /**
  * Options for start command
@@ -254,11 +259,14 @@ export async function runAgentLoop(
   // Initialize channel history with SQLite persistence (Sprint 3 F5)
   initChannelHistory(db);
 
+  const envelopeBootstrap = buildRuntimeEnvelopeBootstrap(db, config, process.env);
   const mamaDbPath = expandPath(config.database.path);
   const toolExecutor = new GatewayToolExecutor({
     mamaDbPath: mamaDbPath,
     sessionStore: sessionStore,
     rolesConfig: config.roles, // Pass roles from config.yaml
+    envelopeIssuanceMode: envelopeBootstrap.metadata.issuance,
+    metricsStore,
   });
 
   const validBackends = ['claude', 'codex-mcp'] as const;
@@ -279,7 +287,7 @@ export async function runAgentLoop(
     db,
     metricsStore,
     runtimeBackend,
-    options
+    { ...options, envelopeIssuanceMode: envelopeBootstrap.metadata.issuance }
   );
 
   // ── Phase 3: MAMA Core API ────────────────────────────────────────────────
@@ -292,9 +300,16 @@ export async function runAgentLoop(
 
   // ── Phase 4: Memory Agent + MessageRouter ─────────────────────────────────
 
-  const messageRouter = new MessageRouter(sessionStore, agentLoopClient, mamaApiClient, {
-    backend: runtimeBackend,
-  });
+  const messageRouter = new MessageRouter(
+    sessionStore,
+    agentLoopClient,
+    mamaApiClient,
+    {
+      backend: runtimeBackend,
+    },
+    envelopeBootstrap.envelopeConfig,
+    envelopeBootstrap.envelopeAuthority
+  );
   messageRouter.setSessionsDb(db);
 
   // validationService wired after creation (Phase 5 below)
@@ -337,21 +352,55 @@ export async function runAgentLoop(
     graphHandlerOptions.executeCodeAct = async (code: string) => {
       const { CodeActSandbox, HostBridge } = await import('../../agent/code-act/index.js');
       const sandbox = new CodeActSandbox();
-      const bridge = new HostBridge(toolExecutor);
+      const codeActAgentId = config.multi_agent?.default_agent || 'conductor';
+      let executionContext: GatewayToolExecutionContext | null = null;
+      if (envelopeBootstrap.envelopeAuthority && envelopeBootstrap.metadata.issuance !== 'off') {
+        const projectId = resolveReactiveProjectRoot(config, process.env);
+        const projectRef = { kind: 'project' as const, id: projectId };
+        const wallSeconds = Math.min(
+          Math.max(Math.floor((config.timeouts?.agent_ms ?? 300_000) / 1000), 1),
+          300
+        );
+        const envelope = envelopeBootstrap.envelopeAuthority.buildAndPersist({
+          agent_id: codeActAgentId,
+          instance_id: randomUUID(),
+          source: 'watch',
+          channel_id: 'api:code-act',
+          trigger_context: { user_text: '<api-code-act invocation>' },
+          scope: {
+            project_refs: [projectRef],
+            raw_connectors: [],
+            memory_scopes: deriveMemoryScopes({
+              source: 'viewer',
+              channelId: 'api:code-act',
+              userId: 'api',
+              projectId,
+            }),
+            allowed_destinations: [],
+          },
+          tier: 2,
+          budget: { wall_seconds: wallSeconds },
+          expires_at: new Date(Date.now() + wallSeconds * 1000 + 30_000).toISOString(),
+        });
+        executionContext = {
+          agentId: codeActAgentId,
+          source: 'watch',
+          channelId: 'api:code-act',
+          envelope,
+          executionSurface: 'code_act',
+        };
+      }
+      const bridge = new HostBridge(toolExecutor, undefined, executionContext);
       const toolCalls: { name: string; input: Record<string, unknown> }[] = [];
       bridge.onToolUse = (toolName, input, result) => {
         if (result !== undefined) {
           toolCalls.push({ name: toolName, input });
         }
       };
-      // Set default agent context for /api/code-act calls (Conductor, tier 1)
+      // Set default agent context for /api/code-act calls (Conductor, tier 2 sandbox)
       // In normal agent loop execution, this is set per-request by the handler
-      toolExecutor.setCurrentAgentContext(
-        config.multi_agent?.default_agent || 'conductor',
-        'api',
-        'code-act'
-      );
-      bridge.injectInto(sandbox, 1);
+      toolExecutor.setCurrentAgentContext(codeActAgentId, 'api', 'code-act');
+      bridge.injectInto(sandbox, 2);
       const result = await sandbox.execute(code);
       return {
         success: result.success,
@@ -592,6 +641,7 @@ export async function runAgentLoop(
     enabledConnectors: enabledConnectorNames,
     agentLoop,
     getAdapter,
+    envelopeMetadata: envelopeBootstrap.metadata,
   });
 
   await registerApiRoutes({

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -20,7 +20,7 @@ import { writePid, isDaemonRunning } from '../utils/pid-manager.js';
 import { killProcessesOnPorts, killAllMamaDaemons, killAllMamaWatchdogs } from './stop.js';
 import { OAuthManager } from '../../auth/index.js';
 import { GatewayToolExecutor } from '../../agent/gateway-tool-executor.js';
-import type { GatewayToolExecutionContext } from '../../agent/types.js';
+import type { AgentContext, GatewayToolExecutionContext } from '../../agent/types.js';
 import { SessionStore, MessageRouter, initChannelHistory } from '../../gateways/index.js';
 import { createGraphHandler } from '../../api/graph-api.js';
 import type { GraphHandlerOptions } from '../../api/graph-api-types.js';
@@ -57,6 +57,7 @@ import { installShutdownHandlers } from '../runtime/shutdown.js';
 import { buildRuntimeEnvelopeBootstrap } from '../runtime/envelope-bootstrap.js';
 import { resolveReactiveProjectRoot } from '../../envelope/reactive-config.js';
 import { deriveMemoryScopes } from '../../memory/scope-context.js';
+import { DEFAULT_ROLES } from '../config/types.js';
 import { randomUUID } from 'node:crypto';
 import * as debugLogger from '@jungjaehoon/mama-core/debug-logger';
 
@@ -374,36 +375,58 @@ export async function runAgentLoop(
       const { CodeActSandbox, HostBridge } = await import('../../agent/code-act/index.js');
       const sandbox = new CodeActSandbox();
       const codeActAgentId = config.multi_agent?.default_agent || 'conductor';
+      const codeActReadOnly = isTruthyEnvValue(process.env.MAMA_CODE_ACT_READ_ONLY);
+      const codeActTier = codeActReadOnly ? 3 : 2;
       let executionContext: GatewayToolExecutionContext | null = null;
       if (envelopeBootstrap.envelopeAuthority && envelopeBootstrap.metadata.issuance !== 'off') {
         const projectId = resolveReactiveProjectRoot(config, process.env);
         const projectRef = { kind: 'project' as const, id: projectId };
+        const memoryScopes = deriveMemoryScopes({
+          source: 'watch',
+          channelId: 'api:code-act',
+          userId: 'api',
+          projectId,
+        });
+        const instanceId = randomUUID();
         const wallSeconds = Math.min(
           Math.max(Math.floor((config.timeouts?.agent_ms ?? 300_000) / 1000), 1),
           300
         );
         const envelope = envelopeBootstrap.envelopeAuthority.buildAndPersist({
           agent_id: codeActAgentId,
-          instance_id: randomUUID(),
+          instance_id: instanceId,
           source: 'watch',
           channel_id: 'api:code-act',
           trigger_context: { user_text: '<api-code-act invocation>' },
           scope: {
             project_refs: [projectRef],
             raw_connectors: [],
-            memory_scopes: deriveMemoryScopes({
-              source: 'viewer',
-              channelId: 'api:code-act',
-              userId: 'api',
-              projectId,
-            }),
+            memory_scopes: memoryScopes,
             allowed_destinations: [],
           },
-          tier: 2,
+          tier: codeActTier,
           budget: { wall_seconds: wallSeconds },
           expires_at: new Date(Date.now() + wallSeconds * 1000 + 30_000).toISOString(),
         });
+        const roleName = config.roles?.sourceMapping?.watch ?? 'os_agent';
+        const role = config.roles?.definitions?.[roleName] ?? DEFAULT_ROLES.definitions.os_agent;
+        const agentContext: AgentContext = {
+          source: 'watch',
+          platform: 'cli',
+          roleName,
+          role,
+          session: {
+            sessionId: `api:code-act:${instanceId}`,
+            channelId: 'api:code-act',
+            startedAt: new Date(),
+          },
+          capabilities: ['code_act'],
+          limitations: codeActReadOnly ? ['Code-Act read-only mode: memory writes disabled'] : [],
+          tier: codeActTier,
+          backend: 'claude',
+        };
         executionContext = {
+          agentContext,
           agentId: codeActAgentId,
           source: 'watch',
           channelId: 'api:code-act',
@@ -412,7 +435,6 @@ export async function runAgentLoop(
         };
       }
       const bridge = new HostBridge(toolExecutor, undefined, executionContext);
-      const codeActReadOnly = isTruthyEnvValue(process.env.MAMA_CODE_ACT_READ_ONLY);
       const toolCalls: { name: string; input: Record<string, unknown> }[] = [];
       bridge.onToolUse = (toolName, input, result) => {
         if (result !== undefined) {
@@ -429,10 +451,10 @@ export async function runAgentLoop(
       };
       const previousRoutingContext = toolExecutor.getCurrentAgentRoutingContext();
       try {
-        // Set default agent context for /api/code-act calls (Conductor, tier 2 sandbox).
+        // Set default agent context for /api/code-act calls (Conductor, tiered sandbox).
         // Per-request executionContext carries envelope data; this routing context is legacy fallback.
         toolExecutor.setCurrentAgentContext(codeActAgentId, 'api', 'code-act');
-        bridge.injectInto(sandbox, codeActReadOnly ? 3 : 2);
+        bridge.injectInto(sandbox, codeActTier);
         const result = await sandbox.execute(code);
         return {
           success: result.success,

--- a/packages/standalone/src/cli/runtime/agent-loop-init.ts
+++ b/packages/standalone/src/cli/runtime/agent-loop-init.ts
@@ -24,6 +24,7 @@ import { AgentLoop } from '../../agent/index.js';
 import type { AgentLoopOptions, ContentBlock as AgentContentBlock } from '../../agent/types.js';
 import type { ContentBlock as GatewayContentBlock } from '../../gateways/types.js';
 import type { AgentLoopClient } from './types.js';
+import type { EnvelopeIssuanceMode } from './envelope-bootstrap.js';
 import type { MetricsStore } from '../../observability/metrics-store.js';
 import type { SQLiteDatabase } from '../../sqlite.js';
 import { insertTokenUsage } from '../../api/index.js';
@@ -56,7 +57,7 @@ export function initMainAgentLoop(
   db: SQLiteDatabase,
   metricsStore: MetricsStore | null,
   runtimeBackend: 'claude' | 'codex-mcp',
-  options?: { osAgentMode?: boolean }
+  options?: { osAgentMode?: boolean; envelopeIssuanceMode?: EnvelopeIssuanceMode }
 ): AgentLoopInitResult {
   // Reasoning collector for Discord display
   let reasoningLog: string[] = [];
@@ -191,6 +192,8 @@ export function initMainAgentLoop(
     undefined,
     {
       mamaDbPath: config.database.path.replace(/^~/, homedir()),
+      envelopeIssuanceMode: options?.envelopeIssuanceMode ?? 'off',
+      metricsStore,
     }
   );
   console.log('✓ Lane-based concurrency enabled (reasoning collection)');

--- a/packages/standalone/src/cli/runtime/agent-loop-init.ts
+++ b/packages/standalone/src/cli/runtime/agent-loop-init.ts
@@ -21,6 +21,8 @@ import { join } from 'node:path';
 import type { MAMAConfig } from '../config/types.js';
 import type { OAuthManager } from '../../auth/index.js';
 import { AgentLoop } from '../../agent/index.js';
+import type { AgentLoopOptions, ContentBlock as AgentContentBlock } from '../../agent/types.js';
+import type { ContentBlock as GatewayContentBlock } from '../../gateways/types.js';
 import type { AgentLoopClient } from './types.js';
 import type { MetricsStore } from '../../observability/metrics-store.js';
 import type { SQLiteDatabase } from '../../sqlite.js';
@@ -205,16 +207,7 @@ export function initMainAgentLoop(
   // Create AgentLoopClient wrapper (adapts AgentLoopResult -> { response })
   // Also sets session key for lane-based concurrency and includes reasoning
   const agentLoopClient: AgentLoopClient = {
-    run: async (
-      prompt: string,
-      options?: {
-        userId?: string;
-        source?: string;
-        channelId?: string;
-        systemPrompt?: string;
-        model?: string;
-      }
-    ) => {
+    run: async (prompt: string, options?: AgentLoopOptions) => {
       // Reset reasoning log for new request
       reasoningLog = [];
       turnCount = 0;
@@ -255,18 +248,7 @@ export function initMainAgentLoop(
       const response = `${header}\n${result.response}`;
       return { response };
     },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    runWithContent: async (
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      content: any[],
-      options?: {
-        userId?: string;
-        source?: string;
-        channelId?: string;
-        systemPrompt?: string;
-        model?: string;
-      }
-    ) => {
+    runWithContent: async (content: GatewayContentBlock[], options?: AgentLoopOptions) => {
       // Reset reasoning log for new request
       reasoningLog = [];
       turnCount = 0;
@@ -283,7 +265,10 @@ export function initMainAgentLoop(
         // Override role-based model selection for Codex-MCP backend
         options.model = config.agent.model;
       }
-      const result = await agentLoop.runWithContent(content, options);
+      const result = await agentLoop.runWithContent(
+        content as unknown as AgentContentBlock[],
+        options
+      );
 
       // Check if auto-recall was used
       if (result.history && result.history.length > 0) {

--- a/packages/standalone/src/cli/runtime/api-server-init.ts
+++ b/packages/standalone/src/cli/runtime/api-server-init.ts
@@ -58,6 +58,7 @@ export async function initApiServer(params: InitApiServerParams): Promise<InitAp
     enabledConnectors,
     agentLoop,
     getAdapter,
+    envelopeMetadata,
   } = params;
 
   // ── SkillRegistry + MCP config migration ──────────────────────────────
@@ -109,6 +110,7 @@ export async function initApiServer(params: InitApiServerParams): Promise<InitAp
     rawStore,
     enabledConnectors,
     eventBus,
+    envelope: envelopeMetadata,
     onHeartbeat: async (prompt) => {
       try {
         const result = await agentLoop.run(prompt);

--- a/packages/standalone/src/cli/runtime/api-server-init.ts
+++ b/packages/standalone/src/cli/runtime/api-server-init.ts
@@ -18,6 +18,7 @@ import type { HealthCheckService } from '../../observability/health-check.js';
 import type { RawStore } from '../../connectors/framework/raw-store.js';
 import type { SQLiteDatabase } from '../../sqlite.js';
 import type { MAMAConfig } from '../config/types.js';
+import type { RuntimeEnvelopeBootstrap } from './envelope-bootstrap.js';
 import { API_PORT } from './utilities.js';
 
 // Re-export SkillRegistry for consumers that need the same instance
@@ -32,6 +33,7 @@ export interface InitApiServerParams {
   rawStore: RawStore | undefined;
   enabledConnectors: string[];
   agentLoop: AgentLoop;
+  envelopeMetadata?: RuntimeEnvelopeBootstrap['metadata'];
   /** mama-core getAdapter() — used to create the memoryDb shim */
   getAdapter: () => {
     prepare: (sql: string) => unknown;

--- a/packages/standalone/src/cli/runtime/envelope-bootstrap.ts
+++ b/packages/standalone/src/cli/runtime/envelope-bootstrap.ts
@@ -1,0 +1,65 @@
+import type { SQLiteDatabase } from '../../sqlite.js';
+import type { MAMAConfig } from '../config/types.js';
+import { applyEnvelopeTablesMigration } from '../../db/migrations/envelope-tables.js';
+import { EnvelopeAuthority } from '../../envelope/authority.js';
+import { loadEnvelopeSigningKeyFromEnv, makeEnvKeyLookup } from '../../envelope/key-provider.js';
+import { createDefaultReactiveEnvelopeConfig } from '../../envelope/reactive-config.js';
+import type { EnvLike, ReactiveEnvelopeConfig } from '../../envelope/reactive-config.js';
+import { EnvelopeStore } from '../../envelope/store.js';
+
+export type EnvelopeIssuanceMode = 'off' | 'enabled' | 'required';
+
+export interface RuntimeEnvelopeBootstrap {
+  envelopeConfig?: ReactiveEnvelopeConfig;
+  envelopeAuthority?: EnvelopeAuthority;
+  metadata: {
+    issuance: EnvelopeIssuanceMode;
+    key_id?: string;
+    key_version?: number;
+  };
+}
+
+function parseEnvelopeIssuanceMode(env: EnvLike): EnvelopeIssuanceMode {
+  const raw = env.MAMA_ENVELOPE_ISSUANCE?.trim().toLowerCase();
+  if (!raw || raw === 'off' || raw === 'false') {
+    return 'off';
+  }
+  if (raw === 'enabled' || raw === 'required') {
+    return raw;
+  }
+  throw new Error(
+    `[envelope] MAMA_ENVELOPE_ISSUANCE must be one of off, false, enabled, required; got ${env.MAMA_ENVELOPE_ISSUANCE}`
+  );
+}
+
+export function buildRuntimeEnvelopeBootstrap(
+  db: SQLiteDatabase,
+  config: MAMAConfig,
+  env: EnvLike = process.env
+): RuntimeEnvelopeBootstrap {
+  const issuance = parseEnvelopeIssuanceMode(env);
+
+  if (issuance === 'off') {
+    return {
+      metadata: { issuance },
+    };
+  }
+
+  const signingKey = loadEnvelopeSigningKeyFromEnv(env);
+  applyEnvelopeTablesMigration(db);
+  const envelopeAuthority = new EnvelopeAuthority(
+    new EnvelopeStore(db),
+    signingKey,
+    makeEnvKeyLookup(signingKey)
+  );
+
+  return {
+    envelopeConfig: createDefaultReactiveEnvelopeConfig(config, env),
+    envelopeAuthority,
+    metadata: {
+      issuance,
+      key_id: signingKey.key_id,
+      key_version: signingKey.key_version,
+    },
+  };
+}

--- a/packages/standalone/src/db/agent-store.ts
+++ b/packages/standalone/src/db/agent-store.ts
@@ -363,6 +363,7 @@ export function getActivity(
   options: GetActivityOptions = {}
 ): ActivityRow[] {
   const traceClause = options.includeTrace ? '' : "AND type != 'gateway_tool_call'";
+  const normalizedLimit = normalizeActivityLimit(limit);
   return db
     .prepare(
       `SELECT * FROM agent_activity
@@ -370,7 +371,7 @@ export function getActivity(
        ORDER BY created_at DESC, id DESC
        LIMIT ?`
     )
-    .all(agentId, limit) as ActivityRow[];
+    .all(agentId, normalizedLimit) as ActivityRow[];
 }
 
 export function listGatewayToolCalls(db: DB, input: GatewayToolCallQuery = {}): ActivityRow[] {

--- a/packages/standalone/src/db/agent-store.ts
+++ b/packages/standalone/src/db/agent-store.ts
@@ -334,7 +334,7 @@ export function logActivity(db: DB, input: LogActivityInput): ActivityRow {
     input.envelopeHash ?? null,
     input.requestedScopes ? JSON.stringify(input.requestedScopes) : null,
     input.envelopeScopesSnapshot ? JSON.stringify(input.envelopeScopesSnapshot) : null,
-    input.scopeMismatch === true ? 1 : Number(input.scopeMismatch ?? 0)
+    Number(Boolean(input.scopeMismatch))
   );
   return db
     .prepare('SELECT * FROM agent_activity WHERE id = ?')

--- a/packages/standalone/src/db/agent-store.ts
+++ b/packages/standalone/src/db/agent-store.ts
@@ -9,6 +9,7 @@ import type { SQLiteDatabase } from '../sqlite.js';
 import { applyAgentStoreTablesMigration } from './migrations/agent-store-tables.js';
 import { applyAgentMetricsResponseAverageMigration } from './migrations/agent-metrics-response-avg.js';
 import { applyAgentActivityValidationColumnsMigration } from './migrations/agent-activity-validation-columns.js';
+import { applyAgentActivityEnvelopeColumnsMigration } from './migrations/agent-activity-envelope-hash.js';
 import { applyEnvelopeTablesMigration } from './migrations/envelope-tables.js';
 
 type DB = SQLiteDatabase;
@@ -35,6 +36,7 @@ export function initAgentTables(db: SQLiteDatabase): void {
   applyAgentStoreTablesMigration(db);
   applyAgentMetricsResponseAverageMigration(db);
   applyAgentActivityValidationColumnsMigration(db);
+  applyAgentActivityEnvelopeColumnsMigration(db);
   applyEnvelopeTablesMigration(db);
 }
 
@@ -256,6 +258,10 @@ export interface LogActivityInput {
   run_id?: string;
   execution_status?: string;
   trigger_reason?: string;
+  envelopeHash?: string | null;
+  requestedScopes?: unknown[] | null;
+  envelopeScopesSnapshot?: unknown[] | null;
+  scopeMismatch?: boolean | number;
 }
 
 export interface ActivityRow {
@@ -274,7 +280,25 @@ export interface ActivityRow {
   run_id: string | null;
   execution_status: string | null;
   trigger_reason: string | null;
+  envelope_hash: string | null;
+  requested_scopes: string | null;
+  envelope_scopes_snapshot: string | null;
+  scope_mismatch: number;
   created_at: string;
+}
+
+export interface GetActivityOptions {
+  includeTrace?: boolean;
+}
+
+export interface GatewayToolCallQuery {
+  envelopeHash?: string;
+  agentId?: string;
+  limit?: number;
+}
+
+export interface ScopeMismatchQuery extends GatewayToolCallQuery {
+  since?: string;
 }
 
 // ── Activity CRUD ──────────────────────────────────────────────────────────
@@ -283,9 +307,10 @@ export function logActivity(db: DB, input: LogActivityInput): ActivityRow {
   const stmt = db.prepare(`
     INSERT INTO agent_activity (
       agent_id, agent_version, type, input_summary, output_summary, tokens_used,
-      tools_called, duration_ms, score, details, error_message, run_id, execution_status, trigger_reason
+      tools_called, duration_ms, score, details, error_message, run_id, execution_status, trigger_reason,
+      envelope_hash, requested_scopes, envelope_scopes_snapshot, scope_mismatch
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
   const result = stmt.run(
     input.agent_id,
@@ -301,7 +326,11 @@ export function logActivity(db: DB, input: LogActivityInput): ActivityRow {
     input.error_message ?? null,
     input.run_id ?? null,
     input.execution_status ?? null,
-    input.trigger_reason ?? null
+    input.trigger_reason ?? null,
+    input.envelopeHash ?? null,
+    input.requestedScopes ? JSON.stringify(input.requestedScopes) : null,
+    input.envelopeScopesSnapshot ? JSON.stringify(input.envelopeScopesSnapshot) : null,
+    input.scopeMismatch === true ? 1 : Number(input.scopeMismatch ?? 0)
   );
   return db
     .prepare('SELECT * FROM agent_activity WHERE id = ?')
@@ -323,12 +352,80 @@ export function updateActivityScore(
   return db.prepare('SELECT * FROM agent_activity WHERE id = ?').get(activityId) as ActivityRow;
 }
 
-export function getActivity(db: DB, agentId: string, limit: number): ActivityRow[] {
+export function getActivity(
+  db: DB,
+  agentId: string,
+  limit: number,
+  options: GetActivityOptions = {}
+): ActivityRow[] {
+  const traceClause = options.includeTrace ? '' : "AND type != 'gateway_tool_call'";
   return db
     .prepare(
-      'SELECT * FROM agent_activity WHERE agent_id = ? ORDER BY created_at DESC, id DESC LIMIT ?'
+      `SELECT * FROM agent_activity
+       WHERE agent_id = ? ${traceClause}
+       ORDER BY created_at DESC, id DESC
+       LIMIT ?`
     )
     .all(agentId, limit) as ActivityRow[];
+}
+
+export function listGatewayToolCalls(db: DB, input: GatewayToolCallQuery = {}): ActivityRow[] {
+  const conditions = ["type = 'gateway_tool_call'"];
+  const params: Array<string | number> = [];
+
+  if (input.envelopeHash) {
+    conditions.push('envelope_hash = ?');
+    params.push(input.envelopeHash);
+  }
+  if (input.agentId) {
+    conditions.push('agent_id = ?');
+    params.push(input.agentId);
+  }
+
+  params.push(normalizeActivityLimit(input.limit));
+  return db
+    .prepare(
+      `SELECT * FROM agent_activity
+       WHERE ${conditions.join(' AND ')}
+       ORDER BY created_at DESC, id DESC
+       LIMIT ?`
+    )
+    .all(...params) as ActivityRow[];
+}
+
+export function listScopeMismatches(db: DB, input: ScopeMismatchQuery = {}): ActivityRow[] {
+  const conditions = ['scope_mismatch = 1'];
+  const params: Array<string | number> = [];
+
+  if (input.envelopeHash) {
+    conditions.push('envelope_hash = ?');
+    params.push(input.envelopeHash);
+  }
+  if (input.agentId) {
+    conditions.push('agent_id = ?');
+    params.push(input.agentId);
+  }
+  if (input.since) {
+    conditions.push('created_at >= ?');
+    params.push(input.since);
+  }
+
+  params.push(normalizeActivityLimit(input.limit));
+  return db
+    .prepare(
+      `SELECT * FROM agent_activity
+       WHERE ${conditions.join(' AND ')}
+       ORDER BY created_at DESC, id DESC
+       LIMIT ?`
+    )
+    .all(...params) as ActivityRow[];
+}
+
+function normalizeActivityLimit(limit: number | undefined): number {
+  if (!Number.isFinite(limit) || limit === undefined) {
+    return 100;
+  }
+  return Math.min(Math.max(Math.floor(limit), 1), 1000);
 }
 
 // ── Activity Summary ───────────────────────────────────────────────────────

--- a/packages/standalone/src/db/agent-store.ts
+++ b/packages/standalone/src/db/agent-store.ts
@@ -301,6 +301,10 @@ export interface ScopeMismatchQuery extends GatewayToolCallQuery {
   since?: string;
 }
 
+export interface ScopeMismatchCountQuery {
+  since?: string;
+}
+
 // ── Activity CRUD ──────────────────────────────────────────────────────────
 
 export function logActivity(db: DB, input: LogActivityInput): ActivityRow {
@@ -419,6 +423,21 @@ export function listScopeMismatches(db: DB, input: ScopeMismatchQuery = {}): Act
        LIMIT ?`
     )
     .all(...params) as ActivityRow[];
+}
+
+export function countScopeMismatches(db: DB, input: ScopeMismatchCountQuery = {}): number {
+  const conditions = ['scope_mismatch = 1'];
+  const params: string[] = [];
+
+  if (input.since) {
+    conditions.push('created_at >= ?');
+    params.push(input.since);
+  }
+
+  const row = db
+    .prepare(`SELECT COUNT(*) as count FROM agent_activity WHERE ${conditions.join(' AND ')}`)
+    .get(...params) as { count: number } | undefined;
+  return row?.count ?? 0;
 }
 
 function normalizeActivityLimit(limit: number | undefined): number {

--- a/packages/standalone/src/db/agent-store.ts
+++ b/packages/standalone/src/db/agent-store.ts
@@ -410,7 +410,7 @@ export function listScopeMismatches(db: DB, input: ScopeMismatchQuery = {}): Act
     params.push(input.agentId);
   }
   if (input.since) {
-    conditions.push('created_at >= ?');
+    conditions.push('created_at >= datetime(?)');
     params.push(input.since);
   }
 
@@ -430,7 +430,7 @@ export function countScopeMismatches(db: DB, input: ScopeMismatchCountQuery = {}
   const params: string[] = [];
 
   if (input.since) {
-    conditions.push('created_at >= ?');
+    conditions.push('created_at >= datetime(?)');
     params.push(input.since);
   }
 

--- a/packages/standalone/src/db/migrations/agent-activity-envelope-hash.ts
+++ b/packages/standalone/src/db/migrations/agent-activity-envelope-hash.ts
@@ -1,0 +1,37 @@
+import type { SQLiteDatabase } from '../../sqlite.js';
+
+export function applyAgentActivityEnvelopeColumnsMigration(db: SQLiteDatabase): void {
+  const tableExists = db
+    .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'agent_activity'")
+    .get() as { 1: number } | undefined;
+
+  if (!tableExists) {
+    return;
+  }
+
+  const columns = (
+    db.prepare('PRAGMA table_info(agent_activity)').all() as Array<{ name: string }>
+  ).map((column) => column.name);
+
+  if (!columns.includes('envelope_hash')) {
+    db.exec('ALTER TABLE agent_activity ADD COLUMN envelope_hash TEXT');
+  }
+  if (!columns.includes('requested_scopes')) {
+    db.exec('ALTER TABLE agent_activity ADD COLUMN requested_scopes TEXT');
+  }
+  if (!columns.includes('envelope_scopes_snapshot')) {
+    db.exec('ALTER TABLE agent_activity ADD COLUMN envelope_scopes_snapshot TEXT');
+  }
+  if (!columns.includes('scope_mismatch')) {
+    db.exec('ALTER TABLE agent_activity ADD COLUMN scope_mismatch INTEGER DEFAULT 0');
+  }
+
+  db.exec(
+    'CREATE INDEX IF NOT EXISTS idx_agent_activity_envelope_hash ON agent_activity(envelope_hash)'
+  );
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_agent_activity_scope_mismatch
+     ON agent_activity(scope_mismatch, created_at)
+     WHERE scope_mismatch = 1`
+  );
+}

--- a/packages/standalone/src/db/migrations/agent-store-tables.ts
+++ b/packages/standalone/src/db/migrations/agent-store-tables.ts
@@ -57,7 +57,7 @@ export function applyAgentStoreTablesMigration(db: SQLiteDatabase): void {
       envelope_hash    TEXT,
       requested_scopes TEXT,
       envelope_scopes_snapshot TEXT,
-      scope_mismatch   INTEGER DEFAULT 0,
+      scope_mismatch   INTEGER DEFAULT 0 CHECK (scope_mismatch IN (0, 1)),
       created_at       TEXT NOT NULL DEFAULT (datetime('now'))
     )
   `);

--- a/packages/standalone/src/db/migrations/agent-store-tables.ts
+++ b/packages/standalone/src/db/migrations/agent-store-tables.ts
@@ -54,6 +54,10 @@ export function applyAgentStoreTablesMigration(db: SQLiteDatabase): void {
       run_id           TEXT,
       execution_status TEXT,
       trigger_reason   TEXT,
+      envelope_hash    TEXT,
+      requested_scopes TEXT,
+      envelope_scopes_snapshot TEXT,
+      scope_mismatch   INTEGER DEFAULT 0,
       created_at       TEXT NOT NULL DEFAULT (datetime('now'))
     )
   `);

--- a/packages/standalone/src/envelope/enforcer.ts
+++ b/packages/standalone/src/envelope/enforcer.ts
@@ -3,7 +3,8 @@ import type { Envelope } from './types.js';
 export class EnvelopeViolation extends Error {
   constructor(
     message: string,
-    public readonly code: string
+    public readonly code: string,
+    public readonly metadata: Record<string, unknown> = {}
   ) {
     super(`[${code}] ${message}`);
     this.name = 'EnvelopeViolation';
@@ -32,6 +33,8 @@ const WRITE_OR_SEND_TOOLS = new Set<string>([
   'discord_send',
   'webchat_send',
   'report.publish',
+  'report_publish',
+  'wiki_publish',
   'human.correction',
 ]);
 
@@ -83,7 +86,8 @@ export class EnvelopeEnforcer {
     if (!allowed) {
       throw new EnvelopeViolation(
         `Destination ${destinationKind}:${destinationId} not in envelope.scope.allowed_destinations`,
-        'destination_out_of_scope'
+        'destination_out_of_scope',
+        { allowed: envelope.scope.allowed_destinations }
       );
     }
   }
@@ -100,7 +104,8 @@ export class EnvelopeEnforcer {
     if (outOfScope.length > 0) {
       throw new EnvelopeViolation(
         `Raw connectors ${outOfScope.join(',')} not in envelope.scope.raw_connectors`,
-        'connector_out_of_scope'
+        'connector_out_of_scope',
+        { allowed: envelope.scope.raw_connectors }
       );
     }
   }
@@ -109,7 +114,8 @@ export class EnvelopeEnforcer {
     if (envelope.tier === 3 && WRITE_OR_SEND_TOOLS.has(toolName)) {
       throw new EnvelopeViolation(
         `Tool ${toolName} not allowed at tier 3 (read-only)`,
-        'tier_violation'
+        'tier_violation',
+        { tier_required: 2, allowed: false }
       );
     }
   }

--- a/packages/standalone/src/envelope/index.ts
+++ b/packages/standalone/src/envelope/index.ts
@@ -6,3 +6,4 @@ export * from './store.js';
 export * from './authority.js';
 export * from './enforcer.js';
 export * from './subset.js';
+export * from './reactive-config.js';

--- a/packages/standalone/src/envelope/reactive-config.ts
+++ b/packages/standalone/src/envelope/reactive-config.ts
@@ -82,7 +82,12 @@ const REACTIVE_ROUTE_TABLE = {
 function isReactiveEnvelopeConfig(
   config: MAMAConfig | ReactiveEnvelopeConfig
 ): config is ReactiveEnvelopeConfig {
-  return typeof (config as ReactiveEnvelopeConfig).projectRefsFor === 'function';
+  const candidate = config as Partial<ReactiveEnvelopeConfig>;
+  return (
+    typeof candidate.projectRefsFor === 'function' &&
+    typeof candidate.rawConnectorsFor === 'function' &&
+    typeof candidate.memoryScopesFor === 'function'
+  );
 }
 
 function getStaticRoute(message: NormalizedMessage): StaticRoute {
@@ -177,14 +182,23 @@ export function createDefaultReactiveEnvelopeConfig(
 ): ReactiveEnvelopeConfig {
   const budgetSeconds = reactiveBudgetSeconds(config);
   resolveReactiveProjectRoot(config, env);
+  const policyCache = new WeakMap<NormalizedMessage, ReactiveRoutePolicy>();
+  const policyFor = (message: NormalizedMessage): ReactiveRoutePolicy => {
+    const cached = policyCache.get(message);
+    if (cached) {
+      return cached;
+    }
+    const policy = getReactiveRoutePolicy(message, config, env);
+    policyCache.set(message, policy);
+    return policy;
+  };
 
   return {
-    projectRefsFor: (message) => getReactiveRoutePolicy(message, config, env).projectRefs,
-    rawConnectorsFor: (message) => getReactiveRoutePolicy(message, config, env).rawConnectors,
-    memoryScopesFor: (message) => getReactiveRoutePolicy(message, config, env).memoryScopes,
-    sourceFor: (message) => getReactiveRoutePolicy(message, config, env).source,
-    allowedDestinationsFor: (message) =>
-      getReactiveRoutePolicy(message, config, env).allowedDestinations,
+    projectRefsFor: (message) => policyFor(message).projectRefs,
+    rawConnectorsFor: (message) => policyFor(message).rawConnectors,
+    memoryScopesFor: (message) => policyFor(message).memoryScopes,
+    sourceFor: (message) => policyFor(message).source,
+    allowedDestinationsFor: (message) => policyFor(message).allowedDestinations,
     reactiveBudgetSeconds: budgetSeconds,
   };
 }

--- a/packages/standalone/src/envelope/reactive-config.ts
+++ b/packages/standalone/src/envelope/reactive-config.ts
@@ -86,7 +86,8 @@ function isReactiveEnvelopeConfig(
   return (
     typeof candidate.projectRefsFor === 'function' &&
     typeof candidate.rawConnectorsFor === 'function' &&
-    typeof candidate.memoryScopesFor === 'function'
+    typeof candidate.memoryScopesFor === 'function' &&
+    typeof candidate.reactiveBudgetSeconds === 'number'
   );
 }
 

--- a/packages/standalone/src/envelope/reactive-config.ts
+++ b/packages/standalone/src/envelope/reactive-config.ts
@@ -195,11 +195,11 @@ export function createDefaultReactiveEnvelopeConfig(
   };
 
   return {
-    projectRefsFor: (message) => policyFor(message).projectRefs,
-    rawConnectorsFor: (message) => policyFor(message).rawConnectors,
-    memoryScopesFor: (message) => policyFor(message).memoryScopes,
+    projectRefsFor: (message) => [...policyFor(message).projectRefs],
+    rawConnectorsFor: (message) => [...policyFor(message).rawConnectors],
+    memoryScopesFor: (message) => [...policyFor(message).memoryScopes],
     sourceFor: (message) => policyFor(message).source,
-    allowedDestinationsFor: (message) => policyFor(message).allowedDestinations,
+    allowedDestinationsFor: (message) => [...policyFor(message).allowedDestinations],
     reactiveBudgetSeconds: budgetSeconds,
   };
 }

--- a/packages/standalone/src/envelope/reactive-config.ts
+++ b/packages/standalone/src/envelope/reactive-config.ts
@@ -1,0 +1,190 @@
+import { homedir } from 'node:os';
+import { isAbsolute, join, resolve } from 'node:path';
+import type { MAMAConfig } from '../cli/config/types.js';
+import type { NormalizedMessage } from '../gateways/types.js';
+import { deriveMemoryScopes } from '../memory/scope-context.js';
+import type { DestinationRef, Envelope, MemoryScope, ProjectRef } from './types.js';
+
+export type EnvLike = Record<string, string | undefined>;
+
+export interface ReactiveEnvelopeConfig {
+  projectRefsFor(message: NormalizedMessage): ProjectRef[];
+  rawConnectorsFor(message: NormalizedMessage): string[];
+  memoryScopesFor(message: NormalizedMessage): MemoryScope[];
+  sourceFor?(message: NormalizedMessage): Envelope['source'];
+  allowedDestinationsFor?(message: NormalizedMessage): DestinationRef[];
+  reactiveBudgetSeconds: number;
+}
+
+export interface ReactiveRoutePolicy {
+  source: Envelope['source'];
+  projectRefs: ProjectRef[];
+  rawConnectors: string[];
+  memoryScopes: MemoryScope[];
+  allowedDestinations: DestinationRef[];
+  reactiveBudgetSeconds: number;
+}
+
+type StaticRoute = {
+  source: Envelope['source'];
+  rawConnectors: string[];
+  allowedDestinations(message: NormalizedMessage): DestinationRef[];
+};
+
+const REACTIVE_ROUTE_TABLE = {
+  telegram: {
+    source: 'telegram',
+    rawConnectors: ['telegram'],
+    allowedDestinations: (message: NormalizedMessage) => [
+      { kind: 'telegram', id: message.channelId },
+    ],
+  },
+  slack: {
+    source: 'slack',
+    rawConnectors: ['slack'],
+    allowedDestinations: (message: NormalizedMessage) => [{ kind: 'slack', id: message.channelId }],
+  },
+  chatwork: {
+    source: 'chatwork',
+    rawConnectors: ['chatwork'],
+    allowedDestinations: (message: NormalizedMessage) => [
+      { kind: 'chatwork', id: message.channelId },
+    ],
+  },
+  discord: {
+    source: 'discord',
+    rawConnectors: ['discord'],
+    allowedDestinations: (message: NormalizedMessage) => [
+      { kind: 'discord', id: message.channelId },
+    ],
+  },
+  viewer: {
+    source: 'viewer',
+    rawConnectors: [],
+    allowedDestinations: (message: NormalizedMessage) => [
+      { kind: 'webchat', id: message.channelId },
+    ],
+  },
+  mobile: {
+    source: 'viewer',
+    rawConnectors: [],
+    allowedDestinations: (message: NormalizedMessage) => [
+      { kind: 'webchat', id: message.channelId },
+    ],
+  },
+  system: {
+    source: 'watch',
+    rawConnectors: [],
+    allowedDestinations: () => [],
+  },
+} satisfies Record<NormalizedMessage['source'], StaticRoute>;
+
+function isReactiveEnvelopeConfig(
+  config: MAMAConfig | ReactiveEnvelopeConfig
+): config is ReactiveEnvelopeConfig {
+  return typeof (config as ReactiveEnvelopeConfig).projectRefsFor === 'function';
+}
+
+function getStaticRoute(message: NormalizedMessage): StaticRoute {
+  const route = REACTIVE_ROUTE_TABLE[message.source];
+  if (!route) {
+    throw new Error(`[envelope] unsupported message source: ${String(message.source)}`);
+  }
+  return route;
+}
+
+function homeFromEnv(env: EnvLike): string {
+  const home = env.HOME;
+  return home && home.trim() ? home : homedir();
+}
+
+function expandRequiredPath(rawPath: string, env: EnvLike, label: string): string {
+  const home = homeFromEnv(env);
+  let expanded = rawPath.trim();
+  if (!expanded) {
+    throw new Error(`[envelope] ${label} must not be empty`);
+  }
+  expanded = expanded
+    .replace(/^~(?=$|\/)/, home)
+    .replace(/\$\{HOME\}/g, home)
+    .replace(/\$HOME(?=$|\/)/g, home);
+
+  if (!isAbsolute(expanded)) {
+    throw new Error(`[envelope] ${label} must resolve to an absolute path`);
+  }
+  return resolve(expanded);
+}
+
+export function resolveReactiveProjectRoot(config: MAMAConfig, env: EnvLike = process.env): string {
+  if (config.workspace?.path !== undefined) {
+    return expandRequiredPath(config.workspace.path, env, 'workspace.path');
+  }
+
+  const workspaceFromEnv = env.MAMA_WORKSPACE;
+  if (workspaceFromEnv !== undefined) {
+    return expandRequiredPath(workspaceFromEnv, env, 'MAMA_WORKSPACE');
+  }
+
+  return expandRequiredPath(join(homeFromEnv(env), '.mama', 'workspace'), env, 'default workspace');
+}
+
+function reactiveBudgetSeconds(config: MAMAConfig): number {
+  const seconds = Number(config.timeouts?.agent_ms) / 1000;
+  return Number.isFinite(seconds) && seconds > 0 ? seconds : 300;
+}
+
+export function getReactiveRoutePolicy(
+  message: NormalizedMessage,
+  config: MAMAConfig | ReactiveEnvelopeConfig,
+  env: EnvLike = process.env
+): ReactiveRoutePolicy {
+  const route = getStaticRoute(message);
+
+  if (isReactiveEnvelopeConfig(config)) {
+    return {
+      source: config.sourceFor?.(message) ?? route.source,
+      projectRefs: config.projectRefsFor(message),
+      rawConnectors: config.rawConnectorsFor(message),
+      memoryScopes: config.memoryScopesFor(message),
+      allowedDestinations:
+        config.allowedDestinationsFor?.(message) ?? route.allowedDestinations(message),
+      reactiveBudgetSeconds: config.reactiveBudgetSeconds,
+    };
+  }
+
+  const source = route.source;
+  const projectId = resolveReactiveProjectRoot(config, env);
+  const memoryScopes = deriveMemoryScopes({
+    source,
+    channelId: message.channelId,
+    userId: message.userId,
+    projectId,
+  }) as MemoryScope[];
+
+  return {
+    source,
+    projectRefs: [{ kind: 'project', id: projectId }],
+    rawConnectors: [...route.rawConnectors],
+    memoryScopes,
+    allowedDestinations: route.allowedDestinations(message),
+    reactiveBudgetSeconds: reactiveBudgetSeconds(config),
+  };
+}
+
+export function createDefaultReactiveEnvelopeConfig(
+  config: MAMAConfig,
+  env: EnvLike = process.env
+): ReactiveEnvelopeConfig {
+  const budgetSeconds = reactiveBudgetSeconds(config);
+  resolveReactiveProjectRoot(config, env);
+
+  return {
+    projectRefsFor: (message) => getReactiveRoutePolicy(message, config, env).projectRefs,
+    rawConnectorsFor: (message) => getReactiveRoutePolicy(message, config, env).rawConnectors,
+    memoryScopesFor: (message) => getReactiveRoutePolicy(message, config, env).memoryScopes,
+    sourceFor: (message) => getReactiveRoutePolicy(message, config, env).source,
+    allowedDestinationsFor: (message) =>
+      getReactiveRoutePolicy(message, config, env).allowedDestinations,
+    reactiveBudgetSeconds: budgetSeconds,
+  };
+}

--- a/packages/standalone/src/gateways/message-router.ts
+++ b/packages/standalone/src/gateways/message-router.ts
@@ -46,9 +46,14 @@ import { formatAuditNotice, formatRecallBundle } from '../memory/recall-bundle-f
 import { extractSaveCandidates } from '../memory/save-candidate-extractor.js';
 import { getLatestVersion, logActivity } from '../db/agent-store.js';
 import { EnvelopeAuthority } from '../envelope/index.js';
-import type { DestinationRef, Envelope, MemoryScope, ProjectRef } from '../envelope/types.js';
+import {
+  getReactiveRoutePolicy,
+  type ReactiveEnvelopeConfig,
+} from '../envelope/reactive-config.js';
+import type { Envelope } from '../envelope/types.js';
 
 export type { AgentLoopOptions } from '../agent/types.js';
+export type { ReactiveEnvelopeConfig } from '../envelope/reactive-config.js';
 
 const { DebugLogger } = debugLogger as {
   DebugLogger: new (context?: string) => {
@@ -127,101 +132,28 @@ const KOREAN_TARGETS = new Set(['korean', '한국어']);
 const VIEWER_CONTEXT_AGENT_LIST_LIMIT = 5;
 const VIEWER_CONTEXT_ALERT_LIMIT = 3;
 const REACTIVE_ENVELOPE_EXPIRY_MULTIPLIER = 4;
-const MESSAGE_ENVELOPE_ROUTES = {
-  telegram: {
-    source: 'telegram',
-    destinations: (message: NormalizedMessage): DestinationRef[] => [
-      { kind: 'telegram', id: message.channelId },
-    ],
-  },
-  slack: {
-    source: 'slack',
-    destinations: (message: NormalizedMessage): DestinationRef[] => [
-      { kind: 'slack', id: message.channelId },
-    ],
-  },
-  chatwork: {
-    source: 'chatwork',
-    destinations: (message: NormalizedMessage): DestinationRef[] => [
-      { kind: 'chatwork', id: message.channelId },
-    ],
-  },
-  discord: {
-    source: 'discord',
-    destinations: (message: NormalizedMessage): DestinationRef[] => [
-      { kind: 'discord', id: message.channelId },
-    ],
-  },
-  viewer: {
-    source: 'viewer',
-    destinations: (message: NormalizedMessage): DestinationRef[] => [
-      { kind: 'webchat', id: message.channelId },
-    ],
-  },
-  mobile: {
-    source: 'viewer',
-    destinations: (message: NormalizedMessage): DestinationRef[] => [
-      { kind: 'webchat', id: message.channelId },
-    ],
-  },
-  system: {
-    source: 'watch',
-    destinations: (): DestinationRef[] => [],
-  },
-} satisfies Record<
-  NormalizedMessage['source'],
-  {
-    source: Envelope['source'];
-    destinations: (message: NormalizedMessage) => DestinationRef[];
-  }
->;
-
-export interface ReactiveEnvelopeConfig {
-  projectRefsFor(message: NormalizedMessage): ProjectRef[];
-  rawConnectorsFor(message: NormalizedMessage): string[];
-  memoryScopesFor(message: NormalizedMessage): MemoryScope[];
-  reactiveBudgetSeconds: number;
-}
-
-function envelopeSourceForMessage(message: NormalizedMessage): Envelope['source'] {
-  // Mobile is treated as viewer so its webchat-scoped replies use the same envelope source.
-  const route = MESSAGE_ENVELOPE_ROUTES[message.source];
-  if (!route) {
-    throw new Error(`[envelope] unsupported message source: ${String(message.source)}`);
-  }
-  return route.source;
-}
-
-function allowedDestinationsForMessage(message: NormalizedMessage): DestinationRef[] {
-  // Mobile is treated as viewer, so routing back to the webchat channel is allowed.
-  const route = MESSAGE_ENVELOPE_ROUTES[message.source];
-  if (!route) {
-    throw new Error(`[envelope] unsupported destination source: ${String(message.source)}`);
-  }
-  return route.destinations(message);
-}
-
 function buildReactiveEnvelopeInput(
   message: NormalizedMessage,
   config: ReactiveEnvelopeConfig
 ): Omit<Envelope, 'envelope_hash' | 'signature'> {
+  const policy = getReactiveRoutePolicy(message, config);
   return {
     agent_id: 'worker',
     instance_id: `inst_${randomUUID()}`,
-    source: envelopeSourceForMessage(message),
+    source: policy.source,
     channel_id: message.channelId,
     trigger_context: { user_text: message.text },
     scope: {
-      project_refs: config.projectRefsFor(message),
-      raw_connectors: config.rawConnectorsFor(message),
-      memory_scopes: config.memoryScopesFor(message),
-      allowed_destinations: allowedDestinationsForMessage(message),
+      project_refs: policy.projectRefs,
+      raw_connectors: policy.rawConnectors,
+      memory_scopes: policy.memoryScopes,
+      allowed_destinations: policy.allowedDestinations,
     },
     tier: 1,
-    budget: { wall_seconds: config.reactiveBudgetSeconds },
+    budget: { wall_seconds: policy.reactiveBudgetSeconds },
     // Wall budget limits agent work; envelope validity gets slack for tool finalization.
     expires_at: new Date(
-      Date.now() + config.reactiveBudgetSeconds * 1000 * REACTIVE_ENVELOPE_EXPIRY_MULTIPLIER
+      Date.now() + policy.reactiveBudgetSeconds * 1000 * REACTIVE_ENVELOPE_EXPIRY_MULTIPLIER
     ).toISOString(),
   };
 }

--- a/packages/standalone/src/multi-agent/agent-process-manager.ts
+++ b/packages/standalone/src/multi-agent/agent-process-manager.ts
@@ -9,7 +9,7 @@
  */
 
 import { readFile } from 'fs/promises';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
 import { loadBackendAgentsMd, getGatewayToolsPrompt } from '../agent/agent-loop.js';
 import { ToolRegistry } from '../agent/tool-registry.js';
@@ -267,10 +267,12 @@ export class AgentProcessManager extends EventEmitter {
         // Code-Act agents: only provide code-act MCP server
         const codeActOnlyConfig = resolve(homedir(), '.mama', 'code-act-only-mcp-config.json');
         try {
-          const fullConfig = JSON.parse(require('fs').readFileSync(mcpConfigPath, 'utf-8'));
+          const fullConfig = JSON.parse(readFileSync(mcpConfigPath, 'utf-8')) as {
+            mcpServers?: Record<string, unknown>;
+          };
           const codeActEntry = fullConfig.mcpServers?.['code-act'];
           if (codeActEntry) {
-            require('fs').writeFileSync(
+            writeFileSync(
               codeActOnlyConfig,
               JSON.stringify({ mcpServers: { 'code-act': codeActEntry } }, null, 2),
               'utf-8'

--- a/packages/standalone/tests/agent/delegation-executor.test.ts
+++ b/packages/standalone/tests/agent/delegation-executor.test.ts
@@ -73,12 +73,26 @@ function createHarness(
 }
 
 describe('DelegationExecutor', () => {
-  it('runs delegate with conductor/viewer/default routing fallback', async () => {
+  it('fails closed when delegation routing is missing', async () => {
+    const { executor, getProcess, isDelegationAllowed } = createHarness();
+
+    await expect(
+      executor.runDelegate(
+        { agentId: 'developer', task: 'Implement the patch' },
+        { agentId: '', source: '', channelId: '' }
+      )
+    ).rejects.toThrow('[delegation] missing routing.agentId');
+
+    expect(isDelegationAllowed).not.toHaveBeenCalled();
+    expect(getProcess).not.toHaveBeenCalled();
+  });
+
+  it('runs delegate with explicit routing', async () => {
     const { executor, getProcess, isDelegationAllowed, buildDelegationPrompt } = createHarness();
 
     const result = await executor.runDelegate(
       { agentId: 'developer', task: 'Implement the patch' },
-      { agentId: '', source: '', channelId: '' }
+      { agentId: 'conductor', source: 'viewer', channelId: 'main' }
     );
 
     expect(result).toMatchObject({
@@ -86,7 +100,7 @@ describe('DelegationExecutor', () => {
       data: expect.objectContaining({ agentId: 'developer', response: 'done' }),
     });
     expect(isDelegationAllowed).toHaveBeenCalledWith('conductor', 'developer');
-    expect(getProcess).toHaveBeenCalledWith('viewer', 'default', 'developer');
+    expect(getProcess).toHaveBeenCalledWith('viewer', 'main', 'developer');
     expect(buildDelegationPrompt).toHaveBeenCalledWith('conductor', 'Implement the patch');
   });
 
@@ -191,6 +205,35 @@ describe('DelegationExecutor', () => {
       error: expect.stringContaining("Invalid sample_count for 'qa-monitor'"),
     });
     expect(getProcess).not.toHaveBeenCalled();
+  });
+
+  it('retries background delegation after transient busy failures', async () => {
+    const firstSend = vi.fn().mockRejectedValue(new Error('Process is busy'));
+    const secondSend = vi.fn().mockResolvedValue({ response: 'Recovered in background' });
+    const { executor, getProcess } = createHarness();
+    getProcess
+      .mockResolvedValueOnce({
+        sendMessage: firstSend,
+        getSessionId: vi.fn().mockReturnValue('delegation-session'),
+      })
+      .mockResolvedValueOnce({
+        sendMessage: secondSend,
+        getSessionId: vi.fn().mockReturnValue('delegation-session'),
+      });
+
+    const result = await executor.runDelegate(
+      { agentId: 'developer', task: 'Background patch', background: true },
+      { agentId: 'conductor', source: 'viewer', channelId: 'main' }
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      data: expect.objectContaining({ background: true }),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(getProcess).toHaveBeenCalledTimes(2);
+    expect(secondSend).toHaveBeenCalled();
   });
 
   it('returns the delegation denial reason without starting a process', async () => {

--- a/packages/standalone/tests/agent/delegation-executor.test.ts
+++ b/packages/standalone/tests/agent/delegation-executor.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DelegationExecutor } from '../../src/agent/delegation-executor.js';
+import type { AgentProcessManager } from '../../src/multi-agent/agent-process-manager.js';
+import type { DelegationManager } from '../../src/multi-agent/delegation-manager.js';
+import Database, { type SQLiteDatabase } from '../../src/sqlite.js';
+import { initAgentTables } from '../../src/db/agent-store.js';
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function createHarness(
+  options: {
+    response?: string;
+    sendMessage?: ReturnType<typeof vi.fn>;
+    sessionsDb?: SQLiteDatabase;
+    allowed?: boolean;
+    denialReason?: string;
+  } = {}
+) {
+  const sendMessage = options.sendMessage ?? vi.fn().mockResolvedValue({ response: 'done' });
+  if (options.response !== undefined && !options.sendMessage) {
+    sendMessage.mockResolvedValue({ response: options.response });
+  }
+  const getProcess = vi.fn().mockResolvedValue({
+    sendMessage,
+    getSessionId: vi.fn().mockReturnValue('delegation-session'),
+  });
+  const stopProcess = vi.fn();
+  const isDelegationAllowed = vi.fn().mockReturnValue({
+    allowed: options.allowed ?? true,
+    reason: options.denialReason ?? 'ok',
+  });
+  const buildDelegationPrompt = vi.fn(
+    (sourceAgentId: string, task: string) => `[${sourceAgentId}] ${task}`
+  );
+  const getAgentConfig = vi.fn().mockReturnValue({ connectors: [] });
+
+  const executor = new DelegationExecutor({
+    agentProcessManager: { getProcess, stopProcess } as unknown as AgentProcessManager,
+    delegationManagerRef: {
+      isDelegationAllowed,
+      buildDelegationPrompt,
+      getAgentConfig,
+    } as unknown as DelegationManager,
+    sessionsDb: options.sessionsDb,
+    retryDelayMs: 1,
+    resolveManagedAgentId: (id) => id,
+    checkViewerOnly: () => null,
+  });
+
+  return {
+    executor,
+    sendMessage,
+    getProcess,
+    stopProcess,
+    isDelegationAllowed,
+    buildDelegationPrompt,
+  };
+}
+
+describe('DelegationExecutor', () => {
+  it('runs delegate with conductor/viewer/default routing fallback', async () => {
+    const { executor, getProcess, isDelegationAllowed, buildDelegationPrompt } = createHarness();
+
+    const result = await executor.runDelegate(
+      { agentId: 'developer', task: 'Implement the patch' },
+      { agentId: '', source: '', channelId: '' }
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      data: expect.objectContaining({ agentId: 'developer', response: 'done' }),
+    });
+    expect(isDelegationAllowed).toHaveBeenCalledWith('conductor', 'developer');
+    expect(getProcess).toHaveBeenCalledWith('viewer', 'default', 'developer');
+    expect(buildDelegationPrompt).toHaveBeenCalledWith('conductor', 'Implement the patch');
+  });
+
+  it('persists delegate start and completion activity rows when sessions DB is available', async () => {
+    const db = new Database(':memory:');
+    initAgentTables(db);
+    const { executor } = createHarness({ sessionsDb: db, response: 'Task completed' });
+
+    const result = await executor.runDelegate(
+      { agentId: 'developer', task: 'Audit routing' },
+      { agentId: 'conductor', source: 'discord', channelId: 'channel-1' }
+    );
+
+    expect(result.success).toBe(true);
+    const rows = db
+      .prepare(
+        'SELECT type, execution_status, trigger_reason, input_summary, output_summary FROM agent_activity ORDER BY id'
+      )
+      .all() as Array<{
+      type: string;
+      execution_status: string | null;
+      trigger_reason: string | null;
+      input_summary: string | null;
+      output_summary: string | null;
+    }>;
+    expect(rows).toEqual([
+      {
+        type: 'task_start',
+        execution_status: 'started',
+        trigger_reason: 'delegate_run',
+        input_summary: 'Audit routing',
+        output_summary: null,
+      },
+      {
+        type: 'task_complete',
+        execution_status: 'completed',
+        trigger_reason: 'delegate_run',
+        input_summary: 'Audit routing',
+        output_summary: 'Task completed',
+      },
+    ]);
+    db.close();
+  });
+
+  it('keeps one agent_test in flight per managed agent', async () => {
+    const deferred = createDeferred<{ response: string }>();
+    const sendMessage = vi.fn().mockReturnValue(deferred.promise);
+    const { executor } = createHarness({ sendMessage });
+
+    const first = executor.runAgentTest(
+      {
+        agent_id: 'qa-monitor',
+        test_data: [{ input: 'case-1', expected: 'expected output' }],
+      },
+      { agentId: 'conductor', source: 'viewer', channelId: 'channel-1' }
+    );
+    const second = await executor.runAgentTest(
+      {
+        agent_id: 'qa-monitor',
+        test_data: [{ input: 'case-2', expected: 'expected output' }],
+      },
+      { agentId: 'conductor', source: 'viewer', channelId: 'channel-1' }
+    );
+
+    expect(second).toEqual({ success: false, error: 'test_already_running' });
+
+    deferred.resolve({ response: 'expected output' });
+    await expect(first).resolves.toMatchObject({
+      success: true,
+      data: expect.objectContaining({ auto_score: 100 }),
+    });
+  });
+
+  it('rejects invalid agent_test sample_count before delegation starts', async () => {
+    const { executor, getProcess } = createHarness();
+
+    const result = await executor.runAgentTest(
+      { agent_id: 'qa-monitor', sample_count: 0, test_data: [{ input: 'case-1' }] },
+      { agentId: 'conductor', source: 'viewer', channelId: 'channel-1' }
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("Invalid sample_count for 'qa-monitor'"),
+    });
+    expect(getProcess).not.toHaveBeenCalled();
+  });
+
+  it('returns the delegation denial reason without starting a process', async () => {
+    const { executor, getProcess } = createHarness({
+      allowed: false,
+      denialReason: 'developer cannot delegate',
+    });
+
+    const result = await executor.runDelegate(
+      { agentId: 'reviewer', task: 'Review this' },
+      { agentId: 'developer', source: 'discord', channelId: 'channel-1' }
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Delegation denied: developer cannot delegate',
+    });
+    expect(getProcess).not.toHaveBeenCalled();
+  });
+});

--- a/packages/standalone/tests/agent/delegation-executor.test.ts
+++ b/packages/standalone/tests/agent/delegation-executor.test.ts
@@ -28,6 +28,7 @@ function createHarness(
     sessionsDb?: SQLiteDatabase;
     allowed?: boolean;
     denialReason?: string;
+    resolveManagedAgentId?: (id: string) => string;
   } = {}
 ) {
   const sendMessage = options.sendMessage ?? vi.fn().mockResolvedValue({ response: 'done' });
@@ -57,7 +58,7 @@ function createHarness(
     } as unknown as DelegationManager,
     sessionsDb: options.sessionsDb,
     retryDelayMs: 1,
-    resolveManagedAgentId: (id) => id,
+    resolveManagedAgentId: options.resolveManagedAgentId ?? ((id) => id),
     checkViewerOnly: () => null,
   });
 
@@ -87,6 +88,24 @@ describe('DelegationExecutor', () => {
     expect(isDelegationAllowed).toHaveBeenCalledWith('conductor', 'developer');
     expect(getProcess).toHaveBeenCalledWith('viewer', 'default', 'developer');
     expect(buildDelegationPrompt).toHaveBeenCalledWith('conductor', 'Implement the patch');
+  });
+
+  it('normalizes managed-agent aliases before delegate permission and process routing', async () => {
+    const { executor, getProcess, isDelegationAllowed } = createHarness({
+      resolveManagedAgentId: (id) => (id === 'dev' ? 'developer' : id),
+    });
+
+    const result = await executor.runDelegate(
+      { agentId: 'dev', task: 'Implement the patch' },
+      { agentId: 'conductor', source: 'viewer', channelId: 'main' }
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      data: expect.objectContaining({ agentId: 'developer' }),
+    });
+    expect(isDelegationAllowed).toHaveBeenCalledWith('conductor', 'developer');
+    expect(getProcess).toHaveBeenCalledWith('viewer', 'main', 'developer');
   });
 
   it('persists delegate start and completion activity rows when sessions DB is available', async () => {

--- a/packages/standalone/tests/agent/post-tool-handler.test.ts
+++ b/packages/standalone/tests/agent/post-tool-handler.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { PostToolHandler } from '../../src/agent/post-tool-handler.js';
+import type { GatewayToolExecutionContext } from '../../src/agent/types.js';
 
 describe('PostToolHandler', () => {
   let executeTool: ReturnType<typeof vi.fn>;
@@ -523,6 +524,34 @@ describe('PostToolHandler', () => {
       if (searchCalls.length > 0) {
         expect(searchCalls[0][1]).toHaveProperty('limit', 3);
       }
+    });
+  });
+
+  describe('processInBackground() - execution context propagation', () => {
+    it('should forward execution context to duplicate search and contract save calls', async () => {
+      executeTool.mockResolvedValue({ results: [] });
+      handler = new PostToolHandler(executeTool, { enabled: true });
+      const executionContext = {
+        agentId: 'chat_bot',
+        source: 'telegram',
+        channelId: 'tg:1',
+        envelope: { envelope_hash: 'envhash_post_tool' },
+      } as unknown as GatewayToolExecutionContext;
+
+      handler.processInBackground(
+        'Write',
+        { path: 'src/api.ts' },
+        'export function test(id: string): string { return id; }',
+        executionContext
+      );
+      await new Promise((r) => setTimeout(r, 100));
+
+      const searchCalls = executeTool.mock.calls.filter((call) => call[0] === 'mama_search');
+      const saveCalls = executeTool.mock.calls.filter((call) => call[0] === 'mama_save');
+      expect(searchCalls.length).toBeGreaterThan(0);
+      expect(saveCalls.length).toBeGreaterThan(0);
+      expect(searchCalls[0][2]).toBe(executionContext);
+      expect(saveCalls[0][2]).toBe(executionContext);
     });
   });
 

--- a/packages/standalone/tests/agent/post-tool-handler.test.ts
+++ b/packages/standalone/tests/agent/post-tool-handler.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { PostToolHandler } from '../../src/agent/post-tool-handler.js';
 import type { GatewayToolExecutionContext } from '../../src/agent/types.js';
+import { makeSignedEnvelope } from '../envelope/fixtures.js';
 
 describe('PostToolHandler', () => {
   let executeTool: ReturnType<typeof vi.fn>;
@@ -527,31 +528,37 @@ describe('PostToolHandler', () => {
     });
   });
 
-  describe('processInBackground() - execution context propagation', () => {
-    it('should forward execution context to duplicate search and contract save calls', async () => {
-      executeTool.mockResolvedValue({ results: [] });
-      handler = new PostToolHandler(executeTool, { enabled: true });
-      const executionContext = {
-        agentId: 'chat_bot',
-        source: 'telegram',
-        channelId: 'tg:1',
-        envelope: { envelope_hash: 'envhash_post_tool' },
-      } as unknown as GatewayToolExecutionContext;
+  describe('Story M1R: PostToolHandler execution context propagation', () => {
+    describe('AC: forwards context to duplicate search and contract save calls', () => {
+      it('should forward execution context to duplicate search and contract save calls', async () => {
+        executeTool.mockResolvedValue({ results: [] });
+        handler = new PostToolHandler(executeTool, { enabled: true });
+        const executionContext: GatewayToolExecutionContext = {
+          agentId: 'chat_bot',
+          source: 'telegram',
+          channelId: 'tg:1',
+          envelope: makeSignedEnvelope({
+            source: 'telegram',
+            channel_id: 'tg:1',
+          }),
+          executionSurface: 'reactive_internal',
+        };
 
-      handler.processInBackground(
-        'Write',
-        { path: 'src/api.ts' },
-        'export function test(id: string): string { return id; }',
-        executionContext
-      );
-      await new Promise((r) => setTimeout(r, 100));
+        handler.processInBackground(
+          'Write',
+          { path: 'src/api.ts' },
+          'export function test(id: string): string { return id; }',
+          executionContext
+        );
+        await new Promise((r) => setTimeout(r, 100));
 
-      const searchCalls = executeTool.mock.calls.filter((call) => call[0] === 'mama_search');
-      const saveCalls = executeTool.mock.calls.filter((call) => call[0] === 'mama_save');
-      expect(searchCalls.length).toBeGreaterThan(0);
-      expect(saveCalls.length).toBeGreaterThan(0);
-      expect(searchCalls[0][2]).toBe(executionContext);
-      expect(saveCalls[0][2]).toBe(executionContext);
+        const searchCalls = executeTool.mock.calls.filter((call) => call[0] === 'mama_search');
+        const saveCalls = executeTool.mock.calls.filter((call) => call[0] === 'mama_save');
+        expect(searchCalls.length).toBeGreaterThan(0);
+        expect(saveCalls.length).toBeGreaterThan(0);
+        expect(searchCalls[0][2]).toBe(executionContext);
+        expect(saveCalls[0][2]).toBe(executionContext);
+      });
     });
   });
 

--- a/packages/standalone/tests/agent/pre-compact-handler.test.ts
+++ b/packages/standalone/tests/agent/pre-compact-handler.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { PreCompactHandler } from '../../src/agent/pre-compact-handler.js';
+import type { GatewayToolExecutionContext } from '../../src/agent/types.js';
 
 describe('PreCompactHandler', () => {
   let mockExecuteTool: ReturnType<typeof vi.fn>;
@@ -153,6 +154,28 @@ describe('PreCompactHandler', () => {
         type: 'decision',
         limit: 20,
       });
+    });
+
+    it('should forward execution context to mama_search', async () => {
+      const handler = new PreCompactHandler(mockExecuteTool, { enabled: true });
+      mockExecuteTool.mockResolvedValue({ results: [] });
+      const executionContext = {
+        agentId: 'chat_bot',
+        source: 'telegram',
+        channelId: 'tg:1',
+        envelope: { envelope_hash: 'envhash_precompact' },
+      } as unknown as GatewayToolExecutionContext;
+
+      await handler.process(['decided: use JWT tokens'], executionContext);
+
+      expect(mockExecuteTool).toHaveBeenCalledWith(
+        'mama_search',
+        {
+          type: 'decision',
+          limit: 20,
+        },
+        executionContext
+      );
     });
 
     it('should extract topics from search results', async () => {

--- a/packages/standalone/tests/agent/pre-compact-handler.test.ts
+++ b/packages/standalone/tests/agent/pre-compact-handler.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { PreCompactHandler } from '../../src/agent/pre-compact-handler.js';
 import type { GatewayToolExecutionContext } from '../../src/agent/types.js';
+import { makeSignedEnvelope } from '../envelope/fixtures.js';
 
 describe('PreCompactHandler', () => {
   let mockExecuteTool: ReturnType<typeof vi.fn>;
@@ -159,12 +160,16 @@ describe('PreCompactHandler', () => {
     it('should forward execution context to mama_search', async () => {
       const handler = new PreCompactHandler(mockExecuteTool, { enabled: true });
       mockExecuteTool.mockResolvedValue({ results: [] });
-      const executionContext = {
+      const executionContext: GatewayToolExecutionContext = {
         agentId: 'chat_bot',
         source: 'telegram',
         channelId: 'tg:1',
-        envelope: { envelope_hash: 'envhash_precompact' },
-      } as unknown as GatewayToolExecutionContext;
+        envelope: makeSignedEnvelope({
+          source: 'telegram',
+          channel_id: 'tg:1',
+        }),
+        executionSurface: 'reactive_internal',
+      };
 
       await handler.process(['decided: use JWT tokens'], executionContext);
 

--- a/packages/standalone/tests/api/envelope-status-auth.test.ts
+++ b/packages/standalone/tests/api/envelope-status-auth.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import request from 'supertest';
+import Database from '../../src/sqlite.js';
+import { createApiServer } from '../../src/api/index.js';
+import { initAgentTables, logActivity } from '../../src/db/agent-store.js';
+import { CronScheduler } from '../../src/scheduler/index.js';
+
+const TUNNEL_HEADERS = {
+  'cf-connecting-ip': '198.51.100.7',
+  'x-forwarded-for': '198.51.100.7',
+};
+
+function sqliteTimestamp(date: Date): string {
+  return date.toISOString().slice(0, 19).replace('T', ' ');
+}
+
+function setActivityCreatedAt(db: Database, id: number, createdAt: string): void {
+  db.prepare('UPDATE agent_activity SET created_at = ? WHERE id = ?').run(createdAt, id);
+}
+
+describe('M1R authenticated /api/envelope/status', () => {
+  const originalAuthToken = process.env.MAMA_AUTH_TOKEN;
+  let db: Database;
+  let scheduler: CronScheduler;
+
+  beforeEach(() => {
+    process.env.MAMA_AUTH_TOKEN = 'test-token';
+    db = new Database(':memory:');
+    initAgentTables(db);
+    scheduler = new CronScheduler();
+  });
+
+  afterEach(() => {
+    scheduler.shutdown();
+    db.close();
+    if (originalAuthToken === undefined) {
+      delete process.env.MAMA_AUTH_TOKEN;
+    } else {
+      process.env.MAMA_AUTH_TOKEN = originalAuthToken;
+    }
+  });
+
+  it('requires auth for tunneled requests and reports durable 24h mismatch count', async () => {
+    const now = Date.now();
+    const recentOne = logActivity(db, {
+      agent_id: 'os_agent',
+      agent_version: 1,
+      type: 'gateway_tool_call',
+      execution_status: 'completed',
+      envelopeHash: 'env_recent_1',
+      scopeMismatch: 1,
+    });
+    const recentTwo = logActivity(db, {
+      agent_id: 'os_agent',
+      agent_version: 1,
+      type: 'gateway_tool_call',
+      execution_status: 'completed',
+      envelopeHash: 'env_recent_2',
+      scopeMismatch: 1,
+    });
+    const older = logActivity(db, {
+      agent_id: 'os_agent',
+      agent_version: 1,
+      type: 'gateway_tool_call',
+      execution_status: 'completed',
+      envelopeHash: 'env_old',
+      scopeMismatch: 1,
+    });
+    logActivity(db, {
+      agent_id: 'os_agent',
+      agent_version: 1,
+      type: 'gateway_tool_call',
+      execution_status: 'completed',
+      envelopeHash: 'env_match',
+      scopeMismatch: 0,
+    });
+    setActivityCreatedAt(db, recentOne.id, sqliteTimestamp(new Date(now - 60_000)));
+    setActivityCreatedAt(db, recentTwo.id, sqliteTimestamp(new Date(now - 23 * 60 * 60_000)));
+    setActivityCreatedAt(db, older.id, sqliteTimestamp(new Date(now - 25 * 60 * 60_000)));
+
+    const apiServer = createApiServer({
+      scheduler,
+      port: 0,
+      db,
+      envelope: {
+        issuance: 'enabled',
+        key_id: 'local-2026-04',
+        key_version: 7,
+      },
+    });
+
+    const unauthenticated = await request(apiServer.app)
+      .get('/api/envelope/status')
+      .set(TUNNEL_HEADERS);
+    expect(unauthenticated.status).toBe(401);
+
+    const authenticated = await request(apiServer.app)
+      .get('/api/envelope/status')
+      .set(TUNNEL_HEADERS)
+      .set('Authorization', 'Bearer test-token');
+    expect(authenticated.status).toBe(200);
+    expect(authenticated.body).toEqual({
+      issuance: 'enabled',
+      key_id: 'local-2026-04',
+      key_version: 7,
+      recent_mismatch_count_24h: 2,
+    });
+
+    const serializedBody = JSON.stringify(authenticated.body);
+    expect(serializedBody).not.toContain('MAMA_ENVELOPE_HMAC_KEY_BASE64');
+    expect(serializedBody).not.toContain('test-token');
+
+    const localhostBypass = await request(apiServer.app).get('/api/envelope/status');
+    expect(localhostBypass.status).toBe(200);
+  });
+
+  it('returns audit_db_unavailable when authenticated but sessions DB is absent', async () => {
+    const apiServer = createApiServer({
+      scheduler,
+      port: 0,
+      envelope: {
+        issuance: 'required',
+        key_id: 'local-2026-04',
+        key_version: 8,
+      },
+    });
+
+    const response = await request(apiServer.app)
+      .get('/api/envelope/status')
+      .set(TUNNEL_HEADERS)
+      .set('Authorization', 'Bearer test-token');
+
+    expect(response.status).toBe(503);
+    expect(response.body).toEqual({
+      error: true,
+      code: 'audit_db_unavailable',
+      message: 'Envelope audit database is unavailable.',
+    });
+  });
+});

--- a/packages/standalone/tests/api/envelope-status-auth.test.ts
+++ b/packages/standalone/tests/api/envelope-status-auth.test.ts
@@ -18,7 +18,7 @@ function setActivityCreatedAt(db: Database, id: number, createdAt: string): void
   db.prepare('UPDATE agent_activity SET created_at = ? WHERE id = ?').run(createdAt, id);
 }
 
-describe('M1R authenticated /api/envelope/status', () => {
+describe('Story M1R: Authenticated /api/envelope/status', () => {
   const originalAuthToken = process.env.MAMA_AUTH_TOKEN;
   let db: Database;
   let scheduler: CronScheduler;
@@ -40,101 +40,105 @@ describe('M1R authenticated /api/envelope/status', () => {
     }
   });
 
-  it('requires auth for tunneled requests and reports durable 24h mismatch count', async () => {
-    const now = Date.now();
-    const recentOne = logActivity(db, {
-      agent_id: 'os_agent',
-      agent_version: 1,
-      type: 'gateway_tool_call',
-      execution_status: 'completed',
-      envelopeHash: 'env_recent_1',
-      scopeMismatch: 1,
-    });
-    const recentTwo = logActivity(db, {
-      agent_id: 'os_agent',
-      agent_version: 1,
-      type: 'gateway_tool_call',
-      execution_status: 'completed',
-      envelopeHash: 'env_recent_2',
-      scopeMismatch: 1,
-    });
-    const older = logActivity(db, {
-      agent_id: 'os_agent',
-      agent_version: 1,
-      type: 'gateway_tool_call',
-      execution_status: 'completed',
-      envelopeHash: 'env_old',
-      scopeMismatch: 1,
-    });
-    logActivity(db, {
-      agent_id: 'os_agent',
-      agent_version: 1,
-      type: 'gateway_tool_call',
-      execution_status: 'completed',
-      envelopeHash: 'env_match',
-      scopeMismatch: 0,
-    });
-    setActivityCreatedAt(db, recentOne.id, sqliteTimestamp(new Date(now - 60_000)));
-    setActivityCreatedAt(db, recentTwo.id, sqliteTimestamp(new Date(now - 23 * 60 * 60_000)));
-    setActivityCreatedAt(db, older.id, sqliteTimestamp(new Date(now - 25 * 60 * 60_000)));
+  describe('AC: auth-gated status reports durable mismatch count', () => {
+    it('requires auth for tunneled requests and reports durable 24h mismatch count', async () => {
+      const now = Date.now();
+      const recentOne = logActivity(db, {
+        agent_id: 'os_agent',
+        agent_version: 1,
+        type: 'gateway_tool_call',
+        execution_status: 'completed',
+        envelopeHash: 'env_recent_1',
+        scopeMismatch: 1,
+      });
+      const recentTwo = logActivity(db, {
+        agent_id: 'os_agent',
+        agent_version: 1,
+        type: 'gateway_tool_call',
+        execution_status: 'completed',
+        envelopeHash: 'env_recent_2',
+        scopeMismatch: 1,
+      });
+      const older = logActivity(db, {
+        agent_id: 'os_agent',
+        agent_version: 1,
+        type: 'gateway_tool_call',
+        execution_status: 'completed',
+        envelopeHash: 'env_old',
+        scopeMismatch: 1,
+      });
+      logActivity(db, {
+        agent_id: 'os_agent',
+        agent_version: 1,
+        type: 'gateway_tool_call',
+        execution_status: 'completed',
+        envelopeHash: 'env_match',
+        scopeMismatch: 0,
+      });
+      setActivityCreatedAt(db, recentOne.id, sqliteTimestamp(new Date(now - 60_000)));
+      setActivityCreatedAt(db, recentTwo.id, sqliteTimestamp(new Date(now - 23 * 60 * 60_000)));
+      setActivityCreatedAt(db, older.id, sqliteTimestamp(new Date(now - 25 * 60 * 60_000)));
 
-    const apiServer = createApiServer({
-      scheduler,
-      port: 0,
-      db,
-      envelope: {
+      const apiServer = createApiServer({
+        scheduler,
+        port: 0,
+        db,
+        envelope: {
+          issuance: 'enabled',
+          key_id: 'local-2026-04',
+          key_version: 7,
+        },
+      });
+
+      const unauthenticated = await request(apiServer.app)
+        .get('/api/envelope/status')
+        .set(TUNNEL_HEADERS);
+      expect(unauthenticated.status).toBe(401);
+
+      const authenticated = await request(apiServer.app)
+        .get('/api/envelope/status')
+        .set(TUNNEL_HEADERS)
+        .set('Authorization', 'Bearer test-token');
+      expect(authenticated.status).toBe(200);
+      expect(authenticated.body).toEqual({
         issuance: 'enabled',
         key_id: 'local-2026-04',
         key_version: 7,
-      },
+        recent_mismatch_count_24h: 2,
+      });
+
+      const serializedBody = JSON.stringify(authenticated.body);
+      expect(serializedBody).not.toContain('MAMA_ENVELOPE_HMAC_KEY_BASE64');
+      expect(serializedBody).not.toContain('test-token');
+
+      const localhostBypass = await request(apiServer.app).get('/api/envelope/status');
+      expect(localhostBypass.status).toBe(200);
     });
-
-    const unauthenticated = await request(apiServer.app)
-      .get('/api/envelope/status')
-      .set(TUNNEL_HEADERS);
-    expect(unauthenticated.status).toBe(401);
-
-    const authenticated = await request(apiServer.app)
-      .get('/api/envelope/status')
-      .set(TUNNEL_HEADERS)
-      .set('Authorization', 'Bearer test-token');
-    expect(authenticated.status).toBe(200);
-    expect(authenticated.body).toEqual({
-      issuance: 'enabled',
-      key_id: 'local-2026-04',
-      key_version: 7,
-      recent_mismatch_count_24h: 2,
-    });
-
-    const serializedBody = JSON.stringify(authenticated.body);
-    expect(serializedBody).not.toContain('MAMA_ENVELOPE_HMAC_KEY_BASE64');
-    expect(serializedBody).not.toContain('test-token');
-
-    const localhostBypass = await request(apiServer.app).get('/api/envelope/status');
-    expect(localhostBypass.status).toBe(200);
   });
 
-  it('returns audit_db_unavailable when authenticated but sessions DB is absent', async () => {
-    const apiServer = createApiServer({
-      scheduler,
-      port: 0,
-      envelope: {
-        issuance: 'required',
-        key_id: 'local-2026-04',
-        key_version: 8,
-      },
-    });
+  describe('AC: missing audit DB returns explicit failure', () => {
+    it('returns audit_db_unavailable when authenticated but sessions DB is absent', async () => {
+      const apiServer = createApiServer({
+        scheduler,
+        port: 0,
+        envelope: {
+          issuance: 'required',
+          key_id: 'local-2026-04',
+          key_version: 8,
+        },
+      });
 
-    const response = await request(apiServer.app)
-      .get('/api/envelope/status')
-      .set(TUNNEL_HEADERS)
-      .set('Authorization', 'Bearer test-token');
+      const response = await request(apiServer.app)
+        .get('/api/envelope/status')
+        .set(TUNNEL_HEADERS)
+        .set('Authorization', 'Bearer test-token');
 
-    expect(response.status).toBe(503);
-    expect(response.body).toEqual({
-      error: true,
-      code: 'audit_db_unavailable',
-      message: 'Envelope audit database is unavailable.',
+      expect(response.status).toBe(503);
+      expect(response.body).toEqual({
+        error: true,
+        code: 'audit_db_unavailable',
+        message: 'Envelope audit database is unavailable.',
+      });
     });
   });
 });

--- a/packages/standalone/tests/api/graph-api.test.ts
+++ b/packages/standalone/tests/api/graph-api.test.ts
@@ -262,6 +262,105 @@ describe('graph api helpers', () => {
     expect(res._body).toContain('Invalid JSON');
   });
 
+  it('rate-limits Code-Act execution requests per client', async () => {
+    const previousLimit = process.env.MAMA_CODE_ACT_RATE_LIMIT_PER_MINUTE;
+    const previousAuthToken = process.env.MAMA_AUTH_TOKEN;
+    process.env.MAMA_CODE_ACT_RATE_LIMIT_PER_MINUTE = '2';
+    process.env.MAMA_AUTH_TOKEN = 'test-code-act-token';
+    try {
+      const executeCodeAct = vi.fn().mockResolvedValue({
+        success: true,
+        value: 1,
+        logs: [],
+        metrics: { durationMs: 1, hostCallCount: 0, memoryUsedBytes: 0 },
+      });
+      const handler = createGraphHandler({ executeCodeAct });
+
+      for (let i = 0; i < 2; i++) {
+        const req = createBodyReq('/api/code-act', JSON.stringify({ code: '1 + 1' }), {
+          remoteAddress: '127.0.0.77',
+          headers: { authorization: 'Bearer test-code-act-token' },
+        });
+        const res = createMockRes();
+        const handled = await handler(req, res as unknown as ServerResponse);
+        expect(handled).toBe(true);
+        expect(res._status).toBe(200);
+      }
+
+      const limitedReq = createBodyReq('/api/code-act', JSON.stringify({ code: '1 + 1' }), {
+        remoteAddress: '127.0.0.77',
+        headers: { authorization: 'Bearer test-code-act-token' },
+      });
+      const limitedRes = createMockRes();
+      const handled = await handler(limitedReq, limitedRes as unknown as ServerResponse);
+
+      expect(handled).toBe(true);
+      expect(limitedRes._status).toBe(429);
+      expect(limitedRes._body).toContain('rate limit exceeded');
+      expect(executeCodeAct).toHaveBeenCalledTimes(2);
+    } finally {
+      if (previousLimit === undefined) {
+        delete process.env.MAMA_CODE_ACT_RATE_LIMIT_PER_MINUTE;
+      } else {
+        process.env.MAMA_CODE_ACT_RATE_LIMIT_PER_MINUTE = previousLimit;
+      }
+      if (previousAuthToken === undefined) {
+        delete process.env.MAMA_AUTH_TOKEN;
+      } else {
+        process.env.MAMA_AUTH_TOKEN = previousAuthToken;
+      }
+    }
+  });
+
+  it('ignores spoofed x-forwarded-for for Code-Act rate limits from untrusted peers', async () => {
+    const previousLimit = process.env.MAMA_CODE_ACT_RATE_LIMIT_PER_MINUTE;
+    const previousAuthToken = process.env.MAMA_AUTH_TOKEN;
+    process.env.MAMA_CODE_ACT_RATE_LIMIT_PER_MINUTE = '1';
+    process.env.MAMA_AUTH_TOKEN = 'test-code-act-token';
+    try {
+      const executeCodeAct = vi.fn().mockResolvedValue({
+        success: true,
+        value: 1,
+        logs: [],
+        metrics: { durationMs: 1, hostCallCount: 0, memoryUsedBytes: 0 },
+      });
+      const handler = createGraphHandler({ executeCodeAct });
+      const firstReq = createBodyReq('/api/code-act', JSON.stringify({ code: '1 + 1' }), {
+        remoteAddress: '198.51.100.77',
+        headers: {
+          authorization: 'Bearer test-code-act-token',
+          'x-forwarded-for': '203.0.113.1',
+        },
+      });
+      const firstRes = createMockRes();
+      expect(await handler(firstReq, firstRes as unknown as ServerResponse)).toBe(true);
+      expect(firstRes._status).toBe(200);
+
+      const spoofedReq = createBodyReq('/api/code-act', JSON.stringify({ code: '1 + 1' }), {
+        remoteAddress: '198.51.100.77',
+        headers: {
+          authorization: 'Bearer test-code-act-token',
+          'x-forwarded-for': '203.0.113.2',
+        },
+      });
+      const spoofedRes = createMockRes();
+      expect(await handler(spoofedReq, spoofedRes as unknown as ServerResponse)).toBe(true);
+      expect(spoofedRes._status).toBe(429);
+      expect(executeCodeAct).toHaveBeenCalledTimes(1);
+    } finally {
+      if (previousLimit === undefined) {
+        delete process.env.MAMA_CODE_ACT_RATE_LIMIT_PER_MINUTE;
+      } else {
+        process.env.MAMA_CODE_ACT_RATE_LIMIT_PER_MINUTE = previousLimit;
+      }
+      if (previousAuthToken === undefined) {
+        delete process.env.MAMA_AUTH_TOKEN;
+      } else {
+        process.env.MAMA_AUTH_TOKEN = previousAuthToken;
+      }
+    }
+  });
+
   it('returns 400 for malformed JSON on managed-agent update POST', async () => {
     const handler = createGraphHandler({ sessionsDb: db });
     const req = createBodyReq('/api/agents/dashboard-agent', '{bad-json');
@@ -397,13 +496,17 @@ function createMockRes() {
   };
 }
 
-function createBodyReq(url: string, body: string): IncomingMessage {
+function createBodyReq(
+  url: string,
+  body: string,
+  options: { remoteAddress?: string; headers?: Record<string, string> } = {}
+): IncomingMessage {
   const listeners = new Map<string, Array<(value?: unknown) => void>>();
   const req = {
     method: 'POST',
     url,
-    headers: { host: 'localhost', 'content-type': 'application/json' },
-    socket: { remoteAddress: '127.0.0.1' },
+    headers: { host: 'localhost', 'content-type': 'application/json', ...options.headers },
+    socket: { remoteAddress: options.remoteAddress ?? '127.0.0.1' },
     on(event: string, handler: (value?: unknown) => void) {
       const bucket = listeners.get(event) ?? [];
       bucket.push(handler);

--- a/packages/standalone/tests/api/health-envelope.test.ts
+++ b/packages/standalone/tests/api/health-envelope.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import request from 'supertest';
+import { createApiServer } from '../../src/api/index.js';
+import { CronScheduler } from '../../src/scheduler/index.js';
+
+const ENVELOPE_MODES = ['off', 'enabled', 'required'] as const;
+const LONG_BASE64_PATTERN = /[A-Za-z0-9+/]{32,}={0,2}/;
+
+describe('M1R public /health envelope isolation', () => {
+  const originalAuthToken = process.env.MAMA_AUTH_TOKEN;
+
+  beforeEach(() => {
+    process.env.MAMA_AUTH_TOKEN = 'test-token';
+  });
+
+  afterEach(() => {
+    if (originalAuthToken === undefined) {
+      delete process.env.MAMA_AUTH_TOKEN;
+    } else {
+      process.env.MAMA_AUTH_TOKEN = originalAuthToken;
+    }
+  });
+
+  it.each(ENVELOPE_MODES)(
+    'keeps /health public and envelope-free when issuance is %s',
+    async (issuance) => {
+      const scheduler = new CronScheduler();
+      const apiServer = createApiServer({
+        scheduler,
+        port: 0,
+        envelope: {
+          issuance,
+          key_id: issuance === 'off' ? undefined : 'local-2026-04',
+          key_version: issuance === 'off' ? undefined : 1,
+        },
+      });
+
+      const response = await request(apiServer.app)
+        .get('/health')
+        .set('cf-connecting-ip', '198.51.100.7');
+
+      expect(response.status).toBe(200);
+      expect(Object.keys(response.body).sort()).toEqual(['status', 'timestamp']);
+      expect(response.body.status).toBe('ok');
+      expect(Number.isFinite(response.body.timestamp)).toBe(true);
+
+      const serializedBody = JSON.stringify(response.body);
+      expect(serializedBody).not.toContain('issuance');
+      expect(serializedBody).not.toContain('key_id');
+      expect(serializedBody).not.toContain('key_version');
+      expect(serializedBody).not.toContain('envelope');
+      expect(serializedBody).not.toContain('local-2026-04');
+      expect(serializedBody).not.toMatch(LONG_BASE64_PATTERN);
+
+      scheduler.shutdown();
+    }
+  );
+});

--- a/packages/standalone/tests/api/health-envelope.test.ts
+++ b/packages/standalone/tests/api/health-envelope.test.ts
@@ -6,7 +6,7 @@ import { CronScheduler } from '../../src/scheduler/index.js';
 const ENVELOPE_MODES = ['off', 'enabled', 'required'] as const;
 const LONG_BASE64_PATTERN = /[A-Za-z0-9+/]{32,}={0,2}/;
 
-describe('M1R public /health envelope isolation', () => {
+describe('Story M1R: Public /health envelope isolation', () => {
   const originalAuthToken = process.env.MAMA_AUTH_TOKEN;
 
   beforeEach(() => {
@@ -21,38 +21,42 @@ describe('M1R public /health envelope isolation', () => {
     }
   });
 
-  it.each(ENVELOPE_MODES)(
-    'keeps /health public and envelope-free when issuance is %s',
-    async (issuance) => {
-      const scheduler = new CronScheduler();
-      const apiServer = createApiServer({
-        scheduler,
-        port: 0,
-        envelope: {
-          issuance,
-          key_id: issuance === 'off' ? undefined : 'local-2026-04',
-          key_version: issuance === 'off' ? undefined : 1,
-        },
-      });
+  describe('AC: /health stays public and envelope-free', () => {
+    it.each(ENVELOPE_MODES)(
+      'keeps /health public and envelope-free when issuance is %s',
+      async (issuance) => {
+        const scheduler = new CronScheduler();
+        try {
+          const apiServer = createApiServer({
+            scheduler,
+            port: 0,
+            envelope: {
+              issuance,
+              key_id: issuance === 'off' ? undefined : 'local-2026-04',
+              key_version: issuance === 'off' ? undefined : 1,
+            },
+          });
 
-      const response = await request(apiServer.app)
-        .get('/health')
-        .set('cf-connecting-ip', '198.51.100.7');
+          const response = await request(apiServer.app)
+            .get('/health')
+            .set('cf-connecting-ip', '198.51.100.7');
 
-      expect(response.status).toBe(200);
-      expect(Object.keys(response.body).sort()).toEqual(['status', 'timestamp']);
-      expect(response.body.status).toBe('ok');
-      expect(Number.isFinite(response.body.timestamp)).toBe(true);
+          expect(response.status).toBe(200);
+          expect(Object.keys(response.body).sort()).toEqual(['status', 'timestamp']);
+          expect(response.body.status).toBe('ok');
+          expect(Number.isFinite(response.body.timestamp)).toBe(true);
 
-      const serializedBody = JSON.stringify(response.body);
-      expect(serializedBody).not.toContain('issuance');
-      expect(serializedBody).not.toContain('key_id');
-      expect(serializedBody).not.toContain('key_version');
-      expect(serializedBody).not.toContain('envelope');
-      expect(serializedBody).not.toContain('local-2026-04');
-      expect(serializedBody).not.toMatch(LONG_BASE64_PATTERN);
-
-      scheduler.shutdown();
-    }
-  );
+          const serializedBody = JSON.stringify(response.body);
+          expect(serializedBody).not.toContain('issuance');
+          expect(serializedBody).not.toContain('key_id');
+          expect(serializedBody).not.toContain('key_version');
+          expect(serializedBody).not.toContain('envelope');
+          expect(serializedBody).not.toContain('local-2026-04');
+          expect(serializedBody).not.toMatch(LONG_BASE64_PATTERN);
+        } finally {
+          scheduler.shutdown();
+        }
+      }
+    );
+  });
 });

--- a/packages/standalone/tests/cli/runtime/agent-loop-init-envelope-options.test.ts
+++ b/packages/standalone/tests/cli/runtime/agent-loop-init-envelope-options.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentContext, AgentLoopOptions, ContentBlock } from '../../../src/agent/types.js';
+import type { MAMAConfig } from '../../../src/cli/config/types.js';
+import type { OAuthManager } from '../../../src/auth/index.js';
+import type { MetricsStore } from '../../../src/observability/metrics-store.js';
+import type { SQLiteDatabase } from '../../../src/sqlite.js';
+import { makeSignedEnvelope } from '../../envelope/fixtures.js';
+
+const { runMock, runWithContentMock, setSessionKeyMock } = vi.hoisted(() => ({
+  runMock: vi.fn(),
+  runWithContentMock: vi.fn(),
+  setSessionKeyMock: vi.fn(),
+}));
+
+vi.mock('../../../src/agent/index.js', () => ({
+  AgentLoop: vi.fn().mockImplementation(() => ({
+    run: runMock,
+    runWithContent: runWithContentMock,
+    setSessionKey: setSessionKeyMock,
+  })),
+}));
+
+vi.mock('../../../src/cli/runtime/utilities.js', () => ({
+  syncBuiltinSkills: vi.fn(),
+}));
+
+vi.mock('../../../src/db/agent-store.js', () => ({
+  getLatestVersion: vi.fn().mockReturnValue(null),
+  upsertMetrics: vi.fn(),
+}));
+
+vi.mock('../../../src/api/index.js', () => ({
+  insertTokenUsage: vi.fn(),
+}));
+
+import { initMainAgentLoop } from '../../../src/cli/runtime/agent-loop-init.js';
+
+function createConfig(): MAMAConfig {
+  return {
+    agent: {
+      model: 'claude-sonnet-4-6',
+      timeout: 1000,
+      max_turns: 5,
+      tools: {},
+    },
+    database: { path: ':memory:' },
+    multi_agent: { agents: {} },
+  } as unknown as MAMAConfig;
+}
+
+function createAgentContext(): AgentContext {
+  return {
+    source: 'telegram',
+    platform: 'telegram',
+    roleName: 'chat_bot',
+    role: { allowedTools: ['*'], systemControl: false, sensitiveAccess: false },
+    session: {
+      sessionId: 'telegram:session',
+      channelId: 'tg:1',
+      userId: 'user-1',
+      startedAt: new Date(),
+    },
+    capabilities: ['*'],
+    limitations: [],
+    tier: 2,
+  };
+}
+
+function createOptions(): AgentLoopOptions {
+  return {
+    userId: 'user-1',
+    source: 'telegram',
+    channelId: 'tg:1',
+    systemPrompt: 'system',
+    model: 'claude-sonnet-4-6',
+    envelope: makeSignedEnvelope({ agent_id: 'chat_bot', source: 'telegram', channel_id: 'tg:1' }),
+    agentContext: createAgentContext(),
+    cliSessionId: 'cli-session-1',
+    resumeSession: true,
+  };
+}
+
+describe('initMainAgentLoop AgentLoopClient envelope options', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runMock.mockResolvedValue({
+      response: 'ok',
+      turns: 1,
+      history: [],
+      totalUsage: { input_tokens: 1, output_tokens: 1 },
+      stopReason: 'end_turn',
+    });
+    runWithContentMock.mockResolvedValue({
+      response: 'ok',
+      turns: 1,
+      history: [],
+      totalUsage: { input_tokens: 1, output_tokens: 1 },
+      stopReason: 'end_turn',
+    });
+  });
+
+  it('preserves envelope-bearing options through run()', async () => {
+    const { agentLoopClient } = initMainAgentLoop(
+      createConfig(),
+      { getToken: vi.fn() } as unknown as OAuthManager,
+      {} as SQLiteDatabase,
+      null as MetricsStore | null,
+      'claude'
+    );
+    const options = createOptions();
+
+    await agentLoopClient.run('hello', options);
+
+    expect(runMock).toHaveBeenCalledWith('hello', expect.objectContaining(options));
+  });
+
+  it('preserves envelope-bearing options through runWithContent()', async () => {
+    const { agentLoopClient } = initMainAgentLoop(
+      createConfig(),
+      { getToken: vi.fn() } as unknown as OAuthManager,
+      {} as SQLiteDatabase,
+      null as MetricsStore | null,
+      'claude'
+    );
+    const content: ContentBlock[] = [{ type: 'text', text: 'hello' }];
+    const options = createOptions();
+
+    await agentLoopClient.runWithContent?.(content, options);
+
+    expect(runWithContentMock).toHaveBeenCalledWith(content, expect.objectContaining(options));
+  });
+});

--- a/packages/standalone/tests/cli/runtime/agent-loop-init-envelope-options.test.ts
+++ b/packages/standalone/tests/cli/runtime/agent-loop-init-envelope-options.test.ts
@@ -1,38 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AgentLoop } from '../../../src/agent/index.js';
 import type { AgentContext, AgentLoopOptions, ContentBlock } from '../../../src/agent/types.js';
 import type { MAMAConfig } from '../../../src/cli/config/types.js';
 import type { OAuthManager } from '../../../src/auth/index.js';
 import type { MetricsStore } from '../../../src/observability/metrics-store.js';
 import type { SQLiteDatabase } from '../../../src/sqlite.js';
 import { makeSignedEnvelope } from '../../envelope/fixtures.js';
-
-const { runMock, runWithContentMock, setSessionKeyMock } = vi.hoisted(() => ({
-  runMock: vi.fn(),
-  runWithContentMock: vi.fn(),
-  setSessionKeyMock: vi.fn(),
-}));
-
-vi.mock('../../../src/agent/index.js', () => ({
-  AgentLoop: vi.fn().mockImplementation(() => ({
-    run: runMock,
-    runWithContent: runWithContentMock,
-    setSessionKey: setSessionKeyMock,
-  })),
-}));
-
-vi.mock('../../../src/cli/runtime/utilities.js', () => ({
-  syncBuiltinSkills: vi.fn(),
-}));
-
-vi.mock('../../../src/db/agent-store.js', () => ({
-  getLatestVersion: vi.fn().mockReturnValue(null),
-  upsertMetrics: vi.fn(),
-}));
-
-vi.mock('../../../src/api/index.js', () => ({
-  insertTokenUsage: vi.fn(),
-}));
-
 import { initMainAgentLoop } from '../../../src/cli/runtime/agent-loop-init.js';
 
 function createConfig(): MAMAConfig {
@@ -80,17 +56,24 @@ function createOptions(): AgentLoopOptions {
   };
 }
 
-describe('initMainAgentLoop AgentLoopClient envelope options', () => {
+describe('Story M1R: initMainAgentLoop envelope options', () => {
+  let previousHome: string | undefined;
+  let tempHome: string;
+  let runSpy: ReturnType<typeof vi.spyOn>;
+  let runWithContentSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
-    vi.clearAllMocks();
-    runMock.mockResolvedValue({
+    previousHome = process.env.HOME;
+    tempHome = mkdtempSync(join(tmpdir(), 'mama-agent-loop-init-'));
+    process.env.HOME = tempHome;
+    runSpy = vi.spyOn(AgentLoop.prototype, 'run').mockResolvedValue({
       response: 'ok',
       turns: 1,
       history: [],
       totalUsage: { input_tokens: 1, output_tokens: 1 },
       stopReason: 'end_turn',
     });
-    runWithContentMock.mockResolvedValue({
+    runWithContentSpy = vi.spyOn(AgentLoop.prototype, 'runWithContent').mockResolvedValue({
       response: 'ok',
       turns: 1,
       history: [],
@@ -99,34 +82,46 @@ describe('initMainAgentLoop AgentLoopClient envelope options', () => {
     });
   });
 
-  it('preserves envelope-bearing options through run()', async () => {
-    const { agentLoopClient } = initMainAgentLoop(
-      createConfig(),
-      { getToken: vi.fn() } as unknown as OAuthManager,
-      {} as SQLiteDatabase,
-      null as MetricsStore | null,
-      'claude'
-    );
-    const options = createOptions();
-
-    await agentLoopClient.run('hello', options);
-
-    expect(runMock).toHaveBeenCalledWith('hello', expect.objectContaining(options));
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+    rmSync(tempHome, { recursive: true, force: true });
   });
 
-  it('preserves envelope-bearing options through runWithContent()', async () => {
-    const { agentLoopClient } = initMainAgentLoop(
-      createConfig(),
-      { getToken: vi.fn() } as unknown as OAuthManager,
-      {} as SQLiteDatabase,
-      null as MetricsStore | null,
-      'claude'
-    );
-    const content: ContentBlock[] = [{ type: 'text', text: 'hello' }];
-    const options = createOptions();
+  describe('AC: preserves envelope-bearing options', () => {
+    it('preserves envelope-bearing options through run()', async () => {
+      const { agentLoopClient } = initMainAgentLoop(
+        createConfig(),
+        { getToken: vi.fn() } as unknown as OAuthManager,
+        {} as SQLiteDatabase,
+        null as MetricsStore | null,
+        'claude'
+      );
+      const options = createOptions();
 
-    await agentLoopClient.runWithContent?.(content, options);
+      await agentLoopClient.run('hello', options);
 
-    expect(runWithContentMock).toHaveBeenCalledWith(content, expect.objectContaining(options));
+      expect(runSpy).toHaveBeenCalledWith('hello', expect.objectContaining(options));
+    });
+
+    it('preserves envelope-bearing options through runWithContent()', async () => {
+      const { agentLoopClient } = initMainAgentLoop(
+        createConfig(),
+        { getToken: vi.fn() } as unknown as OAuthManager,
+        {} as SQLiteDatabase,
+        null as MetricsStore | null,
+        'claude'
+      );
+      const content: ContentBlock[] = [{ type: 'text', text: 'hello' }];
+      const options = createOptions();
+
+      await agentLoopClient.runWithContent?.(content, options);
+
+      expect(runWithContentSpy).toHaveBeenCalledWith(content, expect.objectContaining(options));
+    });
   });
 });

--- a/packages/standalone/tests/cli/runtime/envelope-bootstrap.test.ts
+++ b/packages/standalone/tests/cli/runtime/envelope-bootstrap.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import Database, { type SQLiteDatabase } from '../../../src/sqlite.js';
 import type { MAMAConfig } from '../../../src/cli/config/types.js';
 import type { AgentLoopOptions } from '../../../src/agent/types.js';
@@ -11,6 +11,7 @@ import { createMockMamaApi } from '../../../src/gateways/context-injector.js';
 import { MessageRouter, type AgentLoopClient } from '../../../src/gateways/message-router.js';
 import { SessionStore } from '../../../src/gateways/session-store.js';
 import { EnvelopeStore } from '../../../src/envelope/store.js';
+import type { EnvelopeAuthority } from '../../../src/envelope/authority.js';
 import { buildRuntimeEnvelopeBootstrap } from '../../../src/cli/runtime/envelope-bootstrap.js';
 
 function makeConfig(overrides: Partial<MAMAConfig> = {}): MAMAConfig {
@@ -54,191 +55,212 @@ function makeKeyEnv(mode: 'enabled' | 'required' = 'enabled'): Record<string, st
   };
 }
 
-describe('runtime envelope bootstrap', () => {
-  it.each([undefined, '', 'off', 'false'] as Array<string | undefined>)(
-    'treats issuance mode %s as disabled without loading key material',
-    (mode) => {
+describe('STORY-M1R-BOOTSTRAP-1: issuance/config validation', () => {
+  describe('AC: buildRuntimeEnvelopeBootstrap validates issuance mode and key material', () => {
+    it.each([undefined, '', 'off', 'false'] as Array<string | undefined>)(
+      'treats issuance mode %s as disabled without loading key material',
+      (mode) => {
+        const db: SQLiteDatabase = new Database(':memory:');
+        const env = mode === undefined ? {} : { MAMA_ENVELOPE_ISSUANCE: mode };
+
+        const bootstrap = buildRuntimeEnvelopeBootstrap(db, makeConfig(), env);
+
+        expect(bootstrap.metadata).toEqual({ issuance: 'off' });
+        expect(bootstrap.envelopeAuthority).toBeUndefined();
+        expect(bootstrap.envelopeConfig).toBeUndefined();
+      }
+    );
+
+    it('loads enabled signing config and returns only non-secret metadata', () => {
       const db: SQLiteDatabase = new Database(':memory:');
-      const env = mode === undefined ? {} : { MAMA_ENVELOPE_ISSUANCE: mode };
+      const env = makeKeyEnv('enabled');
 
       const bootstrap = buildRuntimeEnvelopeBootstrap(db, makeConfig(), env);
 
-      expect(bootstrap.metadata).toEqual({ issuance: 'off' });
-      expect(bootstrap.envelopeAuthority).toBeUndefined();
-      expect(bootstrap.envelopeConfig).toBeUndefined();
-    }
-  );
-
-  it('loads enabled signing config and returns only non-secret metadata', () => {
-    const db: SQLiteDatabase = new Database(':memory:');
-    const env = makeKeyEnv('enabled');
-
-    const bootstrap = buildRuntimeEnvelopeBootstrap(db, makeConfig(), env);
-
-    expect(bootstrap.envelopeAuthority).toBeDefined();
-    expect(bootstrap.envelopeConfig).toBeDefined();
-    expect(bootstrap.metadata).toEqual({
-      issuance: 'enabled',
-      key_id: 'test-key',
-      key_version: 3,
-    });
-    expect(JSON.stringify(bootstrap.metadata)).not.toContain(env.MAMA_ENVELOPE_HMAC_KEY_BASE64);
-  });
-
-  it('requires a valid signing key in required mode', () => {
-    const db: SQLiteDatabase = new Database(':memory:');
-
-    expect(() =>
-      buildRuntimeEnvelopeBootstrap(db, makeConfig(), { MAMA_ENVELOPE_ISSUANCE: 'required' })
-    ).toThrow(/MAMA_ENVELOPE_HMAC_KEY/);
-
-    expect(() =>
-      buildRuntimeEnvelopeBootstrap(db, makeConfig(), {
-        MAMA_ENVELOPE_ISSUANCE: 'required',
-        MAMA_ENVELOPE_HMAC_KEY_BASE64: 'not base64',
-      })
-    ).toThrow(/base64/i);
-  });
-
-  it('rejects invalid issuance modes', () => {
-    const db: SQLiteDatabase = new Database(':memory:');
-
-    expect(() =>
-      buildRuntimeEnvelopeBootstrap(db, makeConfig(), { MAMA_ENVELOPE_ISSUANCE: 'sometimes' })
-    ).toThrow(/MAMA_ENVELOPE_ISSUANCE/i);
-  });
-
-  it('applies envelope migrations before returning an authority', () => {
-    const db: SQLiteDatabase = new Database(':memory:');
-    const bootstrap = buildRuntimeEnvelopeBootstrap(db, makeConfig(), makeKeyEnv('enabled'));
-    const envelope = bootstrap.envelopeAuthority!.buildAndPersist({
-      agent_id: 'worker',
-      instance_id: 'inst_bootstrap_test',
-      source: 'telegram',
-      channel_id: 'tg:1',
-      trigger_context: { user_text: 'hello' },
-      scope: {
-        project_refs: [{ kind: 'project', id: '/workspace/project-a' }],
-        raw_connectors: ['telegram'],
-        memory_scopes: [{ kind: 'channel', id: 'telegram:tg:1' }],
-        allowed_destinations: [{ kind: 'telegram', id: 'tg:1' }],
-      },
-      tier: 1,
-      budget: { wall_seconds: 30 },
-      expires_at: new Date(Date.now() + 60_000).toISOString(),
+      expect(bootstrap.envelopeAuthority).toBeDefined();
+      expect(bootstrap.envelopeConfig).toBeDefined();
+      expect(bootstrap.metadata).toEqual({
+        issuance: 'enabled',
+        key_id: 'test-key',
+        key_version: 3,
+      });
+      expect(JSON.stringify(bootstrap.metadata)).not.toContain(env.MAMA_ENVELOPE_HMAC_KEY_BASE64);
     });
 
-    expect(new EnvelopeStore(db).getByHash(envelope.envelope_hash)?.instance_id).toBe(
-      'inst_bootstrap_test'
-    );
-  });
+    it('requires a valid signing key in required mode', () => {
+      const db: SQLiteDatabase = new Database(':memory:');
 
-  it('keeps off-mode reactive tool calls open without legacy bypass', async () => {
-    const previousBypass = process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS;
-    const previousHome = process.env.HOME;
-    const tempHome = mkdtempSync(join(tmpdir(), 'mama-envelope-bootstrap-home-'));
-    delete process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS;
-    process.env.HOME = tempHome;
-    try {
+      expect(() =>
+        buildRuntimeEnvelopeBootstrap(db, makeConfig(), { MAMA_ENVELOPE_ISSUANCE: 'required' })
+      ).toThrow(/MAMA_ENVELOPE_HMAC_KEY/);
+
+      expect(() =>
+        buildRuntimeEnvelopeBootstrap(db, makeConfig(), {
+          MAMA_ENVELOPE_ISSUANCE: 'required',
+          MAMA_ENVELOPE_HMAC_KEY_BASE64: 'not base64',
+        })
+      ).toThrow(/base64/i);
+    });
+
+    it('rejects invalid issuance modes', () => {
+      const db: SQLiteDatabase = new Database(':memory:');
+
+      expect(() =>
+        buildRuntimeEnvelopeBootstrap(db, makeConfig(), { MAMA_ENVELOPE_ISSUANCE: 'sometimes' })
+      ).toThrow(/MAMA_ENVELOPE_ISSUANCE/i);
+    });
+  });
+});
+
+describe('STORY-M1R-BOOTSTRAP-2: persistence/migrations', () => {
+  describe('AC: EnvelopeStore can persist envelopes after bootstrap migrations', () => {
+    it('applies envelope migrations before returning an authority', () => {
+      const db: SQLiteDatabase = new Database(':memory:');
+      const bootstrap = buildRuntimeEnvelopeBootstrap(db, makeConfig(), makeKeyEnv('enabled'));
+      const envelope = bootstrap.envelopeAuthority!.buildAndPersist({
+        agent_id: 'worker',
+        instance_id: 'inst_bootstrap_test',
+        source: 'telegram',
+        channel_id: 'tg:1',
+        trigger_context: { user_text: 'hello' },
+        scope: {
+          project_refs: [{ kind: 'project', id: '/workspace/project-a' }],
+          raw_connectors: ['telegram'],
+          memory_scopes: [{ kind: 'channel', id: 'telegram:tg:1' }],
+          allowed_destinations: [{ kind: 'telegram', id: 'tg:1' }],
+        },
+        tier: 1,
+        budget: { wall_seconds: 30 },
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+      });
+
+      expect(new EnvelopeStore(db).getByHash(envelope.envelope_hash)?.instance_id).toBe(
+        'inst_bootstrap_test'
+      );
+    });
+  });
+});
+
+describe('STORY-M1R-BOOTSTRAP-3: off-mode behavior', () => {
+  describe('AC: MessageRouter and GatewayToolExecutor keep off-mode tool calls open', () => {
+    it('keeps off-mode reactive tool calls open without legacy bypass', async () => {
+      const previousBypass = process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS;
+      const previousHome = process.env.HOME;
+      const tempHome = mkdtempSync(join(tmpdir(), 'mama-envelope-bootstrap-home-'));
+      delete process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS;
+      process.env.HOME = tempHome;
+      try {
+        const db: SQLiteDatabase = new Database(':memory:');
+        const sessionStore = new SessionStore(db);
+        let capturedOptions: AgentLoopOptions | undefined;
+        const agentLoop: AgentLoopClient = {
+          async run(_prompt, options) {
+            capturedOptions = options;
+            return { response: 'ok' };
+          },
+        };
+        const bootstrap = buildRuntimeEnvelopeBootstrap(db, makeConfig(), {
+          MAMA_ENVELOPE_ISSUANCE: 'off',
+        });
+        const router = new MessageRouter(
+          sessionStore,
+          agentLoop,
+          createMockMamaApi([]),
+          {},
+          bootstrap.envelopeConfig,
+          bootstrap.envelopeAuthority
+        );
+        await router.process({
+          source: 'telegram',
+          channelId: 'tg:1',
+          userId: 'u:1',
+          text: 'read memory',
+        });
+        const executor = new GatewayToolExecutor({
+          mamaApi: createMockMamaApi([]),
+          envelopeIssuanceMode: bootstrap.metadata.issuance,
+        });
+        const readablePath = join(
+          homedir(),
+          '.mama',
+          'workspace',
+          'test-fixtures',
+          'off-mode-read.txt'
+        );
+        mkdirSync(join(homedir(), '.mama', 'workspace', 'test-fixtures'), { recursive: true });
+        writeFileSync(readablePath, 'off mode read fixture', 'utf-8');
+
+        expect(capturedOptions).toBeDefined();
+        const result = await executor.execute(
+          'Read',
+          { path: readablePath },
+          buildAgentToolExecutionContext(capturedOptions) ?? undefined
+        );
+
+        expect(result).toMatchObject({ success: true });
+      } finally {
+        if (previousBypass === undefined) {
+          delete process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS;
+        } else {
+          process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS = previousBypass;
+        }
+        if (previousHome === undefined) {
+          delete process.env.HOME;
+        } else {
+          process.env.HOME = previousHome;
+        }
+        rmSync(tempHome, { recursive: true, force: true });
+      }
+    });
+  });
+});
+
+describe('STORY-M1R-BOOTSTRAP-4: concurrency/lock release', () => {
+  describe('AC: SessionStore releases MessageRouter locks after envelopeAuthority failures', () => {
+    it('releases the session lock when envelope creation fails after acquisition', async () => {
       const db: SQLiteDatabase = new Database(':memory:');
       const sessionStore = new SessionStore(db);
-      let capturedOptions: AgentLoopOptions | undefined;
-      const agentLoop: AgentLoopClient = {
-        async run(_prompt, options) {
-          capturedOptions = options;
-          return { response: 'ok' };
+      const bootstrap = buildRuntimeEnvelopeBootstrap(db, makeConfig(), makeKeyEnv('enabled'));
+      let failNextBuild = true;
+      const fakeAuthority = {
+        buildAndPersist(input: Parameters<EnvelopeAuthority['buildAndPersist']>[0]) {
+          if (failNextBuild) {
+            failNextBuild = false;
+            throw new Error('synthetic envelope failure');
+          }
+          return bootstrap.envelopeAuthority!.buildAndPersist(input);
         },
-      };
-      const bootstrap = buildRuntimeEnvelopeBootstrap(db, makeConfig(), {
-        MAMA_ENVELOPE_ISSUANCE: 'off',
-      });
+      } as unknown as EnvelopeAuthority;
       const router = new MessageRouter(
         sessionStore,
-        agentLoop,
+        {
+          async run() {
+            return { response: 'ok' };
+          },
+        },
         createMockMamaApi([]),
         {},
         bootstrap.envelopeConfig,
-        bootstrap.envelopeAuthority
-      );
-      await router.process({
-        source: 'telegram',
-        channelId: 'tg:1',
-        userId: 'u:1',
-        text: 'read memory',
-      });
-      const executor = new GatewayToolExecutor({
-        mamaApi: createMockMamaApi([]),
-        envelopeIssuanceMode: bootstrap.metadata.issuance,
-      });
-      const readablePath = join(
-        homedir(),
-        '.mama',
-        'workspace',
-        'test-fixtures',
-        'off-mode-read.txt'
-      );
-      mkdirSync(join(homedir(), '.mama', 'workspace', 'test-fixtures'), { recursive: true });
-      writeFileSync(readablePath, 'off mode read fixture', 'utf-8');
-
-      expect(capturedOptions).toBeDefined();
-      const result = await executor.execute(
-        'Read',
-        { path: readablePath },
-        buildAgentToolExecutionContext(capturedOptions) ?? undefined
+        fakeAuthority
       );
 
-      expect(result).toMatchObject({ success: true });
-    } finally {
-      if (previousBypass === undefined) {
-        delete process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS;
-      } else {
-        process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS = previousBypass;
-      }
-      if (previousHome === undefined) {
-        delete process.env.HOME;
-      } else {
-        process.env.HOME = previousHome;
-      }
-      rmSync(tempHome, { recursive: true, force: true });
-    }
-  });
+      await expect(
+        router.process({
+          source: 'telegram',
+          channelId: 'tg:lock-release',
+          userId: 'u:1',
+          text: 'hello',
+        })
+      ).rejects.toThrow('synthetic envelope failure');
 
-  it('releases the session lock when envelope creation fails after acquisition', async () => {
-    const db: SQLiteDatabase = new Database(':memory:');
-    const sessionStore = new SessionStore(db);
-    const bootstrap = buildRuntimeEnvelopeBootstrap(db, makeConfig(), makeKeyEnv('enabled'));
-    vi.spyOn(bootstrap.envelopeAuthority!, 'buildAndPersist').mockImplementationOnce(() => {
-      throw new Error('synthetic envelope failure');
+      await expect(
+        router.process({
+          source: 'telegram',
+          channelId: 'tg:lock-release',
+          userId: 'u:1',
+          text: 'hello again',
+        })
+      ).resolves.toMatchObject({ response: 'ok' });
     });
-    const router = new MessageRouter(
-      sessionStore,
-      {
-        async run() {
-          return { response: 'ok' };
-        },
-      },
-      createMockMamaApi([]),
-      {},
-      bootstrap.envelopeConfig,
-      bootstrap.envelopeAuthority
-    );
-
-    await expect(
-      router.process({
-        source: 'telegram',
-        channelId: 'tg:lock-release',
-        userId: 'u:1',
-        text: 'hello',
-      })
-    ).rejects.toThrow('synthetic envelope failure');
-
-    await expect(
-      router.process({
-        source: 'telegram',
-        channelId: 'tg:lock-release',
-        userId: 'u:1',
-        text: 'hello again',
-      })
-    ).resolves.toMatchObject({ response: 'ok' });
   });
 });

--- a/packages/standalone/tests/cli/runtime/envelope-bootstrap.test.ts
+++ b/packages/standalone/tests/cli/runtime/envelope-bootstrap.test.ts
@@ -180,6 +180,7 @@ describe('runtime envelope bootstrap', () => {
       mkdirSync(join(homedir(), '.mama', 'workspace', 'test-fixtures'), { recursive: true });
       writeFileSync(readablePath, 'off mode read fixture', 'utf-8');
 
+      expect(capturedOptions).toBeDefined();
       const result = await executor.execute(
         'Read',
         { path: readablePath },

--- a/packages/standalone/tests/cli/runtime/envelope-bootstrap.test.ts
+++ b/packages/standalone/tests/cli/runtime/envelope-bootstrap.test.ts
@@ -1,5 +1,5 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import Database, { type SQLiteDatabase } from '../../../src/sqlite.js';
@@ -135,7 +135,10 @@ describe('runtime envelope bootstrap', () => {
 
   it('keeps off-mode reactive tool calls open without legacy bypass', async () => {
     const previousBypass = process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS;
+    const previousHome = process.env.HOME;
+    const tempHome = mkdtempSync(join(tmpdir(), 'mama-envelope-bootstrap-home-'));
     delete process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS;
+    process.env.HOME = tempHome;
     try {
       const db: SQLiteDatabase = new Database(':memory:');
       const sessionStore = new SessionStore(db);
@@ -190,6 +193,12 @@ describe('runtime envelope bootstrap', () => {
       } else {
         process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS = previousBypass;
       }
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      rmSync(tempHome, { recursive: true, force: true });
     }
   });
 
@@ -197,14 +206,14 @@ describe('runtime envelope bootstrap', () => {
     const db: SQLiteDatabase = new Database(':memory:');
     const sessionStore = new SessionStore(db);
     const bootstrap = buildRuntimeEnvelopeBootstrap(db, makeConfig(), makeKeyEnv('enabled'));
-    vi.spyOn(bootstrap.envelopeAuthority!, 'buildAndPersist').mockImplementation(() => {
+    vi.spyOn(bootstrap.envelopeAuthority!, 'buildAndPersist').mockImplementationOnce(() => {
       throw new Error('synthetic envelope failure');
     });
     const router = new MessageRouter(
       sessionStore,
       {
         async run() {
-          return { response: 'unreachable' };
+          return { response: 'ok' };
         },
       },
       createMockMamaApi([]),
@@ -221,5 +230,14 @@ describe('runtime envelope bootstrap', () => {
         text: 'hello',
       })
     ).rejects.toThrow('synthetic envelope failure');
+
+    await expect(
+      router.process({
+        source: 'telegram',
+        channelId: 'tg:lock-release',
+        userId: 'u:1',
+        text: 'hello again',
+      })
+    ).resolves.toMatchObject({ response: 'ok' });
   });
 });

--- a/packages/standalone/tests/cli/runtime/envelope-bootstrap.test.ts
+++ b/packages/standalone/tests/cli/runtime/envelope-bootstrap.test.ts
@@ -1,0 +1,225 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import Database, { type SQLiteDatabase } from '../../../src/sqlite.js';
+import type { MAMAConfig } from '../../../src/cli/config/types.js';
+import type { AgentLoopOptions } from '../../../src/agent/types.js';
+import { buildAgentToolExecutionContext } from '../../../src/agent/agent-loop.js';
+import { GatewayToolExecutor } from '../../../src/agent/gateway-tool-executor.js';
+import { createMockMamaApi } from '../../../src/gateways/context-injector.js';
+import { MessageRouter, type AgentLoopClient } from '../../../src/gateways/message-router.js';
+import { SessionStore } from '../../../src/gateways/session-store.js';
+import { EnvelopeStore } from '../../../src/envelope/store.js';
+import { buildRuntimeEnvelopeBootstrap } from '../../../src/cli/runtime/envelope-bootstrap.js';
+
+function makeConfig(overrides: Partial<MAMAConfig> = {}): MAMAConfig {
+  return {
+    version: 1,
+    agent: {
+      model: 'claude-sonnet-4-6',
+      timeout: 300_000,
+      max_turns: 5,
+      tools: { gateway: true, mcp: false },
+    },
+    database: { path: ':memory:' },
+    logging: { level: 'info', file: '~/.mama/mama.log' },
+    timeouts: {
+      request_ms: 120_000,
+      codex_request_ms: 120_000,
+      initialize_ms: 60_000,
+      session_ms: 1_800_000,
+      session_cleanup_ms: 300_000,
+      agent_ms: 300_000,
+      ultrawork_ms: 300_000,
+      workflow_step_ms: 600_000,
+      workflow_max_ms: 1_800_000,
+      busy_retry_ms: 5_000,
+    },
+    workspace: {
+      path: '/workspace/project-a',
+      scripts: '/workspace/project-a/scripts',
+      data: '/workspace/project-a/data',
+    },
+    ...overrides,
+  } as unknown as MAMAConfig;
+}
+
+function makeKeyEnv(mode: 'enabled' | 'required' = 'enabled'): Record<string, string> {
+  return {
+    MAMA_ENVELOPE_ISSUANCE: mode,
+    MAMA_ENVELOPE_HMAC_KEY_BASE64: Buffer.alloc(32, 7).toString('base64'),
+    MAMA_ENVELOPE_HMAC_KEY_ID: 'test-key',
+    MAMA_ENVELOPE_HMAC_KEY_VERSION: '3',
+  };
+}
+
+describe('runtime envelope bootstrap', () => {
+  it.each([undefined, '', 'off', 'false'] as Array<string | undefined>)(
+    'treats issuance mode %s as disabled without loading key material',
+    (mode) => {
+      const db: SQLiteDatabase = new Database(':memory:');
+      const env = mode === undefined ? {} : { MAMA_ENVELOPE_ISSUANCE: mode };
+
+      const bootstrap = buildRuntimeEnvelopeBootstrap(db, makeConfig(), env);
+
+      expect(bootstrap.metadata).toEqual({ issuance: 'off' });
+      expect(bootstrap.envelopeAuthority).toBeUndefined();
+      expect(bootstrap.envelopeConfig).toBeUndefined();
+    }
+  );
+
+  it('loads enabled signing config and returns only non-secret metadata', () => {
+    const db: SQLiteDatabase = new Database(':memory:');
+    const env = makeKeyEnv('enabled');
+
+    const bootstrap = buildRuntimeEnvelopeBootstrap(db, makeConfig(), env);
+
+    expect(bootstrap.envelopeAuthority).toBeDefined();
+    expect(bootstrap.envelopeConfig).toBeDefined();
+    expect(bootstrap.metadata).toEqual({
+      issuance: 'enabled',
+      key_id: 'test-key',
+      key_version: 3,
+    });
+    expect(JSON.stringify(bootstrap.metadata)).not.toContain(env.MAMA_ENVELOPE_HMAC_KEY_BASE64);
+  });
+
+  it('requires a valid signing key in required mode', () => {
+    const db: SQLiteDatabase = new Database(':memory:');
+
+    expect(() =>
+      buildRuntimeEnvelopeBootstrap(db, makeConfig(), { MAMA_ENVELOPE_ISSUANCE: 'required' })
+    ).toThrow(/MAMA_ENVELOPE_HMAC_KEY/);
+
+    expect(() =>
+      buildRuntimeEnvelopeBootstrap(db, makeConfig(), {
+        MAMA_ENVELOPE_ISSUANCE: 'required',
+        MAMA_ENVELOPE_HMAC_KEY_BASE64: 'not base64',
+      })
+    ).toThrow(/base64/i);
+  });
+
+  it('rejects invalid issuance modes', () => {
+    const db: SQLiteDatabase = new Database(':memory:');
+
+    expect(() =>
+      buildRuntimeEnvelopeBootstrap(db, makeConfig(), { MAMA_ENVELOPE_ISSUANCE: 'sometimes' })
+    ).toThrow(/MAMA_ENVELOPE_ISSUANCE/i);
+  });
+
+  it('applies envelope migrations before returning an authority', () => {
+    const db: SQLiteDatabase = new Database(':memory:');
+    const bootstrap = buildRuntimeEnvelopeBootstrap(db, makeConfig(), makeKeyEnv('enabled'));
+    const envelope = bootstrap.envelopeAuthority!.buildAndPersist({
+      agent_id: 'worker',
+      instance_id: 'inst_bootstrap_test',
+      source: 'telegram',
+      channel_id: 'tg:1',
+      trigger_context: { user_text: 'hello' },
+      scope: {
+        project_refs: [{ kind: 'project', id: '/workspace/project-a' }],
+        raw_connectors: ['telegram'],
+        memory_scopes: [{ kind: 'channel', id: 'telegram:tg:1' }],
+        allowed_destinations: [{ kind: 'telegram', id: 'tg:1' }],
+      },
+      tier: 1,
+      budget: { wall_seconds: 30 },
+      expires_at: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    expect(new EnvelopeStore(db).getByHash(envelope.envelope_hash)?.instance_id).toBe(
+      'inst_bootstrap_test'
+    );
+  });
+
+  it('keeps off-mode reactive tool calls open without legacy bypass', async () => {
+    const previousBypass = process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS;
+    delete process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS;
+    try {
+      const db: SQLiteDatabase = new Database(':memory:');
+      const sessionStore = new SessionStore(db);
+      let capturedOptions: AgentLoopOptions | undefined;
+      const agentLoop: AgentLoopClient = {
+        async run(_prompt, options) {
+          capturedOptions = options;
+          return { response: 'ok' };
+        },
+      };
+      const bootstrap = buildRuntimeEnvelopeBootstrap(db, makeConfig(), {
+        MAMA_ENVELOPE_ISSUANCE: 'off',
+      });
+      const router = new MessageRouter(
+        sessionStore,
+        agentLoop,
+        createMockMamaApi([]),
+        {},
+        bootstrap.envelopeConfig,
+        bootstrap.envelopeAuthority
+      );
+      await router.process({
+        source: 'telegram',
+        channelId: 'tg:1',
+        userId: 'u:1',
+        text: 'read memory',
+      });
+      const executor = new GatewayToolExecutor({
+        mamaApi: createMockMamaApi([]),
+        envelopeIssuanceMode: bootstrap.metadata.issuance,
+      });
+      const readablePath = join(
+        homedir(),
+        '.mama',
+        'workspace',
+        'test-fixtures',
+        'off-mode-read.txt'
+      );
+      mkdirSync(join(homedir(), '.mama', 'workspace', 'test-fixtures'), { recursive: true });
+      writeFileSync(readablePath, 'off mode read fixture', 'utf-8');
+
+      const result = await executor.execute(
+        'Read',
+        { path: readablePath },
+        buildAgentToolExecutionContext(capturedOptions) ?? undefined
+      );
+
+      expect(result).toMatchObject({ success: true });
+    } finally {
+      if (previousBypass === undefined) {
+        delete process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS;
+      } else {
+        process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS = previousBypass;
+      }
+    }
+  });
+
+  it('releases the session lock when envelope creation fails after acquisition', async () => {
+    const db: SQLiteDatabase = new Database(':memory:');
+    const sessionStore = new SessionStore(db);
+    const bootstrap = buildRuntimeEnvelopeBootstrap(db, makeConfig(), makeKeyEnv('enabled'));
+    vi.spyOn(bootstrap.envelopeAuthority!, 'buildAndPersist').mockImplementation(() => {
+      throw new Error('synthetic envelope failure');
+    });
+    const router = new MessageRouter(
+      sessionStore,
+      {
+        async run() {
+          return { response: 'unreachable' };
+        },
+      },
+      createMockMamaApi([]),
+      {},
+      bootstrap.envelopeConfig,
+      bootstrap.envelopeAuthority
+    );
+
+    await expect(
+      router.process({
+        source: 'telegram',
+        channelId: 'tg:lock-release',
+        userId: 'u:1',
+        text: 'hello',
+      })
+    ).rejects.toThrow('synthetic envelope failure');
+  });
+});

--- a/packages/standalone/tests/code-act/host-bridge.test.ts
+++ b/packages/standalone/tests/code-act/host-bridge.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeAll } from 'vitest';
 import { HostBridge } from '../../src/agent/code-act/host-bridge.js';
 import { CodeActSandbox } from '../../src/agent/code-act/sandbox.js';
 import type { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
+import type { GatewayToolExecutionContext } from '../../src/agent/types.js';
 import { RoleManager } from '../../src/agent/role-manager.js';
 import type { RoleConfig } from '../../src/cli/config/types.js';
 
@@ -135,6 +136,33 @@ describe('HostBridge', () => {
       const result = await sandbox.execute('mama_search({ query: "test" })');
       expect(result.success).toBe(true);
       expect(executeFn).toHaveBeenCalledWith('mama_search', { query: 'test' });
+    });
+
+    it('forwards execution context to executor calls when provided', async () => {
+      const executeFn = vi.fn().mockResolvedValue({
+        success: true,
+        results: [],
+        count: 0,
+      });
+      const executionContext = {
+        agentId: 'chat_bot',
+        source: 'telegram',
+        channelId: 'tg:1',
+        envelope: { envelope_hash: 'envhash_code_act' },
+        executionSurface: 'code_act',
+      } as unknown as GatewayToolExecutionContext;
+      const bridge = new HostBridge(
+        makeExecutor({ execute: executeFn }),
+        undefined,
+        executionContext
+      );
+      const sandbox = new CodeActSandbox();
+      bridge.injectInto(sandbox, 1);
+
+      const result = await sandbox.execute('mama_search({ query: "test" })');
+
+      expect(result.success).toBe(true);
+      expect(executeFn).toHaveBeenCalledWith('mama_search', { query: 'test' }, executionContext);
     });
 
     it('passes positional args mapped to param names', async () => {

--- a/packages/standalone/tests/code-act/host-bridge.test.ts
+++ b/packages/standalone/tests/code-act/host-bridge.test.ts
@@ -5,6 +5,7 @@ import type { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.
 import type { GatewayToolExecutionContext } from '../../src/agent/types.js';
 import { RoleManager } from '../../src/agent/role-manager.js';
 import type { RoleConfig } from '../../src/cli/config/types.js';
+import { makeSignedEnvelope } from '../envelope/fixtures.js';
 
 function makeExecutor(overrides?: Partial<GatewayToolExecutor>): GatewayToolExecutor {
   return {
@@ -144,13 +145,16 @@ describe('HostBridge', () => {
         results: [],
         count: 0,
       });
-      const executionContext = {
+      const executionContext: GatewayToolExecutionContext = {
         agentId: 'chat_bot',
         source: 'telegram',
         channelId: 'tg:1',
-        envelope: { envelope_hash: 'envhash_code_act' },
+        envelope: makeSignedEnvelope({
+          source: 'telegram',
+          channel_id: 'tg:1',
+        }),
         executionSurface: 'code_act',
-      } as unknown as GatewayToolExecutionContext;
+      };
       const bridge = new HostBridge(
         makeExecutor({ execute: executeFn }),
         undefined,

--- a/packages/standalone/tests/contract/code-task-delegation-empty-scopes.test.ts
+++ b/packages/standalone/tests/contract/code-task-delegation-empty-scopes.test.ts
@@ -1,14 +1,50 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
+import type { AgentProcessManager } from '../../src/multi-agent/agent-process-manager.js';
+import type { DelegationManager } from '../../src/multi-agent/delegation-manager.js';
 
 const TEST_DIR = dirname(fileURLToPath(import.meta.url));
 
-describe('code-task delegation envelope', () => {
+describe('Story M1R: code-task delegation envelope boundary', () => {
   const p5WiringMarker = join(TEST_DIR, '..', '..', 'src', 'multi-agent', 'delegate-envelope.ts');
 
   it('keeps code-task delegation envelope wiring outside M1R', () => {
     expect(existsSync(p5WiringMarker)).toBe(false);
+  });
+
+  it('keeps legacy code-task delegate execution outside reactive envelope enforcement', async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ response: 'done' });
+    const getProcess = vi.fn().mockResolvedValue({
+      sendMessage,
+      getSessionId: vi.fn().mockReturnValue('delegate-session'),
+    });
+    const isDelegationAllowed = vi.fn().mockReturnValue({ allowed: true, reason: 'ok' });
+    const buildDelegationPrompt = vi.fn(
+      (sourceAgentId: string, task: string) => `[${sourceAgentId}] ${task}`
+    );
+    const executor = new GatewayToolExecutor({ envelopeIssuanceMode: 'enabled' });
+    executor.setAgentProcessManager({
+      getProcess,
+      stopProcess: vi.fn(),
+    } as unknown as AgentProcessManager);
+    executor.setDelegationManager({
+      isDelegationAllowed,
+      buildDelegationPrompt,
+    } as unknown as DelegationManager);
+
+    const result = await executor.execute('delegate', {
+      agentId: 'developer',
+      task: 'implement the code-task change',
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      data: expect.objectContaining({ agentId: 'developer', response: 'done' }),
+    });
+    expect(isDelegationAllowed).toHaveBeenCalledWith('conductor', 'developer');
+    expect(getProcess).toHaveBeenCalledWith('viewer', 'default', 'developer');
   });
 });

--- a/packages/standalone/tests/contract/code-task-delegation-empty-scopes.test.ts
+++ b/packages/standalone/tests/contract/code-task-delegation-empty-scopes.test.ts
@@ -2,48 +2,13 @@ import { describe, expect, it } from 'vitest';
 import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { Envelope } from '../../src/envelope/types.js';
 
-const CODE_TASK_AGENTS = ['architect', 'developer', 'pm', 'reviewer'];
 const TEST_DIR = dirname(fileURLToPath(import.meta.url));
-
-type CodeTaskEnvelopeBuilder = (input: { to_agent_id: string; parent: Envelope }) => Envelope;
 
 describe('code-task delegation envelope', () => {
   const p5WiringMarker = join(TEST_DIR, '..', '..', 'src', 'multi-agent', 'delegate-envelope.ts');
-  const p5Wired = existsSync(p5WiringMarker);
 
-  if (!p5Wired) {
-    it.skip('P5 wiring not yet present; will run when delegate-envelope.ts exists', () => {});
-  } else {
-    it.each(CODE_TASK_AGENTS)(
-      '%s receives envelope with empty memory scopes from real P5 builder',
-      async (agentId) => {
-        const modulePath = '../../src/multi-agent/delegate-envelope.js';
-        const { buildCodeTaskEnvelope } = (await import(modulePath)) as {
-          buildCodeTaskEnvelope: CodeTaskEnvelopeBuilder;
-        };
-        const parent: Envelope = {
-          agent_id: 'parent',
-          instance_id: 'parent-1',
-          source: 'delegate',
-          trigger_context: {},
-          scope: {
-            project_refs: [{ kind: 'project', id: '/A' }],
-            raw_connectors: ['telegram'],
-            memory_scopes: [{ kind: 'project', id: '/A' }],
-            allowed_destinations: [{ kind: 'telegram', id: 'tg:1' }],
-          },
-          tier: 1,
-          budget: { wall_seconds: 60 },
-          expires_at: new Date(Date.now() + 60_000).toISOString(),
-          envelope_hash: 'parent-hash',
-        };
-
-        const env = buildCodeTaskEnvelope({ to_agent_id: agentId, parent });
-        expect(env.scope.memory_scopes).toEqual([]);
-        expect(env.scope.allowed_destinations).toEqual([]);
-      }
-    );
-  }
+  it('keeps code-task delegation envelope wiring outside M1R', () => {
+    expect(existsSync(p5WiringMarker)).toBe(false);
+  });
 });

--- a/packages/standalone/tests/contract/code-task-delegation-empty-scopes.test.ts
+++ b/packages/standalone/tests/contract/code-task-delegation-empty-scopes.test.ts
@@ -1,20 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
-import { existsSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
 import type { AgentProcessManager } from '../../src/multi-agent/agent-process-manager.js';
 import type { DelegationManager } from '../../src/multi-agent/delegation-manager.js';
 
-const TEST_DIR = dirname(fileURLToPath(import.meta.url));
-
 describe('Story M1R: code-task delegation envelope boundary', () => {
-  const p5WiringMarker = join(TEST_DIR, '..', '..', 'src', 'multi-agent', 'delegate-envelope.ts');
-
-  it('keeps code-task delegation envelope wiring outside M1R', () => {
-    expect(existsSync(p5WiringMarker)).toBe(false);
-  });
-
   it('keeps legacy code-task delegate execution outside reactive envelope enforcement', async () => {
     const sendMessage = vi.fn().mockResolvedValue({ response: 'done' });
     const getProcess = vi.fn().mockResolvedValue({
@@ -35,10 +24,19 @@ describe('Story M1R: code-task delegation envelope boundary', () => {
       buildDelegationPrompt,
     } as unknown as DelegationManager);
 
-    const result = await executor.execute('delegate', {
-      agentId: 'developer',
-      task: 'implement the code-task change',
-    });
+    const result = await executor.execute(
+      'delegate',
+      {
+        agentId: 'developer',
+        task: 'implement the code-task change',
+      },
+      {
+        agentId: 'conductor',
+        source: 'viewer',
+        channelId: 'default',
+        executionSurface: 'direct',
+      }
+    );
 
     expect(result).toMatchObject({
       success: true,

--- a/packages/standalone/tests/contract/envelope-callsite-matrix.test.ts
+++ b/packages/standalone/tests/contract/envelope-callsite-matrix.test.ts
@@ -49,10 +49,10 @@ const CLASSIFIED = new Map<string, string>([
   ['gateways/message-router.ts', 'P1 thread: creates signed envelope and passes AgentLoopOptions'],
   [
     'agent/code-act/host-bridge.ts',
-    'P5 deferred: explicit legacy warning until Code-Act envelope plan',
+    'M1R Reactive Main: HostBridge gateway calls carry the active envelope context',
   ],
-  ['multi-agent/', 'P5 deferred: subordinate envelope work'],
-  ['scheduler/', 'P5 deferred: Autonomous Standing envelope issuance in M8'],
+  ['multi-agent/', 'M7-owned: spawn_subordinate delegated memory worker envelopes are outside M1R'],
+  ['scheduler/', 'M8-owned: schedule_worker/Autonomous Standing envelope issuance is outside M1R'],
 ]);
 
 function classificationFor(rel: string): string | undefined {

--- a/packages/standalone/tests/contract/m1r-envelope-completion-matrix.test.ts
+++ b/packages/standalone/tests/contract/m1r-envelope-completion-matrix.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+type Row = {
+  id: string;
+  milestone: 'M1R' | 'M7' | 'M8' | 'outside-memory-twin';
+  status: 'done' | 'partial' | 'missing' | 'owned-by-later-milestone';
+};
+
+const ROWS: Row[] = [
+  { id: 'envelope-table', milestone: 'M1R', status: 'done' },
+  { id: 'enforcer-hook', milestone: 'M1R', status: 'partial' },
+  { id: 'memory-scope-mismatch-logging', milestone: 'M1R', status: 'missing' },
+  { id: 'reactive-runtime-issuance', milestone: 'M1R', status: 'missing' },
+  { id: 'code-act-hostbridge-context', milestone: 'M1R', status: 'missing' },
+  { id: 'agent-loop-client-envelope-options', milestone: 'M1R', status: 'missing' },
+  { id: 'gateway-tool-call-envelope-hash-audit', milestone: 'M1R', status: 'missing' },
+  { id: 'activity-trace-filter', milestone: 'M1R', status: 'missing' },
+  { id: 'delegated-memory-worker-envelope', milestone: 'M7', status: 'owned-by-later-milestone' },
+  { id: 'autonomous-standing-envelope', milestone: 'M8', status: 'owned-by-later-milestone' },
+  {
+    id: 'code-task-delegation',
+    milestone: 'outside-memory-twin',
+    status: 'owned-by-later-milestone',
+  },
+];
+
+describe('Story M1R: Reactive envelope completion matrix', () => {
+  describe('AC: M1R is not allowed to silently absorb M7/M8 work', () => {
+    it('keeps later worker modes outside the M1R completion claim', () => {
+      expect(ROWS.filter((row) => row.milestone === 'M7').map((row) => row.id)).toEqual([
+        'delegated-memory-worker-envelope',
+      ]);
+      expect(ROWS.filter((row) => row.milestone === 'M8').map((row) => row.id)).toEqual([
+        'autonomous-standing-envelope',
+      ]);
+    });
+
+    it('lists the M1R rows this plan must close', () => {
+      expect(
+        ROWS.filter((row) => row.milestone === 'M1R' && row.status !== 'done').map((row) => row.id)
+      ).toEqual([
+        'enforcer-hook',
+        'memory-scope-mismatch-logging',
+        'reactive-runtime-issuance',
+        'code-act-hostbridge-context',
+        'agent-loop-client-envelope-options',
+        'gateway-tool-call-envelope-hash-audit',
+        'activity-trace-filter',
+      ]);
+    });
+
+    it('classifies current Code-Act HostBridge executor calls as M1R work', () => {
+      const hostBridge = readFileSync(
+        join(process.cwd(), 'src/agent/code-act/host-bridge.ts'),
+        'utf8'
+      );
+      expect(hostBridge).toContain('.execute(');
+      expect(ROWS.find((row) => row.id === 'code-act-hostbridge-context')).toMatchObject({
+        milestone: 'M1R',
+        status: 'missing',
+      });
+    });
+  });
+});

--- a/packages/standalone/tests/contract/reactive-envelope-tool-path.test.ts
+++ b/packages/standalone/tests/contract/reactive-envelope-tool-path.test.ts
@@ -146,6 +146,7 @@ describe('Reactive Main envelope tool path', () => {
       source: 'telegram',
       channelId: 'tg:1',
       envelope,
+      executionSurface: 'model_tool',
     });
   });
 });

--- a/packages/standalone/tests/db/agent-activity.test.ts
+++ b/packages/standalone/tests/db/agent-activity.test.ts
@@ -282,6 +282,14 @@ describe('Story V19.6 - Agent Activity Logging', () => {
       });
       expect(JSON.parse(row.requested_scopes!)).toEqual([{ kind: 'global', id: 'system' }]);
 
+      const rowWithNumericAudit = logActivity(db, {
+        agent_id: 'trace-agent',
+        agent_version: 1,
+        type: 'gateway_tool_call',
+        scopeMismatch: 2,
+      });
+      expect(rowWithNumericAudit.scope_mismatch).toBe(1);
+
       const rowWithoutAudit = logActivity(db, {
         agent_id: 'trace-agent',
         agent_version: 1,

--- a/packages/standalone/tests/db/agent-activity.test.ts
+++ b/packages/standalone/tests/db/agent-activity.test.ts
@@ -1,11 +1,59 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import Database from '../../src/sqlite.js';
+import * as agentStore from '../../src/db/agent-store.js';
 import {
+  createAgentVersion,
   initAgentTables,
   logActivity,
   getActivity,
   updateActivityScore,
 } from '../../src/db/agent-store.js';
+import { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
+import type { AgentContext, GatewayToolInput, MAMAApiInterface } from '../../src/agent/types.js';
+
+type AgentStoreWithTraceHelpers = typeof agentStore & {
+  listGatewayToolCalls?: (
+    db: Database,
+    input: { envelopeHash?: string; limit?: number }
+  ) => agentStore.ActivityRow[];
+  listScopeMismatches?: (
+    db: Database,
+    input: { envelopeHash?: string; limit?: number }
+  ) => agentStore.ActivityRow[];
+};
+
+function createMAMAApi(): MAMAApiInterface {
+  return {
+    save: async () => ({ success: true, id: 'decision_1', type: 'decision' }),
+    saveCheckpoint: async () => ({ success: true, id: 'checkpoint_1', type: 'checkpoint' }),
+    listDecisions: async () => [],
+    suggest: async () => ({ success: true, results: [], count: 0 }),
+    updateOutcome: async () => ({ success: true, message: 'updated' }),
+    loadCheckpoint: async () => ({ success: true }),
+  };
+}
+
+function createViewerContext(): AgentContext {
+  return {
+    source: 'viewer',
+    platform: 'viewer',
+    roleName: 'os_agent',
+    role: {
+      allowedTools: ['*'],
+      systemControl: true,
+      sensitiveAccess: true,
+    },
+    session: {
+      sessionId: 'viewer-session',
+      channelId: 'viewer-main',
+      startedAt: new Date(),
+    },
+    capabilities: ['*'],
+    limitations: [],
+    tier: 1,
+    backend: 'claude',
+  };
+}
 
 describe('Story V19.6 - Agent Activity Logging', () => {
   let db: InstanceType<typeof Database>;
@@ -40,6 +88,80 @@ describe('Story V19.6 - Agent Activity Logging', () => {
       expect(columns.some((column) => column.name === 'run_id')).toBe(true);
       expect(columns.some((column) => column.name === 'execution_status')).toBe(true);
       expect(columns.some((column) => column.name === 'trigger_reason')).toBe(true);
+    });
+
+    it('AC #3b: creates envelope audit columns and trace indexes', () => {
+      const columns = db.prepare('PRAGMA table_info(agent_activity)').all() as Array<{
+        name: string;
+      }>;
+      expect(columns.some((column) => column.name === 'envelope_hash')).toBe(true);
+      expect(columns.some((column) => column.name === 'requested_scopes')).toBe(true);
+      expect(columns.some((column) => column.name === 'envelope_scopes_snapshot')).toBe(true);
+      expect(columns.some((column) => column.name === 'scope_mismatch')).toBe(true);
+
+      const indexes = db.prepare('PRAGMA index_list(agent_activity)').all() as Array<{
+        name: string;
+      }>;
+      expect(indexes.some((index) => index.name === 'idx_agent_activity_envelope_hash')).toBe(true);
+      expect(indexes.some((index) => index.name === 'idx_agent_activity_scope_mismatch')).toBe(
+        true
+      );
+    });
+
+    it('AC #3c: migrates old agent_activity rows without data loss', () => {
+      const legacyDb = new Database(':memory:');
+      legacyDb.exec(`
+        CREATE TABLE agent_activity (
+          id               INTEGER PRIMARY KEY AUTOINCREMENT,
+          agent_id         TEXT NOT NULL,
+          agent_version    INTEGER NOT NULL,
+          type             TEXT NOT NULL,
+          input_summary    TEXT,
+          output_summary   TEXT,
+          tokens_used      INTEGER DEFAULT 0,
+          tools_called     TEXT,
+          duration_ms      INTEGER DEFAULT 0,
+          score            REAL,
+          details          TEXT,
+          error_message    TEXT,
+          run_id           TEXT,
+          execution_status TEXT,
+          trigger_reason   TEXT,
+          created_at       TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+      `);
+      legacyDb
+        .prepare(
+          `INSERT INTO agent_activity (
+             agent_id, agent_version, type, input_summary, execution_status
+           ) VALUES (?, ?, ?, ?, ?)`
+        )
+        .run('legacy-agent', 1, 'task_complete', 'before migration', 'completed');
+
+      initAgentTables(legacyDb);
+
+      const row = legacyDb
+        .prepare(
+          `SELECT input_summary, envelope_hash, requested_scopes,
+                  envelope_scopes_snapshot, scope_mismatch
+           FROM agent_activity
+           WHERE agent_id = ?`
+        )
+        .get('legacy-agent') as {
+        input_summary: string;
+        envelope_hash: string | null;
+        requested_scopes: string | null;
+        envelope_scopes_snapshot: string | null;
+        scope_mismatch: number;
+      };
+      expect(row).toEqual({
+        input_summary: 'before migration',
+        envelope_hash: null,
+        requested_scopes: null,
+        envelope_scopes_snapshot: null,
+        scope_mismatch: 0,
+      });
+      legacyDb.close();
     });
   });
 
@@ -134,6 +256,167 @@ describe('Story V19.6 - Agent Activity Logging', () => {
       expect(updated.score).toBe(85);
       expect(JSON.parse(updated.details!).passed).toBe(2);
       expect(JSON.parse(updated.details!).items).toHaveLength(3);
+    });
+
+    it('AC #9b: logs and retrieves envelope audit fields', () => {
+      const row = logActivity(db, {
+        agent_id: 'trace-agent',
+        agent_version: 1,
+        type: 'gateway_tool_call',
+        input_summary: 'mama_save',
+        execution_status: 'completed',
+        envelopeHash: 'env_hash_1',
+        requestedScopes: [{ kind: 'global', id: 'system' }],
+        envelopeScopesSnapshot: [{ kind: 'channel', id: 'telegram:abc' }],
+        scopeMismatch: true,
+      });
+      expect(row).toMatchObject({
+        envelope_hash: 'env_hash_1',
+        scope_mismatch: 1,
+      });
+      expect(JSON.parse(row.requested_scopes!)).toEqual([{ kind: 'global', id: 'system' }]);
+
+      const rowWithoutAudit = logActivity(db, {
+        agent_id: 'trace-agent',
+        agent_version: 1,
+        type: 'task_complete',
+      });
+      expect(rowWithoutAudit).toMatchObject({
+        envelope_hash: null,
+        requested_scopes: null,
+        envelope_scopes_snapshot: null,
+        scope_mismatch: 0,
+      });
+
+      const [retrieved] = getActivity(db, 'trace-agent', 10, { includeTrace: true });
+      expect(retrieved).toMatchObject({
+        input_summary: null,
+        envelope_hash: null,
+        scope_mismatch: 0,
+      });
+    });
+  });
+
+  describe('Acceptance Criteria - envelope trace visibility', () => {
+    it('AC #10: getActivity hides gateway_tool_call rows unless includeTrace is explicit', () => {
+      logActivity(db, {
+        agent_id: 'trace-agent',
+        agent_version: 1,
+        type: 'task_complete',
+        input_summary: 'Visible activity',
+      });
+      logActivity(db, {
+        agent_id: 'trace-agent',
+        agent_version: 1,
+        type: 'gateway_tool_call',
+        input_summary: 'mama_search',
+        execution_status: 'completed',
+      });
+
+      const defaultRows = getActivity(db, 'trace-agent', 10);
+      expect(defaultRows.map((row) => row.type)).toEqual(['task_complete']);
+
+      const rowsWithTrace = (
+        getActivity as unknown as (
+          db: Database,
+          agentId: string,
+          limit: number,
+          options: { includeTrace: boolean }
+        ) => agentStore.ActivityRow[]
+      )(db, 'trace-agent', 10, { includeTrace: true });
+      expect(rowsWithTrace.map((row) => row.type)).toEqual(['gateway_tool_call', 'task_complete']);
+    });
+
+    it('AC #11: agent_activity tool hides trace rows by default and returns them with include_trace', async () => {
+      createAgentVersion(db, {
+        agent_id: 'trace-agent',
+        snapshot: { name: 'Trace Agent', tier: 2 },
+      });
+      logActivity(db, {
+        agent_id: 'trace-agent',
+        agent_version: 1,
+        type: 'task_complete',
+        input_summary: 'Visible activity',
+      });
+      logActivity(db, {
+        agent_id: 'trace-agent',
+        agent_version: 1,
+        type: 'gateway_tool_call',
+        input_summary: 'mama_search',
+        execution_status: 'completed',
+      });
+      const executor = new GatewayToolExecutor({
+        mamaApi: createMAMAApi(),
+        envelopeIssuanceMode: 'off',
+      });
+      executor.setSessionsDb(db);
+      executor.setAgentContext(createViewerContext());
+
+      const defaultResult = (await executor.execute('agent_activity', {
+        agent_id: 'trace-agent',
+        limit: 10,
+      } as unknown as GatewayToolInput)) as {
+        success: boolean;
+        activity: Array<{ type: string }>;
+      };
+      expect(defaultResult.activity.map((row) => row.type)).toEqual(['task_complete']);
+
+      const traceResult = (await executor.execute('agent_activity', {
+        agent_id: 'trace-agent',
+        limit: 10,
+        include_trace: true,
+      } as unknown as GatewayToolInput)) as {
+        success: boolean;
+        activity: Array<{ type: string }>;
+      };
+      expect(traceResult.activity.map((row) => row.type)).toEqual([
+        'gateway_tool_call',
+        'task_complete',
+      ]);
+    });
+
+    it('AC #12: exposes dedicated trace and mismatch query helpers', () => {
+      const helpers = agentStore as AgentStoreWithTraceHelpers;
+      expect(typeof helpers.listGatewayToolCalls).toBe('function');
+      expect(typeof helpers.listScopeMismatches).toBe('function');
+
+      logActivity(db, {
+        agent_id: 'trace-agent',
+        agent_version: 1,
+        type: 'gateway_tool_call',
+        input_summary: 'mama_save',
+        execution_status: 'completed',
+        envelopeHash: 'env_hash_1',
+        scopeMismatch: 1,
+      } as Parameters<typeof logActivity>[1] & {
+        envelopeHash: string;
+        scopeMismatch: number;
+      });
+      logActivity(db, {
+        agent_id: 'trace-agent',
+        agent_version: 1,
+        type: 'gateway_tool_call',
+        input_summary: 'mama_search',
+        execution_status: 'completed',
+        envelopeHash: 'env_hash_2',
+        scopeMismatch: 0,
+      } as Parameters<typeof logActivity>[1] & {
+        envelopeHash: string;
+        scopeMismatch: number;
+      });
+
+      expect(helpers.listGatewayToolCalls!(db, { envelopeHash: 'env_hash_1' })).toEqual([
+        expect.objectContaining({
+          input_summary: 'mama_save',
+          envelope_hash: 'env_hash_1',
+        }),
+      ]);
+      expect(helpers.listScopeMismatches!(db, { envelopeHash: 'env_hash_1' })).toEqual([
+        expect.objectContaining({
+          input_summary: 'mama_save',
+          scope_mismatch: 1,
+        }),
+      ]);
     });
   });
 });

--- a/packages/standalone/tests/db/agent-activity.test.ts
+++ b/packages/standalone/tests/db/agent-activity.test.ts
@@ -18,8 +18,9 @@ type AgentStoreWithTraceHelpers = typeof agentStore & {
   ) => agentStore.ActivityRow[];
   listScopeMismatches?: (
     db: Database,
-    input: { envelopeHash?: string; limit?: number }
+    input: { envelopeHash?: string; limit?: number; since?: string }
   ) => agentStore.ActivityRow[];
+  countScopeMismatches?: (db: Database, input: { since?: string }) => number;
 };
 
 function createMAMAApi(): MAMAApiInterface {
@@ -106,6 +107,11 @@ describe('Story V19.6 - Agent Activity Logging', () => {
       expect(indexes.some((index) => index.name === 'idx_agent_activity_scope_mismatch')).toBe(
         true
       );
+
+      const table = db
+        .prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='agent_activity'")
+        .get() as { sql: string };
+      expect(table.sql).toContain('CHECK (scope_mismatch IN (0, 1))');
     });
 
     it('AC #3c: migrates old agent_activity rows without data loss', () => {
@@ -417,6 +423,35 @@ describe('Story V19.6 - Agent Activity Logging', () => {
           scope_mismatch: 1,
         }),
       ]);
+    });
+
+    it('AC #13: normalizes ISO since filters for scope mismatch queries', () => {
+      const helpers = agentStore as AgentStoreWithTraceHelpers;
+      expect(typeof helpers.listScopeMismatches).toBe('function');
+      expect(typeof helpers.countScopeMismatches).toBe('function');
+
+      logActivity(db, {
+        agent_id: 'trace-agent',
+        agent_version: 1,
+        type: 'gateway_tool_call',
+        input_summary: 'mama_save',
+        execution_status: 'completed',
+        envelopeHash: 'env_hash_recent',
+        scopeMismatch: 1,
+      } as Parameters<typeof logActivity>[1] & {
+        envelopeHash: string;
+        scopeMismatch: number;
+      });
+
+      const sinceIso = new Date(Date.now() - 60_000).toISOString();
+
+      expect(helpers.listScopeMismatches!(db, { since: sinceIso })).toEqual([
+        expect.objectContaining({
+          input_summary: 'mama_save',
+          scope_mismatch: 1,
+        }),
+      ]);
+      expect(helpers.countScopeMismatches!(db, { since: sinceIso })).toBe(1);
     });
   });
 });

--- a/packages/standalone/tests/db/agent-activity.test.ts
+++ b/packages/standalone/tests/db/agent-activity.test.ts
@@ -232,6 +232,14 @@ describe('Story V19.6 - Agent Activity Logging', () => {
       expect(rows).toHaveLength(3);
     });
 
+    it('AC #7b: normalizes invalid activity limits before querying', () => {
+      logActivity(db, { agent_id: 'dev', agent_version: 1, type: 'task_complete' });
+
+      const rows = getActivity(db, 'dev', 0);
+
+      expect(rows).toHaveLength(1);
+    });
+
     it('AC #8: defaults tokens_used and duration_ms to 0', () => {
       const row = logActivity(db, {
         agent_id: 'dev',

--- a/packages/standalone/tests/envelope/agent-loop-internal-tool-context.test.ts
+++ b/packages/standalone/tests/envelope/agent-loop-internal-tool-context.test.ts
@@ -1,65 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { AgentLoop } from '../../src/agent/agent-loop.js';
-import type { AgentContext, MAMAApiInterface } from '../../src/agent/types.js';
+import { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
+import { PersistentCLIAdapter } from '../../src/agent/persistent-cli-adapter.js';
+import type { AgentContext, GatewayToolInput, MAMAApiInterface } from '../../src/agent/types.js';
 import type { OAuthManager } from '../../src/auth/index.js';
 import { makeSignedEnvelope } from './fixtures.js';
-
-const {
-  persistentPromptMock,
-  gatewayExecuteMock,
-  postProcessInBackgroundMock,
-  preCompactProcessMock,
-  updateTokensMock,
-} = vi.hoisted(() => ({
-  persistentPromptMock: vi.fn(),
-  gatewayExecuteMock: vi.fn(),
-  postProcessInBackgroundMock: vi.fn(),
-  preCompactProcessMock: vi.fn(),
-  updateTokensMock: vi.fn(),
-}));
-
-vi.mock('../../src/agent/persistent-cli-adapter.js', () => ({
-  PersistentCLIAdapter: vi.fn().mockImplementation(() => ({
-    prompt: persistentPromptMock,
-    setSessionId: vi.fn(),
-    close: vi.fn(),
-  })),
-}));
-
-vi.mock('../../src/agent/session-pool.js', () => ({
-  SessionPool: vi.fn().mockImplementation(() => ({
-    getSession: vi.fn().mockReturnValue({ sessionId: 'test-session', isNew: true }),
-    getSessionId: vi.fn().mockReturnValue('test-session'),
-    updateTokens: updateTokensMock,
-    releaseSession: vi.fn(),
-  })),
-  getSessionPool: vi.fn().mockReturnValue({
-    getSession: vi.fn().mockReturnValue({ sessionId: 'test-session', isNew: true }),
-    getSessionId: vi.fn().mockReturnValue('test-session'),
-    updateTokens: updateTokensMock,
-    releaseSession: vi.fn(),
-  }),
-  buildChannelKey: vi.fn((source: string, channelId: string) => `${source}:${channelId}`),
-}));
-
-vi.mock('../../src/agent/gateway-tool-executor.js', () => ({
-  GatewayToolExecutor: vi.fn().mockImplementation(() => ({
-    setAgentContext: vi.fn(),
-    execute: gatewayExecuteMock,
-  })),
-}));
-
-vi.mock('../../src/agent/post-tool-handler.js', () => ({
-  PostToolHandler: vi.fn().mockImplementation(() => ({
-    processInBackground: postProcessInBackgroundMock,
-  })),
-}));
-
-vi.mock('../../src/agent/pre-compact-handler.js', () => ({
-  PreCompactHandler: vi.fn().mockImplementation(() => ({
-    process: preCompactProcessMock,
-  })),
-}));
 
 function createMockOAuthManager(): OAuthManager {
   return { getToken: vi.fn().mockResolvedValue('token') } as unknown as OAuthManager;
@@ -67,16 +15,21 @@ function createMockOAuthManager(): OAuthManager {
 
 function createMockApi(): MAMAApiInterface {
   return {
-    save: vi.fn(),
-    saveCheckpoint: vi.fn(),
-    listDecisions: vi.fn(),
-    suggest: vi.fn(),
-    updateOutcome: vi.fn(),
-    loadCheckpoint: vi.fn(),
+    save: vi.fn().mockResolvedValue({ success: true, id: 'decision_1', type: 'decision' }),
+    saveCheckpoint: vi.fn().mockResolvedValue({
+      success: true,
+      id: 'checkpoint_1',
+      type: 'checkpoint',
+    }),
+    listDecisions: vi.fn().mockResolvedValue([]),
+    suggest: vi.fn().mockResolvedValue({ success: true, results: [], count: 0 }),
+    updateOutcome: vi.fn().mockResolvedValue({ success: true, message: 'updated' }),
+    loadCheckpoint: vi.fn().mockResolvedValue({ success: true }),
+    ingestMemory: vi.fn().mockResolvedValue({ success: true, id: 'ingested_1' }),
   };
 }
 
-function createAgentContext(): AgentContext {
+function createAgentContext(allowedPaths: string[]): AgentContext {
   return {
     source: 'telegram',
     platform: 'telegram',
@@ -85,6 +38,7 @@ function createAgentContext(): AgentContext {
       allowedTools: ['*'],
       systemControl: false,
       sensitiveAccess: false,
+      allowedPaths,
     },
     session: {
       sessionId: 'telegram:session',
@@ -99,7 +53,7 @@ function createAgentContext(): AgentContext {
   };
 }
 
-function createExecutionOptions() {
+function createExecutionOptions(tempDir: string) {
   const envelope = makeSignedEnvelope({
     agent_id: 'chat_bot',
     source: 'telegram',
@@ -108,142 +62,163 @@ function createExecutionOptions() {
   return {
     source: 'telegram',
     channelId: 'tg:1',
-    agentContext: createAgentContext(),
+    agentContext: createAgentContext([join(tempDir, '**')]),
     envelope,
     cliSessionId: 'cli-session-1',
     resumeSession: true,
   };
 }
 
-describe('AgentLoop internal tool context propagation', () => {
+function flushBackgroundWork(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 120));
+}
+
+describe('Story M1R: AgentLoop internal tool context propagation', () => {
+  let tempDir: string;
+  let previousHome: string | undefined;
+  let promptSpy: ReturnType<typeof vi.spyOn>;
+  let executeSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
-    vi.clearAllMocks();
-    updateTokensMock.mockReturnValue({ totalTokens: 10, nearThreshold: false });
-    preCompactProcessMock.mockResolvedValue({
-      unsavedDecisions: [],
-      compactionPrompt: '',
-      warningMessage: '',
+    previousHome = process.env.HOME;
+    tempDir = mkdtempSync(join(tmpdir(), 'mama-agent-loop-context-'));
+    process.env.HOME = tempDir;
+    promptSpy = vi.spyOn(PersistentCLIAdapter.prototype, 'prompt');
+    executeSpy = vi.spyOn(GatewayToolExecutor.prototype, 'execute');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('AC: model and post-tool paths carry the correct surface', () => {
+    it('passes active execution context through real GatewayToolExecutor and PostToolHandler', async () => {
+      const writePath = join(tempDir, 'api.ts');
+      promptSpy
+        .mockResolvedValueOnce({
+          response:
+            '```tool_call\n' +
+            JSON.stringify({
+              name: 'Write',
+              input: {
+                path: writePath,
+                content: 'export function test(id: string): string { return id; }',
+              },
+            }) +
+            '\n```',
+          usage: { input_tokens: 10, output_tokens: 5 },
+        })
+        .mockResolvedValueOnce({
+          response: 'Done',
+          usage: { input_tokens: 3, output_tokens: 2 },
+        });
+      const options = createExecutionOptions(tempDir);
+      const agentLoop = new AgentLoop(
+        createMockOAuthManager(),
+        { postToolUse: { enabled: true } },
+        {},
+        { mamaApi: createMockApi(), envelopeIssuanceMode: 'enabled' }
+      );
+
+      await agentLoop.run('write a file', options);
+      await flushBackgroundWork();
+
+      const calls = executeSpy.mock.calls as Array<
+        [string, GatewayToolInput, { executionSurface?: string; envelope?: unknown } | undefined]
+      >;
+      const writeCall = calls.find((call) => call[0] === 'Write');
+      expect(writeCall?.[2]).toEqual(
+        expect.objectContaining({
+          agentContext: options.agentContext,
+          source: 'telegram',
+          channelId: 'tg:1',
+          envelope: options.envelope,
+          executionSurface: 'model_tool',
+        })
+      );
+
+      const reactiveCalls = calls.filter((call) => call[0] === 'mama_search');
+      expect(reactiveCalls.length).toBeGreaterThan(0);
+      expect(reactiveCalls[0][2]).toEqual(
+        expect.objectContaining({
+          agentContext: options.agentContext,
+          source: 'telegram',
+          channelId: 'tg:1',
+          envelope: options.envelope,
+          executionSurface: 'reactive_internal',
+        })
+      );
     });
-    gatewayExecuteMock.mockResolvedValue({ success: true, results: [], count: 0 });
   });
 
-  it('passes active execution context to PostToolHandler background work', async () => {
-    persistentPromptMock
-      .mockResolvedValueOnce({
-        response:
-          '```tool_call\n{"name":"Write","input":{"path":"src/api.ts","content":"export function test() {}"}}\n```',
-        usage: { input_tokens: 10, output_tokens: 5 },
-      })
-      .mockResolvedValueOnce({
+  describe('AC: pre-compact path carries the reactive internal surface', () => {
+    it('passes active execution context to PreCompactHandler when compaction check runs', async () => {
+      promptSpy.mockResolvedValueOnce({
         response: 'Done',
-        usage: { input_tokens: 3, output_tokens: 2 },
+        usage: { input_tokens: 200_000, output_tokens: 5 },
       });
-    const options = createExecutionOptions();
-    const agentLoop = new AgentLoop(
-      createMockOAuthManager(),
-      { postToolUse: { enabled: true } },
-      {},
-      { mamaApi: createMockApi() }
-    );
+      const options = createExecutionOptions(tempDir);
+      delete options.cliSessionId;
+      delete options.resumeSession;
+      const agentLoop = new AgentLoop(
+        createMockOAuthManager(),
+        { preCompact: { enabled: true } },
+        {},
+        { mamaApi: createMockApi(), envelopeIssuanceMode: 'enabled' }
+      );
 
-    await agentLoop.run('write a file', options);
+      await agentLoop.run('decided: use JWT tokens', options);
 
-    const contractSearchCall = gatewayExecuteMock.mock.calls.find(
-      (call) => call[0] === 'mama_search'
-    );
-    expect(contractSearchCall?.[2]).toEqual(
-      expect.objectContaining({
-        agentContext: options.agentContext,
-        source: 'telegram',
-        channelId: 'tg:1',
-        envelope: options.envelope,
-        executionSurface: 'reactive_internal',
-      })
-    );
-
-    const writeCall = gatewayExecuteMock.mock.calls.find((call) => call[0] === 'Write');
-    expect(writeCall?.[2]).toEqual(
-      expect.objectContaining({
-        agentContext: options.agentContext,
-        source: 'telegram',
-        channelId: 'tg:1',
-        envelope: options.envelope,
-        executionSurface: 'model_tool',
-      })
-    );
-
-    expect(postProcessInBackgroundMock).toHaveBeenCalledWith(
-      'Write',
-      { path: 'src/api.ts', content: 'export function test() {}' },
-      expect.anything(),
-      expect.objectContaining({
-        agentContext: options.agentContext,
-        source: 'telegram',
-        channelId: 'tg:1',
-        envelope: options.envelope,
-        executionSurface: 'reactive_internal',
-      })
-    );
-  });
-
-  it('passes active execution context to PreCompactHandler when compaction check runs', async () => {
-    updateTokensMock.mockReturnValue({ totalTokens: 9000, nearThreshold: true });
-    persistentPromptMock.mockResolvedValueOnce({
-      response: 'Done',
-      usage: { input_tokens: 10, output_tokens: 5 },
+      const searchCall = executeSpy.mock.calls.find((call) => call[0] === 'mama_search');
+      expect(searchCall?.[2]).toEqual(
+        expect.objectContaining({
+          agentContext: options.agentContext,
+          source: 'telegram',
+          channelId: 'tg:1',
+          envelope: options.envelope,
+          executionSurface: 'reactive_internal',
+        })
+      );
     });
-    const options = createExecutionOptions();
-    const agentLoop = new AgentLoop(
-      createMockOAuthManager(),
-      { preCompact: { enabled: true } },
-      {},
-      { mamaApi: createMockApi() }
-    );
-
-    await agentLoop.run('near threshold', options);
-
-    expect(preCompactProcessMock).toHaveBeenCalledWith(
-      ['near threshold'],
-      expect.objectContaining({
-        agentContext: options.agentContext,
-        source: 'telegram',
-        channelId: 'tg:1',
-        envelope: options.envelope,
-        executionSurface: 'reactive_internal',
-      })
-    );
   });
 
-  it('passes active execution context through Code-Act HostBridge tool calls', async () => {
-    persistentPromptMock
-      .mockResolvedValueOnce({
-        response: '```js\nmama_search({ query: "contracts" })\n```',
-        usage: { input_tokens: 10, output_tokens: 5 },
-      })
-      .mockResolvedValueOnce({
-        response: 'Done',
-        usage: { input_tokens: 3, output_tokens: 2 },
-      });
-    const options = createExecutionOptions();
-    const agentLoop = new AgentLoop(
-      createMockOAuthManager(),
-      { useCodeAct: true },
-      {},
-      { mamaApi: createMockApi() }
-    );
+  describe('AC: Code-Act host bridge carries the code_act surface', () => {
+    it('passes active execution context through Code-Act HostBridge tool calls', async () => {
+      promptSpy
+        .mockResolvedValueOnce({
+          response: '```js\nmama_search({ query: "contracts" })\n```',
+          usage: { input_tokens: 10, output_tokens: 5 },
+        })
+        .mockResolvedValueOnce({
+          response: 'Done',
+          usage: { input_tokens: 3, output_tokens: 2 },
+        });
+      const options = createExecutionOptions(tempDir);
+      const agentLoop = new AgentLoop(
+        createMockOAuthManager(),
+        { useCodeAct: true },
+        {},
+        { mamaApi: createMockApi(), envelopeIssuanceMode: 'enabled' }
+      );
 
-    await agentLoop.run('use code act', options);
+      await agentLoop.run('use code act', options);
 
-    expect(gatewayExecuteMock).toHaveBeenCalledWith(
-      'mama_search',
-      { query: 'contracts' },
-      expect.objectContaining({
-        agentContext: options.agentContext,
-        source: 'telegram',
-        channelId: 'tg:1',
-        envelope: options.envelope,
-        executionSurface: 'code_act',
-      })
-    );
+      const codeActCall = executeSpy.mock.calls.find((call) => call[0] === 'mama_search');
+      expect(codeActCall?.[2]).toEqual(
+        expect.objectContaining({
+          agentContext: options.agentContext,
+          source: 'telegram',
+          channelId: 'tg:1',
+          envelope: options.envelope,
+          executionSurface: 'code_act',
+        })
+      );
+    });
   });
 });

--- a/packages/standalone/tests/envelope/agent-loop-internal-tool-context.test.ts
+++ b/packages/standalone/tests/envelope/agent-loop-internal-tool-context.test.ts
@@ -1,0 +1,249 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentLoop } from '../../src/agent/agent-loop.js';
+import type { AgentContext, MAMAApiInterface } from '../../src/agent/types.js';
+import type { OAuthManager } from '../../src/auth/index.js';
+import { makeSignedEnvelope } from './fixtures.js';
+
+const {
+  persistentPromptMock,
+  gatewayExecuteMock,
+  postProcessInBackgroundMock,
+  preCompactProcessMock,
+  updateTokensMock,
+} = vi.hoisted(() => ({
+  persistentPromptMock: vi.fn(),
+  gatewayExecuteMock: vi.fn(),
+  postProcessInBackgroundMock: vi.fn(),
+  preCompactProcessMock: vi.fn(),
+  updateTokensMock: vi.fn(),
+}));
+
+vi.mock('../../src/agent/persistent-cli-adapter.js', () => ({
+  PersistentCLIAdapter: vi.fn().mockImplementation(() => ({
+    prompt: persistentPromptMock,
+    setSessionId: vi.fn(),
+    close: vi.fn(),
+  })),
+}));
+
+vi.mock('../../src/agent/session-pool.js', () => ({
+  SessionPool: vi.fn().mockImplementation(() => ({
+    getSession: vi.fn().mockReturnValue({ sessionId: 'test-session', isNew: true }),
+    getSessionId: vi.fn().mockReturnValue('test-session'),
+    updateTokens: updateTokensMock,
+    releaseSession: vi.fn(),
+  })),
+  getSessionPool: vi.fn().mockReturnValue({
+    getSession: vi.fn().mockReturnValue({ sessionId: 'test-session', isNew: true }),
+    getSessionId: vi.fn().mockReturnValue('test-session'),
+    updateTokens: updateTokensMock,
+    releaseSession: vi.fn(),
+  }),
+  buildChannelKey: vi.fn((source: string, channelId: string) => `${source}:${channelId}`),
+}));
+
+vi.mock('../../src/agent/gateway-tool-executor.js', () => ({
+  GatewayToolExecutor: vi.fn().mockImplementation(() => ({
+    setAgentContext: vi.fn(),
+    execute: gatewayExecuteMock,
+  })),
+}));
+
+vi.mock('../../src/agent/post-tool-handler.js', () => ({
+  PostToolHandler: vi.fn().mockImplementation(() => ({
+    processInBackground: postProcessInBackgroundMock,
+  })),
+}));
+
+vi.mock('../../src/agent/pre-compact-handler.js', () => ({
+  PreCompactHandler: vi.fn().mockImplementation(() => ({
+    process: preCompactProcessMock,
+  })),
+}));
+
+function createMockOAuthManager(): OAuthManager {
+  return { getToken: vi.fn().mockResolvedValue('token') } as unknown as OAuthManager;
+}
+
+function createMockApi(): MAMAApiInterface {
+  return {
+    save: vi.fn(),
+    saveCheckpoint: vi.fn(),
+    listDecisions: vi.fn(),
+    suggest: vi.fn(),
+    updateOutcome: vi.fn(),
+    loadCheckpoint: vi.fn(),
+  };
+}
+
+function createAgentContext(): AgentContext {
+  return {
+    source: 'telegram',
+    platform: 'telegram',
+    roleName: 'chat_bot',
+    role: {
+      allowedTools: ['*'],
+      systemControl: false,
+      sensitiveAccess: false,
+    },
+    session: {
+      sessionId: 'telegram:session',
+      channelId: 'tg:1',
+      userId: 'user-1',
+      startedAt: new Date(),
+    },
+    capabilities: ['*'],
+    limitations: [],
+    tier: 2,
+    backend: 'claude',
+  };
+}
+
+function createExecutionOptions() {
+  const envelope = makeSignedEnvelope({
+    agent_id: 'chat_bot',
+    source: 'telegram',
+    channel_id: 'tg:1',
+  });
+  return {
+    source: 'telegram',
+    channelId: 'tg:1',
+    agentContext: createAgentContext(),
+    envelope,
+    cliSessionId: 'cli-session-1',
+    resumeSession: true,
+  };
+}
+
+describe('AgentLoop internal tool context propagation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateTokensMock.mockReturnValue({ totalTokens: 10, nearThreshold: false });
+    preCompactProcessMock.mockResolvedValue({
+      unsavedDecisions: [],
+      compactionPrompt: '',
+      warningMessage: '',
+    });
+    gatewayExecuteMock.mockResolvedValue({ success: true, results: [], count: 0 });
+  });
+
+  it('passes active execution context to PostToolHandler background work', async () => {
+    persistentPromptMock
+      .mockResolvedValueOnce({
+        response:
+          '```tool_call\n{"name":"Write","input":{"path":"src/api.ts","content":"export function test() {}"}}\n```',
+        usage: { input_tokens: 10, output_tokens: 5 },
+      })
+      .mockResolvedValueOnce({
+        response: 'Done',
+        usage: { input_tokens: 3, output_tokens: 2 },
+      });
+    const options = createExecutionOptions();
+    const agentLoop = new AgentLoop(
+      createMockOAuthManager(),
+      { postToolUse: { enabled: true } },
+      {},
+      { mamaApi: createMockApi() }
+    );
+
+    await agentLoop.run('write a file', options);
+
+    const contractSearchCall = gatewayExecuteMock.mock.calls.find(
+      (call) => call[0] === 'mama_search'
+    );
+    expect(contractSearchCall?.[2]).toEqual(
+      expect.objectContaining({
+        agentContext: options.agentContext,
+        source: 'telegram',
+        channelId: 'tg:1',
+        envelope: options.envelope,
+        executionSurface: 'reactive_internal',
+      })
+    );
+
+    const writeCall = gatewayExecuteMock.mock.calls.find((call) => call[0] === 'Write');
+    expect(writeCall?.[2]).toEqual(
+      expect.objectContaining({
+        agentContext: options.agentContext,
+        source: 'telegram',
+        channelId: 'tg:1',
+        envelope: options.envelope,
+        executionSurface: 'model_tool',
+      })
+    );
+
+    expect(postProcessInBackgroundMock).toHaveBeenCalledWith(
+      'Write',
+      { path: 'src/api.ts', content: 'export function test() {}' },
+      expect.anything(),
+      expect.objectContaining({
+        agentContext: options.agentContext,
+        source: 'telegram',
+        channelId: 'tg:1',
+        envelope: options.envelope,
+        executionSurface: 'reactive_internal',
+      })
+    );
+  });
+
+  it('passes active execution context to PreCompactHandler when compaction check runs', async () => {
+    updateTokensMock.mockReturnValue({ totalTokens: 9000, nearThreshold: true });
+    persistentPromptMock.mockResolvedValueOnce({
+      response: 'Done',
+      usage: { input_tokens: 10, output_tokens: 5 },
+    });
+    const options = createExecutionOptions();
+    const agentLoop = new AgentLoop(
+      createMockOAuthManager(),
+      { preCompact: { enabled: true } },
+      {},
+      { mamaApi: createMockApi() }
+    );
+
+    await agentLoop.run('near threshold', options);
+
+    expect(preCompactProcessMock).toHaveBeenCalledWith(
+      ['near threshold'],
+      expect.objectContaining({
+        agentContext: options.agentContext,
+        source: 'telegram',
+        channelId: 'tg:1',
+        envelope: options.envelope,
+        executionSurface: 'reactive_internal',
+      })
+    );
+  });
+
+  it('passes active execution context through Code-Act HostBridge tool calls', async () => {
+    persistentPromptMock
+      .mockResolvedValueOnce({
+        response: '```js\nmama_search({ query: "contracts" })\n```',
+        usage: { input_tokens: 10, output_tokens: 5 },
+      })
+      .mockResolvedValueOnce({
+        response: 'Done',
+        usage: { input_tokens: 3, output_tokens: 2 },
+      });
+    const options = createExecutionOptions();
+    const agentLoop = new AgentLoop(
+      createMockOAuthManager(),
+      { useCodeAct: true },
+      {},
+      { mamaApi: createMockApi() }
+    );
+
+    await agentLoop.run('use code act', options);
+
+    expect(gatewayExecuteMock).toHaveBeenCalledWith(
+      'mama_search',
+      { query: 'contracts' },
+      expect.objectContaining({
+        agentContext: options.agentContext,
+        source: 'telegram',
+        channelId: 'tg:1',
+        envelope: options.envelope,
+        executionSurface: 'code_act',
+      })
+    );
+  });
+});

--- a/packages/standalone/tests/envelope/code-act-context.test.ts
+++ b/packages/standalone/tests/envelope/code-act-context.test.ts
@@ -1,0 +1,45 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { HostBridge } from '../../src/agent/code-act/host-bridge.js';
+import { CodeActSandbox } from '../../src/agent/code-act/sandbox.js';
+import type { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
+import type { GatewayToolExecutionContext } from '../../src/agent/types.js';
+
+function makeExecutor(overrides?: Partial<GatewayToolExecutor>): GatewayToolExecutor {
+  return {
+    execute: vi.fn().mockResolvedValue({ success: true }),
+    ...overrides,
+  } as unknown as GatewayToolExecutor;
+}
+
+describe('Code-Act envelope context propagation', () => {
+  beforeAll(async () => {
+    await CodeActSandbox.warmup();
+  });
+
+  it('forwards the active envelope context to host bridge gateway calls', async () => {
+    const executeFn = vi.fn().mockResolvedValue({
+      success: true,
+      results: [],
+      count: 0,
+    });
+    const executionContext = {
+      agentId: 'chat_bot',
+      source: 'telegram',
+      channelId: 'tg:1',
+      envelope: { envelope_hash: 'envhash_code_act' },
+      executionSurface: 'code_act',
+    } as unknown as GatewayToolExecutionContext;
+    const bridge = new HostBridge(
+      makeExecutor({ execute: executeFn }),
+      undefined,
+      executionContext
+    );
+    const sandbox = new CodeActSandbox();
+    bridge.injectInto(sandbox, 1);
+
+    const result = await sandbox.execute('mama_search({ query: "contracts" })');
+
+    expect(result.success).toBe(true);
+    expect(executeFn).toHaveBeenCalledWith('mama_search', { query: 'contracts' }, executionContext);
+  });
+});

--- a/packages/standalone/tests/envelope/code-act-context.test.ts
+++ b/packages/standalone/tests/envelope/code-act-context.test.ts
@@ -3,6 +3,7 @@ import { HostBridge } from '../../src/agent/code-act/host-bridge.js';
 import { CodeActSandbox } from '../../src/agent/code-act/sandbox.js';
 import type { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
 import type { GatewayToolExecutionContext } from '../../src/agent/types.js';
+import { makeSignedEnvelope } from './fixtures.js';
 
 function makeExecutor(overrides?: Partial<GatewayToolExecutor>): GatewayToolExecutor {
   return {
@@ -11,35 +12,44 @@ function makeExecutor(overrides?: Partial<GatewayToolExecutor>): GatewayToolExec
   } as unknown as GatewayToolExecutor;
 }
 
-describe('Code-Act envelope context propagation', () => {
+describe('Story M1R: Code-Act envelope context propagation', () => {
   beforeAll(async () => {
     await CodeActSandbox.warmup();
   });
 
-  it('forwards the active envelope context to host bridge gateway calls', async () => {
-    const executeFn = vi.fn().mockResolvedValue({
-      success: true,
-      results: [],
-      count: 0,
+  describe('AC: forwards the active envelope context to host bridge gateway calls', () => {
+    it('forwards the active envelope context to host bridge gateway calls', async () => {
+      const executeFn = vi.fn().mockResolvedValue({
+        success: true,
+        results: [],
+        count: 0,
+      });
+      const executionContext: GatewayToolExecutionContext = {
+        agentId: 'chat_bot',
+        source: 'telegram',
+        channelId: 'tg:1',
+        envelope: makeSignedEnvelope({
+          source: 'telegram',
+          channel_id: 'tg:1',
+        }),
+        executionSurface: 'code_act',
+      };
+      const bridge = new HostBridge(
+        makeExecutor({ execute: executeFn }),
+        undefined,
+        executionContext
+      );
+      const sandbox = new CodeActSandbox();
+      bridge.injectInto(sandbox, 1);
+
+      const result = await sandbox.execute('mama_search({ query: "contracts" })');
+
+      expect(result.success).toBe(true);
+      expect(executeFn).toHaveBeenCalledWith(
+        'mama_search',
+        { query: 'contracts' },
+        executionContext
+      );
     });
-    const executionContext = {
-      agentId: 'chat_bot',
-      source: 'telegram',
-      channelId: 'tg:1',
-      envelope: { envelope_hash: 'envhash_code_act' },
-      executionSurface: 'code_act',
-    } as unknown as GatewayToolExecutionContext;
-    const bridge = new HostBridge(
-      makeExecutor({ execute: executeFn }),
-      undefined,
-      executionContext
-    );
-    const sandbox = new CodeActSandbox();
-    bridge.injectInto(sandbox, 1);
-
-    const result = await sandbox.execute('mama_search({ query: "contracts" })');
-
-    expect(result.success).toBe(true);
-    expect(executeFn).toHaveBeenCalledWith('mama_search', { query: 'contracts' }, executionContext);
   });
 });

--- a/packages/standalone/tests/envelope/executor-audit.test.ts
+++ b/packages/standalone/tests/envelope/executor-audit.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from 'vitest';
+import { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
+import { AgentError, type GatewayToolInput, type MAMAApiInterface } from '../../src/agent/types.js';
+import Database from '../../src/sqlite.js';
+import { initAgentTables } from '../../src/db/agent-store.js';
+import { makeSignedEnvelope } from './fixtures.js';
+
+type GatewayAuditRow = {
+  type: string;
+  input_summary: string | null;
+  execution_status: string | null;
+  error_message: string | null;
+  envelope_hash: string | null;
+};
+
+function createMAMAApi(): MAMAApiInterface {
+  return {
+    save: vi.fn().mockResolvedValue({ success: true, id: 'decision_1', type: 'decision' }),
+    saveCheckpoint: vi.fn().mockResolvedValue({
+      success: true,
+      id: 'checkpoint_1',
+      type: 'checkpoint',
+    }),
+    listDecisions: vi.fn().mockResolvedValue([]),
+    suggest: vi.fn().mockResolvedValue({ success: true, results: [], count: 0 }),
+    updateOutcome: vi.fn().mockResolvedValue({ success: true, message: 'updated' }),
+    loadCheckpoint: vi.fn().mockResolvedValue({ success: true }),
+    recallMemory: vi.fn().mockResolvedValue({
+      profile: { static: [], dynamic: [], evidence: [] },
+      memories: [],
+      graph_context: { primary: [], expanded: [], edges: [] },
+      search_meta: { query: 'test', scope_order: [], retrieval_sources: [] },
+    }),
+    ingestMemory: vi.fn().mockResolvedValue({ success: true, id: 'ingested_1' }),
+  };
+}
+
+function createTelegramGateway() {
+  return {
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    sendFile: vi.fn().mockResolvedValue(undefined),
+    sendImage: vi.fn().mockResolvedValue(undefined),
+    sendSticker: vi.fn().mockResolvedValue(true),
+  };
+}
+
+function readGatewayToolRows(db: Database): GatewayAuditRow[] {
+  return db
+    .prepare(
+      `SELECT type, input_summary, execution_status, error_message, envelope_hash
+       FROM agent_activity
+       WHERE type = 'gateway_tool_call'
+       ORDER BY id ASC`
+    )
+    .all() as GatewayAuditRow[];
+}
+
+describe('Story M1R: gateway tool execution audit ledger', () => {
+  it('records successful gateway calls with envelope hash and completed status', async () => {
+    const db = new Database(':memory:');
+    initAgentTables(db);
+    const executor = new GatewayToolExecutor({ mamaApi: createMAMAApi() });
+    executor.setSessionsDb(db);
+    const envelope = makeSignedEnvelope({
+      source: 'telegram',
+      channel_id: 'abc',
+      scope: {
+        project_refs: [{ kind: 'project', id: '/workspace/project-a' }],
+        raw_connectors: ['telegram'],
+        memory_scopes: [{ kind: 'channel', id: 'telegram:abc' }],
+        allowed_destinations: [{ kind: 'telegram', id: 'abc' }],
+      },
+    });
+
+    const result = await executor.execute(
+      'mama_search',
+      { query: 'audit' },
+      { agentId: 'chat_bot', source: 'telegram', channelId: 'abc', envelope }
+    );
+
+    expect(result).toMatchObject({ success: true });
+    expect(readGatewayToolRows(db)).toEqual([
+      expect.objectContaining({
+        input_summary: 'mama_search',
+        execution_status: 'completed',
+        envelope_hash: envelope.envelope_hash,
+      }),
+    ]);
+    db.close();
+  });
+
+  it('records a generic gateway call row when envelope destination enforcement denies a tool', async () => {
+    const db = new Database(':memory:');
+    initAgentTables(db);
+    const telegramGateway = createTelegramGateway();
+    const executor = new GatewayToolExecutor({ mamaApi: createMAMAApi() });
+    executor.setTelegramGateway(telegramGateway);
+    executor.setSessionsDb(db);
+    const envelope = makeSignedEnvelope({
+      source: 'telegram',
+      channel_id: 'own',
+      scope: {
+        project_refs: [{ kind: 'project', id: '/workspace/project-a' }],
+        raw_connectors: ['telegram'],
+        memory_scopes: [{ kind: 'channel', id: 'telegram:own' }],
+        allowed_destinations: [{ kind: 'telegram', id: 'own' }],
+      },
+    });
+
+    const result = await executor.execute(
+      'telegram_send',
+      { chat_id: 'other', message: 'outside' } as unknown as GatewayToolInput,
+      { agentId: 'chat_bot', source: 'telegram', channelId: 'own', envelope }
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      code: 'destination_out_of_scope',
+      envelope_hash: envelope.envelope_hash,
+    });
+    expect(telegramGateway.sendMessage).not.toHaveBeenCalled();
+    expect(readGatewayToolRows(db)).toEqual([
+      expect.objectContaining({
+        input_summary: 'telegram_send',
+        execution_status: 'failed',
+        envelope_hash: envelope.envelope_hash,
+      }),
+    ]);
+    db.close();
+  });
+
+  it('records failed gateway calls while preserving the original AgentError contract', async () => {
+    const db = new Database(':memory:');
+    initAgentTables(db);
+    const executor = new GatewayToolExecutor({ mamaApi: createMAMAApi() });
+    executor.setSessionsDb(db);
+    const envelope = makeSignedEnvelope({
+      source: 'telegram',
+      channel_id: 'abc',
+      scope: {
+        project_refs: [{ kind: 'project', id: '/workspace/project-a' }],
+        raw_connectors: ['telegram'],
+        memory_scopes: [{ kind: 'channel', id: 'telegram:abc' }],
+        allowed_destinations: [{ kind: 'dashboard_slot', id: 'daily' }],
+      },
+    });
+
+    await expect(
+      executor.execute('report_publish', {} as unknown as GatewayToolInput, {
+        agentId: 'dashboard',
+        source: 'telegram',
+        channelId: 'abc',
+        envelope,
+      })
+    ).rejects.toMatchObject({
+      code: 'TOOL_ERROR',
+      retryable: false,
+    } satisfies Partial<AgentError>);
+
+    expect(readGatewayToolRows(db)).toEqual([
+      expect.objectContaining({
+        input_summary: 'report_publish',
+        execution_status: 'failed',
+        envelope_hash: envelope.envelope_hash,
+        error_message: expect.stringContaining('report_publish requires slots object'),
+      }),
+    ]);
+    db.close();
+  });
+});

--- a/packages/standalone/tests/envelope/executor-integration.test.ts
+++ b/packages/standalone/tests/envelope/executor-integration.test.ts
@@ -69,6 +69,7 @@ describe('gateway-tool-executor envelope integration', () => {
         agentId: 'worker',
         source: 'telegram',
         channelId: 'tg:1',
+        executionSurface: 'model_tool',
       }
     );
 
@@ -78,6 +79,16 @@ describe('gateway-tool-executor envelope integration', () => {
     });
     expect(result.error).toContain('without envelope');
     expect(mamaApi.loadCheckpoint).not.toHaveBeenCalled();
+  });
+
+  it('allows non-reactive direct calls without an envelope context', async () => {
+    const mamaApi = makeMAMAApi();
+    const executor = new GatewayToolExecutor({ mamaApi });
+
+    const result = await executor.execute('mama_load_checkpoint', {});
+
+    expect(result).toEqual({ success: true });
+    expect(mamaApi.loadCheckpoint).toHaveBeenCalledOnce();
   });
 
   it('allows missing-envelope execution only when the legacy bypass is explicit', async () => {
@@ -92,6 +103,7 @@ describe('gateway-tool-executor envelope integration', () => {
         agentId: 'worker',
         source: 'telegram',
         channelId: 'tg:1',
+        executionSurface: 'model_tool',
       }
     );
 
@@ -99,13 +111,15 @@ describe('gateway-tool-executor envelope integration', () => {
     expect(mamaApi.loadCheckpoint).toHaveBeenCalledOnce();
   });
 
-  it('fails loud when any gateway tool call has no envelope', async () => {
+  it('keeps fail-loud scoped to reactive execution surfaces', async () => {
     process.env.MAMA_ENVELOPE_FAIL_LOUD = 'true';
     const mamaApi = makeMAMAApi();
     const executor = new GatewayToolExecutor({ mamaApi });
 
-    await expect(executor.execute('mama_load_checkpoint', {})).rejects.toThrow(/without envelope/);
-    expect(mamaApi.loadCheckpoint).not.toHaveBeenCalled();
+    const result = await executor.execute('mama_load_checkpoint', {});
+
+    expect(result).toEqual({ success: true });
+    expect(mamaApi.loadCheckpoint).toHaveBeenCalledOnce();
   });
 
   it('fails loud when an explicit gateway context has no envelope', async () => {
@@ -121,6 +135,7 @@ describe('gateway-tool-executor envelope integration', () => {
           agentId: 'worker',
           source: 'telegram',
           channelId: 'tg:1',
+          executionSurface: 'model_tool',
         }
       )
     ).rejects.toThrow(/without envelope/);
@@ -132,7 +147,18 @@ describe('gateway-tool-executor envelope integration', () => {
     const mamaApi = makeMAMAApi();
     const executor = new GatewayToolExecutor({ mamaApi });
 
-    await expect(executor.execute('mama_load_checkpoint', {})).rejects.toThrow(/without envelope/);
+    await expect(
+      executor.execute(
+        'mama_load_checkpoint',
+        {},
+        {
+          agentId: 'worker',
+          source: 'telegram',
+          channelId: 'tg:1',
+          executionSurface: 'model_tool',
+        }
+      )
+    ).rejects.toThrow(/without envelope/);
     expect(mamaApi.loadCheckpoint).not.toHaveBeenCalled();
   });
 
@@ -155,7 +181,13 @@ describe('gateway-tool-executor envelope integration', () => {
     const result = await executor.execute(
       'telegram_send',
       { chat_id: 'tg:OTHER_PROJECT', message: 'leak' } as GatewayToolInput,
-      { agentId: 'worker', source: 'telegram', channelId: 'tg:OWN', envelope }
+      {
+        agentId: 'worker',
+        source: 'telegram',
+        channelId: 'tg:OWN',
+        envelope,
+        executionSurface: 'model_tool',
+      }
     );
 
     expect(result).toMatchObject({
@@ -185,7 +217,13 @@ describe('gateway-tool-executor envelope integration', () => {
     const result = await executor.execute(
       'telegram_send',
       { chat_id: 'tg:OWN', message: 'safe' } as GatewayToolInput,
-      { agentId: 'worker', source: 'telegram', channelId: 'tg:OWN', envelope }
+      {
+        agentId: 'worker',
+        source: 'telegram',
+        channelId: 'tg:OWN',
+        envelope,
+        executionSurface: 'model_tool',
+      }
     );
 
     expect(result).toMatchObject({ success: true });
@@ -208,7 +246,13 @@ describe('gateway-tool-executor envelope integration', () => {
         decision: 'Use explicit envelope enforcement',
         reasoning: 'Tier 3 must stay read-only',
       } as GatewayToolInput,
-      { agentId: 'worker', source: 'telegram', channelId: 'tg:1', envelope }
+      {
+        agentId: 'worker',
+        source: 'telegram',
+        channelId: 'tg:1',
+        envelope,
+        executionSurface: 'model_tool',
+      }
     );
 
     expect(result).toMatchObject({

--- a/packages/standalone/tests/envelope/executor-integration.test.ts
+++ b/packages/standalone/tests/envelope/executor-integration.test.ts
@@ -60,7 +60,7 @@ describe('gateway-tool-executor envelope integration', () => {
 
   it('denies gateway tool calls without an envelope by default', async () => {
     const mamaApi = makeMAMAApi();
-    const executor = new GatewayToolExecutor({ mamaApi });
+    const executor = new GatewayToolExecutor({ mamaApi, envelopeIssuanceMode: 'enabled' });
 
     const result = await executor.execute(
       'mama_load_checkpoint',
@@ -81,11 +81,33 @@ describe('gateway-tool-executor envelope integration', () => {
     expect(mamaApi.loadCheckpoint).not.toHaveBeenCalled();
   });
 
-  it('allows non-reactive direct calls without an envelope context', async () => {
+  it('denies missing execution context when issuance is enabled', async () => {
     const mamaApi = makeMAMAApi();
-    const executor = new GatewayToolExecutor({ mamaApi });
+    const executor = new GatewayToolExecutor({ mamaApi, envelopeIssuanceMode: 'enabled' });
 
     const result = await executor.execute('mama_load_checkpoint', {});
+
+    expect(result).toMatchObject({
+      success: false,
+      code: 'envelope_missing',
+    });
+    expect(mamaApi.loadCheckpoint).not.toHaveBeenCalled();
+  });
+
+  it('allows explicit non-reactive direct calls without an envelope', async () => {
+    const mamaApi = makeMAMAApi();
+    const executor = new GatewayToolExecutor({ mamaApi, envelopeIssuanceMode: 'enabled' });
+
+    const result = await executor.execute(
+      'mama_load_checkpoint',
+      {},
+      {
+        agentId: 'direct-test',
+        source: 'viewer',
+        channelId: 'direct',
+        executionSurface: 'direct',
+      }
+    );
 
     expect(result).toEqual({ success: true });
     expect(mamaApi.loadCheckpoint).toHaveBeenCalledOnce();
@@ -93,7 +115,7 @@ describe('gateway-tool-executor envelope integration', () => {
 
   it('denies explicit execution contexts that omit executionSurface', async () => {
     const mamaApi = makeMAMAApi();
-    const executor = new GatewayToolExecutor({ mamaApi });
+    const executor = new GatewayToolExecutor({ mamaApi, envelopeIssuanceMode: 'enabled' });
 
     const result = await executor.execute('mama_load_checkpoint', {}, {
       agentId: 'worker',
@@ -111,7 +133,7 @@ describe('gateway-tool-executor envelope integration', () => {
   it('allows missing-envelope execution only when the legacy bypass is explicit', async () => {
     process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS = 'true';
     const mamaApi = makeMAMAApi();
-    const executor = new GatewayToolExecutor({ mamaApi });
+    const executor = new GatewayToolExecutor({ mamaApi, envelopeIssuanceMode: 'enabled' });
 
     const result = await executor.execute(
       'mama_load_checkpoint',
@@ -131,9 +153,18 @@ describe('gateway-tool-executor envelope integration', () => {
   it('keeps fail-loud scoped to reactive execution surfaces', async () => {
     process.env.MAMA_ENVELOPE_FAIL_LOUD = 'true';
     const mamaApi = makeMAMAApi();
-    const executor = new GatewayToolExecutor({ mamaApi });
+    const executor = new GatewayToolExecutor({ mamaApi, envelopeIssuanceMode: 'enabled' });
 
-    const result = await executor.execute('mama_load_checkpoint', {});
+    const result = await executor.execute(
+      'mama_load_checkpoint',
+      {},
+      {
+        agentId: 'direct-test',
+        source: 'viewer',
+        channelId: 'direct',
+        executionSurface: 'direct',
+      }
+    );
 
     expect(result).toEqual({ success: true });
     expect(mamaApi.loadCheckpoint).toHaveBeenCalledOnce();
@@ -142,7 +173,7 @@ describe('gateway-tool-executor envelope integration', () => {
   it('fails loud when an explicit gateway context has no envelope', async () => {
     process.env.MAMA_ENVELOPE_FAIL_LOUD = 'true';
     const mamaApi = makeMAMAApi();
-    const executor = new GatewayToolExecutor({ mamaApi });
+    const executor = new GatewayToolExecutor({ mamaApi, envelopeIssuanceMode: 'enabled' });
 
     await expect(
       executor.execute(
@@ -162,7 +193,7 @@ describe('gateway-tool-executor envelope integration', () => {
   it('treats common truthy fail-loud env values as enabled', async () => {
     process.env.MAMA_ENVELOPE_FAIL_LOUD = '1';
     const mamaApi = makeMAMAApi();
-    const executor = new GatewayToolExecutor({ mamaApi });
+    const executor = new GatewayToolExecutor({ mamaApi, envelopeIssuanceMode: 'enabled' });
 
     await expect(
       executor.execute(

--- a/packages/standalone/tests/envelope/executor-integration.test.ts
+++ b/packages/standalone/tests/envelope/executor-integration.test.ts
@@ -91,6 +91,23 @@ describe('gateway-tool-executor envelope integration', () => {
     expect(mamaApi.loadCheckpoint).toHaveBeenCalledOnce();
   });
 
+  it('denies explicit execution contexts that omit executionSurface', async () => {
+    const mamaApi = makeMAMAApi();
+    const executor = new GatewayToolExecutor({ mamaApi });
+
+    const result = await executor.execute('mama_load_checkpoint', {}, {
+      agentId: 'worker',
+      source: 'telegram',
+      channelId: 'tg:1',
+    } as Parameters<GatewayToolExecutor['execute']>[2]);
+
+    expect(result).toMatchObject({
+      success: false,
+      code: 'envelope_missing',
+    });
+    expect(mamaApi.loadCheckpoint).not.toHaveBeenCalled();
+  });
+
   it('allows missing-envelope execution only when the legacy bypass is explicit', async () => {
     process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS = 'true';
     const mamaApi = makeMAMAApi();

--- a/packages/standalone/tests/envelope/executor-pipeline.test.ts
+++ b/packages/standalone/tests/envelope/executor-pipeline.test.ts
@@ -131,7 +131,13 @@ describe('Story M1R: GatewayToolExecutor execute pipeline characterization', () 
       const result = await executor.execute(
         'telegram_send',
         { chat_id: 'tg:OWN', message: 'safe' } as GatewayToolInput,
-        { agentId: 'worker', source: 'telegram', channelId: 'tg:OWN', envelope }
+        {
+          agentId: 'worker',
+          source: 'telegram',
+          channelId: 'tg:OWN',
+          envelope,
+          executionSurface: 'model_tool',
+        }
       );
 
       expect(result).toMatchObject({ success: true });
@@ -152,6 +158,7 @@ describe('Story M1R: GatewayToolExecutor execute pipeline characterization', () 
           agentId: 'worker',
           source: 'telegram',
           channelId: 'tg:1',
+          executionSurface: 'model_tool',
         }
       );
 
@@ -193,6 +200,7 @@ describe('Story M1R: GatewayToolExecutor execute pipeline characterization', () 
           agentId: 'worker',
           source: 'telegram',
           channelId: 'tg:1',
+          executionSurface: 'model_tool',
         }
       );
 
@@ -223,7 +231,15 @@ describe('Story M1R: GatewayToolExecutor execute pipeline characterization', () 
       const executor = new GatewayToolExecutor({ mamaApi: makeMAMAApi() });
 
       await expect(
-        executor.execute('unknown_tool', {}, { agentId: 'worker', source: 'telegram' })
+        executor.execute(
+          'unknown_tool',
+          {},
+          {
+            agentId: 'worker',
+            source: 'telegram',
+            executionSurface: 'model_tool',
+          }
+        )
       ).rejects.toMatchObject({
         code: 'UNKNOWN_TOOL',
       } satisfies Partial<AgentError>);
@@ -251,7 +267,13 @@ describe('Story M1R: GatewayToolExecutor execute pipeline characterization', () 
       const result = await executor.execute(
         'telegram_send',
         { chat_id: 'tg:OTHER', message: 'leak' } as GatewayToolInput,
-        { agentId: 'worker', source: 'telegram', channelId: 'tg:OWN', envelope }
+        {
+          agentId: 'worker',
+          source: 'telegram',
+          channelId: 'tg:OWN',
+          envelope,
+          executionSurface: 'model_tool',
+        }
       );
 
       expect(result).toMatchObject({

--- a/packages/standalone/tests/envelope/executor-pipeline.test.ts
+++ b/packages/standalone/tests/envelope/executor-pipeline.test.ts
@@ -157,14 +157,24 @@ describe('Story M1R: GatewayToolExecutor execute pipeline characterization', () 
 
       expect(result).toMatchObject({ success: false, code: 'envelope_missing' });
       expect(mamaApi.loadCheckpoint).not.toHaveBeenCalled();
-      expect(readActivityRows(db)).toEqual([
-        expect.objectContaining({
-          type: 'envelope_missing_denied',
-          input_summary: 'mama_load_checkpoint',
-          execution_status: 'failed',
-          trigger_reason: 'envelope_enforcer',
-        }),
-      ]);
+      const rows = readActivityRows(db);
+      expect(rows).toHaveLength(2);
+      expect(rows).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'envelope_missing_denied',
+            input_summary: 'mama_load_checkpoint',
+            execution_status: 'failed',
+            trigger_reason: 'envelope_enforcer',
+          }),
+          expect.objectContaining({
+            type: 'gateway_tool_call',
+            input_summary: 'mama_load_checkpoint',
+            execution_status: 'failed',
+            trigger_reason: 'gateway_tool_executor',
+          }),
+        ])
+      );
       db.close();
     });
 
@@ -188,14 +198,24 @@ describe('Story M1R: GatewayToolExecutor execute pipeline characterization', () 
 
       expect(result).toEqual({ success: true });
       expect(mamaApi.loadCheckpoint).toHaveBeenCalledOnce();
-      expect(readActivityRows(db)).toEqual([
-        expect.objectContaining({
-          type: 'envelope_missing_legacy',
-          input_summary: 'mama_load_checkpoint',
-          execution_status: 'completed',
-          trigger_reason: 'envelope_enforcer',
-        }),
-      ]);
+      const rows = readActivityRows(db);
+      expect(rows).toHaveLength(2);
+      expect(rows).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'envelope_missing_legacy',
+            input_summary: 'mama_load_checkpoint',
+            execution_status: 'completed',
+            trigger_reason: 'envelope_enforcer',
+          }),
+          expect.objectContaining({
+            type: 'gateway_tool_call',
+            input_summary: 'mama_load_checkpoint',
+            execution_status: 'completed',
+            trigger_reason: 'gateway_tool_executor',
+          }),
+        ])
+      );
       db.close();
     });
 
@@ -240,15 +260,25 @@ describe('Story M1R: GatewayToolExecutor execute pipeline characterization', () 
         envelope_hash: 'envhash_pipeline',
       });
       expect(telegramGateway.sendMessage).not.toHaveBeenCalled();
-      expect(readActivityRows(db)).toEqual([
-        expect.objectContaining({
-          type: 'envelope_violation',
-          input_summary: 'telegram_send',
-          output_summary: 'envelope_hash=envhash_pipeline',
-          execution_status: 'failed',
-          trigger_reason: 'envelope_enforcer',
-        }),
-      ]);
+      const rows = readActivityRows(db);
+      expect(rows).toHaveLength(2);
+      expect(rows).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'envelope_violation',
+            input_summary: 'telegram_send',
+            output_summary: 'envelope_hash=envhash_pipeline',
+            execution_status: 'failed',
+            trigger_reason: 'envelope_enforcer',
+          }),
+          expect.objectContaining({
+            type: 'gateway_tool_call',
+            input_summary: 'telegram_send',
+            execution_status: 'failed',
+            trigger_reason: 'gateway_tool_executor',
+          }),
+        ])
+      );
       db.close();
     });
   });

--- a/packages/standalone/tests/envelope/executor-pipeline.test.ts
+++ b/packages/standalone/tests/envelope/executor-pipeline.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
+import { AgentError, type GatewayToolInput, type MAMAApiInterface } from '../../src/agent/types.js';
+import Database from '../../src/sqlite.js';
+import { initAgentTables } from '../../src/db/agent-store.js';
+import { makeEnvelope } from './fixtures.js';
+
+/*
+ * M1R executor inventory before seam extraction:
+ *
+ * Current execute() phase order:
+ * 1. optional executionContext wrapper through withExecutionContext(...)
+ * 2. VALID_TOOLS unknown-tool rejection
+ * 3. enforceEnvelopeForToolCall(...)
+ * 4. disallowedGatewayTools rejection
+ * 5. checkToolPermission(...)
+ * 6. non-MAMA tool switch
+ * 7. lazy MAMA API initialization
+ * 8. MAMA/report/wiki/kagemusha/notice switch
+ * 9. AgentError passthrough and generic TOOL_ERROR wrapping
+ *
+ * Current execute call-site classification:
+ * - agent/agent-loop.ts model-visible calls: M1R Reactive Main
+ * - agent/agent-loop.ts searchContractsForTool/PostTool/PreCompact callbacks: M1R reactive_internal
+ * - agent/code-act/host-bridge.ts: M1R Reactive Main Code-Act
+ * - multi-agent/multi-agent-base.ts and multi-agent/multi-agent-discord.ts: M7-owned delegated workers
+ * - cli/runtime/agent-loop-init.ts wrapper must preserve full AgentLoopOptions in Task 5B
+ *
+ * codex/provenance-drawer-mainbase overlaps gateway-tool-executor.ts, message-router.ts,
+ * standalone API/viewer modules, and mama-core case/entity migrations. M1R treats it as
+ * reference only and does not import those migrations or UI/API modules.
+ */
+
+function makeMAMAApi(): MAMAApiInterface {
+  return {
+    save: vi.fn().mockResolvedValue({ success: true, id: 'decision_1', type: 'decision' }),
+    saveCheckpoint: vi.fn().mockResolvedValue({
+      success: true,
+      id: 'checkpoint_1',
+      type: 'checkpoint',
+    }),
+    listDecisions: vi.fn().mockResolvedValue([]),
+    suggest: vi.fn().mockResolvedValue({ success: true, results: [], count: 0 }),
+    updateOutcome: vi.fn().mockResolvedValue({ success: true, message: 'updated' }),
+    loadCheckpoint: vi.fn().mockResolvedValue({ success: true }),
+    recallMemory: vi.fn().mockResolvedValue({
+      profile: { static: [], dynamic: [], evidence: [] },
+      memories: [],
+      graph_context: { primary: [], expanded: [], edges: [] },
+      search_meta: { query: 'test', scope_order: [], retrieval_sources: [] },
+    }),
+    ingestMemory: vi.fn().mockResolvedValue({ success: true, id: 'ingested_1' }),
+  };
+}
+
+function makeTelegramGateway() {
+  return {
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    sendFile: vi.fn().mockResolvedValue(undefined),
+    sendImage: vi.fn().mockResolvedValue(undefined),
+    sendSticker: vi.fn().mockResolvedValue(true),
+  };
+}
+
+function readActivityRows(db: Database): Array<{
+  type: string;
+  input_summary: string | null;
+  output_summary: string | null;
+  error_message: string | null;
+  execution_status: string | null;
+  trigger_reason: string | null;
+}> {
+  return db
+    .prepare(
+      `
+      SELECT type, input_summary, output_summary, error_message, execution_status, trigger_reason
+      FROM agent_activity
+      ORDER BY id ASC
+    `
+    )
+    .all() as Array<{
+    type: string;
+    input_summary: string | null;
+    output_summary: string | null;
+    error_message: string | null;
+    execution_status: string | null;
+    trigger_reason: string | null;
+  }>;
+}
+
+describe('Story M1R: GatewayToolExecutor execute pipeline characterization', () => {
+  let previousFailLoud: string | undefined;
+  let previousAllowLegacyBypass: string | undefined;
+
+  beforeEach(() => {
+    previousFailLoud = process.env.MAMA_ENVELOPE_FAIL_LOUD;
+    previousAllowLegacyBypass = process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS;
+    delete process.env.MAMA_ENVELOPE_FAIL_LOUD;
+    delete process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS;
+  });
+
+  afterEach(() => {
+    if (previousFailLoud === undefined) {
+      delete process.env.MAMA_ENVELOPE_FAIL_LOUD;
+    } else {
+      process.env.MAMA_ENVELOPE_FAIL_LOUD = previousFailLoud;
+    }
+    if (previousAllowLegacyBypass === undefined) {
+      delete process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS;
+    } else {
+      process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS = previousAllowLegacyBypass;
+    }
+  });
+
+  describe('AC: public execute contract stays stable during seam extraction', () => {
+    it('keeps explicit executionContext visible to envelope enforcement', async () => {
+      const telegramGateway = makeTelegramGateway();
+      const executor = new GatewayToolExecutor({ mamaApi: makeMAMAApi() });
+      executor.setTelegramGateway(telegramGateway);
+      const envelope = makeEnvelope({
+        source: 'telegram',
+        channel_id: 'tg:OWN',
+        scope: {
+          project_refs: [{ kind: 'project', id: '/workspace/project-a' }],
+          raw_connectors: ['telegram'],
+          memory_scopes: [{ kind: 'project', id: '/workspace/project-a' }],
+          allowed_destinations: [{ kind: 'telegram', id: 'tg:OWN' }],
+        },
+      });
+
+      const result = await executor.execute(
+        'telegram_send',
+        { chat_id: 'tg:OWN', message: 'safe' } as GatewayToolInput,
+        { agentId: 'worker', source: 'telegram', channelId: 'tg:OWN', envelope }
+      );
+
+      expect(result).toMatchObject({ success: true });
+      expect(telegramGateway.sendMessage).toHaveBeenCalledWith('tg:OWN', 'safe');
+    });
+
+    it('denies missing envelopes by default and records the existing incident row', async () => {
+      const db = new Database(':memory:');
+      initAgentTables(db);
+      const mamaApi = makeMAMAApi();
+      const executor = new GatewayToolExecutor({ mamaApi });
+      executor.setSessionsDb(db);
+
+      const result = await executor.execute(
+        'mama_load_checkpoint',
+        {},
+        {
+          agentId: 'worker',
+          source: 'telegram',
+          channelId: 'tg:1',
+        }
+      );
+
+      expect(result).toMatchObject({ success: false, code: 'envelope_missing' });
+      expect(mamaApi.loadCheckpoint).not.toHaveBeenCalled();
+      expect(readActivityRows(db)).toEqual([
+        expect.objectContaining({
+          type: 'envelope_missing_denied',
+          input_summary: 'mama_load_checkpoint',
+          execution_status: 'failed',
+          trigger_reason: 'envelope_enforcer',
+        }),
+      ]);
+      db.close();
+    });
+
+    it('keeps the explicit legacy bypass path and records its incident row', async () => {
+      process.env.MAMA_ENVELOPE_ALLOW_LEGACY_BYPASS = 'true';
+      const db = new Database(':memory:');
+      initAgentTables(db);
+      const mamaApi = makeMAMAApi();
+      const executor = new GatewayToolExecutor({ mamaApi });
+      executor.setSessionsDb(db);
+
+      const result = await executor.execute(
+        'mama_load_checkpoint',
+        {},
+        {
+          agentId: 'worker',
+          source: 'telegram',
+          channelId: 'tg:1',
+        }
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(mamaApi.loadCheckpoint).toHaveBeenCalledOnce();
+      expect(readActivityRows(db)).toEqual([
+        expect.objectContaining({
+          type: 'envelope_missing_legacy',
+          input_summary: 'mama_load_checkpoint',
+          execution_status: 'completed',
+          trigger_reason: 'envelope_enforcer',
+        }),
+      ]);
+      db.close();
+    });
+
+    it('throws AgentError with UNKNOWN_TOOL for unknown tools before envelope handling', async () => {
+      const executor = new GatewayToolExecutor({ mamaApi: makeMAMAApi() });
+
+      await expect(
+        executor.execute('unknown_tool', {}, { agentId: 'worker', source: 'telegram' })
+      ).rejects.toMatchObject({
+        code: 'UNKNOWN_TOOL',
+      } satisfies Partial<AgentError>);
+    });
+
+    it('returns destination envelope violations as agent-visible failures and records incident rows', async () => {
+      const db = new Database(':memory:');
+      initAgentTables(db);
+      const telegramGateway = makeTelegramGateway();
+      const executor = new GatewayToolExecutor({ mamaApi: makeMAMAApi() });
+      executor.setTelegramGateway(telegramGateway);
+      executor.setSessionsDb(db);
+      const envelope = makeEnvelope({
+        envelope_hash: 'envhash_pipeline',
+        source: 'telegram',
+        channel_id: 'tg:OWN',
+        scope: {
+          project_refs: [{ kind: 'project', id: '/workspace/project-a' }],
+          raw_connectors: ['telegram'],
+          memory_scopes: [{ kind: 'project', id: '/workspace/project-a' }],
+          allowed_destinations: [{ kind: 'telegram', id: 'tg:OWN' }],
+        },
+      });
+
+      const result = await executor.execute(
+        'telegram_send',
+        { chat_id: 'tg:OTHER', message: 'leak' } as GatewayToolInput,
+        { agentId: 'worker', source: 'telegram', channelId: 'tg:OWN', envelope }
+      );
+
+      expect(result).toMatchObject({
+        success: false,
+        code: 'destination_out_of_scope',
+        envelope_hash: 'envhash_pipeline',
+      });
+      expect(telegramGateway.sendMessage).not.toHaveBeenCalled();
+      expect(readActivityRows(db)).toEqual([
+        expect.objectContaining({
+          type: 'envelope_violation',
+          input_summary: 'telegram_send',
+          output_summary: 'envelope_hash=envhash_pipeline',
+          execution_status: 'failed',
+          trigger_reason: 'envelope_enforcer',
+        }),
+      ]);
+      db.close();
+    });
+  });
+});

--- a/packages/standalone/tests/envelope/memory-scope-mismatch-logging.test.ts
+++ b/packages/standalone/tests/envelope/memory-scope-mismatch-logging.test.ts
@@ -1,0 +1,601 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
+import type {
+  AgentContext,
+  GatewayToolInput,
+  GatewayToolResult,
+  MAMAApiInterface,
+} from '../../src/agent/types.js';
+import Database from '../../src/sqlite.js';
+import { initAgentTables } from '../../src/db/agent-store.js';
+import type { MetricsStore, MetricRecord } from '../../src/observability/metrics-store.js';
+import { makeSignedEnvelope } from './fixtures.js';
+
+const { securityWarnMock } = vi.hoisted(() => ({
+  securityWarnMock: vi.fn(),
+}));
+
+vi.mock('@jungjaehoon/mama-core/debug-logger', () => ({
+  DebugLogger: vi.fn().mockImplementation(() => ({
+    warn: securityWarnMock,
+  })),
+}));
+
+type AuditRow = {
+  id: number;
+  type: string;
+  input_summary: string | null;
+  execution_status: string | null;
+  envelope_hash: string | null;
+  requested_scopes: string | null;
+  envelope_scopes_snapshot: string | null;
+  scope_mismatch: number;
+};
+
+type MetricsStoreMock = Pick<MetricsStore, 'record'> & {
+  record: ReturnType<typeof vi.fn<[MetricRecord], void>>;
+};
+
+function createMAMAApi(): MAMAApiInterface {
+  return {
+    save: vi.fn().mockResolvedValue({ success: true, id: 'decision_1', type: 'decision' }),
+    saveCheckpoint: vi.fn().mockResolvedValue({
+      success: true,
+      id: 'checkpoint_1',
+      type: 'checkpoint',
+    }),
+    listDecisions: vi.fn().mockResolvedValue([]),
+    suggest: vi.fn().mockResolvedValue({ success: true, results: [], count: 0 }),
+    updateOutcome: vi.fn().mockResolvedValue({ success: true, message: 'updated' }),
+    loadCheckpoint: vi.fn().mockResolvedValue({ success: true }),
+    recallMemory: vi.fn().mockResolvedValue({
+      profile: { static: [], dynamic: [], evidence: [] },
+      memories: [],
+      graph_context: { primary: [], expanded: [], edges: [] },
+      search_meta: { query: 'test', scope_order: [], retrieval_sources: [] },
+    }),
+    ingestMemory: vi.fn().mockResolvedValue({ success: true, id: 'ingested_1' }),
+  };
+}
+
+function createMetricsStore(): MetricsStoreMock {
+  return {
+    record: vi.fn(),
+  } as MetricsStoreMock;
+}
+
+function createTelegramContext(channelId = 'abc', allowedPaths?: string[]): AgentContext {
+  return {
+    source: 'telegram',
+    platform: 'telegram',
+    roleName: 'chat_bot',
+    role: {
+      allowedTools: ['*'],
+      systemControl: false,
+      sensitiveAccess: false,
+      allowedPaths,
+    },
+    session: {
+      sessionId: `telegram:${channelId}`,
+      channelId,
+      userId: 'user-1',
+      startedAt: new Date(),
+    },
+    capabilities: ['*'],
+    limitations: [],
+    tier: 2,
+    backend: 'claude',
+  };
+}
+
+function readGatewayToolRows(db: Database): AuditRow[] {
+  return db
+    .prepare(
+      `SELECT id, type, input_summary, execution_status, envelope_hash,
+              requested_scopes, envelope_scopes_snapshot, scope_mismatch
+       FROM agent_activity
+       WHERE type = 'gateway_tool_call'
+       ORDER BY id ASC`
+    )
+    .all() as AuditRow[];
+}
+
+function parseScopes(value: string | null): Array<{ kind: string; id: string }> {
+  return value ? (JSON.parse(value) as Array<{ kind: string; id: string }>) : [];
+}
+
+function createExecutorHarness(options?: {
+  mamaApi?: MAMAApiInterface;
+  metricsStore?: MetricsStoreMock;
+  envelopeIssuanceMode?: 'off' | 'enabled' | 'required';
+}): {
+  db: Database;
+  executor: GatewayToolExecutor;
+  mamaApi: MAMAApiInterface;
+  metricsStore: MetricsStoreMock;
+} {
+  const db = new Database(':memory:');
+  initAgentTables(db);
+  const mamaApi = options?.mamaApi ?? createMAMAApi();
+  const metricsStore = options?.metricsStore ?? createMetricsStore();
+  const executor = new GatewayToolExecutor({
+    mamaApi,
+    metricsStore: metricsStore as unknown as MetricsStore,
+    envelopeIssuanceMode: options?.envelopeIssuanceMode ?? 'enabled',
+  });
+  executor.setSessionsDb(db);
+  return { db, executor, mamaApi, metricsStore };
+}
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('Story M1R: memory scope mismatch audit logging', () => {
+  let previousWorkspace: string | undefined;
+  let previousHome: string | undefined;
+  let tempDir: string;
+
+  beforeEach(() => {
+    previousWorkspace = process.env.MAMA_WORKSPACE;
+    previousHome = process.env.HOME;
+    tempDir = mkdtempSync(join(tmpdir(), 'mama-scope-audit-'));
+    process.env.MAMA_WORKSPACE = join(tempDir, 'workspace');
+    process.env.HOME = tempDir;
+    mkdirSync(process.env.MAMA_WORKSPACE, { recursive: true });
+    securityWarnMock.mockClear();
+  });
+
+  afterEach(() => {
+    if (previousWorkspace === undefined) {
+      delete process.env.MAMA_WORKSPACE;
+    } else {
+      process.env.MAMA_WORKSPACE = previousWorkspace;
+    }
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('records in-scope mama_save writes without mismatch alarms', async () => {
+    const { db, executor, mamaApi, metricsStore } = createExecutorHarness();
+    const envelope = makeSignedEnvelope({
+      source: 'telegram',
+      channel_id: 'abc',
+      scope: {
+        project_refs: [{ kind: 'project', id: process.env.MAMA_WORKSPACE! }],
+        raw_connectors: ['telegram'],
+        memory_scopes: [{ kind: 'channel', id: 'telegram:abc' }],
+        allowed_destinations: [{ kind: 'telegram', id: 'abc' }],
+      },
+    });
+
+    const result = await executor.execute(
+      'mama_save',
+      {
+        type: 'decision',
+        topic: 'scope',
+        decision: 'in scope',
+        reasoning: 'uses the channel scope',
+        scopes: [{ kind: 'channel', id: 'telegram:abc' }],
+      },
+      {
+        agentId: 'chat_bot',
+        source: 'telegram',
+        channelId: 'abc',
+        agentContext: createTelegramContext(),
+        envelope,
+      }
+    );
+
+    expect(result).toMatchObject({ success: true });
+    expect(mamaApi.save).toHaveBeenCalledOnce();
+    const [row] = readGatewayToolRows(db);
+    expect(row).toMatchObject({
+      input_summary: 'mama_save',
+      envelope_hash: envelope.envelope_hash,
+      scope_mismatch: 0,
+      execution_status: 'completed',
+    });
+    expect(metricsStore.record).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'envelope_scope_mismatch' })
+    );
+    expect(securityWarnMock).not.toHaveBeenCalled();
+    db.close();
+  });
+
+  it('logs out-of-scope mama_save writes but still allows the write to proceed', async () => {
+    const { db, executor, mamaApi, metricsStore } = createExecutorHarness();
+    const envelope = makeSignedEnvelope({
+      source: 'telegram',
+      channel_id: 'abc',
+      scope: {
+        project_refs: [{ kind: 'project', id: process.env.MAMA_WORKSPACE! }],
+        raw_connectors: ['telegram'],
+        memory_scopes: [{ kind: 'channel', id: 'telegram:abc' }],
+        allowed_destinations: [{ kind: 'telegram', id: 'abc' }],
+      },
+    });
+
+    const result = await executor.execute(
+      'mama_save',
+      {
+        type: 'decision',
+        topic: 'scope',
+        decision: 'out-of-scope decision payload secret',
+        reasoning: 'uses global system scope',
+        scopes: [{ kind: 'global', id: 'system' }],
+      },
+      {
+        agentId: 'chat_bot',
+        source: 'telegram',
+        channelId: 'abc',
+        agentContext: createTelegramContext(),
+        envelope,
+      }
+    );
+
+    expect(result).toMatchObject({ success: true });
+    expect(mamaApi.save).toHaveBeenCalledOnce();
+    const [row] = readGatewayToolRows(db);
+    expect(row.scope_mismatch).toBe(1);
+    expect(parseScopes(row.requested_scopes)).toEqual([{ kind: 'global', id: 'system' }]);
+    expect(parseScopes(row.envelope_scopes_snapshot)).toEqual([
+      { kind: 'channel', id: 'telegram:abc' },
+    ]);
+    expect(metricsStore.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'envelope_scope_mismatch',
+        value: 1,
+        labels: expect.objectContaining({
+          source: 'telegram',
+          channel_id: 'abc',
+          tool: 'mama_save',
+        }),
+      })
+    );
+    expect(securityWarnMock).toHaveBeenCalledOnce();
+    expect(JSON.stringify(securityWarnMock.mock.calls)).not.toContain(
+      'out-of-scope decision payload secret'
+    );
+    db.close();
+  });
+
+  it('treats omitted memory scopes as forensic mismatch without injecting synthetic scopes', async () => {
+    const { db, executor, mamaApi } = createExecutorHarness();
+    const envelope = makeSignedEnvelope({
+      source: 'telegram',
+      channel_id: 'abc',
+      scope: {
+        project_refs: [{ kind: 'project', id: process.env.MAMA_WORKSPACE! }],
+        raw_connectors: ['telegram'],
+        memory_scopes: [{ kind: 'channel', id: 'telegram:abc' }],
+        allowed_destinations: [{ kind: 'telegram', id: 'abc' }],
+      },
+    });
+
+    const result = await executor.execute(
+      'mama_save',
+      {
+        type: 'decision',
+        topic: 'scope',
+        decision: 'omitted scopes',
+        reasoning: 'keeps existing save semantics',
+      },
+      {
+        agentId: 'chat_bot',
+        source: 'telegram',
+        channelId: 'abc',
+        agentContext: createTelegramContext(),
+        envelope,
+      }
+    );
+
+    expect(result).toMatchObject({ success: true });
+    expect(mamaApi.save).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        scopes: expect.any(Array),
+      })
+    );
+    const [row] = readGatewayToolRows(db);
+    expect(row.scope_mismatch).toBe(1);
+    expect(parseScopes(row.requested_scopes)).toEqual([]);
+    expect(parseScopes(row.envelope_scopes_snapshot)).toEqual([
+      { kind: 'channel', id: 'telegram:abc' },
+    ]);
+    db.close();
+  });
+
+  it('covers each memory-mutating tool and uses effective scopes for derived ingest paths', async () => {
+    const cases: Array<{
+      toolName: 'mama_save' | 'mama_update' | 'mama_add' | 'mama_ingest';
+      input: GatewayToolInput;
+      assertWrite: (api: MAMAApiInterface) => void;
+      expectedRequestedScope?: { kind: string; id: string };
+    }> = [
+      {
+        toolName: 'mama_save',
+        input: {
+          type: 'decision',
+          topic: 'scope',
+          decision: 'save out-of-scope',
+          reasoning: 'global scope request',
+          scopes: [{ kind: 'global', id: 'system' }],
+        },
+        assertWrite: (api) => expect(api.save).toHaveBeenCalledOnce(),
+        expectedRequestedScope: { kind: 'global', id: 'system' },
+      },
+      {
+        toolName: 'mama_update',
+        input: {
+          id: 'decision_1',
+          outcome: 'success',
+        } as unknown as GatewayToolInput,
+        assertWrite: (api) => expect(api.updateOutcome).toHaveBeenCalledOnce(),
+      },
+      {
+        toolName: 'mama_add',
+        input: { content: 'remember this from the telegram channel' },
+        assertWrite: (api) => expect(api.ingestMemory).toHaveBeenCalledOnce(),
+        expectedRequestedScope: { kind: 'channel', id: 'telegram:abc' },
+      },
+      {
+        toolName: 'mama_ingest',
+        input: {
+          content: 'remember this direct ingest',
+          scopes: [{ kind: 'global', id: 'system' }],
+        },
+        assertWrite: (api) => expect(api.ingestMemory).toHaveBeenCalledOnce(),
+        expectedRequestedScope: { kind: 'channel', id: 'telegram:abc' },
+      },
+    ];
+
+    for (const item of cases) {
+      const { db, executor, mamaApi, metricsStore } = createExecutorHarness();
+      const envelope = makeSignedEnvelope({
+        source: 'telegram',
+        channel_id: 'abc',
+        scope: {
+          project_refs: [{ kind: 'project', id: process.env.MAMA_WORKSPACE! }],
+          raw_connectors: ['telegram'],
+          memory_scopes: [{ kind: 'channel', id: 'telegram:other' }],
+          allowed_destinations: [{ kind: 'telegram', id: 'abc' }],
+        },
+      });
+
+      const result = await executor.execute(item.toolName, item.input, {
+        agentId: 'chat_bot',
+        source: 'telegram',
+        channelId: 'abc',
+        agentContext: createTelegramContext(),
+        envelope,
+      });
+
+      expect(result).toMatchObject({ success: true });
+      item.assertWrite(mamaApi);
+      const [row] = readGatewayToolRows(db);
+      expect(row).toMatchObject({
+        input_summary: item.toolName,
+        scope_mismatch: 1,
+        envelope_hash: envelope.envelope_hash,
+      });
+      if (item.expectedRequestedScope) {
+        expect(parseScopes(row.requested_scopes)).toContainEqual(item.expectedRequestedScope);
+      } else {
+        expect(parseScopes(row.requested_scopes)).toEqual([]);
+      }
+      expect(metricsStore.record).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'envelope_scope_mismatch' })
+      );
+      db.close();
+    }
+  });
+
+  it('audits report_publish autosave through the same gateway envelope context', async () => {
+    const { db, executor, metricsStore } = createExecutorHarness();
+    executor.setReportPublisher(vi.fn());
+    const envelope = makeSignedEnvelope({
+      source: 'telegram',
+      channel_id: 'abc',
+      tier: 2,
+      scope: {
+        project_refs: [{ kind: 'project', id: process.env.MAMA_WORKSPACE! }],
+        raw_connectors: ['telegram'],
+        memory_scopes: [{ kind: 'channel', id: 'telegram:abc' }],
+        allowed_destinations: [{ kind: 'dashboard_slot', id: 'daily' }],
+      },
+    });
+
+    const result = await executor.execute(
+      'report_publish',
+      { slots: { daily: '<h1>Daily</h1>' } } as unknown as GatewayToolInput,
+      {
+        agentId: 'dashboard',
+        source: 'telegram',
+        channelId: 'abc',
+        agentContext: createTelegramContext(),
+        envelope,
+      }
+    );
+    await flushMicrotasks();
+
+    expect(result).toEqual({
+      success: true,
+      message: 'Dashboard updated: daily (1 slots)',
+    });
+    const rows = readGatewayToolRows(db);
+    expect(rows.map((row) => row.input_summary)).toEqual(['report_publish', 'mama_save']);
+    expect(new Set(rows.map((row) => row.envelope_hash))).toEqual(
+      new Set([envelope.envelope_hash])
+    );
+    const autosave = rows.find((row) => row.input_summary === 'mama_save');
+    expect(autosave).toMatchObject({ scope_mismatch: 1 });
+    expect(parseScopes(autosave!.requested_scopes)).toEqual([{ kind: 'global', id: 'system' }]);
+    expect(metricsStore.record).toHaveBeenCalledTimes(1);
+    expect(securityWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining('scope mismatch'),
+      expect.objectContaining({ parent: 'report_publish' })
+    );
+    db.close();
+  });
+
+  it('audits wiki_publish autosave through the same gateway envelope context', async () => {
+    const { db, executor, metricsStore } = createExecutorHarness();
+    executor.setWikiPublisher(vi.fn());
+    const envelope = makeSignedEnvelope({
+      source: 'telegram',
+      channel_id: 'abc',
+      tier: 2,
+      scope: {
+        project_refs: [{ kind: 'project', id: process.env.MAMA_WORKSPACE! }],
+        raw_connectors: ['telegram'],
+        memory_scopes: [{ kind: 'channel', id: 'telegram:abc' }],
+        allowed_destinations: [{ kind: 'dashboard_slot', id: 'wiki' }],
+      },
+    });
+
+    const result = await executor.execute(
+      'wiki_publish',
+      {
+        pages: [{ path: '/wiki/a.md', title: 'A', type: 'entity', content: 'A page' }],
+      } as unknown as GatewayToolInput,
+      {
+        agentId: 'wiki',
+        source: 'telegram',
+        channelId: 'abc',
+        agentContext: createTelegramContext(),
+        envelope,
+      }
+    );
+    await flushMicrotasks();
+
+    expect(result).toEqual({
+      success: true,
+      message: 'Wiki published: 1 pages',
+    });
+    const rows = readGatewayToolRows(db);
+    expect(rows.map((row) => row.input_summary)).toEqual(['wiki_publish', 'mama_save']);
+    expect(new Set(rows.map((row) => row.envelope_hash))).toEqual(
+      new Set([envelope.envelope_hash])
+    );
+    const autosave = rows.find((row) => row.input_summary === 'mama_save');
+    expect(autosave).toMatchObject({ scope_mismatch: 1 });
+    expect(parseScopes(autosave!.requested_scopes)).toEqual([{ kind: 'global', id: 'system' }]);
+    expect(metricsStore.record).toHaveBeenCalledTimes(1);
+    expect(securityWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining('scope mismatch'),
+      expect.objectContaining({ parent: 'wiki_publish' })
+    );
+    db.close();
+  });
+
+  it('off issuance mode allows reactive contexts without an envelope for save/search/read', async () => {
+    const { db, executor, mamaApi } = createExecutorHarness({ envelopeIssuanceMode: 'off' });
+    const readPath = join(tempDir, 'readable.txt');
+    writeFileSync(readPath, 'visible');
+    const agentContext = createTelegramContext('abc', [join(tempDir, '**')]);
+
+    const saveResult = await executor.execute(
+      'mama_save',
+      {
+        type: 'decision',
+        topic: 'off-mode',
+        decision: 'save works',
+        reasoning: 'issuance disabled',
+      },
+      {
+        agentId: 'chat_bot',
+        source: 'telegram',
+        channelId: 'abc',
+        agentContext,
+        executionSurface: 'model_tool',
+      }
+    );
+    const searchResult = await executor.execute(
+      'mama_search',
+      { query: 'off-mode' },
+      {
+        agentId: 'chat_bot',
+        source: 'telegram',
+        channelId: 'abc',
+        agentContext,
+        executionSurface: 'model_tool',
+      }
+    );
+    const readResult = await executor.execute(
+      'Read',
+      { path: readPath } as unknown as GatewayToolInput,
+      {
+        agentId: 'chat_bot',
+        source: 'telegram',
+        channelId: 'abc',
+        agentContext,
+        executionSurface: 'model_tool',
+      }
+    );
+
+    expect(saveResult).toMatchObject({ success: true });
+    expect(searchResult).toMatchObject({ success: true });
+    expect(readResult).toMatchObject({ success: true, content: 'visible' });
+    expect(JSON.stringify([saveResult, searchResult, readResult])).not.toContain(
+      'envelope_missing'
+    );
+    expect(mamaApi.save).toHaveBeenCalledOnce();
+    expect(mamaApi.suggest).toHaveBeenCalledOnce();
+    db.close();
+  });
+
+  it('denies report_publish and wiki_publish under tier 3 with tier metadata after tool rename', async () => {
+    const tools: Array<'report_publish' | 'wiki_publish'> = ['report_publish', 'wiki_publish'];
+
+    for (const toolName of tools) {
+      const { db, executor } = createExecutorHarness();
+      executor.setReportPublisher(vi.fn());
+      executor.setWikiPublisher(vi.fn());
+      const envelope = makeSignedEnvelope({
+        source: 'telegram',
+        channel_id: 'abc',
+        tier: 3,
+        scope: {
+          project_refs: [{ kind: 'project', id: process.env.MAMA_WORKSPACE! }],
+          raw_connectors: ['telegram'],
+          memory_scopes: [{ kind: 'channel', id: 'telegram:abc' }],
+          allowed_destinations: [{ kind: 'dashboard_slot', id: 'blocked' }],
+        },
+      });
+      const input =
+        toolName === 'report_publish'
+          ? ({ slots: { blocked: 'blocked' } } as unknown as GatewayToolInput)
+          : ({
+              pages: [{ path: '/wiki/a.md', title: 'A', type: 'entity', content: 'A page' }],
+            } as unknown as GatewayToolInput);
+
+      const result = (await executor.execute(toolName, input, {
+        agentId: 'chat_bot',
+        source: 'telegram',
+        channelId: 'abc',
+        agentContext: createTelegramContext(),
+        envelope,
+      })) as GatewayToolResult & {
+        code?: string;
+        tier_required?: number;
+        allowed?: boolean;
+      };
+
+      expect(result).toMatchObject({
+        success: false,
+        code: 'tier_violation',
+        tier_required: 2,
+        allowed: false,
+        envelope_hash: envelope.envelope_hash,
+      });
+      db.close();
+    }
+  });
+});

--- a/packages/standalone/tests/envelope/memory-scope-mismatch-logging.test.ts
+++ b/packages/standalone/tests/envelope/memory-scope-mismatch-logging.test.ts
@@ -191,6 +191,7 @@ describe('Story M1R: memory scope mismatch audit logging', () => {
         channelId: 'abc',
         agentContext: createTelegramContext(),
         envelope,
+        executionSurface: 'model_tool',
       }
     );
 
@@ -238,6 +239,7 @@ describe('Story M1R: memory scope mismatch audit logging', () => {
         channelId: 'abc',
         agentContext: createTelegramContext(),
         envelope,
+        executionSurface: 'model_tool',
       }
     );
 
@@ -294,6 +296,7 @@ describe('Story M1R: memory scope mismatch audit logging', () => {
         channelId: 'abc',
         agentContext: createTelegramContext(),
         envelope,
+        executionSurface: 'model_tool',
       }
     );
 
@@ -352,7 +355,7 @@ describe('Story M1R: memory scope mismatch audit logging', () => {
           scopes: [{ kind: 'global', id: 'system' }],
         },
         assertWrite: (api) => expect(api.ingestMemory).toHaveBeenCalledOnce(),
-        expectedRequestedScope: { kind: 'channel', id: 'telegram:abc' },
+        expectedRequestedScope: { kind: 'global', id: 'system' },
       },
     ];
 
@@ -375,6 +378,7 @@ describe('Story M1R: memory scope mismatch audit logging', () => {
         channelId: 'abc',
         agentContext: createTelegramContext(),
         envelope,
+        executionSurface: 'model_tool',
       });
 
       expect(result).toMatchObject({ success: true });
@@ -395,6 +399,58 @@ describe('Story M1R: memory scope mismatch audit logging', () => {
       );
       db.close();
     }
+  });
+
+  it('audits caller-supplied mama_ingest scopes while executing with derived fallback scopes', async () => {
+    const { db, executor, mamaApi, metricsStore } = createExecutorHarness();
+    const envelope = makeSignedEnvelope({
+      source: 'telegram',
+      channel_id: 'abc',
+      scope: {
+        project_refs: [{ kind: 'project', id: process.env.MAMA_WORKSPACE! }],
+        raw_connectors: ['telegram'],
+        memory_scopes: [{ kind: 'channel', id: 'telegram:abc' }],
+        allowed_destinations: [{ kind: 'telegram', id: 'abc' }],
+      },
+    });
+
+    const result = await executor.execute(
+      'mama_ingest',
+      {
+        content: 'attempted escalation should remain visible',
+        scopes: [{ kind: 'global', id: 'system' }],
+      },
+      {
+        agentId: 'chat_bot',
+        source: 'telegram',
+        channelId: 'abc',
+        agentContext: createTelegramContext(),
+        envelope,
+        executionSurface: 'model_tool',
+      }
+    );
+
+    expect(result).toMatchObject({ success: true });
+    expect(mamaApi.ingestMemory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopes: expect.arrayContaining([{ kind: 'channel', id: 'telegram:abc' }]),
+      })
+    );
+    expect(mamaApi.ingestMemory).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopes: expect.arrayContaining([{ kind: 'global', id: 'system' }]),
+      })
+    );
+    const [row] = readGatewayToolRows(db);
+    expect(row.scope_mismatch).toBe(1);
+    expect(parseScopes(row.requested_scopes)).toEqual([{ kind: 'global', id: 'system' }]);
+    expect(parseScopes(row.envelope_scopes_snapshot)).toEqual([
+      { kind: 'channel', id: 'telegram:abc' },
+    ]);
+    expect(metricsStore.record).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'envelope_scope_mismatch' })
+    );
+    db.close();
   });
 
   it('audits report_publish autosave through the same gateway envelope context', async () => {
@@ -421,6 +477,7 @@ describe('Story M1R: memory scope mismatch audit logging', () => {
         channelId: 'abc',
         agentContext: createTelegramContext(),
         envelope,
+        executionSurface: 'model_tool',
       }
     );
     await flushMicrotasks();
@@ -471,6 +528,7 @@ describe('Story M1R: memory scope mismatch audit logging', () => {
         channelId: 'abc',
         agentContext: createTelegramContext(),
         envelope,
+        executionSurface: 'model_tool',
       }
     );
     await flushMicrotasks();
@@ -582,6 +640,7 @@ describe('Story M1R: memory scope mismatch audit logging', () => {
         channelId: 'abc',
         agentContext: createTelegramContext(),
         envelope,
+        executionSurface: 'model_tool',
       })) as GatewayToolResult & {
         code?: string;
         tier_required?: number;

--- a/packages/standalone/tests/envelope/reactive-config.test.ts
+++ b/packages/standalone/tests/envelope/reactive-config.test.ts
@@ -1,0 +1,223 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { MAMAConfig } from '../../src/cli/config/types.js';
+import type { NormalizedMessage } from '../../src/gateways/types.js';
+import {
+  createDefaultReactiveEnvelopeConfig,
+  getReactiveRoutePolicy,
+} from '../../src/envelope/reactive-config.js';
+
+function makeConfig(overrides: Partial<MAMAConfig> = {}): MAMAConfig {
+  return {
+    version: 1,
+    agent: {
+      model: 'claude-sonnet-4-6',
+      timeout: 300_000,
+      max_turns: 5,
+      tools: { gateway: true, mcp: false },
+    },
+    database: { path: ':memory:' },
+    logging: { level: 'info', file: '~/.mama/mama.log' },
+    workspace: {
+      path: '/workspace/project-a',
+      scripts: '/workspace/project-a/scripts',
+      data: '/workspace/project-a/data',
+    },
+    timeouts: {
+      request_ms: 120_000,
+      codex_request_ms: 120_000,
+      initialize_ms: 60_000,
+      session_ms: 1_800_000,
+      session_cleanup_ms: 300_000,
+      agent_ms: 120_000,
+      ultrawork_ms: 300_000,
+      workflow_step_ms: 600_000,
+      workflow_max_ms: 1_800_000,
+      busy_retry_ms: 5_000,
+    },
+    ...overrides,
+  } as unknown as MAMAConfig;
+}
+
+function makeMessage(
+  source: NormalizedMessage['source'],
+  channelId = `${source}:1`
+): NormalizedMessage {
+  return {
+    source,
+    channelId,
+    userId: `${source}:user`,
+    text: `hello from ${source}`,
+  };
+}
+
+describe('reactive envelope route policy', () => {
+  it.each([
+    {
+      source: 'telegram' as const,
+      envelopeSource: 'telegram',
+      rawConnectors: ['telegram'],
+      destination: { kind: 'telegram', id: 'tg:1' },
+    },
+    {
+      source: 'slack' as const,
+      envelopeSource: 'slack',
+      rawConnectors: ['slack'],
+      destination: { kind: 'slack', id: 'slack:1' },
+    },
+    {
+      source: 'chatwork' as const,
+      envelopeSource: 'chatwork',
+      rawConnectors: ['chatwork'],
+      destination: { kind: 'chatwork', id: 'chatwork:1' },
+    },
+    {
+      source: 'discord' as const,
+      envelopeSource: 'discord',
+      rawConnectors: ['discord'],
+      destination: { kind: 'discord', id: 'discord:1' },
+    },
+    {
+      source: 'viewer' as const,
+      envelopeSource: 'viewer',
+      rawConnectors: [],
+      destination: { kind: 'webchat', id: 'viewer:1' },
+    },
+    {
+      source: 'mobile' as const,
+      envelopeSource: 'viewer',
+      rawConnectors: [],
+      destination: { kind: 'webchat', id: 'mobile:1' },
+    },
+    {
+      source: 'system' as const,
+      envelopeSource: 'watch',
+      rawConnectors: [],
+      destination: undefined,
+    },
+  ])(
+    'derives one route policy for $source reactive messages',
+    ({ source, envelopeSource, rawConnectors, destination }) => {
+      const channelId = destination?.id ?? 'system:1';
+      const config = makeConfig();
+      const env = { HOME: '/tmp/mama-home' };
+      const message = makeMessage(source, channelId);
+
+      const policy = getReactiveRoutePolicy(message, config, env);
+      const reactiveConfig = createDefaultReactiveEnvelopeConfig(config, env);
+
+      expect(policy.source).toBe(envelopeSource);
+      expect(policy.rawConnectors).toEqual(rawConnectors);
+      expect(policy.allowedDestinations).toEqual(destination ? [destination] : []);
+      expect(policy.memoryScopes).toEqual(
+        expect.arrayContaining([
+          { kind: 'project', id: '/workspace/project-a' },
+          { kind: 'channel', id: `${envelopeSource}:${channelId}` },
+          { kind: 'user', id: `${source}:user` },
+        ])
+      );
+      expect(reactiveConfig.projectRefsFor(message)).toEqual(policy.projectRefs);
+      expect(reactiveConfig.rawConnectorsFor(message)).toEqual(policy.rawConnectors);
+      expect(reactiveConfig.memoryScopesFor(message)).toEqual(policy.memoryScopes);
+      expect(reactiveConfig.reactiveBudgetSeconds).toBe(policy.reactiveBudgetSeconds);
+    }
+  );
+
+  it('keeps MessageRouter on the shared route helper instead of duplicate switches', () => {
+    const routerSource = readFileSync(
+      new URL('../../src/gateways/message-router.ts', import.meta.url),
+      'utf8'
+    );
+
+    expect(routerSource).toContain('getReactiveRoutePolicy');
+    expect(routerSource).not.toContain('MESSAGE_ENVELOPE_ROUTES');
+    expect(routerSource).not.toContain('function envelopeSourceForMessage');
+    expect(routerSource).not.toContain('function allowedDestinationsForMessage');
+  });
+
+  it('resolves project scope from config workspace without daemon cwd fallback', () => {
+    const config = makeConfig({
+      workspace: {
+        path: '$HOME/reactive-project',
+        scripts: '$HOME/reactive-project/scripts',
+        data: '$HOME/reactive-project/data',
+      },
+    });
+
+    const policy = getReactiveRoutePolicy(makeMessage('telegram', 'tg:1'), config, {
+      HOME: '/tmp/mama-home',
+      MAMA_WORKSPACE: '/tmp/ignored-workspace',
+    });
+
+    expect(policy.projectRefs).toEqual([
+      { kind: 'project', id: '/tmp/mama-home/reactive-project' },
+    ]);
+    expect(policy.memoryScopes).toContainEqual({
+      kind: 'project',
+      id: '/tmp/mama-home/reactive-project',
+    });
+    expect(policy.projectRefs[0].id).not.toBe('');
+    expect(policy.projectRefs[0].id).not.toBe(process.cwd());
+  });
+
+  it('falls back to MAMA_WORKSPACE, then HOME workspace, without using process.cwd()', () => {
+    const noWorkspaceConfig = makeConfig({ workspace: undefined });
+
+    expect(
+      getReactiveRoutePolicy(makeMessage('telegram', 'tg:1'), noWorkspaceConfig, {
+        HOME: '/tmp/mama-home',
+        MAMA_WORKSPACE: '/tmp/mama-workspace',
+      }).projectRefs
+    ).toEqual([{ kind: 'project', id: '/tmp/mama-workspace' }]);
+
+    const fallback = getReactiveRoutePolicy(makeMessage('telegram', 'tg:1'), noWorkspaceConfig, {
+      HOME: '/tmp/mama-home',
+    });
+    expect(fallback.projectRefs).toEqual([
+      { kind: 'project', id: resolve('/tmp/mama-home/.mama/workspace') },
+    ]);
+    expect(fallback.projectRefs[0].id).not.toBe(process.cwd());
+  });
+
+  it('rejects malformed explicit workspace values', () => {
+    expect(() =>
+      createDefaultReactiveEnvelopeConfig(
+        makeConfig({
+          workspace: {
+            path: '',
+            scripts: '',
+            data: '',
+          },
+        }),
+        { HOME: '/tmp/mama-home' }
+      )
+    ).toThrow(/workspace/i);
+  });
+
+  it('derives a finite positive budget from config, otherwise defaults to 300 seconds', () => {
+    expect(
+      createDefaultReactiveEnvelopeConfig(
+        makeConfig({
+          timeouts: {
+            ...(makeConfig().timeouts as NonNullable<MAMAConfig['timeouts']>),
+            agent_ms: 90_000,
+          },
+        }),
+        { HOME: '/tmp/mama-home' }
+      ).reactiveBudgetSeconds
+    ).toBe(90);
+
+    expect(
+      createDefaultReactiveEnvelopeConfig(
+        makeConfig({
+          timeouts: {
+            ...(makeConfig().timeouts as NonNullable<MAMAConfig['timeouts']>),
+            agent_ms: Number.POSITIVE_INFINITY,
+          },
+        }),
+        { HOME: '/tmp/mama-home' }
+      ).reactiveBudgetSeconds
+    ).toBe(300);
+  });
+});

--- a/packages/standalone/tests/envelope/reactive-config.test.ts
+++ b/packages/standalone/tests/envelope/reactive-config.test.ts
@@ -1,12 +1,17 @@
-import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type { MAMAConfig } from '../../src/cli/config/types.js';
 import type { NormalizedMessage } from '../../src/gateways/types.js';
+import type { AgentLoopOptions } from '../../src/agent/types.js';
+import Database, { type SQLiteDatabase } from '../../src/sqlite.js';
+import { MessageRouter, type AgentLoopClient } from '../../src/gateways/message-router.js';
+import { SessionStore } from '../../src/gateways/session-store.js';
+import { createMockMamaApi } from '../../src/gateways/context-injector.js';
 import {
   createDefaultReactiveEnvelopeConfig,
   getReactiveRoutePolicy,
 } from '../../src/envelope/reactive-config.js';
+import { makeAuthorityHarness } from './fixtures.js';
 
 function makeConfig(overrides: Partial<MAMAConfig> = {}): MAMAConfig {
   return {
@@ -124,16 +129,41 @@ describe('reactive envelope route policy', () => {
     }
   );
 
-  it('keeps MessageRouter on the shared route helper instead of duplicate switches', () => {
-    const routerSource = readFileSync(
-      new URL('../../src/gateways/message-router.ts', import.meta.url),
-      'utf8'
+  it('keeps MessageRouter envelope scope behavior aligned with shared route policy', async () => {
+    const db: SQLiteDatabase = new Database(':memory:');
+    const sessionStore = new SessionStore(db);
+    const config = makeConfig();
+    const env = { HOME: '/tmp/mama-home' };
+    const message = makeMessage('telegram', 'tg:policy');
+    const expectedPolicy = getReactiveRoutePolicy(message, config, env);
+    const { authority } = makeAuthorityHarness(db);
+    let seenOptions: AgentLoopOptions | undefined;
+    const agentLoop: AgentLoopClient = {
+      async run(_prompt, options) {
+        seenOptions = options;
+        return { response: 'ok' };
+      },
+    };
+
+    const router = new MessageRouter(
+      sessionStore,
+      agentLoop,
+      createMockMamaApi([]),
+      {},
+      createDefaultReactiveEnvelopeConfig(config, env),
+      authority
     );
 
-    expect(routerSource).toContain('getReactiveRoutePolicy');
-    expect(routerSource).not.toContain('MESSAGE_ENVELOPE_ROUTES');
-    expect(routerSource).not.toContain('function envelopeSourceForMessage');
-    expect(routerSource).not.toContain('function allowedDestinationsForMessage');
+    await router.process(message);
+
+    expect(seenOptions?.envelope?.source).toBe(expectedPolicy.source);
+    expect(seenOptions?.envelope?.scope.project_refs).toEqual(expectedPolicy.projectRefs);
+    expect(seenOptions?.envelope?.scope.raw_connectors).toEqual(expectedPolicy.rawConnectors);
+    expect(seenOptions?.envelope?.scope.memory_scopes).toEqual(expectedPolicy.memoryScopes);
+    expect(seenOptions?.envelope?.scope.allowed_destinations).toEqual(
+      expectedPolicy.allowedDestinations
+    );
+    sessionStore.close();
   });
 
   it('resolves project scope from config workspace without daemon cwd fallback', () => {

--- a/packages/standalone/tests/envelope/reactive-config.test.ts
+++ b/packages/standalone/tests/envelope/reactive-config.test.ts
@@ -155,6 +155,30 @@ describe('reactive envelope route policy', () => {
     expect(policy.reactiveBudgetSeconds).toBe(300);
   });
 
+  it('returns defensive copies from cached reactive route policy arrays', () => {
+    const config = makeConfig();
+    const message = makeMessage('telegram', 'tg:defensive');
+    const reactiveConfig = createDefaultReactiveEnvelopeConfig(config, { HOME: '/tmp/mama-home' });
+
+    reactiveConfig.projectRefsFor(message).push({ kind: 'project', id: '/tmp/mutated-project' });
+    reactiveConfig.rawConnectorsFor(message).push('discord');
+    reactiveConfig.memoryScopesFor(message).push({ kind: 'project', id: '/tmp/mutated-memory' });
+    reactiveConfig.allowedDestinationsFor(message).push({ kind: 'discord', id: 'mutated-channel' });
+
+    expect(reactiveConfig.projectRefsFor(message)).not.toContainEqual({
+      kind: 'project',
+      id: '/tmp/mutated-project',
+    });
+    expect(reactiveConfig.rawConnectorsFor(message)).toEqual(['telegram']);
+    expect(reactiveConfig.memoryScopesFor(message)).not.toContainEqual({
+      kind: 'project',
+      id: '/tmp/mutated-memory',
+    });
+    expect(reactiveConfig.allowedDestinationsFor(message)).toEqual([
+      { kind: 'telegram', id: 'tg:defensive' },
+    ]);
+  });
+
   it('keeps MessageRouter envelope scope behavior aligned with shared route policy', async () => {
     const db: SQLiteDatabase = new Database(':memory:');
     const sessionStore = new SessionStore(db);

--- a/packages/standalone/tests/envelope/reactive-config.test.ts
+++ b/packages/standalone/tests/envelope/reactive-config.test.ts
@@ -10,6 +10,7 @@ import { createMockMamaApi } from '../../src/gateways/context-injector.js';
 import {
   createDefaultReactiveEnvelopeConfig,
   getReactiveRoutePolicy,
+  type ReactiveEnvelopeConfig,
 } from '../../src/envelope/reactive-config.js';
 import { makeAuthorityHarness } from './fixtures.js';
 
@@ -128,6 +129,31 @@ describe('reactive envelope route policy', () => {
       expect(reactiveConfig.reactiveBudgetSeconds).toBe(policy.reactiveBudgetSeconds);
     }
   );
+
+  it('does not treat partial reactive config objects without a budget as reactive config', () => {
+    const partialReactiveConfig = {
+      projectRefsFor: () => {
+        throw new Error('partial reactive config should not be used');
+      },
+      rawConnectorsFor: () => {
+        throw new Error('partial reactive config should not be used');
+      },
+      memoryScopesFor: () => {
+        throw new Error('partial reactive config should not be used');
+      },
+    } as unknown as MAMAConfig | ReactiveEnvelopeConfig;
+
+    const policy = getReactiveRoutePolicy(
+      makeMessage('telegram', 'tg:partial'),
+      partialReactiveConfig,
+      { HOME: '/tmp/mama-home' }
+    );
+
+    expect(policy.projectRefs).toEqual([
+      { kind: 'project', id: resolve('/tmp/mama-home/.mama/workspace') },
+    ]);
+    expect(policy.reactiveBudgetSeconds).toBe(300);
+  });
 
   it('keeps MessageRouter envelope scope behavior aligned with shared route policy', async () => {
     const db: SQLiteDatabase = new Database(':memory:');

--- a/packages/standalone/tests/gateways/discord.test.ts
+++ b/packages/standalone/tests/gateways/discord.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Message } from 'discord.js';
 import { DiscordGateway } from '../../src/gateways/discord.js';
 import { MessageRouter } from '../../src/gateways/message-router.js';
 
@@ -54,6 +55,26 @@ const mockMessageRouter = {
 
 describe('DiscordGateway', () => {
   let gateway: DiscordGateway;
+  type TestMessage = {
+    content: string;
+    guild: { id: string } | null;
+    channel: { id: string };
+  };
+  type GatewayShouldRespond = {
+    shouldRespond(message: Message, isDM: boolean, isMentioned: boolean): boolean;
+  };
+  const asDiscordMessage = (message: TestMessage): Message => message as unknown as Message;
+  const shouldRespondFor = (
+    target: DiscordGateway,
+    message: TestMessage,
+    isDM: boolean,
+    isMentioned: boolean
+  ): boolean =>
+    (target as unknown as GatewayShouldRespond).shouldRespond(
+      asDiscordMessage(message),
+      isDM,
+      isMentioned
+    );
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -232,10 +253,9 @@ describe('DiscordGateway', () => {
         content: 'DELEGATE::developer::Do the thing',
         guild: { id: 'g1' },
         channel: { id: 'c1' },
-      } as any;
+      };
 
-      const shouldRespond = (gateway as any).shouldRespond.bind(gateway);
-      expect(shouldRespond(message, false, false)).toBe(true);
+      expect(shouldRespondFor(gateway, message, false, false)).toBe(true);
     });
 
     it('should respond to DELEGATE commands even with no guild config (mentions normally required)', () => {
@@ -244,10 +264,9 @@ describe('DiscordGateway', () => {
         content: 'DELEGATE_BG::reviewer::Review this',
         guild: { id: 'g1' },
         channel: { id: 'c1' },
-      } as any;
+      };
 
-      const shouldRespond = (gateway as any).shouldRespond.bind(gateway);
-      expect(shouldRespond(message, false, false)).toBe(true);
+      expect(shouldRespondFor(gateway, message, false, false)).toBe(true);
     });
 
     it('should not respond to normal messages when mention is required', () => {
@@ -261,10 +280,9 @@ describe('DiscordGateway', () => {
         content: 'hello',
         guild: { id: 'g1' },
         channel: { id: 'c1' },
-      } as any;
+      };
 
-      const shouldRespond = (gateway as any).shouldRespond.bind(gateway);
-      expect(shouldRespond(message, false, false)).toBe(false);
+      expect(shouldRespondFor(gateway, message, false, false)).toBe(false);
     });
   });
 });

--- a/packages/standalone/tests/gateways/discord.test.ts
+++ b/packages/standalone/tests/gateways/discord.test.ts
@@ -6,27 +6,29 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Message } from 'discord.js';
+import { ChannelType, Events, type Message } from 'discord.js';
 import { DiscordGateway } from '../../src/gateways/discord.js';
 import { MessageRouter } from '../../src/gateways/message-router.js';
 
 // Mock discord.js
-vi.mock('discord.js', () => {
-  const mockClient = {
-    user: { id: '123456789', tag: 'TestBot#1234' },
-    login: vi.fn().mockResolvedValue('token'),
-    destroy: vi.fn().mockResolvedValue(undefined),
-    once: vi.fn(),
-    on: vi.fn(),
-  };
+const discordClientMock = vi.hoisted(() => ({
+  user: { id: '123456789', tag: 'TestBot#1234', username: 'TestBot' },
+  login: vi.fn().mockResolvedValue('token'),
+  destroy: vi.fn().mockResolvedValue(undefined),
+  once: vi.fn(),
+  on: vi.fn(),
+}));
 
+vi.mock('discord.js', () => {
   return {
-    Client: vi.fn(() => mockClient),
+    Client: vi.fn(() => discordClientMock),
     GatewayIntentBits: {
       Guilds: 1,
       GuildMessages: 2,
       DirectMessages: 4,
       MessageContent: 8,
+      GuildMembers: 16,
+      GuildMessageReactions: 32,
     },
     Partials: {
       Channel: 1,
@@ -41,6 +43,7 @@ vi.mock('discord.js', () => {
       DM: 1,
       GuildText: 0,
     },
+    AttachmentBuilder: vi.fn(),
   };
 });
 
@@ -55,26 +58,45 @@ const mockMessageRouter = {
 
 describe('DiscordGateway', () => {
   let gateway: DiscordGateway;
-  type TestMessage = {
-    content: string;
-    guild: { id: string } | null;
-    channel: { id: string };
-  };
-  type GatewayShouldRespond = {
-    shouldRespond(message: Message, isDM: boolean, isMentioned: boolean): boolean;
-  };
-  const asDiscordMessage = (message: TestMessage): Message => message as unknown as Message;
-  const shouldRespondFor = (
-    target: DiscordGateway,
-    message: TestMessage,
-    isDM: boolean,
-    isMentioned: boolean
-  ): boolean =>
-    (target as unknown as GatewayShouldRespond).shouldRespond(
-      asDiscordMessage(message),
-      isDM,
-      isMentioned
-    );
+
+  function getMessageCreateHandler(): (message: Message) => Promise<void> {
+    const call = discordClientMock.on.mock.calls.find(([event]) => event === Events.MessageCreate);
+    expect(call).toBeDefined();
+    return call![1] as (message: Message) => Promise<void>;
+  }
+
+  function makeGuildMessage(
+    content: string,
+    isMentioned = false
+  ): Message & {
+    reply: ReturnType<typeof vi.fn>;
+  } {
+    const channel = {
+      id: 'c1',
+      type: ChannelType.GuildText,
+      name: 'general',
+      sendTyping: vi.fn().mockResolvedValue(undefined),
+      send: vi.fn().mockResolvedValue({ id: 'sent-1', content: 'sent' }),
+      messages: { fetch: vi.fn() },
+      isDMBased: () => false,
+    };
+    return {
+      id: 'm1',
+      content,
+      guild: { id: 'g1', name: 'Guild One' },
+      channel,
+      author: {
+        id: 'u1',
+        username: 'tester',
+        tag: 'tester#0001',
+        bot: false,
+      },
+      mentions: { has: vi.fn().mockReturnValue(isMentioned) },
+      attachments: new Map(),
+      react: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue({ id: 'reply-1', content: 'Test response' }),
+    } as unknown as Message & { reply: ReturnType<typeof vi.fn> };
+  }
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -241,48 +263,45 @@ describe('DiscordGateway', () => {
     });
   });
 
-  describe('shouldRespond() - delegation trigger bypass', () => {
-    it('should respond to DELEGATE commands even when mention is required', () => {
+  describe('STORY-DISCORD-1: delegation trigger routing', () => {
+    it('AC: responds to DELEGATE commands through the public message event when mention is required', async () => {
       gateway.setConfig({
         guilds: {
           '*': { requireMention: true },
         },
       });
 
-      const message = {
-        content: 'DELEGATE::developer::Do the thing',
-        guild: { id: 'g1' },
-        channel: { id: 'c1' },
-      };
+      const message = makeGuildMessage('DELEGATE::developer::Do the thing');
 
-      expect(shouldRespondFor(gateway, message, false, false)).toBe(true);
+      await getMessageCreateHandler()(message);
+
+      expect(mockMessageRouter.process).toHaveBeenCalledOnce();
+      expect(message.reply).toHaveBeenCalled();
     });
 
-    it('should respond to DELEGATE commands even with no guild config (mentions normally required)', () => {
+    it('AC: responds to DELEGATE_BG commands with no guild config through the public message event', async () => {
       // Default: no guild config set -> shouldRespond returns isMentioned for normal messages.
-      const message = {
-        content: 'DELEGATE_BG::reviewer::Review this',
-        guild: { id: 'g1' },
-        channel: { id: 'c1' },
-      };
+      const message = makeGuildMessage('DELEGATE_BG::reviewer::Review this');
 
-      expect(shouldRespondFor(gateway, message, false, false)).toBe(true);
+      await getMessageCreateHandler()(message);
+
+      expect(mockMessageRouter.process).toHaveBeenCalledOnce();
+      expect(message.reply).toHaveBeenCalled();
     });
 
-    it('should not respond to normal messages when mention is required', () => {
+    it('AC: does not dispatch normal guild messages when mention is required', async () => {
       gateway.setConfig({
         guilds: {
           '*': { requireMention: true },
         },
       });
 
-      const message = {
-        content: 'hello',
-        guild: { id: 'g1' },
-        channel: { id: 'c1' },
-      };
+      const message = makeGuildMessage('hello');
 
-      expect(shouldRespondFor(gateway, message, false, false)).toBe(false);
+      await getMessageCreateHandler()(message);
+
+      expect(mockMessageRouter.process).not.toHaveBeenCalled();
+      expect(message.reply).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Completes the Reactive envelope runtime path from startup issuance through gateway tool execution context propagation.
- Adds durable `agent_activity` envelope audit rows, memory-scope mismatch logging, metrics/security alarms, and trace query helpers.
- Splits public `/health` from authenticated `/api/envelope/status`, and documents M1R setup, threat posture, and verification.

## Test Plan
- `pnpm -C packages/standalone exec vitest run tests/contract/m1r-envelope-completion-matrix.test.ts tests/contract/envelope-callsite-matrix.test.ts tests/agent/delegation-executor.test.ts tests/envelope/executor-pipeline.test.ts tests/envelope/agent-loop-internal-tool-context.test.ts tests/envelope/code-act-context.test.ts tests/cli/runtime/agent-loop-init-envelope-options.test.ts tests/cli/runtime/envelope-bootstrap.test.ts tests/envelope/reactive-config.test.ts tests/envelope/memory-scope-mismatch-logging.test.ts tests/envelope/executor-audit.test.ts tests/db/agent-activity.test.ts tests/api/health-envelope.test.ts tests/api/envelope-status-auth.test.ts tests/envelope/executor-integration.test.ts tests/contract/reactive-envelope.test.ts tests/contract/reactive-envelope-tool-path.test.ts tests/contract/envelope-drift-sentinel.test.ts tests/contract/code-task-delegation-empty-scopes.test.ts`
- `pnpm -C packages/standalone typecheck`
- `pnpm -C packages/standalone test`
- `pnpm test`
- `pnpm build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signed reactive envelope support with runtime issuance modes, audited gateway tool calls, memory-scope enforcement, and a new /api/envelope/status endpoint
  * Delegation executor for agent testing and foreground/background delegation; expanded Tier‑2 write tool set
  * Per-client rate limiting for Code‑Act and sandbox tier injection controls

* **Documentation**
  * Testing guide, threat model, and standalone setup docs for envelope issuance and validation

* **Tests**
  * Extensive envelope, audit, delegation, execution‑context, and memory‑scope test suites added
<!-- end of auto-generated comment: release notes by coderabbit.ai -->