### PR TITLE
feat(m2): add memory provenance foundation

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -92,6 +92,26 @@ keeps local and CI runs faster and less sensitive to embedding runtime latency.
 `/api/envelope/status`, with the count sourced from `agent_activity`, not
 best-effort metrics.
 
+### M2 Memory Provenance Foundation
+
+Use this focused suite when changing memory provenance columns, trusted
+provenance sanitization, gateway correlation ids, or memory provenance query
+helpers:
+
+```bash
+pnpm -C packages/mama-core exec vitest run tests/memory/memory-provenance.test.ts tests/memory/memory-provenance-query.test.ts tests/cases/migration-chain.test.ts tests/cases/migration-runner-duplicate-column.test.ts
+pnpm -C packages/mcp-server exec vitest run tests/tools/save-decision-v2.test.js tests/tools/ingest-conversation-provenance.test.js
+pnpm -C packages/standalone exec vitest run tests/envelope/memory-provenance-context.test.ts tests/envelope/executor-audit.test.ts tests/envelope/memory-scope-mismatch-logging.test.ts tests/db/agent-activity.test.ts tests/gateways/message-router.test.ts tests/agent/gateway-tool-executor.test.ts tests/cli/runtime/memory-agent-init.test.ts
+pnpm -C packages/mama-core typecheck
+pnpm -C packages/standalone typecheck
+git diff --check
+```
+
+These tests prove that public callers cannot spoof trusted provenance, direct
+writes still create fallback save events, gateway memory writes receive a typed
+`gateway_call_id`, and provenance reads use `memory_scope_bindings` for scoped
+visibility.
+
 ---
 
 ## Test Coverage

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -9,6 +9,7 @@
 - [Security Model](#security-model)
 - [Envelope Threat Model and Posture](#envelope-threat-model-and-posture)
 - [Built-in Detection and Response](#built-in-detection-and-response)
+- [Memory Provenance Foundation](#memory-provenance-foundation)
 - [Localhost-Only Mode (Default)](#localhost-only-mode-default)
 - [External Access via Tunnels](#external-access-via-tunnels)
 - [🌟 Cloudflare Zero Trust (Recommended for Production)](#cloudflare-zero-trust-recommended-for-production)
@@ -118,6 +119,25 @@ When mismatches spike, compare `requested_scopes` with
 `envelope_scopes_snapshot` for the same `envelope_hash`. Classify the cause as
 prompt injection, agent hallucination, or a legitimate caller-side scope
 derivation bug before changing policy.
+
+### Memory Provenance Foundation
+
+M2 provenance foundation records compact origin metadata on new memory writes:
+`agent_id`, `envelope_hash`, `gateway_call_id`, `model_run_id`, source refs, and
+the matching `memory_events(event_type='save')` row. This explains where a
+memory row came from and gives operators a stable join from standalone
+`agent_activity.gateway_call_id` to mama-core `decisions.gateway_call_id`.
+
+Caller-supplied provenance from MCP, LLM-visible gateway tool input, or public
+core APIs is ignored. Trusted provenance can only arrive through runtime-only
+options guarded by an in-process capability, so it is not a boundary against
+malicious arbitrary code running inside the same Node process.
+
+The compact provenance record intentionally excludes prompts, raw tool
+arguments, model completions, raw connector payloads, and other high-cardinality
+or sensitive payload bodies. For memory-scope visibility, provenance reads use
+`memory_scope_bindings` as the source of truth instead of trusting provenance
+JSON.
 
 ---
 
@@ -1120,8 +1140,8 @@ The Code-Act sandbox is accessible via `POST /api/code-act`. This endpoint:
   the socket peer is the rate-limit identity
 - Records gateway audit rows with envelope hash, requested scopes, envelope
   scope snapshots, and `scope_mismatch`. The signed envelope/audit row gives
-  durable request provenance; independent tamper-evidence for the memory row
-  itself remains future work.
+  durable request provenance, while the memory row stores compact M2 origin
+  metadata for operator lookup.
 
 ### Risk Assessment
 

--- a/packages/mama-core/db/migrations/032-add-memory-provenance-columns.sql
+++ b/packages/mama-core/db/migrations/032-add-memory-provenance-columns.sql
@@ -1,0 +1,21 @@
+ALTER TABLE decisions ADD COLUMN agent_id TEXT;
+ALTER TABLE decisions ADD COLUMN model_run_id TEXT;
+ALTER TABLE decisions ADD COLUMN envelope_hash TEXT;
+ALTER TABLE decisions ADD COLUMN gateway_call_id TEXT;
+ALTER TABLE decisions ADD COLUMN source_refs_json TEXT;
+ALTER TABLE decisions ADD COLUMN provenance_json TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_decisions_envelope_hash
+  ON decisions(envelope_hash);
+
+CREATE INDEX IF NOT EXISTS idx_decisions_model_run_id
+  ON decisions(model_run_id);
+
+CREATE INDEX IF NOT EXISTS idx_decisions_gateway_call_id
+  ON decisions(gateway_call_id);
+
+CREATE INDEX IF NOT EXISTS idx_memory_events_memory_created
+  ON memory_events(memory_id, created_at DESC);
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES (32, 'Add nullable memory provenance columns');

--- a/packages/mama-core/src/db-adapter/node-sqlite-adapter.ts
+++ b/packages/mama-core/src/db-adapter/node-sqlite-adapter.ts
@@ -15,6 +15,7 @@ import { cosineSimilarity } from '../embeddings.js';
 
 const LEGACY_DB_PATH = path.join(os.homedir(), '.spinelift', 'memories.db');
 const DEFAULT_DB_PATH = path.join(os.homedir(), '.claude', 'mama-memory.db');
+const SQLITE_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 interface SQLiteAdapterConfig {
   dbPath?: string;
@@ -429,6 +430,12 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
         this.exec('ROLLBACK');
         const message = err instanceof Error ? err.message : String(err);
 
+        if (message.includes('duplicate column') && version === 32) {
+          this.recoverMemoryProvenanceMigration032();
+          info(`[node-sqlite-adapter] Migration ${file} recovered successfully`);
+          continue;
+        }
+
         if (message.includes('duplicate column')) {
           warn(
             `[node-sqlite-adapter] Migration ${file} skipped (duplicate column - already applied)`
@@ -469,6 +476,92 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
     }
 
     this.migrateFromVssMemories();
+  }
+
+  private recoverMemoryProvenanceMigration032(): void {
+    this.transaction(() => {
+      const expectedDecisionColumns = [
+        'agent_id',
+        'model_run_id',
+        'envelope_hash',
+        'gateway_call_id',
+        'source_refs_json',
+        'provenance_json',
+      ];
+      const decisionColumns = this.tableColumns('decisions');
+      for (const column of expectedDecisionColumns) {
+        if (!decisionColumns.has(column)) {
+          this.exec(`ALTER TABLE decisions ADD COLUMN ${column} TEXT`);
+          decisionColumns.add(column);
+        }
+      }
+
+      this.exec(`
+        CREATE INDEX IF NOT EXISTS idx_decisions_envelope_hash
+          ON decisions(envelope_hash)
+      `);
+      this.exec(`
+        CREATE INDEX IF NOT EXISTS idx_decisions_model_run_id
+          ON decisions(model_run_id)
+      `);
+      this.exec(`
+        CREATE INDEX IF NOT EXISTS idx_decisions_gateway_call_id
+          ON decisions(gateway_call_id)
+      `);
+      this.exec(`
+        CREATE INDEX IF NOT EXISTS idx_memory_events_memory_created
+          ON memory_events(memory_id, created_at DESC)
+      `);
+
+      this.assertMigration032Complete();
+      this.prepare('INSERT OR IGNORE INTO schema_version (version, description) VALUES (?, ?)').run(
+        32,
+        'Add nullable memory provenance columns'
+      );
+    });
+  }
+
+  private assertMigration032Complete(): void {
+    const decisionColumns = this.tableColumns('decisions');
+    for (const column of [
+      'agent_id',
+      'model_run_id',
+      'envelope_hash',
+      'gateway_call_id',
+      'source_refs_json',
+      'provenance_json',
+    ]) {
+      if (!decisionColumns.has(column)) {
+        throw new Error(`Migration 032 recovery failed: missing decisions.${column}`);
+      }
+    }
+
+    for (const indexName of [
+      'idx_decisions_envelope_hash',
+      'idx_decisions_model_run_id',
+      'idx_decisions_gateway_call_id',
+      'idx_memory_events_memory_created',
+    ]) {
+      if (!this.indexExists(indexName)) {
+        throw new Error(`Migration 032 recovery failed: missing index ${indexName}`);
+      }
+    }
+  }
+
+  private tableColumns(tableName: string): Set<string> {
+    if (!SQLITE_IDENTIFIER_PATTERN.test(tableName)) {
+      throw new Error('Invalid SQLite table identifier');
+    }
+
+    const rows = this.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>;
+    return new Set(rows.map((row) => row.name));
+  }
+
+  private indexExists(indexName: string): boolean {
+    const row = this.prepare("SELECT name FROM sqlite_master WHERE type='index' AND name = ?").get(
+      indexName
+    ) as { name?: string } | undefined;
+    return row?.name === indexName;
   }
 
   private migrateFromVssMemories(): void {

--- a/packages/mama-core/src/db-manager.ts
+++ b/packages/mama-core/src/db-manager.ts
@@ -479,6 +479,12 @@ export interface DecisionInput {
   event_date?: string | null;
   /** Source event timestamp in milliseconds when known. */
   event_datetime?: number | null;
+  agent_id?: string | null;
+  model_run_id?: string | null;
+  envelope_hash?: string | null;
+  gateway_call_id?: string | null;
+  source_refs_json?: string | null;
+  provenance_json?: string | null;
 }
 
 /**
@@ -547,8 +553,9 @@ export async function insertDecisionWithEmbedding(decision: DecisionInput): Prom
           confidence, created_at, updated_at,
           needs_validation, validation_attempts, last_validated_at, usage_count,
           trust_context, usage_success, usage_failure, time_saved,
-          evidence, alternatives, risks, event_date, event_datetime
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          evidence, alternatives, risks, event_date, event_datetime,
+          agent_id, model_run_id, envelope_hash, gateway_call_id, source_refs_json, provenance_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
 
       const insertResult = stmt.run(
@@ -582,7 +589,13 @@ export async function insertDecisionWithEmbedding(decision: DecisionInput): Prom
         decision.alternatives || null,
         decision.risks || null,
         decision.event_date || null,
-        decision.event_datetime ?? null
+        decision.event_datetime ?? null,
+        decision.agent_id ?? null,
+        decision.model_run_id ?? null,
+        decision.envelope_hash ?? null,
+        decision.gateway_call_id ?? null,
+        decision.source_refs_json ?? null,
+        decision.provenance_json ?? null
       );
 
       const rowid = Number(insertResult.lastInsertRowid);

--- a/packages/mama-core/src/index.ts
+++ b/packages/mama-core/src/index.ts
@@ -93,7 +93,13 @@ export {
   type MemoryStatus,
   type MemoryEdgeType,
   type MemoryScopeRef,
+  type MemorySourceRef,
   type MemoryRecord,
+  type MemoryWriteProvenance,
+  type MemoryProvenanceRecord,
+  type PublicSaveMemoryInput,
+  type PublicIngestMemoryInput,
+  type PublicIngestConversationInput,
   type MemorySearchResultHit,
   type MemoryEdge,
   type ProfileSnapshot,
@@ -105,20 +111,34 @@ export {
 } from './memory/types.js';
 export {
   saveMemory,
+  saveMemoryWithTrustedProvenance,
   recallMemory,
   buildProfile,
   ingestMemory,
+  ingestWithTrustedProvenance,
   evolveMemory,
   buildMemoryBootstrap,
   createAuditAck,
   recordMemoryAudit,
   ingestConversation,
+  ingestConversationWithTrustedProvenance,
   setExtractionFn,
   upsertChannelSummary,
   getChannelSummary,
 } from './memory/api.js';
 export { buildExtractionPrompt, parseExtractionResponse } from './memory/extraction-prompt.js';
-export { appendMemoryEvent, listRecentMemoryEvents } from './memory/event-store.js';
+export {
+  appendMemoryEvent,
+  insertMemoryEventInTransaction,
+  listMemoryEventsForMemory,
+  listRecentMemoryEvents,
+} from './memory/event-store.js';
+export {
+  getMemoryProvenance,
+  listMemoriesByEnvelopeHash,
+  listMemoriesByGatewayCallId,
+  listMemoriesByModelRunId,
+} from './memory/provenance-query.js';
 export * from './entities/types.js';
 export * from './entities/errors.js';
 export * from './entities/store.js';

--- a/packages/mama-core/src/mama-api.ts
+++ b/packages/mama-core/src/mama-api.ts
@@ -41,9 +41,13 @@ import { generate } from './ollama-client.js';
 import { warn as logWarn, error as logError } from './debug-logger.js';
 import {
   saveMemory,
+  saveMemoryWithTrustedProvenance,
   recallMemory,
   buildProfile,
   ingestMemory,
+  ingestWithTrustedProvenance,
+  ingestConversation,
+  ingestConversationWithTrustedProvenance,
   evolveMemory,
   buildMemoryBootstrap,
   createAuditAck,
@@ -52,7 +56,14 @@ import {
   getChannelSummary,
 } from './memory/api.js';
 import { listOpenAuditFindings } from './memory/finding-store.js';
-import { listRecentMemoryEvents } from './memory/event-store.js';
+import { listMemoryEventsForMemory, listRecentMemoryEvents } from './memory/event-store.js';
+import type { TrustedMemoryWriteOptions } from './memory/provenance.js';
+import {
+  getMemoryProvenance,
+  listMemoriesByEnvelopeHash,
+  listMemoriesByGatewayCallId,
+  listMemoriesByModelRunId,
+} from './memory/provenance-query.js';
 import {
   rollUpSearchHits,
   type SearchRollupLeafHit,
@@ -515,21 +526,24 @@ const WARNING_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
  *   outcome: 'success'
  * });
  */
-async function save({
-  topic,
-  decision,
-  reasoning,
-  confidence = 0.5,
-  type = 'user_decision',
-  outcome = 'pending',
-  failure_reason = null,
-  limitation = null,
-  trust_context: _trust_context = null,
-  is_static,
-  scopes: inputScopes,
-  event_date,
-  timelineEvent,
-}: SaveParams): Promise<SaveResult> {
+async function saveInternal(
+  {
+    topic,
+    decision,
+    reasoning,
+    confidence = 0.5,
+    type = 'user_decision',
+    outcome = 'pending',
+    failure_reason = null,
+    limitation = null,
+    trust_context: _trust_context = null,
+    is_static,
+    scopes: inputScopes,
+    event_date,
+    timelineEvent,
+  }: SaveParams,
+  options?: TrustedMemoryWriteOptions
+): Promise<SaveResult> {
   // Validate required fields
   if (!topic || typeof topic !== 'string') {
     throw new Error('mama.save() requires topic (string)');
@@ -595,20 +609,38 @@ async function save({
     id: decisionId,
     timeline_event_id: timelineEventId,
     timeline_event_ids: timelineEventIds,
-  } = await saveMemory({
-    topic,
-    kind: is_static === 1 ? 'preference' : 'decision',
-    summary: decision,
-    details: reasoning,
-    confidence,
-    scopes: Array.isArray(inputScopes) && inputScopes.length > 0 ? inputScopes : [],
-    source: {
-      package: 'mama-core',
-      source_type: 'legacy_save',
-    },
-    eventDate: event_date ?? undefined,
-    timelineEvent,
-  });
+  } = options
+    ? await saveMemoryWithTrustedProvenance(
+        {
+          topic,
+          kind: is_static === 1 ? 'preference' : 'decision',
+          summary: decision,
+          details: reasoning,
+          confidence,
+          scopes: Array.isArray(inputScopes) && inputScopes.length > 0 ? inputScopes : [],
+          source: {
+            package: 'mama-core',
+            source_type: 'legacy_save',
+          },
+          eventDate: event_date ?? undefined,
+          timelineEvent,
+        },
+        options
+      )
+    : await saveMemory({
+        topic,
+        kind: is_static === 1 ? 'preference' : 'decision',
+        summary: decision,
+        details: reasoning,
+        confidence,
+        scopes: Array.isArray(inputScopes) && inputScopes.length > 0 ? inputScopes : [],
+        source: {
+          package: 'mama-core',
+          source_type: 'legacy_save',
+        },
+        eventDate: event_date ?? undefined,
+        timelineEvent,
+      });
   logComplete(`Decision saved: ${decisionId.substring(0, 20)}...`);
 
   // Update user_involvement, outcome, failure_reason, limitation
@@ -701,9 +733,7 @@ async function save({
         if (searchResults && typeof searchResults === 'object' && 'results' in searchResults) {
           // Filter out the decision we just saved
           similar_decisions = (searchResults.results as SimilarDecision[])
-            .filter(
-              (d: SimilarDecision & { source_type?: string }) => d.source_type === 'decision'
-            )
+            .filter((d: SimilarDecision & { source_type?: string }) => d.source_type === 'decision')
             .filter((d: SimilarDecision) => d.id !== decisionId)
             .map((d: SimilarDecision) => ({
               id: d.id,
@@ -1528,6 +1558,17 @@ function mapRolledUpResult(result: SearchRollupResult) {
     source_type: result.source_type,
     contributing_leaves: result.contributing_leaves ?? null,
   };
+}
+
+async function save(params: SaveParams): Promise<SaveResult> {
+  return saveInternal(params);
+}
+
+async function saveWithTrustedProvenance(
+  params: SaveParams,
+  options: TrustedMemoryWriteOptions
+): Promise<SaveResult> {
+  return saveInternal(params, options);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -3815,14 +3856,19 @@ function formatQualityReportMarkdown(report: {
 const mama = {
   // Core functions (used by 4 MCP tools)
   save,
+  saveWithTrustedProvenance,
   suggest,
   saveMemory,
+  saveMemoryWithTrustedProvenance,
   recallMemory,
   list: listDecisions,
   listCheckpoints,
   updateOutcome,
   buildProfile,
   ingestMemory,
+  ingestWithTrustedProvenance,
+  ingestConversation,
+  ingestConversationWithTrustedProvenance,
   evolveMemory,
   buildMemoryBootstrap,
   createAuditAck,
@@ -3830,6 +3876,11 @@ const mama = {
   upsertChannelSummary,
   getChannelSummary,
   listAuditFindings: listOpenAuditFindings,
+  getMemoryProvenance,
+  listMemoriesByEnvelopeHash,
+  listMemoriesByGatewayCallId,
+  listMemoriesByModelRunId,
+  listMemoryEventsForMemory,
   listRecentMemoryEvents,
   saveCheckpoint,
   loadCheckpoint,
@@ -3860,14 +3911,19 @@ const mama = {
 // Named exports for ESM consumers
 export {
   save,
+  saveWithTrustedProvenance,
   suggest,
   saveMemory,
+  saveMemoryWithTrustedProvenance,
   recallMemory,
   listDecisions as list,
   listCheckpoints,
   updateOutcome,
   buildProfile,
   ingestMemory,
+  ingestWithTrustedProvenance,
+  ingestConversation,
+  ingestConversationWithTrustedProvenance,
   evolveMemory,
   buildMemoryBootstrap,
   createAuditAck,
@@ -3875,6 +3931,11 @@ export {
   upsertChannelSummary,
   getChannelSummary,
   listOpenAuditFindings,
+  getMemoryProvenance,
+  listMemoriesByEnvelopeHash,
+  listMemoriesByGatewayCallId,
+  listMemoriesByModelRunId,
+  listMemoryEventsForMemory,
   listRecentMemoryEvents,
   saveCheckpoint,
   loadCheckpoint,

--- a/packages/mama-core/src/memory/api.ts
+++ b/packages/mama-core/src/memory/api.ts
@@ -35,50 +35,25 @@ import type {
   MemoryStatus,
   MemoryTruthRow,
   ProfileSnapshot,
+  PublicIngestMemoryInput,
+  PublicSaveMemoryInput,
   RecallBundle,
   IngestConversationInput,
   ExtractedMemoryUnit,
   IngestConversationResult,
 } from './types.js';
+import { insertMemoryEventInTransaction } from './event-store.js';
+import {
+  appendProvenanceSourceRefs,
+  normalizeMemoryWriteProvenance,
+  sanitizePublicIngestConversationInput,
+  sanitizePublicIngestMemoryInput,
+  sanitizePublicSaveMemoryInput,
+  type TrustedMemoryWriteOptions,
+} from './provenance.js';
 
-interface SaveMemoryInput {
-  topic: string;
-  kind: MemoryKind;
-  summary: string;
-  details: string;
-  confidence?: number;
-  status?: MemoryStatus;
-  scopes: MemoryScopeRef[];
-  source: {
-    package: 'mama-core' | 'mcp-server' | 'standalone' | 'claude-code-plugin';
-    source_type: string;
-    user_id?: string;
-    channel_id?: string;
-    project_id?: string;
-  };
-  /** IDs to exclude from supersede candidates (e.g., sibling facts from same ingestion batch) */
-  excludeIds?: string[];
-  /**
-   * ISO 8601 date string for when the event actually occurred (e.g. "2023-01-15").
-   * Stored in the event_date column. Defaults to created_at if omitted.
-   */
-  eventDate?: string;
-  /** Source event timestamp in milliseconds when known. */
-  eventDateTime?: number;
-  entityObservationIds?: string[];
-  timelineEvent?: {
-    id?: string;
-    entity_id?: string;
-    event_type: string;
-    role?: string | null;
-    valid_from?: number | null;
-    valid_to?: number | null;
-    observed_at?: number | null;
-    source_ref?: string | null;
-    summary: string;
-    details?: string | null;
-  };
-}
+type SaveMemoryInput = PublicSaveMemoryInput;
+type IngestMemoryInput = PublicIngestMemoryInput;
 
 interface RecallMemoryOptions {
   scopes?: MemoryScopeRef[];
@@ -87,14 +62,6 @@ interface RecallMemoryOptions {
   skipGraphExpansion?: boolean;
   topicPrefix?: string;
   limit?: number;
-}
-
-interface IngestMemoryInput {
-  content: string;
-  scopes?: MemoryScopeRef[];
-  source: SaveMemoryInput['source'];
-  eventDate?: string;
-  eventDateTime?: number;
 }
 
 export interface FusedHit {
@@ -111,6 +78,17 @@ interface SaveMemoryRollbackError extends Error {
 function buildDecisionId(topic: string): string {
   const safeTopic = topic.replace(/[^a-z0-9_]+/gi, '_').toLowerCase();
   return `decision_${safeTopic}_${Date.now()}_${crypto.randomUUID().slice(0, 8)}`;
+}
+
+function buildSaveEventReason(toolName: string | null, gatewayCallId: string | null): string {
+  const parts = ['saved'];
+  if (toolName) {
+    parts.push(`via ${toolName}`);
+  }
+  if (gatewayCallId) {
+    parts.push(`gateway_call_id=${gatewayCallId}`);
+  }
+  return parts.join(' ');
 }
 
 function toMemoryRecord(
@@ -623,18 +601,24 @@ export async function loadEdgesForIds(ids: string[]): Promise<MemoryEdge[]> {
   }));
 }
 
-export async function saveMemory(input: SaveMemoryInput): Promise<{
+type SaveMemoryResult = {
   success: boolean;
   id: string;
   saved_decision_id?: string;
   timeline_event_id?: string | null;
   timeline_event_ids?: string[];
-}> {
+};
+
+async function saveMemoryInternal(
+  input: SaveMemoryInput,
+  options?: TrustedMemoryWriteOptions
+): Promise<SaveMemoryResult> {
   await initDB();
   const adapter = getAdapter();
 
   const id = buildDecisionId(input.topic);
   const now = Date.now();
+  const provenance = normalizeMemoryWriteProvenance(options);
   // Find evolution candidates: exact topic match first, then semantic search fallback
   const primaryScope = input.scopes.length > 0 ? input.scopes[0] : null;
   const excludeIds = new Set(input.excludeIds ?? []);
@@ -792,6 +776,43 @@ export async function saveMemory(input: SaveMemoryInput): Promise<{
           .run(id, scopeId, isPrimary ? 1 : 0);
       }
 
+      adapter
+        .prepare(
+          `
+            UPDATE decisions
+            SET agent_id = ?,
+                model_run_id = ?,
+                envelope_hash = ?,
+                gateway_call_id = ?,
+                source_refs_json = ?,
+                provenance_json = ?,
+                updated_at = ?
+            WHERE id = ?
+          `
+        )
+        .run(
+          provenance.agent_id,
+          provenance.model_run_id,
+          provenance.envelope_hash,
+          provenance.gateway_call_id,
+          JSON.stringify(provenance.source_refs),
+          JSON.stringify(provenance.provenance),
+          now,
+          id
+        );
+
+      insertMemoryEventInTransaction(adapter, {
+        event_type: 'save',
+        actor: provenance.actor,
+        source_turn_id: provenance.source_turn_id ?? undefined,
+        memory_id: id,
+        topic: input.topic,
+        scope_refs: input.scopes,
+        evidence_refs: provenance.source_refs,
+        reason: buildSaveEventReason(provenance.tool_name, provenance.gateway_call_id),
+        created_at: now,
+      });
+
       for (const entityObservationId of entityObservationIds) {
         adapter
           .prepare(
@@ -860,6 +881,17 @@ export async function saveMemory(input: SaveMemoryInput): Promise<{
     timeline_event_id: timelineEvent?.id ?? null,
     timeline_event_ids: timelineEvent ? [timelineEvent.id] : [],
   };
+}
+
+export async function saveMemory(input: SaveMemoryInput): Promise<SaveMemoryResult> {
+  return saveMemoryInternal(sanitizePublicSaveMemoryInput(input));
+}
+
+export async function saveMemoryWithTrustedProvenance(
+  input: SaveMemoryInput,
+  options: TrustedMemoryWriteOptions
+): Promise<SaveMemoryResult> {
+  return saveMemoryInternal(sanitizePublicSaveMemoryInput(input), options);
 }
 
 export async function buildProfile(scopes: MemoryScopeRef[]): Promise<ProfileSnapshot> {
@@ -1443,25 +1475,42 @@ export async function recallMemory(
   return bundle;
 }
 
+async function ingestMemoryInternal(
+  input: IngestMemoryInput,
+  options?: TrustedMemoryWriteOptions
+): Promise<{ success: boolean; id: string }> {
+  const normalized = input.content.trim();
+  return saveMemoryInternal(
+    {
+      topic:
+        normalized
+          .slice(0, 40)
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '_')
+          .replace(/^_+|_+$/g, '') || 'ingested_memory',
+      kind: 'fact',
+      summary: normalized.slice(0, 200),
+      details: normalized,
+      scopes: input.scopes ?? [],
+      source: input.source,
+      eventDate: input.eventDate,
+      eventDateTime: input.eventDateTime,
+    },
+    options
+  );
+}
+
 export async function ingestMemory(
   input: IngestMemoryInput
 ): Promise<{ success: boolean; id: string }> {
-  const normalized = input.content.trim();
-  return saveMemory({
-    topic:
-      normalized
-        .slice(0, 40)
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '_')
-        .replace(/^_+|_+$/g, '') || 'ingested_memory',
-    kind: 'fact',
-    summary: normalized.slice(0, 200),
-    details: normalized,
-    scopes: input.scopes ?? [],
-    source: input.source,
-    eventDate: input.eventDate,
-    eventDateTime: input.eventDateTime,
-  });
+  return ingestMemoryInternal(sanitizePublicIngestMemoryInput(input));
+}
+
+export async function ingestWithTrustedProvenance(
+  input: IngestMemoryInput,
+  options: TrustedMemoryWriteOptions
+): Promise<{ success: boolean; id: string }> {
+  return ingestMemoryInternal(sanitizePublicIngestMemoryInput(input), options);
 }
 
 export async function evolveMemory(input: Parameters<typeof resolveMemoryEvolution>[0]) {
@@ -1544,8 +1593,9 @@ export function setExtractionFn(fn: typeof callExtractionLLM | null): void {
   extractionFn = fn ?? callExtractionLLM;
 }
 
-export async function ingestConversation(
-  input: IngestConversationInput
+async function ingestConversationInternal(
+  input: IngestConversationInput,
+  options?: TrustedMemoryWriteOptions
 ): Promise<IngestConversationResult> {
   if (!input.messages || input.messages.length === 0) {
     throw new Error('messages array must not be empty');
@@ -1554,12 +1604,15 @@ export async function ingestConversation(
   const conversationText = input.messages.map((m) => `${m.role}: ${m.content}`).join('\n');
   const topicPrefix = input.topicPrefix || '';
 
-  const rawResult = await ingestMemory({
-    content: topicPrefix ? `${topicPrefix}${conversationText}` : conversationText,
-    scopes: input.scopes,
-    source: input.source,
-    eventDate: input.sessionDate,
-  });
+  const rawResult = await ingestMemoryInternal(
+    {
+      content: topicPrefix ? `${topicPrefix}${conversationText}` : conversationText,
+      scopes: input.scopes,
+      source: input.source,
+      eventDate: input.sessionDate,
+    },
+    options
+  );
 
   const result: IngestConversationResult = {
     rawId: rawResult.id,
@@ -1619,17 +1672,20 @@ export async function ingestConversation(
 
   for (const unit of units) {
     try {
-      const saved = await saveMemory({
-        topic: topicPrefix ? `${topicPrefix}${unit.topic}` : unit.topic,
-        kind: unit.kind,
-        summary: unit.summary,
-        details: unit.details,
-        confidence: unit.confidence,
-        scopes: input.scopes,
-        source: input.source,
-        excludeIds: batchSavedIds,
-        eventDate: input.sessionDate,
-      });
+      const saved = await saveMemoryInternal(
+        {
+          topic: topicPrefix ? `${topicPrefix}${unit.topic}` : unit.topic,
+          kind: unit.kind,
+          summary: unit.summary,
+          details: unit.details,
+          confidence: unit.confidence,
+          scopes: input.scopes,
+          source: input.source,
+          excludeIds: batchSavedIds,
+          eventDate: input.sessionDate,
+        },
+        appendProvenanceSourceRefs(options, [`raw_memory:${rawResult.id}`])
+      );
 
       const now = Date.now();
       adapter
@@ -1660,6 +1716,19 @@ export async function ingestConversation(
   }
 
   return result;
+}
+
+export async function ingestConversation(
+  input: IngestConversationInput
+): Promise<IngestConversationResult> {
+  return ingestConversationInternal(sanitizePublicIngestConversationInput(input));
+}
+
+export async function ingestConversationWithTrustedProvenance(
+  input: IngestConversationInput,
+  options: TrustedMemoryWriteOptions
+): Promise<IngestConversationResult> {
+  return ingestConversationInternal(sanitizePublicIngestConversationInput(input), options);
 }
 
 export { upsertChannelSummary, getChannelSummary };

--- a/packages/mama-core/src/memory/api.ts
+++ b/packages/mama-core/src/memory/api.ts
@@ -736,6 +736,12 @@ async function saveMemoryInternal(
     trust_context: JSON.stringify({ source: input.source }),
     event_date: input.eventDate ?? null,
     event_datetime: eventDateTime,
+    agent_id: provenance.agent_id,
+    model_run_id: provenance.model_run_id,
+    envelope_hash: provenance.envelope_hash,
+    gateway_call_id: provenance.gateway_call_id,
+    source_refs_json: JSON.stringify(provenance.source_refs),
+    provenance_json: JSON.stringify(provenance.provenance),
   });
 
   // Pre-resolve scope IDs before the synchronous transaction
@@ -775,31 +781,6 @@ async function saveMemoryInternal(
           )
           .run(id, scopeId, isPrimary ? 1 : 0);
       }
-
-      adapter
-        .prepare(
-          `
-            UPDATE decisions
-            SET agent_id = ?,
-                model_run_id = ?,
-                envelope_hash = ?,
-                gateway_call_id = ?,
-                source_refs_json = ?,
-                provenance_json = ?,
-                updated_at = ?
-            WHERE id = ?
-          `
-        )
-        .run(
-          provenance.agent_id,
-          provenance.model_run_id,
-          provenance.envelope_hash,
-          provenance.gateway_call_id,
-          JSON.stringify(provenance.source_refs),
-          JSON.stringify(provenance.provenance),
-          now,
-          id
-        );
 
       insertMemoryEventInTransaction(adapter, {
         event_type: 'save',

--- a/packages/mama-core/src/memory/event-store.ts
+++ b/packages/mama-core/src/memory/event-store.ts
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 
 import { getAdapter, initDB } from '../db-manager.js';
+import type { DatabaseAdapter } from '../db-manager.js';
 import type { MemoryEventRecord } from './types.js';
 
 function deserializeEvent(row: Record<string, unknown>): MemoryEventRecord {
@@ -30,6 +31,13 @@ export async function appendMemoryEvent(
 ): Promise<string> {
   await initDB();
   const adapter = getAdapter();
+  return insertMemoryEventInTransaction(adapter, input);
+}
+
+export function insertMemoryEventInTransaction(
+  adapter: Pick<DatabaseAdapter, 'prepare'>,
+  input: Omit<MemoryEventRecord, 'event_id'>
+): string {
   const eventId = `evt_${crypto.randomUUID().replace(/-/g, '')}`;
 
   adapter
@@ -69,10 +77,29 @@ export async function listMemoryEventsForTopic(topic: string): Promise<MemoryEve
                scope_refs, evidence_refs, reason, created_at
         FROM memory_events
         WHERE topic = ?
-        ORDER BY created_at DESC
+        ORDER BY created_at DESC, rowid DESC
       `
     )
     .all(topic) as Record<string, unknown>[];
+
+  return rows.map(deserializeEvent);
+}
+
+export async function listMemoryEventsForMemory(memoryId: string): Promise<MemoryEventRecord[]> {
+  await initDB();
+  const adapter = getAdapter();
+
+  const rows = adapter
+    .prepare(
+      `
+        SELECT event_id, event_type, actor, source_turn_id, memory_id, topic,
+               scope_refs, evidence_refs, reason, created_at
+        FROM memory_events
+        WHERE memory_id = ?
+        ORDER BY created_at DESC, rowid DESC
+      `
+    )
+    .all(memoryId) as Record<string, unknown>[];
 
   return rows.map(deserializeEvent);
 }
@@ -87,7 +114,7 @@ export async function listRecentMemoryEvents(limit = 10): Promise<MemoryEventRec
         SELECT event_id, event_type, actor, source_turn_id, memory_id, topic,
                scope_refs, evidence_refs, reason, created_at
         FROM memory_events
-        ORDER BY created_at DESC
+        ORDER BY created_at DESC, rowid DESC
         LIMIT ?
       `
     )

--- a/packages/mama-core/src/memory/provenance-query.ts
+++ b/packages/mama-core/src/memory/provenance-query.ts
@@ -1,0 +1,222 @@
+import { getAdapter, initDB } from '../db-manager.js';
+import type { MemoryProvenanceRecord, MemoryScopeRef } from './types.js';
+import { listMemoryEventsForMemory } from './event-store.js';
+
+export interface MemoryProvenanceQueryOptions {
+  scopes?: MemoryScopeRef[];
+  includeLegacyUnscoped?: boolean;
+  limit?: number;
+}
+
+type ProvenanceRow = {
+  id: string;
+  agent_id: string | null;
+  model_run_id: string | null;
+  envelope_hash: string | null;
+  gateway_call_id: string | null;
+  source_refs_json: string | null;
+  provenance_json: string | null;
+  created_at: number | string;
+};
+
+export async function getMemoryProvenance(
+  memoryId: string,
+  options: MemoryProvenanceQueryOptions = {}
+): Promise<MemoryProvenanceRecord | null> {
+  await initDB();
+  const adapter = getAdapter();
+  const row = adapter
+    .prepare(
+      `
+        SELECT id, agent_id, model_run_id, envelope_hash, gateway_call_id,
+               source_refs_json, provenance_json, created_at
+        FROM decisions
+        WHERE id = ?
+      `
+    )
+    .get(memoryId) as ProvenanceRow | undefined;
+
+  if (!row || !(await isVisibleMemory(row.id, options))) {
+    return null;
+  }
+  return toProvenanceRecord(row);
+}
+
+export async function listMemoriesByEnvelopeHash(
+  envelopeHash: string,
+  options: MemoryProvenanceQueryOptions = {}
+): Promise<MemoryProvenanceRecord[]> {
+  return listMemoriesByColumn('envelope_hash', envelopeHash, options);
+}
+
+export async function listMemoriesByGatewayCallId(
+  gatewayCallId: string,
+  options: MemoryProvenanceQueryOptions = {}
+): Promise<MemoryProvenanceRecord[]> {
+  return listMemoriesByColumn('gateway_call_id', gatewayCallId, options);
+}
+
+export async function listMemoriesByModelRunId(
+  modelRunId: string,
+  options: MemoryProvenanceQueryOptions = {}
+): Promise<MemoryProvenanceRecord[]> {
+  return listMemoriesByColumn('model_run_id', modelRunId, options);
+}
+
+async function listMemoriesByColumn(
+  column: 'envelope_hash' | 'gateway_call_id' | 'model_run_id',
+  value: string,
+  options: MemoryProvenanceQueryOptions
+): Promise<MemoryProvenanceRecord[]> {
+  await initDB();
+  const adapter = getAdapter();
+  const limit = normalizeLimit(options.limit);
+  const batchSize = options.scopes ? Math.max(limit * 5, 25) : limit;
+  const statement = adapter.prepare(
+    `
+      SELECT id, agent_id, model_run_id, envelope_hash, gateway_call_id,
+             source_refs_json, provenance_json, created_at
+      FROM decisions
+      WHERE ${column} = ?
+      ORDER BY created_at DESC, id DESC
+      LIMIT ? OFFSET ?
+    `
+  );
+  const records: MemoryProvenanceRecord[] = [];
+  let offset = 0;
+
+  while (records.length < limit) {
+    const rows = statement.all(value, batchSize, offset) as ProvenanceRow[];
+    if (rows.length === 0) {
+      break;
+    }
+
+    for (const row of rows) {
+      if (await isVisibleMemory(row.id, options)) {
+        records.push(await toProvenanceRecord(row));
+      }
+      if (records.length >= limit) {
+        break;
+      }
+    }
+
+    offset += rows.length;
+  }
+
+  return records;
+}
+
+async function toProvenanceRecord(row: ProvenanceRow): Promise<MemoryProvenanceRecord> {
+  const events = await listMemoryEventsForMemory(row.id);
+  return {
+    memory_id: row.id,
+    agent_id: row.agent_id,
+    model_run_id: row.model_run_id,
+    envelope_hash: row.envelope_hash,
+    gateway_call_id: row.gateway_call_id,
+    source_refs: parseStringArray(row.source_refs_json),
+    provenance: parseObject(row.provenance_json),
+    latest_event: events[0],
+  };
+}
+
+async function isVisibleMemory(
+  memoryId: string,
+  options: MemoryProvenanceQueryOptions
+): Promise<boolean> {
+  if (!options.scopes) {
+    return true;
+  }
+
+  await initDB();
+  const adapter = getAdapter();
+  const scopeIds = [];
+  for (const scope of options.scopes) {
+    const scopeId = resolveMemoryScopeId(scope.kind, scope.id);
+    if (scopeId) {
+      scopeIds.push(scopeId);
+    }
+  }
+
+  const bindingCount = (
+    adapter
+      .prepare(
+        `
+          SELECT COUNT(*) as count
+          FROM memory_scope_bindings
+          WHERE memory_id = ?
+        `
+      )
+      .get(memoryId) as { count: number }
+  ).count;
+
+  if (bindingCount === 0) {
+    return options.includeLegacyUnscoped === true;
+  }
+  if (scopeIds.length === 0) {
+    return false;
+  }
+
+  const placeholders = scopeIds.map(() => '?').join(', ');
+  const row = adapter
+    .prepare(
+      `
+        SELECT 1 as visible
+        FROM memory_scope_bindings
+        WHERE memory_id = ? AND scope_id IN (${placeholders})
+        LIMIT 1
+      `
+    )
+    .get(memoryId, ...scopeIds) as { visible: number } | undefined;
+  return row?.visible === 1;
+}
+
+function resolveMemoryScopeId(kind: string, externalId: string): string | null {
+  const adapter = getAdapter();
+  const row = adapter
+    .prepare(
+      `
+        SELECT id
+        FROM memory_scopes
+        WHERE kind = ? AND external_id = ?
+        LIMIT 1
+      `
+    )
+    .get(kind, externalId) as { id: string } | undefined;
+  return row?.id ?? null;
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  if (!Number.isFinite(limit)) {
+    return 50;
+  }
+  return Math.max(1, Math.min(200, Math.floor(limit as number)));
+}
+
+function parseStringArray(value: string | null): string[] {
+  if (!value) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseObject(value: string | null): Record<string, unknown> {
+  if (!value) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}

--- a/packages/mama-core/src/memory/provenance-query.ts
+++ b/packages/mama-core/src/memory/provenance-query.ts
@@ -71,39 +71,86 @@ async function listMemoriesByColumn(
   await initDB();
   const adapter = getAdapter();
   const limit = normalizeLimit(options.limit);
-  const batchSize = options.scopes ? Math.max(limit * 5, 25) : limit;
-  const statement = adapter.prepare(
-    `
-      SELECT id, agent_id, model_run_id, envelope_hash, gateway_call_id,
-             source_refs_json, provenance_json, created_at
-      FROM decisions
-      WHERE ${column} = ?
-      ORDER BY created_at DESC, id DESC
-      LIMIT ? OFFSET ?
-    `
-  );
+  const visibility = buildVisibilityPredicate(options);
+  const rows = adapter
+    .prepare(
+      `
+        SELECT d.id, d.agent_id, d.model_run_id, d.envelope_hash, d.gateway_call_id,
+               d.source_refs_json, d.provenance_json, d.created_at
+        FROM decisions d
+        WHERE d.${column} = ?${visibility.sql}
+        ORDER BY d.created_at DESC, d.id DESC
+        LIMIT ?
+      `
+    )
+    .all(value, ...visibility.params, limit) as ProvenanceRow[];
+
   const records: MemoryProvenanceRecord[] = [];
-  let offset = 0;
-
-  while (records.length < limit) {
-    const rows = statement.all(value, batchSize, offset) as ProvenanceRow[];
-    if (rows.length === 0) {
-      break;
-    }
-
-    for (const row of rows) {
-      if (await isVisibleMemory(row.id, options)) {
-        records.push(await toProvenanceRecord(row));
-      }
-      if (records.length >= limit) {
-        break;
-      }
-    }
-
-    offset += rows.length;
+  for (const row of rows) {
+    records.push(await toProvenanceRecord(row));
   }
 
   return records;
+}
+
+function buildVisibilityPredicate(options: MemoryProvenanceQueryOptions): {
+  sql: string;
+  params: string[];
+} {
+  if (!hasScopeFilter(options)) {
+    return { sql: '', params: [] };
+  }
+
+  const scopeIds = resolveMemoryScopeIds(options.scopes);
+  const legacyUnscopedPredicate = `
+          NOT EXISTS (
+            SELECT 1
+            FROM memory_scope_bindings msb_legacy
+            WHERE msb_legacy.memory_id = d.id
+          )
+        `;
+
+  if (scopeIds.length === 0) {
+    return options.includeLegacyUnscoped === true
+      ? { sql: ` AND ${legacyUnscopedPredicate}`, params: [] }
+      : { sql: ' AND 0 = 1', params: [] };
+  }
+
+  const placeholders = scopeIds.map(() => '?').join(', ');
+  const scopedPredicate = `
+        EXISTS (
+          SELECT 1
+          FROM memory_scope_bindings msb_scope
+          WHERE msb_scope.memory_id = d.id
+            AND msb_scope.scope_id IN (${placeholders})
+        )
+      `;
+
+  if (options.includeLegacyUnscoped === true) {
+    return {
+      sql: ` AND (${scopedPredicate} OR ${legacyUnscopedPredicate})`,
+      params: scopeIds,
+    };
+  }
+
+  return { sql: ` AND ${scopedPredicate}`, params: scopeIds };
+}
+
+function hasScopeFilter(
+  options: MemoryProvenanceQueryOptions
+): options is MemoryProvenanceQueryOptions & { scopes: MemoryScopeRef[] } {
+  return Array.isArray(options.scopes) && options.scopes.length > 0;
+}
+
+function resolveMemoryScopeIds(scopes: MemoryScopeRef[]): string[] {
+  const scopeIds: string[] = [];
+  for (const scope of scopes) {
+    const scopeId = resolveMemoryScopeId(scope.kind, scope.id);
+    if (scopeId) {
+      scopeIds.push(scopeId);
+    }
+  }
+  return scopeIds;
 }
 
 async function toProvenanceRecord(row: ProvenanceRow): Promise<MemoryProvenanceRecord> {
@@ -124,33 +171,26 @@ async function isVisibleMemory(
   memoryId: string,
   options: MemoryProvenanceQueryOptions
 ): Promise<boolean> {
-  if (!options.scopes) {
+  if (!hasScopeFilter(options)) {
     return true;
   }
 
   await initDB();
   const adapter = getAdapter();
-  const scopeIds = [];
-  for (const scope of options.scopes) {
-    const scopeId = resolveMemoryScopeId(scope.kind, scope.id);
-    if (scopeId) {
-      scopeIds.push(scopeId);
-    }
-  }
+  const scopeIds = resolveMemoryScopeIds(options.scopes);
 
-  const bindingCount = (
-    adapter
-      .prepare(
-        `
+  const bindingCount = adapter
+    .prepare(
+      `
           SELECT COUNT(*) as count
           FROM memory_scope_bindings
           WHERE memory_id = ?
         `
-      )
-      .get(memoryId) as { count: number }
-  ).count;
+    )
+    .get(memoryId) as { count: number };
+  const count = bindingCount.count;
 
-  if (bindingCount === 0) {
+  if (count === 0) {
     return options.includeLegacyUnscoped === true;
   }
   if (scopeIds.length === 0) {

--- a/packages/mama-core/src/memory/provenance.ts
+++ b/packages/mama-core/src/memory/provenance.ts
@@ -1,0 +1,182 @@
+import type {
+  MemoryEventRecord,
+  MemoryWriteProvenance,
+  PublicIngestConversationInput,
+  PublicIngestMemoryInput,
+  PublicSaveMemoryInput,
+} from './types.js';
+
+const issuedCapabilities = new WeakSet<object>();
+
+const ALLOWED_PROVENANCE_FIELDS = new Set<keyof MemoryWriteProvenance>([
+  'actor',
+  'agent_id',
+  'model_run_id',
+  'envelope_hash',
+  'tool_name',
+  'gateway_call_id',
+  'source_turn_id',
+  'source_message_ref',
+  'source_refs',
+]);
+
+export interface TrustedProvenanceCapability {
+  readonly __trustedProvenanceCapability: 'mama-core';
+}
+
+export interface TrustedMemoryWriteOptions {
+  provenance: MemoryWriteProvenance;
+  capability: TrustedProvenanceCapability;
+}
+
+export interface NormalizedMemoryProvenance {
+  actor: MemoryEventRecord['actor'];
+  agent_id: string | null;
+  model_run_id: string | null;
+  envelope_hash: string | null;
+  tool_name: string | null;
+  gateway_call_id: string | null;
+  source_turn_id: string | null;
+  source_message_ref: string | null;
+  source_refs: string[];
+  provenance: Record<string, unknown>;
+}
+
+export function createTrustedProvenanceCapability(): TrustedProvenanceCapability {
+  const capability = Object.freeze({
+    __trustedProvenanceCapability: 'mama-core' as const,
+  });
+  issuedCapabilities.add(capability);
+  return capability;
+}
+
+export function assertTrustedProvenanceCapability(
+  capability: TrustedProvenanceCapability | undefined
+): asserts capability is TrustedProvenanceCapability {
+  if (!capability || typeof capability !== 'object' || !issuedCapabilities.has(capability)) {
+    throw new Error('Invalid trusted provenance capability');
+  }
+}
+
+export function stripCallerProvenance<T extends Record<string, unknown>>(input: T): T {
+  if (!Object.prototype.hasOwnProperty.call(input, 'provenance')) {
+    return input;
+  }
+  const { provenance: _provenance, ...rest } = input;
+  return rest as T;
+}
+
+export function sanitizePublicSaveMemoryInput(input: PublicSaveMemoryInput): PublicSaveMemoryInput {
+  return stripCallerProvenance(input as PublicSaveMemoryInput & Record<string, unknown>);
+}
+
+export function sanitizePublicIngestMemoryInput(
+  input: PublicIngestMemoryInput
+): PublicIngestMemoryInput {
+  return stripCallerProvenance(input as PublicIngestMemoryInput & Record<string, unknown>);
+}
+
+export function sanitizePublicIngestConversationInput(
+  input: PublicIngestConversationInput
+): PublicIngestConversationInput {
+  return stripCallerProvenance(input as PublicIngestConversationInput & Record<string, unknown>);
+}
+
+export function normalizeMemoryWriteProvenance(
+  options?: TrustedMemoryWriteOptions
+): NormalizedMemoryProvenance {
+  if (!options) {
+    return buildFallbackProvenance();
+  }
+
+  assertTrustedProvenanceCapability(options.capability);
+  const provenance = options.provenance ?? {};
+  const actor = provenance.actor ?? 'main_agent';
+  const sourceRefs = normalizeStringArray(provenance.source_refs);
+  const compact: Record<string, unknown> = {
+    actor,
+  };
+
+  for (const [key, value] of Object.entries(provenance as Record<string, unknown>)) {
+    if (!ALLOWED_PROVENANCE_FIELDS.has(key as keyof MemoryWriteProvenance)) {
+      continue;
+    }
+    if (key === 'source_refs') {
+      compact.source_refs = sourceRefs;
+      continue;
+    }
+    if (isCompactValue(value)) {
+      compact[key] = value;
+    }
+  }
+
+  return {
+    actor,
+    agent_id: normalizeNullableString(provenance.agent_id),
+    model_run_id: normalizeNullableString(provenance.model_run_id),
+    envelope_hash: normalizeNullableString(provenance.envelope_hash),
+    tool_name: normalizeNullableString(provenance.tool_name),
+    gateway_call_id: normalizeNullableString(provenance.gateway_call_id),
+    source_turn_id: normalizeNullableString(provenance.source_turn_id),
+    source_message_ref: normalizeNullableString(provenance.source_message_ref),
+    source_refs: sourceRefs,
+    provenance: compact,
+  };
+}
+
+export function appendProvenanceSourceRefs(
+  options: TrustedMemoryWriteOptions | undefined,
+  refs: string[]
+): TrustedMemoryWriteOptions | undefined {
+  if (!options) {
+    return undefined;
+  }
+  assertTrustedProvenanceCapability(options.capability);
+  return {
+    capability: options.capability,
+    provenance: {
+      ...options.provenance,
+      source_refs: [...(options.provenance.source_refs ?? []), ...refs],
+    },
+  };
+}
+
+function buildFallbackProvenance(): NormalizedMemoryProvenance {
+  const actor: MemoryEventRecord['actor'] = 'actor:direct_client';
+  return {
+    actor,
+    agent_id: null,
+    model_run_id: null,
+    envelope_hash: null,
+    tool_name: null,
+    gateway_call_id: null,
+    source_turn_id: null,
+    source_message_ref: null,
+    source_refs: [],
+    provenance: {
+      actor,
+      source_type: 'direct_client',
+    },
+  };
+}
+
+function normalizeNullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === 'string' && item.length > 0);
+}
+
+function isCompactValue(value: unknown): boolean {
+  if (value === null) {
+    return true;
+  }
+  if (['string', 'number', 'boolean'].includes(typeof value)) {
+    return true;
+  }
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}

--- a/packages/mama-core/src/memory/types.ts
+++ b/packages/mama-core/src/memory/types.ts
@@ -75,13 +75,7 @@ export interface MemoryRecord {
   confidence: number;
   status: MemoryStatus;
   scopes: MemoryScopeRef[];
-  source: {
-    package: 'mama-core' | 'mcp-server' | 'standalone' | 'claude-code-plugin';
-    source_type: string;
-    user_id?: string;
-    channel_id?: string;
-    project_id?: string;
-  };
+  source: MemorySourceRef;
   created_at: number | string;
   updated_at: number | string;
   /** ISO 8601 date when the event actually occurred (e.g. "2023-01-15"). Null if not set. */
@@ -435,13 +429,7 @@ export interface ConversationMessage {
 export interface IngestConversationInput {
   messages: ConversationMessage[];
   scopes: MemoryScopeRef[];
-  source: {
-    package: 'mama-core' | 'mcp-server' | 'standalone' | 'claude-code-plugin';
-    source_type: string;
-    user_id?: string;
-    channel_id?: string;
-    project_id?: string;
-  };
+  source: MemorySourceRef;
   extract?: {
     enabled: boolean;
     model?: string;

--- a/packages/mama-core/src/memory/types.ts
+++ b/packages/mama-core/src/memory/types.ts
@@ -58,6 +58,14 @@ export interface MemoryScopeRef {
   id: string;
 }
 
+export interface MemorySourceRef {
+  package: 'mama-core' | 'mcp-server' | 'standalone' | 'claude-code-plugin';
+  source_type: string;
+  user_id?: string;
+  channel_id?: string;
+  project_id?: string;
+}
+
 export interface MemoryRecord {
   id: string;
   topic: string;
@@ -183,6 +191,66 @@ export interface MemoryEventRecord {
   reason?: string;
   created_at: number;
 }
+
+export interface MemoryWriteProvenance {
+  actor?: MemoryEventRecord['actor'];
+  agent_id?: string;
+  model_run_id?: string;
+  envelope_hash?: string;
+  tool_name?: string;
+  gateway_call_id?: string;
+  source_turn_id?: string;
+  source_message_ref?: string;
+  source_refs?: string[];
+}
+
+export interface MemoryProvenanceRecord {
+  memory_id: string;
+  agent_id: string | null;
+  model_run_id: string | null;
+  envelope_hash: string | null;
+  gateway_call_id: string | null;
+  source_refs: string[];
+  provenance: Record<string, unknown>;
+  latest_event?: MemoryEventRecord;
+}
+
+export interface PublicSaveMemoryInput {
+  topic: string;
+  kind: MemoryKind;
+  summary: string;
+  details: string;
+  confidence?: number;
+  status?: MemoryStatus;
+  scopes: MemoryScopeRef[];
+  source: MemorySourceRef;
+  excludeIds?: string[];
+  eventDate?: string;
+  eventDateTime?: number;
+  entityObservationIds?: string[];
+  timelineEvent?: {
+    id?: string;
+    entity_id?: string;
+    event_type: string;
+    role?: string | null;
+    valid_from?: number | null;
+    valid_to?: number | null;
+    observed_at?: number | null;
+    source_ref?: string | null;
+    summary: string;
+    details?: string | null;
+  };
+}
+
+export interface PublicIngestMemoryInput {
+  content: string;
+  scopes?: MemoryScopeRef[];
+  source: MemorySourceRef;
+  eventDate?: string;
+  eventDateTime?: number;
+}
+
+export type PublicIngestConversationInput = IngestConversationInput;
 
 export interface AuditFindingRecord {
   finding_id: string;

--- a/packages/mama-core/src/runtime/trusted-provenance.ts
+++ b/packages/mama-core/src/runtime/trusted-provenance.ts
@@ -1,0 +1,5 @@
+export { createTrustedProvenanceCapability } from '../memory/provenance.js';
+export type {
+  TrustedMemoryWriteOptions,
+  TrustedProvenanceCapability,
+} from '../memory/provenance.js';

--- a/packages/mama-core/tests/cases/migration-chain.test.ts
+++ b/packages/mama-core/tests/cases/migration-chain.test.ts
@@ -155,20 +155,18 @@ describe('Case-First Memory Substrate (migration 030, consolidated Phase 1+2+3)'
     applyAll(db);
 
     const baselineTables = (
-      db
-        .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
-        .all() as Array<{ name: string }>
+      db.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all() as Array<{
+        name: string;
+      }>
     ).map((row) => row.name);
 
-    const alreadyApplied = !!db
-      .prepare('SELECT 1 FROM schema_version WHERE version = ?')
-      .get(30);
+    const alreadyApplied = !!db.prepare('SELECT 1 FROM schema_version WHERE version = ?').get(30);
     expect(alreadyApplied).toBe(true);
 
     const afterTables = (
-      db
-        .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
-        .all() as Array<{ name: string }>
+      db.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all() as Array<{
+        name: string;
+      }>
     ).map((row) => row.name);
     expect(afterTables).toEqual(baselineTables);
 
@@ -183,9 +181,9 @@ describe('Case-First Memory Substrate (migration 030, consolidated Phase 1+2+3)'
     applyAll(db);
 
     const baselineTables = (
-      db
-        .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
-        .all() as Array<{ name: string }>
+      db.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all() as Array<{
+        name: string;
+      }>
     ).map((row) => row.name);
 
     const badSql = `
@@ -207,9 +205,9 @@ describe('Case-First Memory Substrate (migration 030, consolidated Phase 1+2+3)'
     expect(tableExists(db, 'fixture_partial_999')).toBe(false);
 
     const afterTables = (
-      db
-        .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
-        .all() as Array<{ name: string }>
+      db.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all() as Array<{
+        name: string;
+      }>
     ).map((row) => row.name);
     expect(afterTables).toEqual(baselineTables);
 
@@ -226,6 +224,36 @@ describe('Case-First Memory Substrate (migration 030, consolidated Phase 1+2+3)'
       .get() as { version: number; description: string } | undefined;
     expect(row?.version).toBe(30);
     expect(row?.description).toContain('Case-First Memory Substrate');
+
+    db.close();
+  });
+
+  it('records migration 032 memory provenance columns and indexes', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyAll(db);
+
+    for (const column of [
+      'agent_id',
+      'model_run_id',
+      'envelope_hash',
+      'gateway_call_id',
+      'source_refs_json',
+      'provenance_json',
+    ]) {
+      expect(columnExists(db, 'decisions', column)).toBe(true);
+    }
+
+    expect(indexExists(db, 'idx_decisions_envelope_hash')).toBe(true);
+    expect(indexExists(db, 'idx_decisions_model_run_id')).toBe(true);
+    expect(indexExists(db, 'idx_decisions_gateway_call_id')).toBe(true);
+    expect(indexExists(db, 'idx_memory_events_memory_created')).toBe(true);
+
+    const row = db
+      .prepare('SELECT version, description FROM schema_version WHERE version = 32')
+      .get() as { version: number; description: string } | undefined;
+    expect(row?.version).toBe(32);
+    expect(row?.description).toContain('memory provenance');
 
     db.close();
   });

--- a/packages/mama-core/tests/cases/migration-runner-duplicate-column.test.ts
+++ b/packages/mama-core/tests/cases/migration-runner-duplicate-column.test.ts
@@ -43,40 +43,44 @@ describe('Story M2.1: Migration 032 duplicate-column recovery', () => {
     }
   });
 
-  it('repairs a partially applied 032 migration when agent_id already exists', () => {
-    tempDir = mkdtempSync(join(tmpdir(), 'mama-migration-032-'));
-    const dbPath = join(tempDir, 'partial-032.db');
-    const setupDb = new Database(dbPath);
-    setupDb.pragma('foreign_keys = ON');
-    applyThrough031(setupDb);
-    setupDb.exec('ALTER TABLE decisions ADD COLUMN agent_id TEXT');
-    setupDb.close();
+  describe('Acceptance Criteria', () => {
+    describe('AC #1: partial migration recovery', () => {
+      it('repairs a partially applied 032 migration when agent_id already exists', () => {
+        tempDir = mkdtempSync(join(tmpdir(), 'mama-migration-032-'));
+        const dbPath = join(tempDir, 'partial-032.db');
+        const setupDb = new Database(dbPath);
+        setupDb.pragma('foreign_keys = ON');
+        applyThrough031(setupDb);
+        setupDb.exec('ALTER TABLE decisions ADD COLUMN agent_id TEXT');
+        setupDb.close();
 
-    const adapter = new NodeSQLiteAdapter({ dbPath });
-    adapter.connect();
-    adapter.runMigrations(MIGRATIONS_DIR);
-    adapter.disconnect();
+        const adapter = new NodeSQLiteAdapter({ dbPath });
+        adapter.connect();
+        adapter.runMigrations(MIGRATIONS_DIR);
+        adapter.disconnect();
 
-    const db = new Database(dbPath);
-    for (const column of [
-      'agent_id',
-      'model_run_id',
-      'envelope_hash',
-      'gateway_call_id',
-      'source_refs_json',
-      'provenance_json',
-    ]) {
-      expect(columnExists(db, 'decisions', column)).toBe(true);
-    }
-    expect(indexExists(db, 'idx_decisions_envelope_hash')).toBe(true);
-    expect(indexExists(db, 'idx_decisions_model_run_id')).toBe(true);
-    expect(indexExists(db, 'idx_decisions_gateway_call_id')).toBe(true);
-    expect(indexExists(db, 'idx_memory_events_memory_created')).toBe(true);
+        const db = new Database(dbPath);
+        for (const column of [
+          'agent_id',
+          'model_run_id',
+          'envelope_hash',
+          'gateway_call_id',
+          'source_refs_json',
+          'provenance_json',
+        ]) {
+          expect(columnExists(db, 'decisions', column)).toBe(true);
+        }
+        expect(indexExists(db, 'idx_decisions_envelope_hash')).toBe(true);
+        expect(indexExists(db, 'idx_decisions_model_run_id')).toBe(true);
+        expect(indexExists(db, 'idx_decisions_gateway_call_id')).toBe(true);
+        expect(indexExists(db, 'idx_memory_events_memory_created')).toBe(true);
 
-    const row = db.prepare('SELECT version FROM schema_version WHERE version = 32').get() as
-      | { version: number }
-      | undefined;
-    expect(row?.version).toBe(32);
-    db.close();
+        const row = db.prepare('SELECT version FROM schema_version WHERE version = 32').get() as
+          | { version: number }
+          | undefined;
+        expect(row?.version).toBe(32);
+        db.close();
+      });
+    });
   });
 });

--- a/packages/mama-core/tests/cases/migration-runner-duplicate-column.test.ts
+++ b/packages/mama-core/tests/cases/migration-runner-duplicate-column.test.ts
@@ -1,0 +1,82 @@
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { NodeSQLiteAdapter } from '../../src/db-adapter/node-sqlite-adapter.js';
+
+const MIGRATIONS_DIR = join(__dirname, '..', '..', 'db', 'migrations');
+let tempDir: string | null = null;
+
+function migrationFilesThrough031(): string[] {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((file) => /^\d{3}-.+\.sql$/.test(file))
+    .filter((file) => Number(file.slice(0, 3)) <= 31)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function applyThrough031(db: Database.Database): void {
+  for (const file of migrationFilesThrough031()) {
+    db.exec(readFileSync(join(MIGRATIONS_DIR, file), 'utf8'));
+  }
+}
+
+function columnExists(db: Database.Database, table: string, column: string): boolean {
+  const columns = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  return columns.some((item) => item.name === column);
+}
+
+function indexExists(db: Database.Database, indexName: string): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name = ?")
+    .get(indexName) as { name?: string } | undefined;
+  return Boolean(row?.name);
+}
+
+describe('Story M2.1: Migration 032 duplicate-column recovery', () => {
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  it('repairs a partially applied 032 migration when agent_id already exists', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'mama-migration-032-'));
+    const dbPath = join(tempDir, 'partial-032.db');
+    const setupDb = new Database(dbPath);
+    setupDb.pragma('foreign_keys = ON');
+    applyThrough031(setupDb);
+    setupDb.exec('ALTER TABLE decisions ADD COLUMN agent_id TEXT');
+    setupDb.close();
+
+    const adapter = new NodeSQLiteAdapter({ dbPath });
+    adapter.connect();
+    adapter.runMigrations(MIGRATIONS_DIR);
+    adapter.disconnect();
+
+    const db = new Database(dbPath);
+    for (const column of [
+      'agent_id',
+      'model_run_id',
+      'envelope_hash',
+      'gateway_call_id',
+      'source_refs_json',
+      'provenance_json',
+    ]) {
+      expect(columnExists(db, 'decisions', column)).toBe(true);
+    }
+    expect(indexExists(db, 'idx_decisions_envelope_hash')).toBe(true);
+    expect(indexExists(db, 'idx_decisions_model_run_id')).toBe(true);
+    expect(indexExists(db, 'idx_decisions_gateway_call_id')).toBe(true);
+    expect(indexExists(db, 'idx_memory_events_memory_created')).toBe(true);
+
+    const row = db.prepare('SELECT version FROM schema_version WHERE version = 32').get() as
+      | { version: number }
+      | undefined;
+    expect(row?.version).toBe(32);
+    db.close();
+  });
+});

--- a/packages/mama-core/tests/memory/memory-provenance-query.test.ts
+++ b/packages/mama-core/tests/memory/memory-provenance-query.test.ts
@@ -1,0 +1,134 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDB, getAdapter } from '../../src/db-manager.js';
+import { saveMemoryWithTrustedProvenance } from '../../src/memory/api.js';
+import { createTrustedProvenanceCapability } from '../../src/memory/provenance.js';
+import {
+  getMemoryProvenance,
+  listMemoriesByEnvelopeHash,
+  listMemoriesByGatewayCallId,
+  listMemoriesByModelRunId,
+} from '../../src/memory/provenance-query.js';
+import type { MemoryScopeRef } from '../../src/memory/types.js';
+
+const TEST_DB = path.join(os.tmpdir(), `test-memory-provenance-query-${randomUUID()}.db`);
+const PROJECT_A: MemoryScopeRef = { kind: 'project', id: 'repo:query-a' };
+const PROJECT_B: MemoryScopeRef = { kind: 'project', id: 'repo:query-b' };
+
+function cleanupDb(): void {
+  for (const file of [TEST_DB, `${TEST_DB}-journal`, `${TEST_DB}-wal`, `${TEST_DB}-shm`]) {
+    try {
+      fs.unlinkSync(file);
+    } catch {
+      // cleanup best effort
+    }
+  }
+}
+
+async function saveFixture(topic: string, scope: MemoryScopeRef) {
+  return saveMemoryWithTrustedProvenance(
+    {
+      topic,
+      kind: 'decision',
+      summary: `Summary for ${topic}`,
+      details: `Details for ${topic}`,
+      scopes: [scope],
+      source: { package: 'mama-core', source_type: 'test', project_id: scope.id },
+    },
+    {
+      capability: createTrustedProvenanceCapability(),
+      provenance: {
+        actor: 'main_agent',
+        envelope_hash: 'env_query',
+        gateway_call_id: 'gw_query',
+        model_run_id: 'model_query',
+        source_refs: [`message:${topic}`],
+      },
+    }
+  );
+}
+
+function setCreatedAt(memoryId: string, createdAt: number): void {
+  getAdapter()
+    .prepare(
+      `
+        UPDATE decisions
+        SET created_at = ?
+        WHERE id = ?
+      `
+    )
+    .run(createdAt, memoryId);
+}
+
+describe('Story M2.1: Memory Provenance Query Helpers', () => {
+  beforeEach(async () => {
+    await closeDB();
+    cleanupDb();
+    process.env.MAMA_DB_PATH = TEST_DB;
+    process.env.MAMA_FORCE_TIER_3 = 'true';
+  });
+
+  afterEach(async () => {
+    await closeDB();
+    delete process.env.MAMA_DB_PATH;
+    delete process.env.MAMA_FORCE_TIER_3;
+    cleanupDb();
+  });
+
+  describe('AC: indexed provenance lookups return compact lineage', () => {
+    it('looks up memories by memory id, envelope hash, gateway call id, and model run id', async () => {
+      const saved = await saveFixture('query_helper_contract', PROJECT_A);
+
+      const byId = await getMemoryProvenance(saved.id);
+      expect(byId?.source_refs).toEqual(['message:query_helper_contract']);
+      expect(byId?.latest_event?.event_type).toBe('save');
+
+      await expect(listMemoriesByEnvelopeHash('env_query')).resolves.toMatchObject([
+        { memory_id: saved.id },
+      ]);
+      await expect(listMemoriesByGatewayCallId('gw_query')).resolves.toMatchObject([
+        { memory_id: saved.id },
+      ]);
+      await expect(listMemoriesByModelRunId('model_query')).resolves.toMatchObject([
+        { memory_id: saved.id },
+      ]);
+    });
+  });
+
+  describe('AC: scoped reads use memory_scope_bindings as source of truth', () => {
+    it('does not return a different project memory for scoped provenance reads', async () => {
+      const projectA = await saveFixture('project_a_memory', PROJECT_A);
+      const projectB = await saveFixture('project_b_memory', PROJECT_B);
+
+      const scoped = await listMemoriesByGatewayCallId('gw_query', { scopes: [PROJECT_A] });
+      expect(scoped.map((item) => item.memory_id)).toContain(projectA.id);
+      expect(scoped.map((item) => item.memory_id)).not.toContain(projectB.id);
+
+      await expect(getMemoryProvenance(projectB.id, { scopes: [PROJECT_A] })).resolves.toBeNull();
+    });
+
+    it('continues paging until it finds the requested number of visible memories', async () => {
+      const visibleOne = await saveFixture('project_a_visible_1', PROJECT_A);
+      const visibleTwo = await saveFixture('project_a_visible_2', PROJECT_A);
+      setCreatedAt(visibleOne.id, 1_000);
+      setCreatedAt(visibleTwo.id, 1_001);
+
+      for (let index = 0; index < 10; index += 1) {
+        const hidden = await saveFixture(`project_b_hidden_${index}`, PROJECT_B);
+        setCreatedAt(hidden.id, 2_000 + index);
+      }
+
+      const scoped = await listMemoriesByGatewayCallId('gw_query', {
+        scopes: [PROJECT_A],
+        limit: 2,
+      });
+
+      expect(scoped.map((item) => item.memory_id)).toEqual([visibleTwo.id, visibleOne.id]);
+    });
+  });
+});

--- a/packages/mama-core/tests/memory/memory-provenance-query.test.ts
+++ b/packages/mama-core/tests/memory/memory-provenance-query.test.ts
@@ -112,6 +112,17 @@ describe('Story M2.1: Memory Provenance Query Helpers', () => {
       await expect(getMemoryProvenance(projectB.id, { scopes: [PROJECT_A] })).resolves.toBeNull();
     });
 
+    it('treats an empty scopes array as no scope filter', async () => {
+      const projectA = await saveFixture('project_a_empty_scope_filter', PROJECT_A);
+
+      await expect(getMemoryProvenance(projectA.id, { scopes: [] })).resolves.toMatchObject({
+        memory_id: projectA.id,
+      });
+      await expect(listMemoriesByGatewayCallId('gw_query', { scopes: [] })).resolves.toEqual(
+        expect.arrayContaining([expect.objectContaining({ memory_id: projectA.id })])
+      );
+    });
+
     it('continues paging until it finds the requested number of visible memories', async () => {
       const visibleOne = await saveFixture('project_a_visible_1', PROJECT_A);
       const visibleTwo = await saveFixture('project_a_visible_2', PROJECT_A);

--- a/packages/mama-core/tests/memory/memory-provenance.test.ts
+++ b/packages/mama-core/tests/memory/memory-provenance.test.ts
@@ -1,0 +1,314 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDB, getAdapter } from '../../src/db-manager.js';
+import {
+  ingestConversation,
+  ingestConversationWithTrustedProvenance,
+  ingestMemory,
+  saveMemory,
+  saveMemoryWithTrustedProvenance,
+  setExtractionFn,
+} from '../../src/memory/api.js';
+import {
+  getMemoryProvenance,
+  listMemoriesByGatewayCallId,
+} from '../../src/memory/provenance-query.js';
+import { createTrustedProvenanceCapability } from '../../src/memory/provenance.js';
+import { listMemoryEventsForMemory } from '../../src/memory/event-store.js';
+import mama from '../../src/mama-api.js';
+
+const TEST_DB = path.join(os.tmpdir(), `test-memory-provenance-${randomUUID()}.db`);
+const PROJECT_SCOPE = { kind: 'project' as const, id: 'repo:m2-provenance' };
+
+function cleanupDb(): void {
+  for (const file of [TEST_DB, `${TEST_DB}-journal`, `${TEST_DB}-wal`, `${TEST_DB}-shm`]) {
+    try {
+      fs.unlinkSync(file);
+    } catch {
+      // cleanup best effort
+    }
+  }
+}
+
+describe('Story M2.1: Memory Write Provenance Foundation', () => {
+  beforeEach(async () => {
+    await closeDB();
+    cleanupDb();
+    process.env.MAMA_DB_PATH = TEST_DB;
+    process.env.MAMA_FORCE_TIER_3 = 'true';
+  });
+
+  afterEach(async () => {
+    setExtractionFn(null);
+    await closeDB();
+    delete process.env.MAMA_DB_PATH;
+    delete process.env.MAMA_FORCE_TIER_3;
+    cleanupDb();
+  });
+
+  describe('AC: trusted writes persist compact provenance and save events', () => {
+    it('records a save memory event and nullable provenance columns for a trusted save', async () => {
+      const capability = createTrustedProvenanceCapability();
+
+      const result = await saveMemoryWithTrustedProvenance(
+        {
+          topic: 'm2_provenance_contract',
+          kind: 'decision',
+          summary: 'Memory writes should explain origin',
+          details: 'Operators need memory origin for correction',
+          confidence: 0.9,
+          scopes: [PROJECT_SCOPE],
+          source: { package: 'mama-core', source_type: 'test', project_id: PROJECT_SCOPE.id },
+        },
+        {
+          capability,
+          provenance: {
+            actor: 'main_agent',
+            agent_id: 'agent-main',
+            envelope_hash: 'env_test_hash',
+            tool_name: 'mama_save',
+            gateway_call_id: 'gw_test_1',
+            source_turn_id: 'turn_test_1',
+            source_message_ref: 'discord:channel:turn_test_1',
+            source_refs: ['conversation:test'],
+          },
+        }
+      );
+
+      const provenance = await getMemoryProvenance(result.id);
+      expect(provenance?.memory_id).toBe(result.id);
+      expect(provenance?.agent_id).toBe('agent-main');
+      expect(provenance?.envelope_hash).toBe('env_test_hash');
+      expect(provenance?.gateway_call_id).toBe('gw_test_1');
+      expect(provenance?.source_refs).toEqual(['conversation:test']);
+      expect(provenance?.latest_event?.event_type).toBe('save');
+      expect(provenance?.latest_event?.actor).toBe('main_agent');
+      expect(provenance?.latest_event?.source_turn_id).toBe('turn_test_1');
+    });
+
+    it('rejects plain-object capability spoofing for trusted writes', async () => {
+      await expect(
+        saveMemoryWithTrustedProvenance(
+          {
+            topic: 'plain_object_capability_spoof',
+            kind: 'decision',
+            summary: 'Plain JSON must not unlock trusted provenance',
+            details: 'The trusted path requires a non-serializable capability',
+            scopes: [PROJECT_SCOPE],
+            source: { package: 'mama-core', source_type: 'test', project_id: PROJECT_SCOPE.id },
+          },
+          {
+            capability: {} as never,
+            provenance: {
+              actor: 'main_agent',
+              envelope_hash: 'env_spoof',
+            },
+          }
+        )
+      ).rejects.toThrow(/trusted provenance capability/i);
+    });
+
+    it('sanitizes non-allowlisted fields from trusted provenance', async () => {
+      const capability = createTrustedProvenanceCapability();
+
+      const result = await saveMemoryWithTrustedProvenance(
+        {
+          topic: 'provenance_payload_boundary',
+          kind: 'decision',
+          summary: 'Provenance stays compact',
+          details: 'Prompt and tool payloads do not belong in memory provenance',
+          scopes: [PROJECT_SCOPE],
+          source: { package: 'mama-core', source_type: 'test', project_id: PROJECT_SCOPE.id },
+        },
+        {
+          capability,
+          provenance: {
+            actor: 'main_agent',
+            envelope_hash: 'env_sanitized',
+            tool_name: 'mama_save',
+            prompt: 'raw prompt must not persist',
+            messages: [{ role: 'user', content: 'secret' }],
+            tool_args: { topic: 'secret' },
+            result: { ok: true },
+            unsupported_field: 'must not persist',
+            source_refs: ['message:test'],
+          } as never,
+        }
+      );
+
+      const provenance = await getMemoryProvenance(result.id);
+      expect(provenance?.provenance).toMatchObject({
+        actor: 'main_agent',
+        envelope_hash: 'env_sanitized',
+        tool_name: 'mama_save',
+      });
+      expect(provenance?.provenance).not.toHaveProperty('prompt');
+      expect(provenance?.provenance).not.toHaveProperty('messages');
+      expect(provenance?.provenance).not.toHaveProperty('tool_args');
+      expect(provenance?.provenance).not.toHaveProperty('result');
+      expect(provenance?.provenance).not.toHaveProperty('unsupported_field');
+    });
+  });
+
+  describe('AC: direct public writes get honest fallback provenance', () => {
+    it('inserts a save event with actor:direct_client and no fabricated ids', async () => {
+      const result = await saveMemory({
+        topic: 'direct_save_fallback',
+        kind: 'decision',
+        summary: 'Direct saves still get a save event',
+        details: 'Fallback provenance is honest and nullable',
+        scopes: [PROJECT_SCOPE],
+        source: { package: 'mama-core', source_type: 'test', project_id: PROJECT_SCOPE.id },
+      });
+
+      const provenance = await getMemoryProvenance(result.id);
+      expect(provenance?.latest_event?.event_type).toBe('save');
+      expect(provenance?.latest_event?.actor).toBe('actor:direct_client');
+      expect(provenance?.envelope_hash).toBeNull();
+      expect(provenance?.gateway_call_id).toBeNull();
+      expect(provenance?.model_run_id).toBeNull();
+    });
+
+    it('keeps public mama.save caller-supplied provenance out of stored provenance', async () => {
+      const result = await mama.save({
+        topic: 'public_spoofing_boundary',
+        decision: 'Public callers cannot choose envelope evidence',
+        reasoning: 'Only internal trusted options can set provenance ids',
+        confidence: 0.8,
+        scopes: [PROJECT_SCOPE],
+        provenance: { envelope_hash: 'attacker_env', gateway_call_id: 'attacker_gw' },
+      } as never);
+
+      const provenance = await getMemoryProvenance(result.id);
+      expect(provenance?.envelope_hash).toBeNull();
+      expect(provenance?.gateway_call_id).toBeNull();
+      expect(provenance?.latest_event?.actor).toBe('actor:direct_client');
+    });
+
+    it('preserves existing public save fields while stripping caller provenance', async () => {
+      const observedAt = Date.parse('2026-04-29T10:00:00.000Z');
+      const result = await mama.saveMemory({
+        topic: 'public_wrapper_compatibility',
+        kind: 'decision',
+        summary: 'Public wrappers preserve existing fields',
+        details: 'Compatibility wrappers strip only provenance',
+        scopes: [PROJECT_SCOPE],
+        source: { package: 'mama-core', source_type: 'test', project_id: PROJECT_SCOPE.id },
+        eventDateTime: observedAt,
+        entityObservationIds: [],
+        timelineEvent: {
+          event_type: 'project_update',
+          summary: 'Compatibility event',
+        },
+        excludeIds: [],
+        provenance: { envelope_hash: 'attacker_env' },
+      } as never);
+
+      const row = getAdapter()
+        .prepare('SELECT event_datetime, envelope_hash FROM decisions WHERE id = ?')
+        .get(result.id) as { event_datetime: number | null; envelope_hash: string | null };
+      expect(row.event_datetime).toBe(observedAt);
+      expect(row.envelope_hash).toBeNull();
+    });
+
+    it('keeps public ingestMemory caller-supplied provenance out of stored provenance', async () => {
+      const result = await ingestMemory({
+        content: 'Public ingest should not trust caller provenance',
+        scopes: [PROJECT_SCOPE],
+        source: { package: 'mama-core', source_type: 'test', project_id: PROJECT_SCOPE.id },
+        provenance: { envelope_hash: 'attacker_env', gateway_call_id: 'attacker_gw' },
+      } as never);
+
+      const provenance = await getMemoryProvenance(result.id);
+      expect(provenance?.envelope_hash).toBeNull();
+      expect(provenance?.gateway_call_id).toBeNull();
+      expect(provenance?.latest_event?.actor).toBe('actor:direct_client');
+    });
+  });
+
+  describe('AC: ingest conversation provenance covers raw and extracted memories', () => {
+    it('propagates trusted provenance to raw and extracted memories with raw source refs', async () => {
+      setExtractionFn(async () => [
+        {
+          topic: 'extracted_fact',
+          kind: 'fact',
+          summary: 'Extracted fact summary',
+          details: 'Extracted fact details',
+          confidence: 0.7,
+        },
+      ]);
+
+      const capability = createTrustedProvenanceCapability();
+      const result = await ingestConversationWithTrustedProvenance(
+        {
+          messages: [{ role: 'user', content: 'We decided to keep provenance compact.' }],
+          scopes: [PROJECT_SCOPE],
+          source: { package: 'mama-core', source_type: 'test', project_id: PROJECT_SCOPE.id },
+          extract: { enabled: true, apiKey: 'test-key' },
+        },
+        {
+          capability,
+          provenance: {
+            actor: 'main_agent',
+            envelope_hash: 'env_ingest',
+            gateway_call_id: 'gw_ingest_1',
+            tool_name: 'ingest_conversation',
+            source_refs: ['message:conversation'],
+          },
+        }
+      );
+
+      expect(result.extractedMemories).toHaveLength(1);
+      const rawProvenance = await getMemoryProvenance(result.rawId);
+      const extractedProvenance = await getMemoryProvenance(result.extractedMemories[0].id);
+      expect(rawProvenance?.gateway_call_id).toBe('gw_ingest_1');
+      expect(extractedProvenance?.gateway_call_id).toBe('gw_ingest_1');
+      expect(extractedProvenance?.source_refs).toContain(`raw_memory:${result.rawId}`);
+
+      const byGatewayCall = await listMemoriesByGatewayCallId('gw_ingest_1');
+      expect(byGatewayCall.map((item) => item.memory_id).sort()).toEqual(
+        [result.rawId, result.extractedMemories[0].id].sort()
+      );
+    });
+
+    it('keeps public ingestConversation caller-supplied provenance out of stored provenance', async () => {
+      const result = await ingestConversation({
+        messages: [{ role: 'user', content: 'Public ingest conversation spoof attempt.' }],
+        scopes: [PROJECT_SCOPE],
+        source: { package: 'mama-core', source_type: 'test', project_id: PROJECT_SCOPE.id },
+        extract: { enabled: false },
+        provenance: { envelope_hash: 'attacker_env', gateway_call_id: 'attacker_gw' },
+      } as never);
+
+      const provenance = await getMemoryProvenance(result.rawId);
+      expect(provenance?.envelope_hash).toBeNull();
+      expect(provenance?.gateway_call_id).toBeNull();
+      expect(provenance?.latest_event?.actor).toBe('actor:direct_client');
+    });
+  });
+
+  describe('AC: event readers expose memory-specific save events', () => {
+    it('lists memory events by memory id newest first', async () => {
+      const result = await saveMemory({
+        topic: 'memory_event_reader_contract',
+        kind: 'decision',
+        summary: 'Events can be read by memory id',
+        details: 'Operator provenance views need the latest save event',
+        scopes: [PROJECT_SCOPE],
+        source: { package: 'mama-core', source_type: 'test', project_id: PROJECT_SCOPE.id },
+      });
+
+      const events = await listMemoryEventsForMemory(result.id);
+      expect(events[0]).toMatchObject({
+        event_type: 'save',
+        memory_id: result.id,
+        actor: 'actor:direct_client',
+      });
+    });
+  });
+});

--- a/packages/mama-core/tests/unit/memory-v2-legacy-shims.test.ts
+++ b/packages/mama-core/tests/unit/memory-v2-legacy-shims.test.ts
@@ -26,22 +26,15 @@ const recallMemoryMock = vi.fn(async () => ({
   search_meta: { query: 'legacy save', scope_order: ['project'], retrieval_sources: ['sql_like'] },
 }));
 
-vi.mock('../../src/memory/api.js', () => ({
-  saveMemory: saveMemoryMock,
-  saveMemoryWithTrustedProvenance: saveMemoryMock,
-  recallMemory: recallMemoryMock,
-  buildProfile: vi.fn(),
-  ingestMemory: vi.fn(),
-  ingestWithTrustedProvenance: vi.fn(),
-  ingestConversation: vi.fn(),
-  ingestConversationWithTrustedProvenance: vi.fn(),
-  evolveMemory: vi.fn(),
-  buildMemoryBootstrap: vi.fn(),
-  createAuditAck: vi.fn((input) => input),
-  recordMemoryAudit: vi.fn(),
-  upsertChannelSummary: vi.fn(),
-  getChannelSummary: vi.fn(),
-}));
+vi.mock('../../src/memory/api.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/memory/api.js')>();
+  return {
+    ...actual,
+    saveMemory: saveMemoryMock,
+    saveMemoryWithTrustedProvenance: saveMemoryMock,
+    recallMemory: recallMemoryMock,
+  };
+});
 
 describe('legacy shims', () => {
   beforeAll(() => {

--- a/packages/mama-core/tests/unit/memory-v2-legacy-shims.test.ts
+++ b/packages/mama-core/tests/unit/memory-v2-legacy-shims.test.ts
@@ -28,9 +28,13 @@ const recallMemoryMock = vi.fn(async () => ({
 
 vi.mock('../../src/memory/api.js', () => ({
   saveMemory: saveMemoryMock,
+  saveMemoryWithTrustedProvenance: saveMemoryMock,
   recallMemory: recallMemoryMock,
   buildProfile: vi.fn(),
   ingestMemory: vi.fn(),
+  ingestWithTrustedProvenance: vi.fn(),
+  ingestConversation: vi.fn(),
+  ingestConversationWithTrustedProvenance: vi.fn(),
   evolveMemory: vi.fn(),
   buildMemoryBootstrap: vi.fn(),
   createAuditAck: vi.fn((input) => input),
@@ -112,7 +116,11 @@ describe('legacy shims', () => {
         },
       ],
       graph_context: { primary: [], expanded: [], edges: [] },
-      search_meta: { query: 'legacy save', scope_order: ['project'], retrieval_sources: ['sql_like'] },
+      search_meta: {
+        query: 'legacy save',
+        scope_order: ['project'],
+        retrieval_sources: ['sql_like'],
+      },
     });
 
     const mama = (await import('../../src/mama-api.js')).default;
@@ -143,7 +151,11 @@ describe('legacy shims', () => {
         },
       ],
       graph_context: { primary: [], expanded: [], edges: [] },
-      search_meta: { query: 'legacy fact', scope_order: ['project'], retrieval_sources: ['sql_like'] },
+      search_meta: {
+        query: 'legacy fact',
+        scope_order: ['project'],
+        retrieval_sources: ['sql_like'],
+      },
     });
 
     const mama = (await import('../../src/mama-api.js')).default;
@@ -241,7 +253,9 @@ describe('legacy shims', () => {
     const { initDB, getAdapter } = await import('../../src/db-manager.js');
     await initDB();
     getAdapter().prepare('DELETE FROM case_truth WHERE case_id = ?').run('case-base-top');
-    getAdapter().prepare("DELETE FROM ranker_model_versions WHERE model_id = 'ranker-active'").run();
+    getAdapter()
+      .prepare("DELETE FROM ranker_model_versions WHERE model_id = 'ranker-active'")
+      .run();
     getAdapter()
       .prepare(
         `
@@ -342,7 +356,9 @@ describe('legacy shims', () => {
     const { initDB, getAdapter } = await import('../../src/db-manager.js');
     await initDB();
     getAdapter().prepare('DELETE FROM case_truth WHERE case_id = ?').run('case-base-top');
-    getAdapter().prepare("DELETE FROM ranker_model_versions WHERE model_id = 'ranker-active'").run();
+    getAdapter()
+      .prepare("DELETE FROM ranker_model_versions WHERE model_id = 'ranker-active'")
+      .run();
     getAdapter()
       .prepare(
         `

--- a/packages/mcp-server/tests/tools/ingest-conversation-provenance.test.js
+++ b/packages/mcp-server/tests/tools/ingest-conversation-provenance.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createIngestConversationTool } from '../../src/tools/ingest-conversation.js';
+
+describe('ingest_conversation provenance boundary', () => {
+  it('does not forward caller-supplied provenance to ingestConversation()', async () => {
+    const ingestConversation = vi.fn().mockResolvedValue({
+      rawId: 'raw_1',
+      extractedMemories: [],
+    });
+    const tool = createIngestConversationTool({ ingestConversation });
+
+    const result = await tool.handler({
+      messages: [{ role: 'user', content: 'Remember this safely.' }],
+      scopes: [{ kind: 'project', id: '/repo' }],
+      provenance: { envelope_hash: 'attacker_env', gateway_call_id: 'attacker_gw' },
+    });
+
+    expect(result).toMatchObject({ success: true, raw_id: 'raw_1' });
+    const [input] = ingestConversation.mock.calls[0];
+    expect(input.provenance).toBeUndefined();
+    expect(input.envelope_hash).toBeUndefined();
+    expect(input.gateway_call_id).toBeUndefined();
+  });
+});

--- a/packages/mcp-server/tests/tools/save-decision-v2.test.js
+++ b/packages/mcp-server/tests/tools/save-decision-v2.test.js
@@ -50,6 +50,20 @@ describe('save_decision v2: scopes + event_date', () => {
     expect(callArgs.scopes).toBeUndefined();
   });
 
+  it('does not forward caller-supplied provenance to mama.save()', async () => {
+    await tool.handler({
+      topic: 'test_topic',
+      decision: 'Caller cannot spoof provenance',
+      reasoning: 'MCP input is an untrusted public boundary',
+      provenance: { envelope_hash: 'attacker_env', gateway_call_id: 'attacker_gw' },
+    });
+
+    const callArgs = mockMama.save.mock.calls[0][0];
+    expect(callArgs.provenance).toBeUndefined();
+    expect(callArgs.envelope_hash).toBeUndefined();
+    expect(callArgs.gateway_call_id).toBeUndefined();
+  });
+
   it('scopes appear in inputSchema', () => {
     expect(tool.inputSchema.properties.scopes).toBeDefined();
     expect(tool.inputSchema.properties.scopes.type).toBe('array');

--- a/packages/standalone/src/agent/agent-loop.ts
+++ b/packages/standalone/src/agent/agent-loop.ts
@@ -274,12 +274,15 @@ export function buildAgentToolExecutionContext(
     (options.agentContext === undefined &&
       options.source === undefined &&
       options.channelId === undefined &&
-      options.envelope === undefined)
+      options.envelope === undefined &&
+      options.sourceTurnId === undefined &&
+      options.sourceMessageRef === undefined &&
+      options.modelRunId === undefined)
   ) {
     return null;
   }
   const agentContext = options.agentContext;
-  return {
+  const context: AgentToolExecutionContext = {
     agentContext,
     agentId: agentContext
       ? agentContext.source === 'viewer'
@@ -291,6 +294,16 @@ export function buildAgentToolExecutionContext(
     envelope: options.envelope,
     executionSurface: 'model_tool',
   };
+  if (options.sourceTurnId !== undefined) {
+    context.sourceTurnId = options.sourceTurnId;
+  }
+  if (options.sourceMessageRef !== undefined) {
+    context.sourceMessageRef = options.sourceMessageRef;
+  }
+  if (options.modelRunId !== undefined) {
+    context.modelRunId = options.modelRunId;
+  }
+  return context;
 }
 
 function withExecutionSurface(

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -21,7 +21,7 @@ import {
   realpathSync,
 } from 'fs';
 import { AsyncLocalStorage } from 'async_hooks';
-import { createHash } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import { join, dirname, resolve, relative, isAbsolute, basename } from 'path';
 import { homedir } from 'os';
 import { execSync, spawn, execFile } from 'child_process';
@@ -62,6 +62,7 @@ import type {
   EnvelopeDenialResult,
   GatewayExecutionSurface,
   GatewayToolExecutionContext,
+  TrustedMemoryWriteOptions,
 } from './types.js';
 import { AgentError } from './types.js';
 import {
@@ -111,6 +112,10 @@ const { DebugLogger } = debugLogger as unknown as {
 };
 const securityLogger = new DebugLogger('SecurityAudit');
 const TRUTHY_ENV_VALUES = new Set(['1', 'true', 'yes', 'on']);
+type TrustedProvenanceRuntime = {
+  createTrustedProvenanceCapability: () => TrustedMemoryWriteOptions['capability'];
+};
+let trustedProvenanceRuntime: TrustedProvenanceRuntime | null = null;
 const AGENT_DETAIL_TABS = new Set([
   'config',
   'persona',
@@ -134,6 +139,10 @@ type ActiveGatewayExecutionContext = {
   channelId: string;
   envelope?: Envelope;
   executionSurface?: GatewayExecutionSurface;
+  sourceTurnId?: string;
+  sourceMessageRef?: string;
+  modelRunId?: string | null;
+  gatewayCallId?: string;
   parentToolName?: string;
 };
 
@@ -365,20 +374,47 @@ export class GatewayToolExecutor {
       channelId,
       envelope: executionContext?.envelope,
       executionSurface: executionContext?.executionSurface,
+      sourceTurnId: executionContext?.sourceTurnId,
+      sourceMessageRef: executionContext?.sourceMessageRef,
+      modelRunId: executionContext?.modelRunId ?? null,
+      gatewayCallId: executionContext?.gatewayCallId,
     };
   }
 
   private getExecutionState(): ActiveGatewayExecutionContext {
-    const active = this.executionContextStorage.getStore();
-    if (active) {
-      return active;
-    }
+    return this.mergeWithFallbackExecutionContext(this.executionContextStorage.getStore());
+  }
+
+  private getFallbackExecutionContext(): ActiveGatewayExecutionContext {
     return this.normalizeExecutionContext({
       agentContext: this.currentContext ?? undefined,
       agentId: this.currentAgentId,
       source: this.currentSource,
       channelId: this.currentChannelId,
     });
+  }
+
+  private mergeWithFallbackExecutionContext(
+    active: ActiveGatewayExecutionContext | undefined
+  ): ActiveGatewayExecutionContext {
+    const fallback = this.getFallbackExecutionContext();
+    if (!active) {
+      return fallback;
+    }
+
+    return {
+      agentContext: active.agentContext ?? fallback.agentContext,
+      agentId: active.agentId || fallback.agentId,
+      source: active.source || fallback.source,
+      channelId: active.channelId || fallback.channelId,
+      envelope: active.envelope ?? fallback.envelope,
+      executionSurface: active.executionSurface ?? fallback.executionSurface,
+      sourceTurnId: active.sourceTurnId ?? fallback.sourceTurnId,
+      sourceMessageRef: active.sourceMessageRef ?? fallback.sourceMessageRef,
+      modelRunId: active.modelRunId ?? fallback.modelRunId,
+      gatewayCallId: active.gatewayCallId ?? fallback.gatewayCallId,
+      parentToolName: active.parentToolName ?? fallback.parentToolName,
+    };
   }
 
   private getActiveContext(): AgentContext | null {
@@ -654,11 +690,20 @@ export class GatewayToolExecutor {
 
       this.mamaApi = {
         save: mama.save.bind(mama),
+        saveWithTrustedProvenance: mama.saveWithTrustedProvenance?.bind(mama),
         saveCheckpoint: mama.saveCheckpoint.bind(mama),
         listDecisions: mama.list.bind(mama), // Note: mama exports listDecisions as 'list'
         suggest: mama.suggest.bind(mama),
         recallMemory: mama.recallMemory?.bind(mama),
         ingestMemory: mama.ingestMemory?.bind(mama),
+        ingestWithTrustedProvenance: mama.ingestWithTrustedProvenance?.bind(mama),
+        saveMemoryWithTrustedProvenance: mama.saveMemoryWithTrustedProvenance?.bind(mama),
+        ingestConversationWithTrustedProvenance:
+          mama.ingestConversationWithTrustedProvenance?.bind(mama),
+        getMemoryProvenance: mama.getMemoryProvenance?.bind(mama),
+        listMemoriesByEnvelopeHash: mama.listMemoriesByEnvelopeHash?.bind(mama),
+        listMemoriesByGatewayCallId: mama.listMemoriesByGatewayCallId?.bind(mama),
+        listMemoriesByModelRunId: mama.listMemoriesByModelRunId?.bind(mama),
         buildProfile: mama.buildProfile?.bind(mama),
         updateOutcome: mama.updateOutcome.bind(mama),
         loadCheckpoint: mama.loadCheckpoint.bind(mama),
@@ -851,18 +896,37 @@ export class GatewayToolExecutor {
     }
 
     const startedAt = Date.now();
-    const ctx = this.executionContextStorage.getStore();
+    const baseCtx = this.mergeWithFallbackExecutionContext(this.executionContextStorage.getStore());
+    const gatewayCallId = baseCtx.gatewayCallId ?? `gw_${randomUUID().replace(/-/g, '')}`;
+    const ctx = { ...baseCtx, gatewayCallId };
     const scopeAudit = this.computeScopeAuditFields(toolName, input, ctx);
 
     try {
-      const result = await this.executeWithEnvelopeAndPermissions(toolName, input);
-      this.logGatewayToolCall(ctx, toolName, result, Date.now() - startedAt, scopeAudit);
+      const result = await this.executionContextStorage.run(ctx, () =>
+        this.executeWithEnvelopeAndPermissions(toolName, input, gatewayCallId)
+      );
+      this.logGatewayToolCall(
+        ctx,
+        toolName,
+        result,
+        Date.now() - startedAt,
+        scopeAudit,
+        gatewayCallId
+      );
       if (scopeAudit.mismatch) {
         this.alarmScopeMismatch(ctx, toolName);
       }
       return result;
     } catch (error) {
-      this.logGatewayToolCall(ctx, toolName, undefined, Date.now() - startedAt, scopeAudit, error);
+      this.logGatewayToolCall(
+        ctx,
+        toolName,
+        undefined,
+        Date.now() - startedAt,
+        scopeAudit,
+        gatewayCallId,
+        error
+      );
       if (scopeAudit.mismatch) {
         this.alarmScopeMismatch(ctx, toolName);
       }
@@ -950,12 +1014,64 @@ export class GatewayToolExecutor {
     });
   }
 
+  private buildTrustedMemoryWriteOptions(
+    toolName: string,
+    gatewayCallId: string
+  ): TrustedMemoryWriteOptions {
+    const ctx = this.mergeWithFallbackExecutionContext(this.executionContextStorage.getStore());
+    const capability = getTrustedProvenanceRuntime().createTrustedProvenanceCapability();
+    return {
+      capability,
+      provenance: {
+        actor: ctx?.agentContext?.roleName === 'memory_agent' ? 'memory_agent' : 'main_agent',
+        agent_id: ctx?.agentId,
+        model_run_id: ctx?.modelRunId ?? undefined,
+        envelope_hash: ctx?.envelope?.envelope_hash,
+        tool_name: toolName,
+        gateway_call_id: gatewayCallId,
+        source_turn_id: ctx?.sourceTurnId,
+        source_message_ref: ctx?.sourceMessageRef,
+        source_refs: [
+          ...(ctx?.envelope?.envelope_hash ? [`envelope:${ctx.envelope.envelope_hash}`] : []),
+          ...(ctx?.sourceMessageRef ? [`message:${ctx.sourceMessageRef}`] : []),
+        ],
+      },
+    };
+  }
+
+  private supportsTrustedIngest(api: MAMAApiInterface): boolean {
+    return Boolean(api.ingestWithTrustedProvenance);
+  }
+
+  private supportsTrustedSave(api: MAMAApiInterface): boolean {
+    return Boolean(api.saveWithTrustedProvenance);
+  }
+
+  private isMemoryDecisionSaveInput(input: SaveInput): boolean {
+    const candidate = input as {
+      type?: unknown;
+      topic?: unknown;
+      decision?: unknown;
+      reasoning?: unknown;
+    };
+    return (
+      candidate.type === 'decision' &&
+      typeof candidate.topic === 'string' &&
+      candidate.topic.length > 0 &&
+      typeof candidate.decision === 'string' &&
+      candidate.decision.length > 0 &&
+      typeof candidate.reasoning === 'string' &&
+      candidate.reasoning.length > 0
+    );
+  }
+
   private logGatewayToolCall(
     ctx: ActiveGatewayExecutionContext | undefined,
     toolName: string,
     result: GatewayToolResult | undefined,
     durationMs: number,
     scopeAudit: ScopeAuditFields,
+    gatewayCallId: string,
     error?: unknown
   ): void {
     try {
@@ -978,6 +1094,7 @@ export class GatewayToolExecutor {
         trigger_reason: 'gateway_tool_executor',
         error_message: errorMessage,
         envelopeHash: ctx?.envelope?.envelope_hash ?? null,
+        gatewayCallId,
         requestedScopes: scopeAudit.requestedScopes,
         envelopeScopesSnapshot: scopeAudit.envelopeScopesSnapshot,
         scopeMismatch: scopeAudit.mismatch,
@@ -985,6 +1102,7 @@ export class GatewayToolExecutor {
           source: ctx?.source ?? 'unknown',
           channel_id: ctx?.channelId ?? 'unknown',
           tool: toolName,
+          gateway_call_id: gatewayCallId,
           ...(resultCode ? { code: resultCode } : {}),
           ...(ctx?.parentToolName ? { parent: ctx.parentToolName } : {}),
         },
@@ -1048,7 +1166,8 @@ export class GatewayToolExecutor {
 
   private async executeWithEnvelopeAndPermissions(
     toolName: string,
-    input: GatewayToolInput
+    input: GatewayToolInput,
+    gatewayCallId: string
   ): Promise<GatewayToolResult> {
     if (!VALID_TOOLS.includes(toolName as GatewayToolName)) {
       throw new AgentError(
@@ -1409,14 +1528,20 @@ export class GatewayToolExecutor {
       const getApi = () => this.initializeMAMAApi();
 
       switch (toolName as GatewayToolName) {
-        case 'mama_save':
+        case 'mama_save': {
+          const saveInput = input as SaveInput;
+          const api = await getApi();
           return await handleSave(
-            await getApi(),
-            input as SaveInput,
+            api,
+            saveInput,
             this.sessionStore?.getHistory
               ? () => this.sessionStore!.getHistory!('current')
+              : undefined,
+            this.isMemoryDecisionSaveInput(saveInput) && this.supportsTrustedSave(api)
+              ? this.buildTrustedMemoryWriteOptions('mama_save', gatewayCallId)
               : undefined
           );
+        }
         case 'mama_search':
           return await handleSearch(await getApi(), input as SearchInput);
         case 'mama_recall':
@@ -1425,10 +1550,24 @@ export class GatewayToolExecutor {
           return await handleUpdate(await getApi(), input as UpdateInput);
         case 'mama_load_checkpoint':
           return await handleLoadCheckpoint(await getApi(), input as LoadCheckpointInput);
-        case 'mama_add':
-          return await this.handleMamaAdd(input as { content: string });
-        case 'mama_ingest':
-          return await this.handleMamaIngest(input as { content: string; scopes?: unknown });
+        case 'mama_add': {
+          const api = await getApi();
+          return await this.handleMamaAdd(
+            input as { content: string },
+            this.supportsTrustedIngest(api)
+              ? this.buildTrustedMemoryWriteOptions('mama_add', gatewayCallId)
+              : undefined
+          );
+        }
+        case 'mama_ingest': {
+          const api = await getApi();
+          return await this.handleMamaIngest(
+            input as { content: string; scopes?: unknown },
+            this.supportsTrustedIngest(api)
+              ? this.buildTrustedMemoryWriteOptions('mama_ingest', gatewayCallId)
+              : undefined
+          );
+        }
         case 'report_publish': {
           const slotsInput = (input as { slots?: Record<string, string> }).slots;
           if (!slotsInput || typeof slotsInput !== 'object') {
@@ -2989,7 +3128,10 @@ export class GatewayToolExecutor {
   /**
    * Handle mama_add — auto-extract facts from conversation content with derived memory scopes.
    */
-  private async handleMamaAdd(input: { content: string }): Promise<GatewayToolResult> {
+  private async handleMamaAdd(
+    input: { content: string },
+    options?: TrustedMemoryWriteOptions
+  ): Promise<GatewayToolResult> {
     const context = this.getActiveContext();
     if (!context) {
       return {
@@ -3005,16 +3147,22 @@ export class GatewayToolExecutor {
       projectId: process.env.MAMA_WORKSPACE || process.cwd(),
     });
 
-    return this.handleMamaIngest({
-      ...input,
-      scopes,
-    });
+    return this.handleMamaIngest(
+      {
+        ...input,
+        scopes,
+      },
+      options
+    );
   }
 
-  private async handleMamaIngest(input: {
-    content: string;
-    scopes?: unknown;
-  }): Promise<GatewayToolResult> {
+  private async handleMamaIngest(
+    input: {
+      content: string;
+      scopes?: unknown;
+    },
+    options?: TrustedMemoryWriteOptions
+  ): Promise<GatewayToolResult> {
     const { content } = input;
     if (!content || typeof content !== 'string') {
       return {
@@ -3025,7 +3173,14 @@ export class GatewayToolExecutor {
 
     try {
       const api = await this.initializeMAMAApi();
-      if (!api.ingestMemory) {
+      if (options && !api.ingestWithTrustedProvenance) {
+        return {
+          success: false,
+          error: 'Trusted memory ingest API not available.',
+        } as GatewayToolResult;
+      }
+
+      if (!options && !api.ingestMemory) {
         return {
           success: false,
           error: 'Memory ingest API not available.',
@@ -3056,7 +3211,7 @@ export class GatewayToolExecutor {
         } as GatewayToolResult;
       }
 
-      const result = await api.ingestMemory({
+      const payload = {
         content: content.substring(0, 10_000),
         scopes,
         source: {
@@ -3064,7 +3219,10 @@ export class GatewayToolExecutor {
           source_type: 'gateway_tool_executor',
           source: context?.source || null,
         },
-      });
+      };
+      const result = options
+        ? await api.ingestWithTrustedProvenance!(payload, options)
+        : await api.ingestMemory!(payload);
 
       return {
         success: true,
@@ -3147,6 +3305,55 @@ function isTruthyEnv(name: string): boolean {
     return false;
   }
   return TRUTHY_ENV_VALUES.has(value.trim().toLowerCase());
+}
+
+function getTrustedProvenanceRuntime(): TrustedProvenanceRuntime {
+  if (trustedProvenanceRuntime) {
+    return trustedProvenanceRuntime;
+  }
+
+  let lastError: unknown;
+  const loaders: Array<() => Partial<TrustedProvenanceRuntime>> = [
+    () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const mamaApiPath = require.resolve('@jungjaehoon/mama-core/mama-api');
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      return require(
+        join(dirname(mamaApiPath), 'runtime', 'trusted-provenance.js')
+      ) as Partial<TrustedProvenanceRuntime>;
+    },
+  ];
+
+  if (process.env.NODE_ENV === 'test' || process.env.VITEST === 'true') {
+    loaders.push(() => {
+      // Local Vitest runs execute standalone before mama-core dist/runtime exists.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      return require('../../../mama-core/src/memory/provenance.ts') as Partial<TrustedProvenanceRuntime>;
+    });
+  }
+
+  for (const loadRuntime of loaders) {
+    try {
+      const runtime = loadRuntime();
+      if (typeof runtime.createTrustedProvenanceCapability === 'function') {
+        trustedProvenanceRuntime = {
+          createTrustedProvenanceCapability: runtime.createTrustedProvenanceCapability,
+        };
+        return trustedProvenanceRuntime;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw new AgentError(
+    `Trusted provenance runtime unavailable: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`,
+    'TOOL_ERROR',
+    lastError instanceof Error ? lastError : undefined,
+    false
+  );
 }
 
 function normalizeMemoryScopes(value: unknown): MemoryScope[] | null {

--- a/packages/standalone/src/agent/mama-tool-handlers.ts
+++ b/packages/standalone/src/agent/mama-tool-handlers.ts
@@ -18,6 +18,7 @@ import type {
   UpdateResult,
   LoadCheckpointResult,
   MAMAApiInterface,
+  TrustedMemoryWriteOptions,
 } from './types.js';
 
 function isSearchResultItem(value: unknown): value is SearchResultItem {
@@ -31,7 +32,8 @@ function isSearchResultItem(value: unknown): value is SearchResultItem {
 export async function handleSave(
   api: MAMAApiInterface,
   input: SaveInput,
-  getRecentConversation?: () => unknown[]
+  getRecentConversation?: () => unknown[],
+  options?: TrustedMemoryWriteOptions
 ): Promise<SaveResult> {
   if (input.type === 'decision') {
     const d = input as SaveDecisionInput;
@@ -48,6 +50,12 @@ export async function handleSave(
       scopes: d.scopes,
       ...(d.event_date && { event_date: d.event_date }),
     };
+    if (options) {
+      if (!api.saveWithTrustedProvenance) {
+        return await api.save(payload);
+      }
+      return await api.saveWithTrustedProvenance(payload, options);
+    }
     return await api.save(payload);
   }
 

--- a/packages/standalone/src/agent/types.ts
+++ b/packages/standalone/src/agent/types.ts
@@ -103,6 +103,10 @@ export type GatewayToolExecutionContext = {
   channelId?: string;
   envelope?: Envelope;
   executionSurface: GatewayExecutionSurface;
+  sourceTurnId?: string;
+  sourceMessageRef?: string;
+  modelRunId?: string | null;
+  gatewayCallId?: string;
 };
 
 // ============================================================================
@@ -961,6 +965,12 @@ export interface AgentLoopOptions {
 
   /** Runtime authority envelope bound to this agent loop invocation */
   envelope?: Envelope;
+  /** Stable per-message source turn id for memory provenance. */
+  sourceTurnId?: string;
+  /** Compact source/channel/message ref for memory provenance. */
+  sourceMessageRef?: string;
+  /** Active model-run id for memory provenance. */
+  modelRunId?: string | null;
 
   /**
    * Stop the agent loop after the current tool batch completes when any
@@ -1109,11 +1119,32 @@ export interface GatewayToolExecutorOptions {
   metricsStore?: import('../observability/metrics-store.js').MetricsStore | null;
 }
 
+export interface MemoryWriteProvenance {
+  actor?: 'memory_agent' | 'main_agent' | `actor:${string}`;
+  agent_id?: string;
+  model_run_id?: string;
+  envelope_hash?: string;
+  tool_name?: string;
+  gateway_call_id?: string;
+  source_turn_id?: string;
+  source_message_ref?: string;
+  source_refs?: string[];
+}
+
+export interface TrustedMemoryWriteOptions {
+  provenance: MemoryWriteProvenance;
+  capability: unknown;
+}
+
 /**
  * Interface for MAMA API (for dependency injection)
  */
 export interface MAMAApiInterface {
   save(input: SaveDecisionPayload): Promise<SaveResult>;
+  saveWithTrustedProvenance?(
+    input: SaveDecisionPayload,
+    options: TrustedMemoryWriteOptions
+  ): Promise<SaveResult>;
   saveCheckpoint(
     summary: string,
     openFiles: string[],
@@ -1128,6 +1159,31 @@ export interface MAMAApiInterface {
     options?: { scopes?: ScopeRef[]; includeProfile?: boolean }
   ): Promise<unknown>;
   ingestMemory?(input: Record<string, unknown>): Promise<unknown>;
+  ingestWithTrustedProvenance?(
+    input: Record<string, unknown>,
+    options: TrustedMemoryWriteOptions
+  ): Promise<unknown>;
+  saveMemoryWithTrustedProvenance?(
+    input: Record<string, unknown>,
+    options: TrustedMemoryWriteOptions
+  ): Promise<unknown>;
+  ingestConversationWithTrustedProvenance?(
+    input: Record<string, unknown>,
+    options: TrustedMemoryWriteOptions
+  ): Promise<unknown>;
+  getMemoryProvenance?(memoryId: string, options?: Record<string, unknown>): Promise<unknown>;
+  listMemoriesByEnvelopeHash?(
+    envelopeHash: string,
+    options?: Record<string, unknown>
+  ): Promise<unknown[]>;
+  listMemoriesByGatewayCallId?(
+    gatewayCallId: string,
+    options?: Record<string, unknown>
+  ): Promise<unknown[]>;
+  listMemoriesByModelRunId?(
+    modelRunId: string,
+    options?: Record<string, unknown>
+  ): Promise<unknown[]>;
   buildProfile?(scopes?: ScopeRef[], options?: Record<string, unknown>): Promise<unknown>;
   updateOutcome(
     id: string,

--- a/packages/standalone/src/cli/runtime/memory-agent-init.ts
+++ b/packages/standalone/src/cli/runtime/memory-agent-init.ts
@@ -121,7 +121,14 @@ export async function initMemoryAgent(
     const memoryProcessManager = {
       async getSharedProcess() {
         return {
-          async sendMessage(content: string) {
+          async sendMessage(
+            content: string,
+            options?: {
+              sourceTurnId?: string;
+              sourceMessageRef?: string;
+              parentModelRunId?: string;
+            }
+          ) {
             if (!memoryAgentLoop) {
               throw new Error('Memory agent loop is not initialized');
             }
@@ -166,6 +173,9 @@ export async function initMemoryAgent(
                 channelId: 'shared',
                 agentContext: memoryAgentContext,
                 stopAfterSuccessfulTools: ['mama_save'],
+                sourceTurnId: options?.sourceTurnId,
+                sourceMessageRef: options?.sourceMessageRef,
+                modelRunId: options?.parentModelRunId,
               });
               const afterDecisionCount = Number(
                 adapter.prepare('SELECT COUNT(*) AS count FROM decisions').get().count

--- a/packages/standalone/src/db/agent-store.ts
+++ b/packages/standalone/src/db/agent-store.ts
@@ -10,6 +10,7 @@ import { applyAgentStoreTablesMigration } from './migrations/agent-store-tables.
 import { applyAgentMetricsResponseAverageMigration } from './migrations/agent-metrics-response-avg.js';
 import { applyAgentActivityValidationColumnsMigration } from './migrations/agent-activity-validation-columns.js';
 import { applyAgentActivityEnvelopeColumnsMigration } from './migrations/agent-activity-envelope-hash.js';
+import { applyAgentActivityGatewayCallIdMigration } from './migrations/agent-activity-gateway-call-id.js';
 import { applyEnvelopeTablesMigration } from './migrations/envelope-tables.js';
 
 type DB = SQLiteDatabase;
@@ -37,6 +38,7 @@ export function initAgentTables(db: SQLiteDatabase): void {
   applyAgentMetricsResponseAverageMigration(db);
   applyAgentActivityValidationColumnsMigration(db);
   applyAgentActivityEnvelopeColumnsMigration(db);
+  applyAgentActivityGatewayCallIdMigration(db);
   applyEnvelopeTablesMigration(db);
 }
 
@@ -259,6 +261,7 @@ export interface LogActivityInput {
   execution_status?: string;
   trigger_reason?: string;
   envelopeHash?: string | null;
+  gatewayCallId?: string | null;
   requestedScopes?: unknown[] | null;
   envelopeScopesSnapshot?: unknown[] | null;
   scopeMismatch?: boolean | number;
@@ -281,6 +284,7 @@ export interface ActivityRow {
   execution_status: string | null;
   trigger_reason: string | null;
   envelope_hash: string | null;
+  gateway_call_id: string | null;
   requested_scopes: string | null;
   envelope_scopes_snapshot: string | null;
   scope_mismatch: number;
@@ -294,6 +298,7 @@ export interface GetActivityOptions {
 export interface GatewayToolCallQuery {
   envelopeHash?: string;
   agentId?: string;
+  gatewayCallId?: string;
   limit?: number;
 }
 
@@ -312,9 +317,9 @@ export function logActivity(db: DB, input: LogActivityInput): ActivityRow {
     INSERT INTO agent_activity (
       agent_id, agent_version, type, input_summary, output_summary, tokens_used,
       tools_called, duration_ms, score, details, error_message, run_id, execution_status, trigger_reason,
-      envelope_hash, requested_scopes, envelope_scopes_snapshot, scope_mismatch
+      envelope_hash, gateway_call_id, requested_scopes, envelope_scopes_snapshot, scope_mismatch
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
   const result = stmt.run(
     input.agent_id,
@@ -332,6 +337,7 @@ export function logActivity(db: DB, input: LogActivityInput): ActivityRow {
     input.execution_status ?? null,
     input.trigger_reason ?? null,
     input.envelopeHash ?? null,
+    input.gatewayCallId ?? null,
     input.requestedScopes ? JSON.stringify(input.requestedScopes) : null,
     input.envelopeScopesSnapshot ? JSON.stringify(input.envelopeScopesSnapshot) : null,
     Number(Boolean(input.scopeMismatch))
@@ -386,6 +392,10 @@ export function listGatewayToolCalls(db: DB, input: GatewayToolCallQuery = {}): 
     conditions.push('agent_id = ?');
     params.push(input.agentId);
   }
+  if (input.gatewayCallId) {
+    conditions.push('gateway_call_id = ?');
+    params.push(input.gatewayCallId);
+  }
 
   params.push(normalizeActivityLimit(input.limit));
   return db
@@ -409,6 +419,10 @@ export function listScopeMismatches(db: DB, input: ScopeMismatchQuery = {}): Act
   if (input.agentId) {
     conditions.push('agent_id = ?');
     params.push(input.agentId);
+  }
+  if (input.gatewayCallId) {
+    conditions.push('gateway_call_id = ?');
+    params.push(input.gatewayCallId);
   }
   if (input.since) {
     conditions.push('created_at >= datetime(?)');

--- a/packages/standalone/src/db/migrations/agent-activity-gateway-call-id.ts
+++ b/packages/standalone/src/db/migrations/agent-activity-gateway-call-id.ts
@@ -1,0 +1,23 @@
+import type { SQLiteDatabase } from '../../sqlite.js';
+
+export function applyAgentActivityGatewayCallIdMigration(db: SQLiteDatabase): void {
+  const tableExists = db
+    .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'agent_activity'")
+    .get() as { 1: number } | undefined;
+
+  if (!tableExists) {
+    return;
+  }
+
+  const columns = (
+    db.prepare('PRAGMA table_info(agent_activity)').all() as Array<{ name: string }>
+  ).map((column) => column.name);
+
+  if (!columns.includes('gateway_call_id')) {
+    db.exec('ALTER TABLE agent_activity ADD COLUMN gateway_call_id TEXT');
+  }
+
+  db.exec(
+    'CREATE INDEX IF NOT EXISTS idx_agent_activity_gateway_call_id ON agent_activity(gateway_call_id)'
+  );
+}

--- a/packages/standalone/src/db/migrations/agent-store-tables.ts
+++ b/packages/standalone/src/db/migrations/agent-store-tables.ts
@@ -55,6 +55,7 @@ export function applyAgentStoreTablesMigration(db: SQLiteDatabase): void {
       execution_status TEXT,
       trigger_reason   TEXT,
       envelope_hash    TEXT,
+      gateway_call_id  TEXT,
       requested_scopes TEXT,
       envelope_scopes_snapshot TEXT,
       scope_mismatch   INTEGER DEFAULT 0 CHECK (scope_mismatch IN (0, 1)),

--- a/packages/standalone/src/gateways/message-router.ts
+++ b/packages/standalone/src/gateways/message-router.ts
@@ -84,7 +84,8 @@ export interface AgentLoopClient {
 
 export interface MemoryAgentProcessLike {
   sendMessage(
-    content: string
+    content: string,
+    options?: { sourceTurnId?: string; sourceMessageRef?: string; parentModelRunId?: string }
   ): Promise<{ response?: string; ack?: MemoryAuditAckLike } | { response?: string }>;
 }
 
@@ -360,7 +361,10 @@ export class MessageRouter {
     this.memoryAgentProcessManager = processManager;
     this.memoryAuditQueue = new AuditTaskQueue(async (job) => {
       const process = await processManager.getSharedProcess('memory');
-      const result = await process.sendMessage(this.buildMemoryAuditPrompt(job));
+      const result = await process.sendMessage(this.buildMemoryAuditPrompt(job), {
+        sourceTurnId: job.turnId,
+        sourceMessageRef: [job.source, job.channelId, job.turnId].filter(Boolean).join(':'),
+      });
       if (
         result &&
         typeof result === 'object' &&
@@ -568,6 +572,11 @@ This protects your credentials from being exposed in chat logs.`;
     let cliSessionId = initialSession.sessionId;
     let isNewCliSession = initialSession.isNew;
     const busy = initialSession.busy;
+    const sourceTurnId =
+      message.metadata?.messageId ?? `generated:${randomUUID().replace(/-/g, '')}`;
+    const sourceMessageRef = [message.source, message.channelId, sourceTurnId]
+      .filter(Boolean)
+      .join(':');
 
     // Track lock ownership for proper cleanup in finally block
     let acquiredLock = !busy; // If not busy, we acquired lock from initialSession
@@ -746,6 +755,8 @@ This protects your credentials from being exposed in chat logs.`;
         cliSessionId, // Pass CLI session ID to avoid double-locking
         streamCallbacks: wrappedOnStream || processOptions?.onStream,
         envelope,
+        sourceTurnId,
+        sourceMessageRef,
       };
 
       if (shouldResume) {
@@ -861,7 +872,14 @@ This protects your credentials from being exposed in chat logs.`;
         const rawAssistantText = stripGatewayDecorations(response);
         void (async () => {
           try {
-            await this.triggerMemoryAgent(channelKey, message.text, rawAssistantText, message);
+            await this.triggerMemoryAgent(
+              channelKey,
+              message.text,
+              rawAssistantText,
+              message,
+              sourceTurnId,
+              sourceMessageRef
+            );
           } catch {
             /* non-fatal */
           }
@@ -1501,7 +1519,9 @@ INSTRUCTION:
     channelKey: string,
     userText: string,
     botResponse: string,
-    message?: NormalizedMessage
+    message?: NormalizedMessage,
+    sourceTurnId?: string,
+    _sourceMessageRef?: string
   ): Promise<void> {
     const memoryAuditQueue = this.memoryAuditQueue;
     if (!this.memoryAgentProcessManager || !memoryAuditQueue) {
@@ -1559,7 +1579,7 @@ INSTRUCTION:
       projectId: this.getRuntimeProjectId(),
     });
     const job: MemoryAuditJob = {
-      turnId: `turn_${now}`,
+      turnId: sourceTurnId ?? `turn_${now}`,
       channelKey,
       source,
       channelId,

--- a/packages/standalone/tests/agent/gateway-tool-executor.test.ts
+++ b/packages/standalone/tests/agent/gateway-tool-executor.test.ts
@@ -24,63 +24,71 @@ import type { AgentProcessManager } from '../../src/multi-agent/agent-process-ma
 import type { DelegationManager } from '../../src/multi-agent/delegation-manager.js';
 
 describe('STORY-V019 - GatewayToolExecutor', () => {
-  const createMockApi = (): MAMAApiInterface => ({
-    save: vi.fn().mockResolvedValue({
-      success: true,
-      id: 'decision_test123',
-      type: 'decision',
-      message: 'Decision saved',
-    }),
-    saveCheckpoint: vi.fn().mockResolvedValue({
-      success: true,
-      id: 'checkpoint_test123',
-      type: 'checkpoint',
-      message: 'Checkpoint saved',
-    }),
-    listDecisions: vi.fn().mockResolvedValue([
-      {
-        id: 'decision_recent',
-        topic: 'recent_topic',
-        decision: 'Recent decision',
-        created_at: '2026-01-28',
+  const createMockApi = (): MAMAApiInterface => {
+    const api: MAMAApiInterface = {
+      save: vi.fn().mockResolvedValue({
+        success: true,
+        id: 'decision_test123',
         type: 'decision',
-      },
-    ]),
-    suggest: vi.fn().mockResolvedValue({
-      success: true,
-      results: [
+        message: 'Decision saved',
+      }),
+      saveCheckpoint: vi.fn().mockResolvedValue({
+        success: true,
+        id: 'checkpoint_test123',
+        type: 'checkpoint',
+        message: 'Checkpoint saved',
+      }),
+      listDecisions: vi.fn().mockResolvedValue([
         {
-          id: 'decision_1',
-          topic: 'auth',
-          decision: 'Use JWT',
-          similarity: 0.85,
+          id: 'decision_recent',
+          topic: 'recent_topic',
+          decision: 'Recent decision',
           created_at: '2026-01-28',
           type: 'decision',
         },
-      ],
-      count: 1,
-    }),
-    updateOutcome: vi.fn().mockResolvedValue({
+      ]),
+      suggest: vi.fn().mockResolvedValue({
+        success: true,
+        results: [
+          {
+            id: 'decision_1',
+            topic: 'auth',
+            decision: 'Use JWT',
+            similarity: 0.85,
+            created_at: '2026-01-28',
+            type: 'decision',
+          },
+        ],
+        count: 1,
+      }),
+      updateOutcome: vi.fn().mockResolvedValue({
+        success: true,
+        message: 'Outcome updated',
+      }),
+      loadCheckpoint: vi.fn().mockResolvedValue({
+        success: true,
+        summary: 'Session summary',
+        next_steps: 'Next steps',
+        open_files: ['file1.ts'],
+      }),
+      recallMemory: vi.fn().mockResolvedValue({
+        profile: { static: [], dynamic: [], evidence: [] },
+        memories: [],
+        graph_context: { primary: [], expanded: [], edges: [] },
+        search_meta: { query: 'test', scope_order: ['project'], retrieval_sources: ['mock'] },
+      }),
+      ingestMemory: vi.fn().mockResolvedValue({
+        success: true,
+        id: 'ingested_123',
+      }),
+    };
+    api.saveWithTrustedProvenance = vi.fn((input) => api.save(input));
+    api.ingestWithTrustedProvenance = vi.fn().mockResolvedValue({
       success: true,
-      message: 'Outcome updated',
-    }),
-    loadCheckpoint: vi.fn().mockResolvedValue({
-      success: true,
-      summary: 'Session summary',
-      next_steps: 'Next steps',
-      open_files: ['file1.ts'],
-    }),
-    recallMemory: vi.fn().mockResolvedValue({
-      profile: { static: [], dynamic: [], evidence: [] },
-      memories: [],
-      graph_context: { primary: [], expanded: [], edges: [] },
-      search_meta: { query: 'test', scope_order: ['project'], retrieval_sources: ['mock'] },
-    }),
-    ingestMemory: vi.fn().mockResolvedValue({
-      success: true,
-      id: 'ingested_123',
-    }),
-  });
+      id: 'trusted_ingest_123',
+    });
+    return api;
+  };
 
   // Shared context helpers (used by multiple test suites)
   const createViewerContext = () => ({
@@ -1063,7 +1071,7 @@ describe('STORY-V019 - GatewayToolExecutor', () => {
     });
 
     describe('memory v2 tools', () => {
-      it('should route mama_add through ingestMemory instead of fact JSON parsing', async () => {
+      it('should route mama_add through trusted ingest instead of fact JSON parsing', async () => {
         const mockApi = createMockApi();
         const executor = new GatewayToolExecutor({ mamaApi: mockApi });
         executor.setAgentContext({
@@ -1089,14 +1097,56 @@ describe('STORY-V019 - GatewayToolExecutor', () => {
           content: 'User prefers concise answers in this repo',
         });
 
-        expect(mockApi.ingestMemory).toHaveBeenCalledWith(
+        expect(mockApi.ingestMemory).not.toHaveBeenCalled();
+        expect(mockApi.ingestWithTrustedProvenance).toHaveBeenCalledWith(
           expect.objectContaining({
             scopes: expect.arrayContaining([
               expect.objectContaining({ kind: 'channel', id: 'telegram:7026976631' }),
               expect.objectContaining({ kind: 'user', id: '7026976631' }),
             ]),
+          }),
+          expect.objectContaining({
+            capability: expect.objectContaining({
+              __trustedProvenanceCapability: 'mama-core',
+            }),
+            provenance: expect.objectContaining({
+              actor: 'main_agent',
+              tool_name: 'mama_add',
+              gateway_call_id: expect.stringMatching(/^gw_/),
+            }),
           })
         );
+        expect(result).toMatchObject({ success: true, saved: 1 });
+      });
+
+      it('should keep mama_add working for injected legacy APIs without trusted provenance helpers', async () => {
+        const mockApi = createMockApi();
+        delete mockApi.ingestWithTrustedProvenance;
+        const executor = new GatewayToolExecutor({ mamaApi: mockApi });
+        executor.setAgentContext({
+          source: 'telegram',
+          platform: 'telegram',
+          roleName: 'os_agent',
+          role: {
+            allowedTools: ['*'],
+            systemControl: false,
+            sensitiveAccess: false,
+          },
+          session: {
+            sessionId: 'test-session',
+            channelId: '7026976631',
+            userId: '7026976631',
+            startedAt: new Date(),
+          },
+          capabilities: ['mama_add'],
+          limitations: [],
+        });
+
+        const result = await executor.execute('mama_add', {
+          content: 'User prefers concise answers in this repo',
+        });
+
+        expect(mockApi.ingestMemory).toHaveBeenCalledOnce();
         expect(result).toMatchObject({ success: true, saved: 1 });
       });
     });

--- a/packages/standalone/tests/agent/mama-tool-handlers.test.ts
+++ b/packages/standalone/tests/agent/mama-tool-handlers.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { handleSave } from '../../src/agent/mama-tool-handlers.js';
+import type { MAMAApiInterface, TrustedMemoryWriteOptions } from '../../src/agent/types.js';
+
+function createLegacyApi(): MAMAApiInterface {
+  return {
+    save: vi.fn().mockResolvedValue({
+      success: true,
+      id: 'legacy_save',
+      type: 'decision',
+    }),
+    saveCheckpoint: vi.fn().mockResolvedValue({
+      success: true,
+      id: 'checkpoint_1',
+      type: 'checkpoint',
+    }),
+    listDecisions: vi.fn().mockResolvedValue([]),
+    suggest: vi.fn().mockResolvedValue({ success: true, results: [], count: 0 }),
+    updateOutcome: vi.fn().mockResolvedValue({ success: true, message: 'updated' }),
+    loadCheckpoint: vi.fn().mockResolvedValue({ success: true }),
+  };
+}
+
+describe('Story M2.1: MAMA save handler compatibility', () => {
+  describe('AC: legacy injected APIs remain writable', () => {
+    it('falls back to public save when trusted provenance save is unavailable', async () => {
+      const api = createLegacyApi();
+      const options: TrustedMemoryWriteOptions = {
+        capability: Object.freeze({}),
+        provenance: {
+          actor: 'main_agent',
+          gateway_call_id: 'gw_test',
+        },
+      };
+
+      const result = await handleSave(
+        api,
+        {
+          type: 'decision',
+          topic: 'legacy_save_fallback',
+          decision: 'Legacy API should still save',
+          reasoning: 'Trusted provenance support is optional on injected APIs',
+        },
+        undefined,
+        options
+      );
+
+      expect(result).toMatchObject({ success: true, id: 'legacy_save' });
+      expect(api.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          topic: 'legacy_save_fallback',
+          decision: 'Legacy API should still save',
+          reasoning: 'Trusted provenance support is optional on injected APIs',
+        })
+      );
+    });
+  });
+});

--- a/packages/standalone/tests/cli/runtime/memory-agent-init.test.ts
+++ b/packages/standalone/tests/cli/runtime/memory-agent-init.test.ts
@@ -62,44 +62,55 @@ describe('Story M2.1: Memory Agent Runtime Provenance', () => {
     vi.clearAllMocks();
   });
 
-  it('forwards parent model run id into the memory agent loop run options', async () => {
-    const config = {
-      agent: { model: 'claude-sonnet-4-6' },
-      workspace: { path: tempDir },
-      multi_agent: {
-        agents: {
-          memory: {
-            backend: 'claude',
-            model: 'claude-sonnet-4-6',
+  describe('Acceptance Criteria', () => {
+    describe('AC #1: parent model run provenance is forwarded', () => {
+      it('forwards parent model run id into the memory agent loop run options', async () => {
+        const config = {
+          agent: { model: 'claude-sonnet-4-6' },
+          workspace: { path: tempDir },
+          multi_agent: {
+            agents: {
+              memory: {
+                backend: 'claude',
+                model: 'claude-sonnet-4-6',
+              },
+            },
           },
-        },
-      },
-    } as unknown as MAMAConfig;
-    process.env.MAMA_DB_PATH = join(tempDir, 'mama-memory.db');
-    const { initDB } = require('@jungjaehoon/mama-core/db-manager');
-    await initDB();
-    const messageRouter = {
-      setMemoryAgent(manager: MemoryAgentProcessManagerLike) {
-        processManager = manager;
-      },
-    } as unknown as MessageRouter;
+        } as unknown as MAMAConfig;
+        process.env.MAMA_DB_PATH = join(tempDir, 'mama-memory.db');
+        const { initDB } = require('@jungjaehoon/mama-core/db-manager');
+        await initDB();
+        const messageRouter = {
+          setMemoryAgent(manager: MemoryAgentProcessManagerLike) {
+            processManager = manager;
+          },
+        } as unknown as MessageRouter;
 
-    await initMemoryAgent({} as never, config, {} as never, {} as never, messageRouter, 'claude');
+        await initMemoryAgent(
+          {} as never,
+          config,
+          {} as never,
+          {} as never,
+          messageRouter,
+          'claude'
+        );
 
-    const memoryProcess = await processManager?.getSharedProcess('memory');
-    await memoryProcess?.sendMessage('Audit this turn', {
-      sourceTurnId: 'turn-1',
-      sourceMessageRef: 'telegram:abc:turn-1',
-      parentModelRunId: 'parent-model-run-1',
+        const memoryProcess = await processManager?.getSharedProcess('memory');
+        await memoryProcess?.sendMessage('Audit this turn', {
+          sourceTurnId: 'turn-1',
+          sourceMessageRef: 'telegram:abc:turn-1',
+          parentModelRunId: 'parent-model-run-1',
+        });
+
+        expect(mocks.run).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            sourceTurnId: 'turn-1',
+            sourceMessageRef: 'telegram:abc:turn-1',
+            modelRunId: 'parent-model-run-1',
+          })
+        );
+      });
     });
-
-    expect(mocks.run).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        sourceTurnId: 'turn-1',
-        sourceMessageRef: 'telegram:abc:turn-1',
-        modelRunId: 'parent-model-run-1',
-      })
-    );
   });
 });

--- a/packages/standalone/tests/cli/runtime/memory-agent-init.test.ts
+++ b/packages/standalone/tests/cli/runtime/memory-agent-init.test.ts
@@ -1,0 +1,105 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MAMAConfig } from '../../../src/cli/config/types.js';
+import type {
+  MemoryAgentProcessManagerLike,
+  MessageRouter,
+} from '../../../src/gateways/message-router.js';
+
+const mocks = vi.hoisted(() => ({
+  personaPath: '',
+  run: vi.fn(),
+  setSessionKey: vi.fn(),
+}));
+
+vi.mock('../../../src/agent/index.js', () => ({
+  AgentLoop: vi.fn().mockImplementation(() => ({
+    run: mocks.run,
+    setSessionKey: mocks.setSessionKey,
+  })),
+}));
+
+vi.mock('../../../src/multi-agent/memory-agent-persona.js', () => ({
+  ensureMemoryPersona: vi.fn(() => mocks.personaPath),
+}));
+
+vi.mock('../../../src/memory/bootstrap-context.js', () => ({
+  buildStandaloneMemoryBootstrap: vi.fn(async () => ({})),
+  formatMemoryBootstrap: vi.fn(() => 'memory bootstrap'),
+}));
+
+vi.mock('../../../src/memory/memory-agent-ack.js', () => ({
+  buildMemoryAuditAckFromAgentResult: vi.fn(() => ({ status: 'ignored' })),
+}));
+
+import { initMemoryAgent } from '../../../src/cli/runtime/memory-agent-init.js';
+
+const require = createRequire(import.meta.url);
+
+describe('Story M2.1: Memory Agent Runtime Provenance', () => {
+  let tempDir: string;
+  let processManager: MemoryAgentProcessManagerLike | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'memory-agent-init-'));
+    mocks.personaPath = join(tempDir, 'MEMORY_AGENT.md');
+    writeFileSync(mocks.personaPath, 'Memory agent persona', 'utf-8');
+    mocks.run.mockResolvedValue({ response: 'ack' });
+    mocks.setSessionKey.mockClear();
+    processManager = undefined;
+  });
+
+  afterEach(async () => {
+    const { closeDB } = require('@jungjaehoon/mama-core/db-manager');
+    await closeDB();
+    delete process.env.MAMA_DB_PATH;
+    rmSync(tempDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it('forwards parent model run id into the memory agent loop run options', async () => {
+    const config = {
+      agent: { model: 'claude-sonnet-4-6' },
+      workspace: { path: tempDir },
+      multi_agent: {
+        agents: {
+          memory: {
+            backend: 'claude',
+            model: 'claude-sonnet-4-6',
+          },
+        },
+      },
+    } as unknown as MAMAConfig;
+    process.env.MAMA_DB_PATH = join(tempDir, 'mama-memory.db');
+    const { initDB } = require('@jungjaehoon/mama-core/db-manager');
+    await initDB();
+    const messageRouter = {
+      setMemoryAgent(manager: MemoryAgentProcessManagerLike) {
+        processManager = manager;
+      },
+    } as unknown as MessageRouter;
+
+    await initMemoryAgent({} as never, config, {} as never, {} as never, messageRouter, 'claude');
+
+    const memoryProcess = await processManager?.getSharedProcess('memory');
+    await memoryProcess?.sendMessage('Audit this turn', {
+      sourceTurnId: 'turn-1',
+      sourceMessageRef: 'telegram:abc:turn-1',
+      parentModelRunId: 'parent-model-run-1',
+    });
+
+    expect(mocks.run).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        sourceTurnId: 'turn-1',
+        sourceMessageRef: 'telegram:abc:turn-1',
+        modelRunId: 'parent-model-run-1',
+      })
+    );
+  });
+});

--- a/packages/standalone/tests/db/agent-activity.test.ts
+++ b/packages/standalone/tests/db/agent-activity.test.ts
@@ -14,7 +14,7 @@ import type { AgentContext, GatewayToolInput, MAMAApiInterface } from '../../src
 type AgentStoreWithTraceHelpers = typeof agentStore & {
   listGatewayToolCalls?: (
     db: Database,
-    input: { envelopeHash?: string; limit?: number }
+    input: { envelopeHash?: string; gatewayCallId?: string; limit?: number }
   ) => agentStore.ActivityRow[];
   listScopeMismatches?: (
     db: Database,
@@ -96,6 +96,7 @@ describe('Story V19.6 - Agent Activity Logging', () => {
         name: string;
       }>;
       expect(columns.some((column) => column.name === 'envelope_hash')).toBe(true);
+      expect(columns.some((column) => column.name === 'gateway_call_id')).toBe(true);
       expect(columns.some((column) => column.name === 'requested_scopes')).toBe(true);
       expect(columns.some((column) => column.name === 'envelope_scopes_snapshot')).toBe(true);
       expect(columns.some((column) => column.name === 'scope_mismatch')).toBe(true);
@@ -104,6 +105,9 @@ describe('Story V19.6 - Agent Activity Logging', () => {
         name: string;
       }>;
       expect(indexes.some((index) => index.name === 'idx_agent_activity_envelope_hash')).toBe(true);
+      expect(indexes.some((index) => index.name === 'idx_agent_activity_gateway_call_id')).toBe(
+        true
+      );
       expect(indexes.some((index) => index.name === 'idx_agent_activity_scope_mismatch')).toBe(
         true
       );
@@ -148,7 +152,7 @@ describe('Story V19.6 - Agent Activity Logging', () => {
 
       const row = legacyDb
         .prepare(
-          `SELECT input_summary, envelope_hash, requested_scopes,
+          `SELECT input_summary, envelope_hash, gateway_call_id, requested_scopes,
                   envelope_scopes_snapshot, scope_mismatch
            FROM agent_activity
            WHERE agent_id = ?`
@@ -156,6 +160,7 @@ describe('Story V19.6 - Agent Activity Logging', () => {
         .get('legacy-agent') as {
         input_summary: string;
         envelope_hash: string | null;
+        gateway_call_id: string | null;
         requested_scopes: string | null;
         envelope_scopes_snapshot: string | null;
         scope_mismatch: number;
@@ -163,6 +168,7 @@ describe('Story V19.6 - Agent Activity Logging', () => {
       expect(row).toEqual({
         input_summary: 'before migration',
         envelope_hash: null,
+        gateway_call_id: null,
         requested_scopes: null,
         envelope_scopes_snapshot: null,
         scope_mismatch: 0,
@@ -409,6 +415,7 @@ describe('Story V19.6 - Agent Activity Logging', () => {
         input_summary: 'mama_save',
         execution_status: 'completed',
         envelopeHash: 'env_hash_1',
+        gatewayCallId: 'gw_trace_1',
         scopeMismatch: 1,
       } as Parameters<typeof logActivity>[1] & {
         envelopeHash: string;
@@ -421,6 +428,7 @@ describe('Story V19.6 - Agent Activity Logging', () => {
         input_summary: 'mama_search',
         execution_status: 'completed',
         envelopeHash: 'env_hash_2',
+        gatewayCallId: 'gw_trace_2',
         scopeMismatch: 0,
       } as Parameters<typeof logActivity>[1] & {
         envelopeHash: string;
@@ -431,6 +439,13 @@ describe('Story V19.6 - Agent Activity Logging', () => {
         expect.objectContaining({
           input_summary: 'mama_save',
           envelope_hash: 'env_hash_1',
+          gateway_call_id: 'gw_trace_1',
+        }),
+      ]);
+      expect(helpers.listGatewayToolCalls!(db, { gatewayCallId: 'gw_trace_2' })).toEqual([
+        expect.objectContaining({
+          input_summary: 'mama_search',
+          gateway_call_id: 'gw_trace_2',
         }),
       ]);
       expect(helpers.listScopeMismatches!(db, { envelopeHash: 'env_hash_1' })).toEqual([
@@ -439,6 +454,14 @@ describe('Story V19.6 - Agent Activity Logging', () => {
           scope_mismatch: 1,
         }),
       ]);
+      expect(helpers.listScopeMismatches!(db, { gatewayCallId: 'gw_trace_1' })).toEqual([
+        expect.objectContaining({
+          input_summary: 'mama_save',
+          gateway_call_id: 'gw_trace_1',
+          scope_mismatch: 1,
+        }),
+      ]);
+      expect(helpers.listScopeMismatches!(db, { gatewayCallId: 'gw_trace_2' })).toEqual([]);
     });
 
     it('AC #13: normalizes ISO since filters for scope mismatch queries', () => {

--- a/packages/standalone/tests/db/agent-activity.test.ts
+++ b/packages/standalone/tests/db/agent-activity.test.ts
@@ -18,7 +18,7 @@ type AgentStoreWithTraceHelpers = typeof agentStore & {
   ) => agentStore.ActivityRow[];
   listScopeMismatches?: (
     db: Database,
-    input: { envelopeHash?: string; limit?: number; since?: string }
+    input: { envelopeHash?: string; gatewayCallId?: string; limit?: number; since?: string }
   ) => agentStore.ActivityRow[];
   countScopeMismatches?: (db: Database, input: { since?: string }) => number;
 };

--- a/packages/standalone/tests/envelope/executor-audit.test.ts
+++ b/packages/standalone/tests/envelope/executor-audit.test.ts
@@ -6,6 +6,7 @@ import { initAgentTables } from '../../src/db/agent-store.js';
 import { makeSignedEnvelope } from './fixtures.js';
 
 type GatewayAuditRow = {
+  agent_id: string;
   type: string;
   input_summary: string | null;
   execution_status: string | null;
@@ -47,7 +48,7 @@ function createTelegramGateway() {
 function readGatewayToolRows(db: Database): GatewayAuditRow[] {
   return db
     .prepare(
-      `SELECT type, input_summary, execution_status, error_message, envelope_hash
+      `SELECT agent_id, type, input_summary, execution_status, error_message, envelope_hash
        FROM agent_activity
        WHERE type = 'gateway_tool_call'
        ORDER BY id ASC`
@@ -81,6 +82,64 @@ describe('Story M1R: gateway tool execution audit ledger', () => {
     expect(result).toMatchObject({ success: true });
     expect(readGatewayToolRows(db)).toEqual([
       expect.objectContaining({
+        input_summary: 'mama_search',
+        execution_status: 'completed',
+        envelope_hash: envelope.envelope_hash,
+      }),
+    ]);
+    db.close();
+  });
+
+  it('records gateway audit rows with merged fallback context when async context is partial', async () => {
+    const db = new Database(':memory:');
+    initAgentTables(db);
+    const executor = new GatewayToolExecutor({ mamaApi: createMAMAApi() });
+    executor.setSessionsDb(db);
+    executor.setAgentContext({
+      source: 'telegram',
+      platform: 'telegram',
+      roleName: 'chat_bot',
+      role: {
+        allowedTools: ['*'],
+        systemControl: false,
+        sensitiveAccess: false,
+      },
+      session: {
+        sessionId: 'telegram:abc',
+        channelId: 'abc',
+        userId: 'user-1',
+        startedAt: new Date(),
+      },
+      capabilities: ['*'],
+      limitations: [],
+      tier: 2,
+      backend: 'claude',
+    });
+    executor.setCurrentAgentContext('fallback-chat-bot', 'telegram', 'abc');
+    const envelope = makeSignedEnvelope({
+      source: 'telegram',
+      channel_id: 'abc',
+      scope: {
+        project_refs: [{ kind: 'project', id: '/workspace/project-a' }],
+        raw_connectors: ['telegram'],
+        memory_scopes: [{ kind: 'channel', id: 'telegram:abc' }],
+        allowed_destinations: [{ kind: 'telegram', id: 'abc' }],
+      },
+    });
+
+    const result = await executor.execute(
+      'mama_search',
+      { query: 'audit' },
+      {
+        envelope,
+        executionSurface: 'model_tool',
+      }
+    );
+
+    expect(result).toMatchObject({ success: true });
+    expect(readGatewayToolRows(db)).toEqual([
+      expect.objectContaining({
+        agent_id: 'fallback-chat-bot',
         input_summary: 'mama_search',
         execution_status: 'completed',
         envelope_hash: envelope.envelope_hash,

--- a/packages/standalone/tests/envelope/memory-provenance-context.test.ts
+++ b/packages/standalone/tests/envelope/memory-provenance-context.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
+import type { AgentContext, MAMAApiInterface } from '../../src/agent/types.js';
+import { initAgentTables } from '../../src/db/agent-store.js';
+import Database from '../../src/sqlite.js';
+import { makeSignedEnvelope } from './fixtures.js';
+
+type ProvenanceAwareApi = MAMAApiInterface & {
+  saveWithTrustedProvenance: ReturnType<typeof vi.fn>;
+  ingestWithTrustedProvenance: ReturnType<typeof vi.fn>;
+};
+
+function createContext(): AgentContext {
+  return {
+    source: 'telegram',
+    platform: 'telegram',
+    roleName: 'chat_bot',
+    role: {
+      allowedTools: ['*'],
+      systemControl: false,
+      sensitiveAccess: false,
+    },
+    session: {
+      sessionId: 'telegram:abc',
+      channelId: 'abc',
+      userId: 'user-1',
+      startedAt: new Date(),
+    },
+    capabilities: ['*'],
+    limitations: [],
+    tier: 2,
+    backend: 'claude',
+  };
+}
+
+function createApi(): ProvenanceAwareApi {
+  return {
+    save: vi.fn().mockResolvedValue({ success: true, id: 'public_save', type: 'decision' }),
+    saveWithTrustedProvenance: vi
+      .fn()
+      .mockResolvedValue({ success: true, id: 'trusted_save', type: 'decision' }),
+    saveCheckpoint: vi.fn().mockResolvedValue({
+      success: true,
+      id: 'checkpoint_1',
+      type: 'checkpoint',
+    }),
+    listDecisions: vi.fn().mockResolvedValue([]),
+    suggest: vi.fn().mockResolvedValue({ success: true, results: [], count: 0 }),
+    updateOutcome: vi.fn().mockResolvedValue({ success: true, message: 'updated' }),
+    loadCheckpoint: vi.fn().mockResolvedValue({ success: true }),
+    ingestMemory: vi.fn().mockResolvedValue({ success: true, id: 'public_ingest' }),
+    ingestWithTrustedProvenance: vi.fn().mockResolvedValue({ success: true, id: 'trusted_ingest' }),
+  };
+}
+
+function createEnvelope() {
+  return makeSignedEnvelope({
+    source: 'telegram',
+    channel_id: 'abc',
+    scope: {
+      project_refs: [{ kind: 'project', id: '/workspace/project-a' }],
+      raw_connectors: ['telegram'],
+      memory_scopes: [{ kind: 'channel', id: 'telegram:abc' }],
+      allowed_destinations: [{ kind: 'telegram', id: 'abc' }],
+    },
+  });
+}
+
+describe('Story M2.1: Gateway Memory Provenance Context', () => {
+  it('threads trusted context into mama_save and ignores caller-supplied provenance', async () => {
+    const db = new Database(':memory:');
+    initAgentTables(db);
+    const api = createApi();
+    const executor = new GatewayToolExecutor({ mamaApi: api });
+    executor.setSessionsDb(db);
+    const envelope = createEnvelope();
+
+    const result = await executor.execute(
+      'mama_save',
+      {
+        type: 'decision',
+        topic: 'gateway_trusted_provenance',
+        decision: 'Gateway context chooses provenance',
+        reasoning: 'Caller input cannot spoof envelope hash',
+        provenance: { envelope_hash: 'attacker_env' },
+      },
+      {
+        agentContext: createContext(),
+        agentId: 'chat_bot',
+        source: 'telegram',
+        channelId: 'abc',
+        envelope,
+        executionSurface: 'model_tool',
+        sourceTurnId: 'turn-1',
+        sourceMessageRef: 'telegram:abc:turn-1',
+      }
+    );
+
+    expect(result).toMatchObject({ success: true, id: 'trusted_save' });
+    expect(api.save).not.toHaveBeenCalled();
+    expect(api.saveWithTrustedProvenance).toHaveBeenCalledOnce();
+    const [, options] = api.saveWithTrustedProvenance.mock.calls[0];
+    expect(options.provenance).toMatchObject({
+      actor: 'main_agent',
+      agent_id: 'chat_bot',
+      envelope_hash: envelope.envelope_hash,
+      tool_name: 'mama_save',
+      source_turn_id: 'turn-1',
+      source_message_ref: 'telegram:abc:turn-1',
+    });
+    expect(options.provenance.envelope_hash).not.toBe('attacker_env');
+    expect(options.provenance.gateway_call_id).toMatch(/^gw_/);
+
+    const row = db
+      .prepare(
+        `SELECT gateway_call_id, details
+         FROM agent_activity
+         WHERE type = 'gateway_tool_call'
+         LIMIT 1`
+      )
+      .get() as { gateway_call_id: string | null; details: string };
+    expect(row.gateway_call_id).toBe(options.provenance.gateway_call_id);
+    expect(JSON.parse(row.details).gateway_call_id).toBe(options.provenance.gateway_call_id);
+    db.close();
+  });
+
+  it('threads trusted context into mama_ingest without trusting input provenance', async () => {
+    const db = new Database(':memory:');
+    initAgentTables(db);
+    const api = createApi();
+    const executor = new GatewayToolExecutor({ mamaApi: api });
+    executor.setSessionsDb(db);
+    const envelope = createEnvelope();
+
+    const result = await executor.execute(
+      'mama_ingest',
+      {
+        content: 'User prefers compact provenance.',
+        scopes: [{ kind: 'channel', id: 'telegram:abc' }],
+        provenance: { gateway_call_id: 'attacker_gw' },
+      },
+      {
+        agentContext: createContext(),
+        agentId: 'chat_bot',
+        source: 'telegram',
+        channelId: 'abc',
+        envelope,
+        executionSurface: 'model_tool',
+        sourceTurnId: 'turn-2',
+        sourceMessageRef: 'telegram:abc:turn-2',
+      }
+    );
+
+    expect(result).toMatchObject({ success: true, saved: 1 });
+    expect(api.ingestMemory).not.toHaveBeenCalled();
+    expect(api.ingestWithTrustedProvenance).toHaveBeenCalledOnce();
+    const [, options] = api.ingestWithTrustedProvenance.mock.calls[0];
+    expect(options.provenance.gateway_call_id).toMatch(/^gw_/);
+    expect(options.provenance.gateway_call_id).not.toBe('attacker_gw');
+    expect(options.provenance.envelope_hash).toBe(envelope.envelope_hash);
+    db.close();
+  });
+
+  it('merges fallback agent context and model run id into trusted provenance', async () => {
+    const db = new Database(':memory:');
+    initAgentTables(db);
+    const api = createApi();
+    const executor = new GatewayToolExecutor({ mamaApi: api });
+    executor.setSessionsDb(db);
+    executor.setAgentContext({
+      ...createContext(),
+      roleName: 'memory_agent',
+    });
+    executor.setCurrentAgentContext('memory-agent-1', 'telegram', 'abc');
+    const envelope = createEnvelope();
+
+    const result = await executor.execute(
+      'mama_save',
+      {
+        type: 'decision',
+        topic: 'fallback_context_provenance',
+        decision: 'Fallback context still identifies the actor',
+        reasoning: 'Async context can omit agent fields while runtime fallback has them',
+      },
+      {
+        envelope,
+        executionSurface: 'model_tool',
+        sourceTurnId: 'turn-with-fallback',
+        sourceMessageRef: 'telegram:abc:turn-with-fallback',
+        modelRunId: 'model-run-1',
+      }
+    );
+
+    expect(result).toMatchObject({ success: true, id: 'trusted_save' });
+    expect(api.saveWithTrustedProvenance).toHaveBeenCalledOnce();
+    const [, options] = api.saveWithTrustedProvenance.mock.calls[0];
+    expect(options.provenance.actor).toBe('memory_agent');
+    expect(options.provenance.agent_id).toBe('memory-agent-1');
+    expect(options.provenance.model_run_id).toBe('model-run-1');
+    expect(options.provenance.envelope_hash).toBe(envelope.envelope_hash);
+    expect(options.provenance.source_message_ref).toBe('telegram:abc:turn-with-fallback');
+    db.close();
+  });
+});

--- a/packages/standalone/tests/envelope/memory-scope-mismatch-logging.test.ts
+++ b/packages/standalone/tests/envelope/memory-scope-mismatch-logging.test.ts
@@ -30,6 +30,7 @@ type AuditRow = {
   input_summary: string | null;
   execution_status: string | null;
   envelope_hash: string | null;
+  gateway_call_id: string | null;
   requested_scopes: string | null;
   envelope_scopes_snapshot: string | null;
   scope_mismatch: number;
@@ -40,7 +41,7 @@ type MetricsStoreMock = Pick<MetricsStore, 'record'> & {
 };
 
 function createMAMAApi(): MAMAApiInterface {
-  return {
+  const api: MAMAApiInterface = {
     save: vi.fn().mockResolvedValue({ success: true, id: 'decision_1', type: 'decision' }),
     saveCheckpoint: vi.fn().mockResolvedValue({
       success: true,
@@ -59,6 +60,9 @@ function createMAMAApi(): MAMAApiInterface {
     }),
     ingestMemory: vi.fn().mockResolvedValue({ success: true, id: 'ingested_1' }),
   };
+  api.saveWithTrustedProvenance = vi.fn((input) => api.save(input));
+  api.ingestWithTrustedProvenance = vi.fn((input) => api.ingestMemory!(input));
+  return api;
 }
 
 function createMetricsStore(): MetricsStoreMock {
@@ -94,7 +98,7 @@ function createTelegramContext(channelId = 'abc', allowedPaths?: string[]): Agen
 function readGatewayToolRows(db: Database): AuditRow[] {
   return db
     .prepare(
-      `SELECT id, type, input_summary, execution_status, envelope_hash,
+      `SELECT id, type, input_summary, execution_status, envelope_hash, gateway_call_id,
               requested_scopes, envelope_scopes_snapshot, scope_mismatch
        FROM agent_activity
        WHERE type = 'gateway_tool_call'
@@ -491,6 +495,8 @@ describe('Story M1R: memory scope mismatch audit logging', () => {
     expect(new Set(rows.map((row) => row.envelope_hash))).toEqual(
       new Set([envelope.envelope_hash])
     );
+    expect(new Set(rows.map((row) => row.gateway_call_id)).size).toBe(1);
+    expect(rows[0].gateway_call_id).toMatch(/^gw_/);
     const autosave = rows.find((row) => row.input_summary === 'mama_save');
     expect(autosave).toMatchObject({ scope_mismatch: 1 });
     expect(parseScopes(autosave!.requested_scopes)).toEqual([{ kind: 'global', id: 'system' }]);
@@ -542,6 +548,8 @@ describe('Story M1R: memory scope mismatch audit logging', () => {
     expect(new Set(rows.map((row) => row.envelope_hash))).toEqual(
       new Set([envelope.envelope_hash])
     );
+    expect(new Set(rows.map((row) => row.gateway_call_id)).size).toBe(1);
+    expect(rows[0].gateway_call_id).toMatch(/^gw_/);
     const autosave = rows.find((row) => row.input_summary === 'mama_save');
     expect(autosave).toMatchObject({ scope_mismatch: 1 });
     expect(parseScopes(autosave!.requested_scopes)).toEqual([{ kind: 'global', id: 'system' }]);

--- a/packages/standalone/tests/gateways/message-router.test.ts
+++ b/packages/standalone/tests/gateways/message-router.test.ts
@@ -115,6 +115,38 @@ describe('MessageRouter', () => {
       expect(history[0].bot).toBe('Agent response');
     });
 
+    it('passes stable source turn refs to the agent loop', async () => {
+      const run = vi.fn().mockResolvedValue({ response: 'Agent response' });
+      const customRouter = new MessageRouter(
+        sessionStore,
+        { run },
+        createMockMamaApi(mockDecisions)
+      );
+
+      await customRouter.process({
+        source: 'discord',
+        channelId: 'channel-123',
+        userId: 'user-456',
+        text: 'Hello',
+        metadata: { messageId: 'msg-1' },
+      });
+      await customRouter.process({
+        source: 'discord',
+        channelId: 'channel-123',
+        userId: 'user-456',
+        text: 'Hello again',
+      });
+
+      expect(run.mock.calls[0][1]).toMatchObject({
+        sourceTurnId: 'msg-1',
+        sourceMessageRef: 'discord:channel-123:msg-1',
+      });
+      const generatedTurnId = run.mock.calls[1][1].sourceTurnId;
+      expect(generatedTurnId).toMatch(/^generated:/);
+      expect(run.mock.calls[1][1].sourceMessageRef).toBe(`discord:channel-123:${generatedTurnId}`);
+      expect(generatedTurnId).not.toBe('msg-1');
+    });
+
     it('should inject profile-aware recall bundle into the prompt', async () => {
       let receivedPrompt = '';
       const agentLoop = createMockAgentLoop((prompt) => {
@@ -363,6 +395,10 @@ describe('MessageRouter', () => {
 
       await vi.waitFor(() => {
         expect(sendMessage).toHaveBeenCalled();
+      });
+      expect(sendMessage.mock.calls[0][1]).toMatchObject({
+        sourceTurnId: expect.stringMatching(/^generated:/),
+        sourceMessageRef: expect.stringMatching(/^discord:channel-autosave:generated:/),
       });
       expect(saveSpy).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary
- Add memory write provenance schema and trusted write plumbing for mama-core.
- Thread gateway call, envelope, model run, source turn, and memory event lineage through standalone memory writes.
- Add provenance lookup/audit tests and update security/testing docs.

## Test Plan
- pnpm lint
- pnpm build
- pnpm test
- git diff --check
- coderabbit review --agent -t uncommitted -c AGENTS.md -c CLAUDE.md (0 issues)

## Commit
- 20b66ead feat(m2): add memory provenance foundation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory writes now record and track provenance metadata including agent identity and source information.
  * Added query capabilities to retrieve memories by their origin and context identifiers.

* **Security**
  * System prevents spoofing of memory provenance records by external callers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->