### PR TITLE
feat(m2): add model run tool tracing

### DIFF
--- a/packages/mama-core/db/migrations/033-create-model-runs-and-tool-traces.sql
+++ b/packages/mama-core/db/migrations/033-create-model-runs-and-tool-traces.sql
@@ -1,0 +1,53 @@
+CREATE TABLE IF NOT EXISTS model_runs (
+  model_run_id TEXT PRIMARY KEY,
+  model_id TEXT,
+  model_provider TEXT,
+  prompt_version TEXT,
+  tool_manifest_version TEXT,
+  output_schema_version TEXT,
+  agent_id TEXT,
+  instance_id TEXT,
+  envelope_hash TEXT,
+  parent_model_run_id TEXT,
+  input_snapshot_ref TEXT,
+  input_refs_json TEXT,
+  completion_summary TEXT,
+  status TEXT NOT NULL CHECK (status IN ('running', 'committed', 'failed', 'legacy')),
+  error_summary TEXT,
+  token_count INTEGER DEFAULT 0,
+  cost_estimate REAL,
+  created_at INTEGER NOT NULL,
+  completed_at INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_model_runs_envelope_hash
+  ON model_runs(envelope_hash);
+
+CREATE INDEX IF NOT EXISTS idx_model_runs_status_created
+  ON model_runs(status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_model_runs_agent_created
+  ON model_runs(agent_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS tool_traces (
+  trace_id TEXT PRIMARY KEY,
+  model_run_id TEXT NOT NULL,
+  gateway_call_id TEXT,
+  tool_name TEXT NOT NULL,
+  input_summary TEXT,
+  output_summary TEXT,
+  execution_status TEXT,
+  duration_ms INTEGER DEFAULT 0,
+  envelope_hash TEXT,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (model_run_id) REFERENCES model_runs(model_run_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tool_traces_model_run_id
+  ON tool_traces(model_run_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_tool_traces_gateway_call_id
+  ON tool_traces(gateway_call_id);
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES (33, 'Create model runs and tool traces');

--- a/packages/mama-core/src/index.ts
+++ b/packages/mama-core/src/index.ts
@@ -139,6 +139,16 @@ export {
   listMemoriesByGatewayCallId,
   listMemoriesByModelRunId,
 } from './memory/provenance-query.js';
+export {
+  MODEL_RUN_STATUSES,
+  type ModelRunStatus,
+  type BeginModelRunInput,
+  type ModelRunRecord,
+  type AppendToolTraceInput,
+  type ToolTraceRecord,
+} from './model-runs/types.js';
+export { beginModelRun, commitModelRun, failModelRun, getModelRun } from './model-runs/store.js';
+export { appendToolTrace, listToolTracesForRun } from './model-runs/tool-trace-store.js';
 export * from './entities/types.js';
 export * from './entities/errors.js';
 export * from './entities/store.js';

--- a/packages/mama-core/src/mama-api.ts
+++ b/packages/mama-core/src/mama-api.ts
@@ -64,6 +64,8 @@ import {
   listMemoriesByGatewayCallId,
   listMemoriesByModelRunId,
 } from './memory/provenance-query.js';
+import { beginModelRun, commitModelRun, failModelRun, getModelRun } from './model-runs/store.js';
+import { appendToolTrace, listToolTracesForRun } from './model-runs/tool-trace-store.js';
 import {
   rollUpSearchHits,
   type SearchRollupLeafHit,
@@ -3882,6 +3884,12 @@ const mama = {
   listMemoriesByModelRunId,
   listMemoryEventsForMemory,
   listRecentMemoryEvents,
+  beginModelRun,
+  commitModelRun,
+  failModelRun,
+  getModelRun,
+  appendToolTrace,
+  listToolTracesForRun,
   saveCheckpoint,
   loadCheckpoint,
   // Legacy functions (retained for internal use, not exposed via MCP)
@@ -3937,6 +3945,12 @@ export {
   listMemoriesByModelRunId,
   listMemoryEventsForMemory,
   listRecentMemoryEvents,
+  beginModelRun,
+  commitModelRun,
+  failModelRun,
+  getModelRun,
+  appendToolTrace,
+  listToolTracesForRun,
   saveCheckpoint,
   loadCheckpoint,
   recall,

--- a/packages/mama-core/src/model-runs/store.ts
+++ b/packages/mama-core/src/model-runs/store.ts
@@ -1,0 +1,238 @@
+import crypto from 'node:crypto';
+
+import { getAdapter, initDB } from '../db-manager.js';
+import type { DatabaseAdapter } from '../db-manager.js';
+import { MODEL_RUN_STATUSES } from './types.js';
+import type { BeginModelRunInput, ModelRunRecord, ModelRunStatus } from './types.js';
+
+type ModelRunAdapter = Pick<DatabaseAdapter, 'prepare'>;
+
+function modelRunId(): string {
+  return `mr_${crypto.randomUUID().replace(/-/g, '')}`;
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function formatInvalidValue(value: unknown): string {
+  return typeof value === 'string' ? JSON.stringify(value) : String(value);
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`model_runs.${field} must be a non-empty string: ${formatInvalidValue(value)}`);
+  }
+  return value;
+}
+
+function normalizeTimestamp(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.floor(value) : Date.now();
+}
+
+function requireTimestamp(value: unknown, field: string, modelRunId: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`Invalid model_runs.${field} for ${modelRunId}: ${formatInvalidValue(value)}`);
+  }
+  return Math.floor(value);
+}
+
+function normalizeNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.floor(value) : fallback;
+}
+
+function normalizeCost(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function normalizeInputRefsJson(input: BeginModelRunInput): string | null {
+  if (typeof input.input_refs_json === 'string') {
+    return input.input_refs_json;
+  }
+  if (input.input_refs === null || input.input_refs === undefined) {
+    return null;
+  }
+  return JSON.stringify(input.input_refs);
+}
+
+function parseInputRefs(row: { model_run_id: string; input_refs_json: unknown }): {
+  input_refs_json: string | null;
+  input_refs: Record<string, unknown> | null;
+} {
+  const inputRefsJson = nullableString(row.input_refs_json);
+  if (!inputRefsJson) {
+    return { input_refs_json: null, input_refs: null };
+  }
+  try {
+    const parsed = JSON.parse(inputRefsJson) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return {
+        input_refs_json: inputRefsJson,
+        input_refs: parsed as Record<string, unknown>,
+      };
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid model_runs.input_refs_json for ${row.model_run_id}: ${message}`);
+  }
+  throw new Error(`Invalid model_runs.input_refs_json for ${row.model_run_id}: expected object`);
+}
+
+const MODEL_RUN_STATUS_SET = new Set<string>(MODEL_RUN_STATUSES);
+
+function requireModelRunStatus(value: unknown, modelRunId: string): ModelRunStatus {
+  if (typeof value === 'string' && MODEL_RUN_STATUS_SET.has(value)) {
+    return value as ModelRunStatus;
+  }
+  throw new Error(`Invalid model_runs.status for ${modelRunId}: ${formatInvalidValue(value)}`);
+}
+
+function mapModelRunRow(row: Record<string, unknown>): ModelRunRecord {
+  const model_run_id = requireString(row.model_run_id, 'model_run_id');
+  const inputRefs = parseInputRefs({ model_run_id, input_refs_json: row.input_refs_json });
+  return {
+    model_run_id,
+    model_id: nullableString(row.model_id),
+    model_provider: nullableString(row.model_provider),
+    prompt_version: nullableString(row.prompt_version),
+    tool_manifest_version: nullableString(row.tool_manifest_version),
+    output_schema_version: nullableString(row.output_schema_version),
+    agent_id: nullableString(row.agent_id),
+    instance_id: nullableString(row.instance_id),
+    envelope_hash: nullableString(row.envelope_hash),
+    parent_model_run_id: nullableString(row.parent_model_run_id),
+    input_snapshot_ref: nullableString(row.input_snapshot_ref),
+    input_refs_json: inputRefs.input_refs_json,
+    input_refs: inputRefs.input_refs,
+    completion_summary: nullableString(row.completion_summary),
+    status: requireModelRunStatus(row.status, model_run_id),
+    error_summary: nullableString(row.error_summary),
+    token_count: normalizeNumber(row.token_count, 0),
+    cost_estimate: normalizeCost(row.cost_estimate),
+    created_at: requireTimestamp(row.created_at, 'created_at', model_run_id),
+    completed_at:
+      typeof row.completed_at === 'number' && Number.isFinite(row.completed_at)
+        ? Math.floor(row.completed_at)
+        : null,
+  };
+}
+
+async function initializedAdapter(): Promise<DatabaseAdapter> {
+  await initDB();
+  return getAdapter();
+}
+
+function selectModelRun(adapter: ModelRunAdapter, id: string): ModelRunRecord | null {
+  const row = adapter
+    .prepare(
+      `
+        SELECT
+          model_run_id, model_id, model_provider, prompt_version, tool_manifest_version,
+          output_schema_version, agent_id, instance_id, envelope_hash, parent_model_run_id,
+          input_snapshot_ref, input_refs_json, completion_summary, status, error_summary,
+          token_count, cost_estimate, created_at, completed_at
+        FROM model_runs
+        WHERE model_run_id = ?
+      `
+    )
+    .get(id) as Record<string, unknown> | undefined;
+  return row ? mapModelRunRow(row) : null;
+}
+
+function requireModelRun(adapter: ModelRunAdapter, id: string): ModelRunRecord {
+  const run = selectModelRun(adapter, id);
+  if (!run) {
+    throw new Error(`Model run not found: ${id}`);
+  }
+  return run;
+}
+
+export async function beginModelRun(input: BeginModelRunInput): Promise<ModelRunRecord> {
+  const adapter = await initializedAdapter();
+  const id = nullableString(input.model_run_id) ?? modelRunId();
+  const createdAt = normalizeTimestamp(input.created_at);
+  const status = input.status ?? 'running';
+
+  adapter
+    .prepare(
+      `
+        INSERT INTO model_runs (
+          model_run_id, model_id, model_provider, prompt_version, tool_manifest_version,
+          output_schema_version, agent_id, instance_id, envelope_hash, parent_model_run_id,
+          input_snapshot_ref, input_refs_json, completion_summary, status, error_summary,
+          token_count, cost_estimate, created_at, completed_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      id,
+      nullableString(input.model_id),
+      nullableString(input.model_provider),
+      nullableString(input.prompt_version),
+      nullableString(input.tool_manifest_version),
+      nullableString(input.output_schema_version),
+      nullableString(input.agent_id),
+      nullableString(input.instance_id),
+      nullableString(input.envelope_hash),
+      nullableString(input.parent_model_run_id),
+      nullableString(input.input_snapshot_ref),
+      normalizeInputRefsJson(input),
+      null,
+      status,
+      nullableString(input.error_summary),
+      normalizeNumber(input.token_count, 0),
+      normalizeCost(input.cost_estimate),
+      createdAt,
+      null
+    );
+
+  return requireModelRun(adapter, id);
+}
+
+export async function commitModelRun(
+  modelRunId: string,
+  summary?: string
+): Promise<ModelRunRecord> {
+  const adapter = await initializedAdapter();
+  const completedAt = Date.now();
+  adapter
+    .prepare(
+      `
+        UPDATE model_runs
+        SET status = 'committed',
+            completion_summary = ?,
+            completed_at = ?
+        WHERE model_run_id = ?
+      `
+    )
+    .run(nullableString(summary), completedAt, modelRunId);
+
+  return requireModelRun(adapter, modelRunId);
+}
+
+export async function failModelRun(
+  modelRunId: string,
+  errorSummary: string
+): Promise<ModelRunRecord> {
+  const adapter = await initializedAdapter();
+  const completedAt = Date.now();
+  adapter
+    .prepare(
+      `
+        UPDATE model_runs
+        SET status = 'failed',
+            error_summary = ?,
+            completed_at = ?
+        WHERE model_run_id = ?
+      `
+    )
+    .run(nullableString(errorSummary), completedAt, modelRunId);
+
+  return requireModelRun(adapter, modelRunId);
+}
+
+export async function getModelRun(modelRunId: string): Promise<ModelRunRecord | null> {
+  const adapter = await initializedAdapter();
+  return selectModelRun(adapter, modelRunId);
+}

--- a/packages/mama-core/src/model-runs/store.ts
+++ b/packages/mama-core/src/model-runs/store.ts
@@ -45,14 +45,33 @@ function normalizeCost(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
+function requireInputRefsObject(value: unknown, field: string): Record<string, unknown> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  throw new Error(`model_runs.${field} must be a JSON object`);
+}
+
 function normalizeInputRefsJson(input: BeginModelRunInput): string | null {
   if (typeof input.input_refs_json === 'string') {
+    try {
+      requireInputRefsObject(JSON.parse(input.input_refs_json) as unknown, 'input_refs_json');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Invalid model_runs.input_refs_json: ${message}`);
+    }
     return input.input_refs_json;
   }
   if (input.input_refs === null || input.input_refs === undefined) {
     return null;
   }
-  return JSON.stringify(input.input_refs);
+  const inputRefs = requireInputRefsObject(input.input_refs, 'input_refs');
+  try {
+    return JSON.stringify(inputRefs);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid model_runs.input_refs: ${message}`);
+  }
 }
 
 function parseInputRefs(row: { model_run_id: string; input_refs_json: unknown }): {

--- a/packages/mama-core/src/model-runs/tool-trace-store.ts
+++ b/packages/mama-core/src/model-runs/tool-trace-store.ts
@@ -1,0 +1,145 @@
+import crypto from 'node:crypto';
+
+import { getAdapter, initDB } from '../db-manager.js';
+import type { DatabaseAdapter } from '../db-manager.js';
+import type { AppendToolTraceInput, ToolTraceRecord } from './types.js';
+
+type ToolTraceAdapter = Pick<DatabaseAdapter, 'prepare'>;
+
+function traceId(): string {
+  return `tr_${crypto.randomUUID().replace(/-/g, '')}`;
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(
+      `tool_traces.${field} must be a non-empty string: ${formatInvalidValue(value)}`
+    );
+  }
+  return value;
+}
+
+function formatInvalidValue(value: unknown): string {
+  return typeof value === 'string' ? JSON.stringify(value) : String(value);
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function normalizeTimestamp(value: unknown): number {
+  if (value === undefined || value === null) {
+    return Date.now();
+  }
+  return requiredInteger(value, 'created_at');
+}
+
+function normalizeDuration(value: unknown): number {
+  if (value === undefined || value === null) {
+    return 0;
+  }
+  return requiredNonNegativeInteger(value, 'duration_ms');
+}
+
+function requiredInteger(value: unknown, field: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`tool_traces.${field} must be a finite number: ${formatInvalidValue(value)}`);
+  }
+  return Math.floor(value);
+}
+
+function requiredNonNegativeInteger(value: unknown, field: string): number {
+  const normalized = requiredInteger(value, field);
+  if (normalized < 0) {
+    throw new Error(`tool_traces.${field} must be non-negative: ${formatInvalidValue(value)}`);
+  }
+  return normalized;
+}
+
+function mapToolTraceRow(row: Record<string, unknown>): ToolTraceRecord {
+  return {
+    trace_id: requiredString(row.trace_id, 'trace_id'),
+    model_run_id: requiredString(row.model_run_id, 'model_run_id'),
+    gateway_call_id: nullableString(row.gateway_call_id),
+    tool_name: requiredString(row.tool_name, 'tool_name'),
+    input_summary: nullableString(row.input_summary),
+    output_summary: nullableString(row.output_summary),
+    execution_status: nullableString(row.execution_status),
+    duration_ms: requiredNonNegativeInteger(row.duration_ms, 'duration_ms'),
+    envelope_hash: nullableString(row.envelope_hash),
+    created_at: requiredInteger(row.created_at, 'created_at'),
+  };
+}
+
+async function initializedAdapter(): Promise<DatabaseAdapter> {
+  await initDB();
+  return getAdapter();
+}
+
+function selectToolTrace(adapter: ToolTraceAdapter, id: string): ToolTraceRecord {
+  const row = adapter
+    .prepare(
+      `
+        SELECT
+          trace_id, model_run_id, gateway_call_id, tool_name, input_summary,
+          output_summary, execution_status, duration_ms, envelope_hash, created_at
+        FROM tool_traces
+        WHERE trace_id = ?
+      `
+    )
+    .get(id) as Record<string, unknown> | undefined;
+  if (!row) {
+    throw new Error(`Tool trace not found: ${id}`);
+  }
+  return mapToolTraceRow(row);
+}
+
+export async function appendToolTrace(input: AppendToolTraceInput): Promise<ToolTraceRecord> {
+  const adapter = await initializedAdapter();
+  const id = nullableString(input.trace_id) ?? traceId();
+  const modelRunId = requiredString(input.model_run_id, 'model_run_id');
+  const toolName = requiredString(input.tool_name, 'tool_name');
+
+  adapter
+    .prepare(
+      `
+        INSERT INTO tool_traces (
+          trace_id, model_run_id, gateway_call_id, tool_name, input_summary,
+          output_summary, execution_status, duration_ms, envelope_hash, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(
+      id,
+      modelRunId,
+      nullableString(input.gateway_call_id),
+      toolName,
+      nullableString(input.input_summary),
+      nullableString(input.output_summary),
+      nullableString(input.execution_status),
+      normalizeDuration(input.duration_ms),
+      nullableString(input.envelope_hash),
+      normalizeTimestamp(input.created_at)
+    );
+
+  return selectToolTrace(adapter, id);
+}
+
+export async function listToolTracesForRun(modelRunId: string): Promise<ToolTraceRecord[]> {
+  const adapter = await initializedAdapter();
+  const id = requiredString(modelRunId, 'model_run_id');
+  const rows = adapter
+    .prepare(
+      `
+        SELECT
+          trace_id, model_run_id, gateway_call_id, tool_name, input_summary,
+          output_summary, execution_status, duration_ms, envelope_hash, created_at
+        FROM tool_traces
+        WHERE model_run_id = ?
+        ORDER BY created_at DESC, rowid DESC
+      `
+    )
+    .all(id) as Record<string, unknown>[];
+  return rows.map(mapToolTraceRow);
+}

--- a/packages/mama-core/src/model-runs/types.ts
+++ b/packages/mama-core/src/model-runs/types.ts
@@ -1,0 +1,72 @@
+export const MODEL_RUN_STATUSES = ['running', 'committed', 'failed', 'legacy'] as const;
+export type ModelRunStatus = (typeof MODEL_RUN_STATUSES)[number];
+
+export interface BeginModelRunInput {
+  model_run_id?: string;
+  model_id?: string | null;
+  model_provider?: string | null;
+  prompt_version?: string | null;
+  tool_manifest_version?: string | null;
+  output_schema_version?: string | null;
+  agent_id?: string | null;
+  instance_id?: string | null;
+  envelope_hash?: string | null;
+  parent_model_run_id?: string | null;
+  input_snapshot_ref?: string | null;
+  input_refs?: Record<string, unknown> | null;
+  input_refs_json?: string | null;
+  status?: ModelRunStatus;
+  error_summary?: string | null;
+  token_count?: number | null;
+  cost_estimate?: number | null;
+  created_at?: number;
+}
+
+export interface ModelRunRecord {
+  model_run_id: string;
+  model_id: string | null;
+  model_provider: string | null;
+  prompt_version: string | null;
+  tool_manifest_version: string | null;
+  output_schema_version: string | null;
+  agent_id: string | null;
+  instance_id: string | null;
+  envelope_hash: string | null;
+  parent_model_run_id: string | null;
+  input_snapshot_ref: string | null;
+  input_refs_json: string | null;
+  input_refs: Record<string, unknown> | null;
+  completion_summary: string | null;
+  status: ModelRunStatus;
+  error_summary: string | null;
+  token_count: number;
+  cost_estimate: number | null;
+  created_at: number;
+  completed_at: number | null;
+}
+
+export interface AppendToolTraceInput {
+  trace_id?: string;
+  model_run_id: string;
+  gateway_call_id?: string | null;
+  tool_name: string;
+  input_summary?: string | null;
+  output_summary?: string | null;
+  execution_status?: string | null;
+  duration_ms?: number | null;
+  envelope_hash?: string | null;
+  created_at?: number;
+}
+
+export interface ToolTraceRecord {
+  trace_id: string;
+  model_run_id: string;
+  gateway_call_id: string | null;
+  tool_name: string;
+  input_summary: string | null;
+  output_summary: string | null;
+  execution_status: string | null;
+  duration_ms: number;
+  envelope_hash: string | null;
+  created_at: number;
+}

--- a/packages/mama-core/tests/model-runs/model-run-store.test.ts
+++ b/packages/mama-core/tests/model-runs/model-run-store.test.ts
@@ -172,6 +172,34 @@ describe('Story M2.2: Model Run Ledger', () => {
         });
       });
 
+      it('rejects invalid input refs before inserting a model run row', async () => {
+        await expect(
+          beginModelRun({
+            model_run_id: 'mr_invalid_input_refs_json',
+            input_refs_json: 'not json',
+          })
+        ).rejects.toThrow(/Invalid model_runs\.input_refs_json/);
+        await expect(getModelRun('mr_invalid_input_refs_json')).resolves.toBeNull();
+
+        await expect(
+          beginModelRun({
+            model_run_id: 'mr_non_object_input_refs_json',
+            input_refs_json: '"not an object"',
+          })
+        ).rejects.toThrow(/model_runs\.input_refs_json/);
+        await expect(getModelRun('mr_non_object_input_refs_json')).resolves.toBeNull();
+
+        const circular: Record<string, unknown> = {};
+        circular.self = circular;
+        await expect(
+          beginModelRun({
+            model_run_id: 'mr_circular_input_refs',
+            input_refs: circular,
+          })
+        ).rejects.toThrow(/Invalid model_runs\.input_refs/);
+        await expect(getModelRun('mr_circular_input_refs')).resolves.toBeNull();
+      });
+
       it('commits a model run and persists the completion summary', async () => {
         await beginModelRun({
           model_run_id: 'mr_store_commit',

--- a/packages/mama-core/tests/model-runs/model-run-store.test.ts
+++ b/packages/mama-core/tests/model-runs/model-run-store.test.ts
@@ -1,0 +1,225 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import fs from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDB, getAdapter, initDB } from '../../src/db-manager.js';
+import {
+  beginModelRun,
+  commitModelRun,
+  failModelRun,
+  getModelRun,
+} from '../../src/model-runs/store.js';
+
+const MIGRATIONS_DIR = join(__dirname, '..', '..', 'db', 'migrations');
+const TEST_DB = join(os.tmpdir(), `test-model-run-store-${randomUUID()}.db`);
+
+function cleanupDb(): void {
+  for (const file of [TEST_DB, `${TEST_DB}-journal`, `${TEST_DB}-wal`, `${TEST_DB}-shm`]) {
+    try {
+      fs.unlinkSync(file);
+    } catch {
+      // cleanup best effort
+    }
+  }
+}
+
+function migrationFiles(): string[] {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((file) => /^\d{3}-.+\.sql$/.test(file))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function applyAll(db: Database.Database): void {
+  for (const file of migrationFiles()) {
+    db.exec(readFileSync(join(MIGRATIONS_DIR, file), 'utf8'));
+  }
+}
+
+function tableExists(db: Database.Database, name: string): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?")
+    .get(name) as { name?: string } | undefined;
+  return Boolean(row?.name);
+}
+
+function indexExists(db: Database.Database, name: string): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name = ?")
+    .get(name) as { name?: string } | undefined;
+  return Boolean(row?.name);
+}
+
+function tableSql(db: Database.Database, name: string): string {
+  const row = db
+    .prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name = ?")
+    .get(name) as { sql?: string } | undefined;
+  return row?.sql ?? '';
+}
+
+describe('Story M2.2: Model Run Ledger', () => {
+  beforeEach(async () => {
+    await closeDB();
+    cleanupDb();
+    process.env.MAMA_DB_PATH = TEST_DB;
+  });
+
+  afterEach(async () => {
+    await closeDB();
+    delete process.env.MAMA_DB_PATH;
+    cleanupDb();
+  });
+
+  describe('Acceptance Criteria', () => {
+    describe('AC #1: model run schema', () => {
+      it('creates model_runs with a primary-key model_run_id and migration version 033', () => {
+        const db = new Database(':memory:');
+        db.pragma('foreign_keys = ON');
+        applyAll(db);
+
+        expect(tableExists(db, 'model_runs')).toBe(true);
+        expect(tableSql(db, 'model_runs')).toMatch(/model_run_id\s+TEXT\s+PRIMARY\s+KEY/i);
+
+        const row = db
+          .prepare('SELECT version, description FROM schema_version WHERE version = 33')
+          .get() as { version: number; description: string } | undefined;
+        expect(row?.version).toBe(33);
+        expect(row?.description).toContain('model runs and tool traces');
+
+        db.close();
+      });
+
+      it('rejects model run statuses outside the supported lifecycle', () => {
+        const db = new Database(':memory:');
+        db.pragma('foreign_keys = ON');
+        applyAll(db);
+
+        db.prepare(
+          `
+            INSERT INTO model_runs (model_run_id, status, created_at)
+            VALUES (?, ?, ?)
+          `
+        ).run('mr_running', 'running', Date.now());
+
+        expect(() =>
+          db
+            .prepare(
+              `
+                INSERT INTO model_runs (model_run_id, status, created_at)
+                VALUES (?, ?, ?)
+              `
+            )
+            .run('mr_invalid', 'paused', Date.now())
+        ).toThrow(/CHECK constraint failed|constraint failed/i);
+
+        db.close();
+      });
+
+      it('indexes model runs by envelope, status, and agent recency', () => {
+        const db = new Database(':memory:');
+        db.pragma('foreign_keys = ON');
+        applyAll(db);
+
+        expect(indexExists(db, 'idx_model_runs_envelope_hash')).toBe(true);
+        expect(indexExists(db, 'idx_model_runs_status_created')).toBe(true);
+        expect(indexExists(db, 'idx_model_runs_agent_created')).toBe(true);
+
+        db.close();
+      });
+    });
+
+    describe('AC #2: model run lifecycle helpers', () => {
+      it('begins and reads a model run with compact input refs', async () => {
+        const run = await beginModelRun({
+          model_run_id: 'mr_store_begin',
+          model_id: 'gpt-5.4',
+          model_provider: 'openai',
+          agent_id: 'agent-main',
+          instance_id: 'instance-1',
+          envelope_hash: 'env_store',
+          input_refs: {
+            source: 'discord',
+            channel_id: 'channel-1',
+            source_turn_id: 'turn-1',
+          },
+          created_at: 1_000,
+        });
+
+        expect(run).toMatchObject({
+          model_run_id: 'mr_store_begin',
+          model_id: 'gpt-5.4',
+          model_provider: 'openai',
+          agent_id: 'agent-main',
+          instance_id: 'instance-1',
+          envelope_hash: 'env_store',
+          status: 'running',
+          created_at: 1_000,
+          completed_at: null,
+        });
+        expect(run.input_refs).toEqual({
+          source: 'discord',
+          channel_id: 'channel-1',
+          source_turn_id: 'turn-1',
+        });
+
+        await expect(getModelRun('mr_store_begin')).resolves.toMatchObject({
+          model_run_id: 'mr_store_begin',
+          status: 'running',
+        });
+      });
+
+      it('commits a model run and persists the completion summary', async () => {
+        await beginModelRun({
+          model_run_id: 'mr_store_commit',
+          agent_id: 'agent-main',
+          created_at: 2_000,
+        });
+
+        const committed = await commitModelRun('mr_store_commit', 'saved two memories');
+
+        expect(committed.status).toBe('committed');
+        expect(committed.completion_summary).toBe('saved two memories');
+        expect(committed.completed_at).toEqual(expect.any(Number));
+        await expect(getModelRun('mr_store_commit')).resolves.toMatchObject({
+          status: 'committed',
+          completion_summary: 'saved two memories',
+        });
+      });
+
+      it('marks a model run failed with a compact error summary', async () => {
+        await beginModelRun({
+          model_run_id: 'mr_store_fail',
+          agent_id: 'agent-main',
+          created_at: 3_000,
+        });
+
+        const failed = await failModelRun('mr_store_fail', 'tool execution failed');
+
+        expect(failed.status).toBe('failed');
+        expect(failed.error_summary).toBe('tool execution failed');
+        expect(failed.completed_at).toEqual(expect.any(Number));
+      });
+
+      it('fails loud when persisted status is outside the supported lifecycle', async () => {
+        await initDB();
+        const adapter = getAdapter();
+        adapter.prepare('PRAGMA ignore_check_constraints = ON').run();
+        adapter
+          .prepare(
+            `
+              INSERT INTO model_runs (model_run_id, status, created_at)
+              VALUES (?, ?, ?)
+            `
+          )
+          .run('mr_corrupt_status', 'paused', 5_000);
+        adapter.prepare('PRAGMA ignore_check_constraints = OFF').run();
+
+        await expect(getModelRun('mr_corrupt_status')).rejects.toThrow(/model_runs\.status/);
+      });
+    });
+  });
+});

--- a/packages/mama-core/tests/model-runs/tool-trace-store.test.ts
+++ b/packages/mama-core/tests/model-runs/tool-trace-store.test.ts
@@ -1,0 +1,223 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import fs from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { closeDB, getAdapter, initDB } from '../../src/db-manager.js';
+import { beginModelRun } from '../../src/model-runs/store.js';
+import { appendToolTrace, listToolTracesForRun } from '../../src/model-runs/tool-trace-store.js';
+
+const MIGRATIONS_DIR = join(__dirname, '..', '..', 'db', 'migrations');
+const TEST_DB = join(os.tmpdir(), `test-tool-trace-store-${randomUUID()}.db`);
+
+function cleanupDb(): void {
+  for (const file of [TEST_DB, `${TEST_DB}-journal`, `${TEST_DB}-wal`, `${TEST_DB}-shm`]) {
+    try {
+      fs.unlinkSync(file);
+    } catch {
+      // cleanup best effort
+    }
+  }
+}
+
+function migrationFiles(): string[] {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((file) => /^\d{3}-.+\.sql$/.test(file))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function applyAll(db: Database.Database): void {
+  for (const file of migrationFiles()) {
+    db.exec(readFileSync(join(MIGRATIONS_DIR, file), 'utf8'));
+  }
+}
+
+function tableExists(db: Database.Database, name: string): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?")
+    .get(name) as { name?: string } | undefined;
+  return Boolean(row?.name);
+}
+
+function indexExists(db: Database.Database, name: string): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name = ?")
+    .get(name) as { name?: string } | undefined;
+  return Boolean(row?.name);
+}
+
+function columnNames(db: Database.Database, table: string): string[] {
+  return (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).map(
+    (column) => column.name
+  );
+}
+
+describe('Story M2.2: Tool Trace Ledger', () => {
+  beforeEach(async () => {
+    await closeDB();
+    cleanupDb();
+    process.env.MAMA_DB_PATH = TEST_DB;
+  });
+
+  afterEach(async () => {
+    await closeDB();
+    delete process.env.MAMA_DB_PATH;
+    cleanupDb();
+  });
+
+  describe('Acceptance Criteria', () => {
+    describe('AC #1: tool trace schema', () => {
+      it('creates tool_traces with indexed model-run and gateway-call lookup fields', () => {
+        const db = new Database(':memory:');
+        db.pragma('foreign_keys = ON');
+        applyAll(db);
+
+        expect(tableExists(db, 'tool_traces')).toBe(true);
+        expect(indexExists(db, 'idx_tool_traces_model_run_id')).toBe(true);
+        expect(indexExists(db, 'idx_tool_traces_gateway_call_id')).toBe(true);
+
+        db.close();
+      });
+
+      it('requires each trace to point at an existing model run', () => {
+        const db = new Database(':memory:');
+        db.pragma('foreign_keys = ON');
+        applyAll(db);
+
+        expect(() =>
+          db
+            .prepare(
+              `
+                INSERT INTO tool_traces (trace_id, model_run_id, tool_name, created_at)
+                VALUES (?, ?, ?, ?)
+              `
+            )
+            .run('trace_missing_run', 'mr_missing', 'mama_save', Date.now())
+        ).toThrow(/FOREIGN KEY constraint failed|constraint failed/i);
+
+        db.prepare(
+          `
+            INSERT INTO model_runs (model_run_id, status, created_at)
+            VALUES (?, ?, ?)
+          `
+        ).run('mr_existing', 'running', Date.now());
+        db.prepare(
+          `
+            INSERT INTO tool_traces (trace_id, model_run_id, tool_name, created_at)
+            VALUES (?, ?, ?, ?)
+          `
+        ).run('trace_existing_run', 'mr_existing', 'mama_save', Date.now());
+
+        db.close();
+      });
+
+      it('stores summaries instead of full prompt or result payload columns', () => {
+        const db = new Database(':memory:');
+        db.pragma('foreign_keys = ON');
+        applyAll(db);
+
+        const columns = columnNames(db, 'tool_traces');
+        expect(columns).toContain('input_summary');
+        expect(columns).toContain('output_summary');
+        expect(columns).not.toContain('input_json');
+        expect(columns).not.toContain('output_json');
+        expect(columns).not.toContain('prompt');
+        expect(columns).not.toContain('result_payload');
+
+        db.close();
+      });
+    });
+
+    describe('AC #2: tool trace helpers', () => {
+      it('appends a compact trace and lists traces by model run recency', async () => {
+        await beginModelRun({
+          model_run_id: 'mr_trace_helpers',
+          agent_id: 'agent-main',
+          envelope_hash: 'env_trace',
+          created_at: 1_000,
+        });
+
+        const older = await appendToolTrace({
+          trace_id: 'trace_older',
+          model_run_id: 'mr_trace_helpers',
+          gateway_call_id: 'gw_trace_1',
+          tool_name: 'mama_search',
+          input_summary: 'tool:mama_search',
+          output_summary: 'ok',
+          execution_status: 'success',
+          duration_ms: 12,
+          envelope_hash: 'env_trace',
+          created_at: 2_000,
+        });
+        const newer = await appendToolTrace({
+          trace_id: 'trace_newer',
+          model_run_id: 'mr_trace_helpers',
+          gateway_call_id: 'gw_trace_2',
+          tool_name: 'mama_save',
+          input_summary: 'tool:mama_save',
+          output_summary: 'saved',
+          execution_status: 'success',
+          duration_ms: 20,
+          envelope_hash: 'env_trace',
+          created_at: 3_000,
+        });
+
+        expect(older).toMatchObject({
+          trace_id: 'trace_older',
+          model_run_id: 'mr_trace_helpers',
+          gateway_call_id: 'gw_trace_1',
+          tool_name: 'mama_search',
+          input_summary: 'tool:mama_search',
+          output_summary: 'ok',
+          execution_status: 'success',
+          duration_ms: 12,
+          envelope_hash: 'env_trace',
+          created_at: 2_000,
+        });
+
+        await expect(listToolTracesForRun('mr_trace_helpers')).resolves.toEqual([newer, older]);
+      });
+
+      it('does not insert a trace with a missing model run id', async () => {
+        await expect(
+          appendToolTrace({
+            trace_id: 'trace_missing_model_run',
+            model_run_id: '',
+            tool_name: 'mama_save',
+          })
+        ).rejects.toThrow(/model_run_id/i);
+      });
+
+      it('fails loud when a persisted trace has invalid numeric fields', async () => {
+        await initDB();
+        const adapter = getAdapter();
+        adapter
+          .prepare(
+            `
+              INSERT INTO model_runs (model_run_id, status, created_at)
+              VALUES (?, ?, ?)
+            `
+          )
+          .run('mr_corrupt_trace', 'running', 1_000);
+        adapter
+          .prepare(
+            `
+              INSERT INTO tool_traces (
+                trace_id, model_run_id, tool_name, duration_ms, created_at
+              )
+              VALUES (?, ?, ?, ?, ?)
+            `
+          )
+          .run('trace_corrupt_numeric', 'mr_corrupt_trace', 'mama_search', 'slow', 'later');
+
+        await expect(listToolTracesForRun('mr_corrupt_trace')).rejects.toThrow(
+          /tool_traces\.duration_ms/
+        );
+      });
+    });
+  });
+});

--- a/packages/mama-core/tests/unit/module-exports.test.js
+++ b/packages/mama-core/tests/unit/module-exports.test.js
@@ -19,6 +19,24 @@ describe('Story M1.1: Core Module Exports', () => {
       expect(typeof mama.default.list).toBe('function');
       expect(typeof mama.default.suggest).toBe('function');
       expect(typeof mama.default.updateOutcome).toBe('function');
+      expect(typeof mama.default.beginModelRun).toBe('function');
+      expect(typeof mama.default.commitModelRun).toBe('function');
+      expect(typeof mama.default.failModelRun).toBe('function');
+      expect(typeof mama.default.appendToolTrace).toBe('function');
+      expect(typeof mama.default.listToolTracesForRun).toBe('function');
+    });
+  });
+
+  describe('package root model-run exports', () => {
+    it('should export model run and tool trace helpers', async () => {
+      const core = await import('../../src/index.js');
+
+      expect(typeof core.beginModelRun).toBe('function');
+      expect(typeof core.commitModelRun).toBe('function');
+      expect(typeof core.failModelRun).toBe('function');
+      expect(typeof core.getModelRun).toBe('function');
+      expect(typeof core.appendToolTrace).toBe('function');
+      expect(typeof core.listToolTracesForRun).toBe('function');
     });
   });
 

--- a/packages/standalone/src/agent/agent-loop.ts
+++ b/packages/standalone/src/agent/agent-loop.ts
@@ -47,11 +47,13 @@ import type {
   GatewayToolInput,
   ClaudeClientOptions,
   GatewayToolExecutorOptions,
+  BeginModelRunInput,
   StreamCallbacks,
   AgentContext,
   PromptFinalResponse,
   GatewayExecutionSurface,
   GatewayToolExecutionContext,
+  BackgroundTaskRegistry,
 } from './types.js';
 import { AgentError } from './types.js';
 import { buildMinimalContext } from './context-prompt-builder.js';
@@ -851,8 +853,23 @@ export class AgentLoop {
     const totalUsage = { input_tokens: 0, output_tokens: 0 };
     let turn = 0;
     let stopReason: ClaudeResponse['stop_reason'] = 'end_turn';
+    let ownedModelRunId: string | null = null;
+    let ownedModelRunCommitted = false;
+    const pendingBackgroundTasks: Promise<unknown>[] = [];
+    const backgroundTasks: BackgroundTaskRegistry = {
+      register(task: Promise<unknown>): void {
+        const observedTask = Promise.resolve(task);
+        observedTask.catch(() => {
+          // Re-thrown later by drainBackgroundTasks; attach now to prevent unhandled rejections.
+        });
+        pendingBackgroundTasks.push(observedTask);
+      },
+    };
 
-    const toolExecutionContext = this.buildToolExecutionContext(options);
+    let toolExecutionContext = this.withBackgroundTaskRegistry(
+      this.buildToolExecutionContext(options),
+      backgroundTasks
+    );
 
     // Track current tier for code-act execution and prompt sizing.
     if (options?.agentContext) {
@@ -916,6 +933,20 @@ export class AgentLoop {
     }
 
     try {
+      if (this.shouldBeginModelRun(options)) {
+        const modelRun = await this.mcpExecutor.beginRuntimeModelRun(
+          this.buildModelRunInput(options)
+        );
+        ownedModelRunId = modelRun.model_run_id;
+        toolExecutionContext = this.withBackgroundTaskRegistry(
+          this.buildToolExecutionContext({
+            ...options,
+            modelRunId: ownedModelRunId,
+          }),
+          backgroundTasks
+        );
+      }
+
       if (options?.systemPrompt) {
         // Skip gateway tools if already embedded in systemPrompt (e.g. by MessageRouter)
         const alreadyHasTools =
@@ -1343,13 +1374,34 @@ export class AgentLoop {
       // Extract final text response
       const finalResponse = this.extractTextResponse(history);
 
-      return {
+      const result = {
         response: finalResponse,
         turns: turn,
         history,
         totalUsage,
         stopReason,
+        modelRunId: ownedModelRunId ?? options?.modelRunId ?? null,
       };
+      await this.drainBackgroundTasks(pendingBackgroundTasks);
+      if (ownedModelRunId) {
+        await this.mcpExecutor.commitRuntimeModelRun(ownedModelRunId, 'agent_loop completed');
+        ownedModelRunCommitted = true;
+      }
+      return result;
+    } catch (error) {
+      if (ownedModelRunId && !ownedModelRunCommitted) {
+        try {
+          const summary = error instanceof Error ? error.message : String(error);
+          await this.mcpExecutor.failRuntimeModelRun(ownedModelRunId, summary);
+        } catch (failError) {
+          logger.warn(
+            `Failed to mark model run ${ownedModelRunId} failed: ${
+              failError instanceof Error ? failError.message : String(failError)
+            }`
+          );
+        }
+      }
+      throw error;
     } finally {
       // Always release session lock, even on error
       // BUT only if we own the session (not passed by caller)
@@ -1358,6 +1410,53 @@ export class AgentLoop {
       }
       this.currentStreamCallbacks = undefined;
     }
+  }
+
+  private shouldBeginModelRun(options?: AgentLoopOptions): boolean {
+    return this.isGatewayMode && !options?.modelRunId;
+  }
+
+  private withBackgroundTaskRegistry(
+    context: AgentToolExecutionContext | null,
+    backgroundTasks: BackgroundTaskRegistry
+  ): AgentToolExecutionContext | null {
+    if (!context) {
+      return null;
+    }
+    return {
+      ...context,
+      backgroundTasks,
+    };
+  }
+
+  private async drainBackgroundTasks(tasks: Promise<unknown>[]): Promise<void> {
+    for (let index = 0; index < tasks.length; index += 1) {
+      await tasks[index];
+    }
+  }
+
+  private buildModelRunInput(options?: AgentLoopOptions): BeginModelRunInput {
+    const agentContext = options?.agentContext;
+    return {
+      model_id: options?.model ?? this.model ?? null,
+      model_provider: this.backend,
+      agent_id:
+        agentContext?.source === 'viewer'
+          ? 'os-agent'
+          : (agentContext?.roleName ?? options?.source ?? 'agent'),
+      instance_id: agentContext?.session?.sessionId ?? null,
+      envelope_hash: options?.envelope?.envelope_hash ?? null,
+      parent_model_run_id: options?.parentModelRunId ?? null,
+      status: 'running',
+      input_refs: {
+        source: options?.source ?? agentContext?.source ?? 'default',
+        channelId: options?.channelId ?? agentContext?.session?.channelId ?? this.sessionKey,
+        entrypoint: 'agent_loop',
+        ...(options?.sourceTurnId ? { sourceTurnId: options.sourceTurnId } : {}),
+        ...(options?.sourceMessageRef ? { sourceMessageRef: options.sourceMessageRef } : {}),
+        ...(options?.cliSessionId ? { cliSessionId: options.cliSessionId } : {}),
+      },
+    };
   }
 
   /**

--- a/packages/standalone/src/agent/agent-loop.ts
+++ b/packages/standalone/src/agent/agent-loop.ts
@@ -904,6 +904,7 @@ export class AgentLoop {
     // Claude PersistentCLI: process alive → CONTINUE (stdin message), process dead → NEW (spawn with --session-id)
     // Codex: threadId alive → CONTINUE (codex-reply), threadId null → NEW (codex tool)
     const isCodex = this.backend === 'codex-mcp';
+    let resolvedCliSessionId: string | null = options?.cliSessionId ?? null;
 
     const sessionLabel = (isNew: boolean): string => {
       if (isCodex) {
@@ -926,6 +927,7 @@ export class AgentLoop {
       }
       sessionIsNew = isNew;
       ownedSession = true;
+      resolvedCliSessionId = cliSessionId;
       this.agent.setSessionId(cliSessionId);
       console.log(
         `[AgentLoop] [${isCodex ? 'codex' : 'claude'}] ${channelKey} (${sessionLabel(isNew)})`
@@ -935,7 +937,7 @@ export class AgentLoop {
     try {
       if (this.shouldBeginModelRun(options)) {
         const modelRun = await this.mcpExecutor.beginRuntimeModelRun(
-          this.buildModelRunInput(options)
+          this.buildModelRunInput(options, resolvedCliSessionId)
         );
         ownedModelRunId = modelRun.model_run_id;
         toolExecutionContext = this.withBackgroundTaskRegistry(
@@ -1382,10 +1384,20 @@ export class AgentLoop {
         stopReason,
         modelRunId: ownedModelRunId ?? options?.modelRunId ?? null,
       };
-      await this.drainBackgroundTasks(pendingBackgroundTasks);
-      if (ownedModelRunId) {
-        await this.mcpExecutor.commitRuntimeModelRun(ownedModelRunId, 'agent_loop completed');
-        ownedModelRunCommitted = true;
+      try {
+        await this.drainBackgroundTasks(pendingBackgroundTasks);
+        if (ownedModelRunId) {
+          await this.mcpExecutor.commitRuntimeModelRun(ownedModelRunId, 'agent_loop completed');
+          ownedModelRunCommitted = true;
+        }
+      } catch (finalizationError) {
+        logger.warn(
+          `AgentLoop post-run finalization failed: ${
+            finalizationError instanceof Error
+              ? finalizationError.message
+              : String(finalizationError)
+          }`
+        );
       }
       return result;
     } catch (error) {
@@ -1435,7 +1447,10 @@ export class AgentLoop {
     }
   }
 
-  private buildModelRunInput(options?: AgentLoopOptions): BeginModelRunInput {
+  private buildModelRunInput(
+    options?: AgentLoopOptions,
+    resolvedCliSessionId?: string | null
+  ): BeginModelRunInput {
     const agentContext = options?.agentContext;
     return {
       model_id: options?.model ?? this.model ?? null,
@@ -1454,7 +1469,7 @@ export class AgentLoop {
         entrypoint: 'agent_loop',
         ...(options?.sourceTurnId ? { sourceTurnId: options.sourceTurnId } : {}),
         ...(options?.sourceMessageRef ? { sourceMessageRef: options.sourceMessageRef } : {}),
-        ...(options?.cliSessionId ? { cliSessionId: options.cliSessionId } : {}),
+        ...(resolvedCliSessionId ? { cliSessionId: resolvedCliSessionId } : {}),
       },
     };
   }

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -63,6 +63,9 @@ import type {
   GatewayExecutionSurface,
   GatewayToolExecutionContext,
   TrustedMemoryWriteOptions,
+  BeginModelRunInput,
+  ModelRunRecord,
+  AppendToolTraceInput,
 } from './types.js';
 import { AgentError } from './types.js';
 import {
@@ -144,12 +147,20 @@ type ActiveGatewayExecutionContext = {
   modelRunId?: string | null;
   gatewayCallId?: string;
   parentToolName?: string;
+  backgroundTasks?: GatewayToolExecutionContext['backgroundTasks'];
 };
 
 type ScopeAuditFields = {
   requestedScopes: MemoryScope[] | null;
   envelopeScopesSnapshot: MemoryScope[] | null;
   mismatch: 0 | 1;
+};
+
+type TraceCapableMAMAApi = MAMAApiInterface & {
+  beginModelRun: (input: BeginModelRunInput) => Promise<ModelRunRecord>;
+  commitModelRun: (modelRunId: string, summary?: string) => Promise<ModelRunRecord>;
+  failModelRun: (modelRunId: string, errorSummary: string) => Promise<ModelRunRecord>;
+  appendToolTrace: (input: AppendToolTraceInput) => Promise<unknown>;
 };
 
 const managedAgentMutationTails = new Map<string, Promise<void>>();
@@ -378,6 +389,7 @@ export class GatewayToolExecutor {
       sourceMessageRef: executionContext?.sourceMessageRef,
       modelRunId: executionContext?.modelRunId ?? null,
       gatewayCallId: executionContext?.gatewayCallId,
+      backgroundTasks: executionContext?.backgroundTasks,
     };
   }
 
@@ -414,6 +426,7 @@ export class GatewayToolExecutor {
       modelRunId: active.modelRunId ?? fallback.modelRunId,
       gatewayCallId: active.gatewayCallId ?? fallback.gatewayCallId,
       parentToolName: active.parentToolName ?? fallback.parentToolName,
+      backgroundTasks: active.backgroundTasks ?? fallback.backgroundTasks,
     };
   }
 
@@ -637,6 +650,21 @@ export class GatewayToolExecutor {
     this.refreshDelegationExecutor();
   }
 
+  async beginRuntimeModelRun(input: BeginModelRunInput): Promise<ModelRunRecord> {
+    const api = this.requireTraceApi(await this.initializeMAMAApi(), true);
+    return api.beginModelRun(input);
+  }
+
+  async commitRuntimeModelRun(modelRunId: string, summary?: string): Promise<ModelRunRecord> {
+    const api = this.requireTraceApi(await this.initializeMAMAApi(), true);
+    return api.commitModelRun(modelRunId, summary);
+  }
+
+  async failRuntimeModelRun(modelRunId: string, errorSummary: string): Promise<ModelRunRecord> {
+    const api = this.requireTraceApi(await this.initializeMAMAApi(), true);
+    return api.failModelRun(modelRunId, errorSummary);
+  }
+
   /**
    * Set the current agent context for permission checks
    * @param context - AgentContext with role and permissions
@@ -704,6 +732,12 @@ export class GatewayToolExecutor {
         listMemoriesByEnvelopeHash: mama.listMemoriesByEnvelopeHash?.bind(mama),
         listMemoriesByGatewayCallId: mama.listMemoriesByGatewayCallId?.bind(mama),
         listMemoriesByModelRunId: mama.listMemoriesByModelRunId?.bind(mama),
+        beginModelRun: mama.beginModelRun?.bind(mama),
+        commitModelRun: mama.commitModelRun?.bind(mama),
+        failModelRun: mama.failModelRun?.bind(mama),
+        getModelRun: mama.getModelRun?.bind(mama),
+        appendToolTrace: mama.appendToolTrace?.bind(mama),
+        listToolTracesForRun: mama.listToolTracesForRun?.bind(mama),
         buildProfile: mama.buildProfile?.bind(mama),
         updateOutcome: mama.updateOutcome.bind(mama),
         loadCheckpoint: mama.loadCheckpoint.bind(mama),
@@ -900,11 +934,21 @@ export class GatewayToolExecutor {
     const gatewayCallId = baseCtx.gatewayCallId ?? `gw_${randomUUID().replace(/-/g, '')}`;
     const ctx = { ...baseCtx, gatewayCallId };
     const scopeAudit = this.computeScopeAuditFields(toolName, input, ctx);
+    const traceState = await this.beginTraceIfNeeded(ctx, gatewayCallId);
 
     try {
       const result = await this.executionContextStorage.run(ctx, () =>
         this.executeWithEnvelopeAndPermissions(toolName, input, gatewayCallId)
       );
+      await this.appendToolTraceIfNeeded(
+        traceState,
+        ctx,
+        toolName,
+        result,
+        Date.now() - startedAt,
+        gatewayCallId
+      );
+      await this.completeDirectModelRunIfNeeded(traceState, toolName, result);
       this.logGatewayToolCall(
         ctx,
         toolName,
@@ -918,6 +962,16 @@ export class GatewayToolExecutor {
       }
       return result;
     } catch (error) {
+      await this.appendToolTraceIfNeeded(
+        traceState,
+        ctx,
+        toolName,
+        undefined,
+        Date.now() - startedAt,
+        gatewayCallId,
+        error
+      );
+      await this.failDirectModelRunIfNeeded(traceState, toolName, error);
       this.logGatewayToolCall(
         ctx,
         toolName,
@@ -932,6 +986,134 @@ export class GatewayToolExecutor {
       }
       throw error;
     }
+  }
+
+  private async beginTraceIfNeeded(
+    ctx: ActiveGatewayExecutionContext,
+    gatewayCallId: string
+  ): Promise<{ api: TraceCapableMAMAApi; modelRunId: string; direct: boolean } | null> {
+    if (ctx.modelRunId) {
+      const api = await this.initializeMAMAApi();
+      return {
+        api: this.requireTraceApi(api, false),
+        modelRunId: ctx.modelRunId,
+        direct: false,
+      };
+    }
+
+    if (ctx.executionSurface !== 'direct') {
+      return null;
+    }
+
+    const api = this.requireTraceApi(await this.initializeMAMAApi(), true);
+    const run = await api.beginModelRun({
+      agent_id: 'direct',
+      envelope_hash: null,
+      status: 'running',
+      input_refs: {
+        executionSurface: ctx.executionSurface,
+        source: ctx.source,
+        channelId: ctx.channelId,
+        gateway_call_id: gatewayCallId,
+      },
+    });
+
+    return {
+      api,
+      modelRunId: run.model_run_id,
+      direct: true,
+    };
+  }
+
+  private requireTraceApi(api: MAMAApiInterface, includeLifecycle: boolean): TraceCapableMAMAApi {
+    const missing: string[] = [];
+    if (!api.appendToolTrace) {
+      missing.push('appendToolTrace');
+    }
+    if (includeLifecycle) {
+      if (!api.beginModelRun) {
+        missing.push('beginModelRun');
+      }
+      if (!api.commitModelRun) {
+        missing.push('commitModelRun');
+      }
+      if (!api.failModelRun) {
+        missing.push('failModelRun');
+      }
+    }
+    if (missing.length > 0) {
+      throw new AgentError(
+        `MAMA API missing model-run trace helpers: ${missing.join(', ')}`,
+        'TOOL_ERROR',
+        undefined,
+        false
+      );
+    }
+    return api as TraceCapableMAMAApi;
+  }
+
+  private async appendToolTraceIfNeeded(
+    traceState: { api: TraceCapableMAMAApi; modelRunId: string; direct: boolean } | null,
+    ctx: ActiveGatewayExecutionContext,
+    toolName: string,
+    result: GatewayToolResult | undefined,
+    durationMs: number,
+    gatewayCallId: string,
+    error?: unknown
+  ): Promise<void> {
+    if (!traceState) {
+      return;
+    }
+
+    await traceState.api.appendToolTrace({
+      model_run_id: traceState.modelRunId,
+      gateway_call_id: gatewayCallId,
+      tool_name: toolName,
+      input_summary: `tool:${toolName}`,
+      output_summary: this.summarizeToolTraceOutput(result, error),
+      execution_status: error || result?.success === false ? 'failed' : 'completed',
+      duration_ms: durationMs,
+      envelope_hash: ctx.envelope?.envelope_hash ?? null,
+    });
+  }
+
+  private summarizeToolTraceOutput(result: GatewayToolResult | undefined, error?: unknown): string {
+    if (error) {
+      return (error instanceof Error ? error.message : String(error)).slice(0, 200);
+    }
+    const failure = getFailureMessage(result);
+    if (failure) {
+      return failure.slice(0, 200);
+    }
+    return 'success';
+  }
+
+  private async completeDirectModelRunIfNeeded(
+    traceState: { api: TraceCapableMAMAApi; modelRunId: string; direct: boolean } | null,
+    toolName: string,
+    result: GatewayToolResult
+  ): Promise<void> {
+    if (!traceState?.direct) {
+      return;
+    }
+    const failure = getFailureMessage(result);
+    if (failure) {
+      await traceState.api.failModelRun(traceState.modelRunId, `${toolName} failed: ${failure}`);
+      return;
+    }
+    await traceState.api.commitModelRun(traceState.modelRunId, `${toolName} completed`);
+  }
+
+  private async failDirectModelRunIfNeeded(
+    traceState: { api: TraceCapableMAMAApi; modelRunId: string; direct: boolean } | null,
+    toolName: string,
+    error: unknown
+  ): Promise<void> {
+    if (!traceState?.direct) {
+      return;
+    }
+    const summary = error instanceof Error ? error.message : String(error);
+    await traceState.api.failModelRun(traceState.modelRunId, `${toolName} failed: ${summary}`);
   }
 
   private computeScopeAuditFields(
@@ -1145,7 +1327,7 @@ export class GatewayToolExecutor {
 
   private auditedAutoSave(parentToolName: string, input: SaveInput): void {
     const parentContext = this.executionContextStorage.getStore();
-    void (async () => {
+    const task = (async () => {
       try {
         if (parentContext) {
           const autosaveContext: ActiveGatewayExecutionContext = {
@@ -1162,6 +1344,8 @@ export class GatewayToolExecutor {
         // Autosave is intentionally non-fatal for report/wiki publish tools.
       }
     })();
+    parentContext?.backgroundTasks?.register(task);
+    void task;
   }
 
   private async executeWithEnvelopeAndPermissions(

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -935,45 +935,38 @@ export class GatewayToolExecutor {
     const ctx = { ...baseCtx, gatewayCallId };
     const scopeAudit = this.computeScopeAuditFields(toolName, input, ctx);
     const traceState = await this.beginTraceIfNeeded(ctx, gatewayCallId);
+    const activeCtx = traceState ? { ...ctx, modelRunId: traceState.modelRunId } : ctx;
 
+    let result!: GatewayToolResult;
     try {
-      const result = await this.executionContextStorage.run(ctx, () =>
+      result = await this.executionContextStorage.run(activeCtx, () =>
         this.executeWithEnvelopeAndPermissions(toolName, input, gatewayCallId)
       );
-      await this.appendToolTraceIfNeeded(
-        traceState,
-        ctx,
-        toolName,
-        result,
-        Date.now() - startedAt,
-        gatewayCallId
-      );
-      await this.completeDirectModelRunIfNeeded(traceState, toolName, result);
-      this.logGatewayToolCall(
-        ctx,
-        toolName,
-        result,
-        Date.now() - startedAt,
-        scopeAudit,
-        gatewayCallId
-      );
-      if (scopeAudit.mismatch) {
-        this.alarmScopeMismatch(ctx, toolName);
-      }
-      return result;
     } catch (error) {
       await this.appendToolTraceIfNeeded(
         traceState,
-        ctx,
+        activeCtx,
         toolName,
         undefined,
         Date.now() - startedAt,
         gatewayCallId,
         error
+      ).catch((appendError: unknown) => {
+        securityLogger.warn(
+          '[model-run] failed to append failed tool trace before finalization',
+          appendError
+        );
+      });
+      await this.failDirectModelRunIfNeeded(traceState, toolName, error).catch(
+        (finalizationError: unknown) => {
+          securityLogger.warn(
+            '[model-run] failed to finalize failed direct model run',
+            finalizationError
+          );
+        }
       );
-      await this.failDirectModelRunIfNeeded(traceState, toolName, error);
       this.logGatewayToolCall(
-        ctx,
+        activeCtx,
         toolName,
         undefined,
         Date.now() - startedAt,
@@ -982,10 +975,52 @@ export class GatewayToolExecutor {
         error
       );
       if (scopeAudit.mismatch) {
-        this.alarmScopeMismatch(ctx, toolName);
+        this.alarmScopeMismatch(activeCtx, toolName);
       }
       throw error;
     }
+
+    try {
+      try {
+        await this.appendToolTraceIfNeeded(
+          traceState,
+          activeCtx,
+          toolName,
+          result,
+          Date.now() - startedAt,
+          gatewayCallId
+        );
+      } finally {
+        await this.completeDirectModelRunIfNeeded(traceState, toolName, result);
+      }
+    } catch (postRunError) {
+      this.logGatewayToolCall(
+        activeCtx,
+        toolName,
+        result,
+        Date.now() - startedAt,
+        scopeAudit,
+        gatewayCallId,
+        postRunError
+      );
+      if (scopeAudit.mismatch) {
+        this.alarmScopeMismatch(activeCtx, toolName);
+      }
+      throw postRunError;
+    }
+
+    this.logGatewayToolCall(
+      activeCtx,
+      toolName,
+      result,
+      Date.now() - startedAt,
+      scopeAudit,
+      gatewayCallId
+    );
+    if (scopeAudit.mismatch) {
+      this.alarmScopeMismatch(activeCtx, toolName);
+    }
+    return result;
   }
 
   private async beginTraceIfNeeded(

--- a/packages/standalone/src/agent/post-tool-handler.ts
+++ b/packages/standalone/src/agent/post-tool-handler.ts
@@ -53,9 +53,9 @@ export class PostToolHandler {
       return;
     }
 
-    const task = this.processAsync(toolName, input, result, executionContext).catch(() => {});
+    const task = this.processAsync(toolName, input, result, executionContext);
     executionContext?.backgroundTasks?.register(task);
-    void task;
+    void task.catch(() => {});
   }
 
   private async processAsync(

--- a/packages/standalone/src/agent/post-tool-handler.ts
+++ b/packages/standalone/src/agent/post-tool-handler.ts
@@ -53,7 +53,9 @@ export class PostToolHandler {
       return;
     }
 
-    this.processAsync(toolName, input, result, executionContext).catch(() => {});
+    const task = this.processAsync(toolName, input, result, executionContext).catch(() => {});
+    executionContext?.backgroundTasks?.register(task);
+    void task;
   }
 
   private async processAsync(

--- a/packages/standalone/src/agent/types.ts
+++ b/packages/standalone/src/agent/types.ts
@@ -11,6 +11,19 @@
 
 import type { RoleConfig } from '../cli/config/types.js';
 import type { Envelope } from '../envelope/types.js';
+import type {
+  AppendToolTraceInput,
+  BeginModelRunInput,
+  ModelRunRecord,
+  ToolTraceRecord,
+} from '@jungjaehoon/mama-core';
+
+export type {
+  AppendToolTraceInput,
+  BeginModelRunInput,
+  ModelRunRecord,
+  ToolTraceRecord,
+} from '@jungjaehoon/mama-core';
 
 // ============================================================================
 // Agent Context Types (Role Awareness)
@@ -1143,55 +1156,6 @@ export interface MemoryWriteProvenance {
 export interface TrustedMemoryWriteOptions {
   provenance: MemoryWriteProvenance;
   capability: unknown;
-}
-
-export interface BeginModelRunInput {
-  model_run_id?: string;
-  model_id?: string | null;
-  model_provider?: string | null;
-  prompt_version?: string | null;
-  tool_manifest_version?: string | null;
-  output_schema_version?: string | null;
-  agent_id?: string | null;
-  instance_id?: string | null;
-  envelope_hash?: string | null;
-  parent_model_run_id?: string | null;
-  input_snapshot_ref?: string | null;
-  input_refs?: Record<string, unknown> | null;
-  input_refs_json?: string | null;
-  status?: 'running' | 'committed' | 'failed' | 'legacy';
-  error_summary?: string | null;
-  token_count?: number | null;
-  cost_estimate?: number | null;
-  created_at?: number;
-}
-
-export interface ModelRunRecord {
-  model_run_id: string;
-  status: 'running' | 'committed' | 'failed' | 'legacy';
-  created_at?: number;
-  completed_at?: number | null;
-  [key: string]: unknown;
-}
-
-export interface AppendToolTraceInput {
-  trace_id?: string;
-  model_run_id: string;
-  gateway_call_id?: string | null;
-  tool_name: string;
-  input_summary?: string | null;
-  output_summary?: string | null;
-  execution_status?: string | null;
-  duration_ms?: number | null;
-  envelope_hash?: string | null;
-  created_at?: number;
-}
-
-export interface ToolTraceRecord {
-  trace_id: string;
-  model_run_id: string;
-  tool_name: string;
-  [key: string]: unknown;
 }
 
 /**

--- a/packages/standalone/src/agent/types.ts
+++ b/packages/standalone/src/agent/types.ts
@@ -96,6 +96,10 @@ export interface AgentContext {
 
 export type GatewayExecutionSurface = 'model_tool' | 'reactive_internal' | 'code_act' | 'direct';
 
+export interface BackgroundTaskRegistry {
+  register(task: Promise<unknown>): void;
+}
+
 export type GatewayToolExecutionContext = {
   agentContext?: AgentContext;
   agentId?: string;
@@ -107,6 +111,7 @@ export type GatewayToolExecutionContext = {
   sourceMessageRef?: string;
   modelRunId?: string | null;
   gatewayCallId?: string;
+  backgroundTasks?: BackgroundTaskRegistry;
 };
 
 // ============================================================================
@@ -971,6 +976,8 @@ export interface AgentLoopOptions {
   sourceMessageRef?: string;
   /** Active model-run id for memory provenance. */
   modelRunId?: string | null;
+  /** Parent model-run id when this run is a child/background follow-up. */
+  parentModelRunId?: string | null;
 
   /**
    * Stop the agent loop after the current tool batch completes when any
@@ -1026,6 +1033,8 @@ export interface AgentLoopResult {
   };
   /** Stop reason for the final turn */
   stopReason: StopReason;
+  /** Active model run id when the loop owns or inherited one. */
+  modelRunId?: string | null;
 }
 
 // ============================================================================
@@ -1136,6 +1145,55 @@ export interface TrustedMemoryWriteOptions {
   capability: unknown;
 }
 
+export interface BeginModelRunInput {
+  model_run_id?: string;
+  model_id?: string | null;
+  model_provider?: string | null;
+  prompt_version?: string | null;
+  tool_manifest_version?: string | null;
+  output_schema_version?: string | null;
+  agent_id?: string | null;
+  instance_id?: string | null;
+  envelope_hash?: string | null;
+  parent_model_run_id?: string | null;
+  input_snapshot_ref?: string | null;
+  input_refs?: Record<string, unknown> | null;
+  input_refs_json?: string | null;
+  status?: 'running' | 'committed' | 'failed' | 'legacy';
+  error_summary?: string | null;
+  token_count?: number | null;
+  cost_estimate?: number | null;
+  created_at?: number;
+}
+
+export interface ModelRunRecord {
+  model_run_id: string;
+  status: 'running' | 'committed' | 'failed' | 'legacy';
+  created_at?: number;
+  completed_at?: number | null;
+  [key: string]: unknown;
+}
+
+export interface AppendToolTraceInput {
+  trace_id?: string;
+  model_run_id: string;
+  gateway_call_id?: string | null;
+  tool_name: string;
+  input_summary?: string | null;
+  output_summary?: string | null;
+  execution_status?: string | null;
+  duration_ms?: number | null;
+  envelope_hash?: string | null;
+  created_at?: number;
+}
+
+export interface ToolTraceRecord {
+  trace_id: string;
+  model_run_id: string;
+  tool_name: string;
+  [key: string]: unknown;
+}
+
 /**
  * Interface for MAMA API (for dependency injection)
  */
@@ -1184,6 +1242,12 @@ export interface MAMAApiInterface {
     modelRunId: string,
     options?: Record<string, unknown>
   ): Promise<unknown[]>;
+  beginModelRun?(input: BeginModelRunInput): Promise<ModelRunRecord>;
+  commitModelRun?(modelRunId: string, summary?: string): Promise<ModelRunRecord>;
+  failModelRun?(modelRunId: string, errorSummary: string): Promise<ModelRunRecord>;
+  getModelRun?(modelRunId: string): Promise<ModelRunRecord | null>;
+  appendToolTrace?(input: AppendToolTraceInput): Promise<ToolTraceRecord>;
+  listToolTracesForRun?(modelRunId: string): Promise<ToolTraceRecord[]>;
   buildProfile?(scopes?: ScopeRef[], options?: Record<string, unknown>): Promise<unknown>;
   updateOutcome(
     id: string,

--- a/packages/standalone/src/cli/runtime/memory-agent-init.ts
+++ b/packages/standalone/src/cli/runtime/memory-agent-init.ts
@@ -175,7 +175,7 @@ export async function initMemoryAgent(
                 stopAfterSuccessfulTools: ['mama_save'],
                 sourceTurnId: options?.sourceTurnId,
                 sourceMessageRef: options?.sourceMessageRef,
-                modelRunId: options?.parentModelRunId,
+                parentModelRunId: options?.parentModelRunId,
               });
               const afterDecisionCount = Number(
                 adapter.prepare('SELECT COUNT(*) AS count FROM decisions').get().count

--- a/packages/standalone/src/gateways/message-router.ts
+++ b/packages/standalone/src/gateways/message-router.ts
@@ -72,14 +72,17 @@ export interface AgentLoopClient {
   /**
    * Run the agent loop with a prompt
    */
-  run(prompt: string, options?: AgentLoopOptions): Promise<{ response: string }>;
+  run(
+    prompt: string,
+    options?: AgentLoopOptions
+  ): Promise<{ response: string; modelRunId?: string | null }>;
   /**
    * Run the agent loop with multimodal content
    */
   runWithContent?(
     content: ContentBlock[],
     options?: AgentLoopOptions
-  ): Promise<{ response: string }>;
+  ): Promise<{ response: string; modelRunId?: string | null }>;
 }
 
 export interface MemoryAgentProcessLike {
@@ -364,6 +367,7 @@ export class MessageRouter {
       const result = await process.sendMessage(this.buildMemoryAuditPrompt(job), {
         sourceTurnId: job.turnId,
         sourceMessageRef: [job.source, job.channelId, job.turnId].filter(Boolean).join(':'),
+        parentModelRunId: job.parentModelRunId,
       });
       if (
         result &&
@@ -725,6 +729,7 @@ This protects your credentials from being exposed in chat logs.`;
     }
 
     let response: string;
+    let parentModelRunId: string | undefined;
 
     // Skill on-demand injection: prepend matched skill content to user message
     // (not system prompt — PersistentCLI can't update system prompt after creation)
@@ -857,6 +862,7 @@ This protects your credentials from being exposed in chat logs.`;
         const conductorStart = Date.now();
         const result = await this.agentLoop.runWithContent(contentBlocks, options);
         response = result.response;
+        parentModelRunId = result.modelRunId ?? undefined;
         this.logFrontdoorActivity(message, message.text, response, Date.now() - conductorStart);
       } else {
         const pageCtx = this.getPageContextPrefix(message);
@@ -864,6 +870,7 @@ This protects your credentials from being exposed in chat logs.`;
         const conductorStart = Date.now();
         const result = await this.agentLoop.run(effectiveText, options);
         response = result.response;
+        parentModelRunId = result.modelRunId ?? undefined;
         this.logFrontdoorActivity(message, message.text, response, Date.now() - conductorStart);
       }
 
@@ -878,7 +885,8 @@ This protects your credentials from being exposed in chat logs.`;
               rawAssistantText,
               message,
               sourceTurnId,
-              sourceMessageRef
+              sourceMessageRef,
+              parentModelRunId
             );
           } catch {
             /* non-fatal */
@@ -1521,7 +1529,8 @@ INSTRUCTION:
     botResponse: string,
     message?: NormalizedMessage,
     sourceTurnId?: string,
-    _sourceMessageRef?: string
+    _sourceMessageRef?: string,
+    parentModelRunId?: string
   ): Promise<void> {
     const memoryAuditQueue = this.memoryAuditQueue;
     if (!this.memoryAgentProcessManager || !memoryAuditQueue) {
@@ -1584,6 +1593,7 @@ INSTRUCTION:
       source,
       channelId,
       userId,
+      parentModelRunId,
       scopeContext: scopes,
       conversation: content,
       candidates,
@@ -1715,7 +1725,10 @@ export function createMockAgentLoop(
   responseGenerator: (prompt: string) => string = () => 'Mock response'
 ): AgentLoopClient {
   return {
-    async run(prompt: string, _options?: AgentLoopOptions): Promise<{ response: string }> {
+    async run(
+      prompt: string,
+      _options?: AgentLoopOptions
+    ): Promise<{ response: string; modelRunId?: string | null }> {
       return { response: responseGenerator(prompt) };
     },
   };

--- a/packages/standalone/src/memory/audit-task-queue.ts
+++ b/packages/standalone/src/memory/audit-task-queue.ts
@@ -7,6 +7,7 @@ export interface MemoryAuditJob {
   source?: string;
   channelId?: string;
   userId?: string;
+  parentModelRunId?: string;
   scopeContext: MemoryScopeRef[];
   conversation: string;
   candidates?: SaveCandidate[];

--- a/packages/standalone/tests/agent/agent-loop-streaming.test.ts
+++ b/packages/standalone/tests/agent/agent-loop-streaming.test.ts
@@ -59,28 +59,6 @@ vi.mock('../../src/agent/session-pool.js', () => {
   };
 });
 
-// Mock the GatewayToolExecutor
-vi.mock('../../src/agent/gateway-tool-executor.js', () => {
-  return {
-    GatewayToolExecutor: vi.fn().mockImplementation(() => ({
-      setDiscordGateway: vi.fn(),
-      beginRuntimeModelRun: vi.fn().mockResolvedValue({
-        model_run_id: 'mr_streaming_mock',
-        status: 'running',
-      }),
-      commitRuntimeModelRun: vi.fn().mockResolvedValue({
-        model_run_id: 'mr_streaming_mock',
-        status: 'committed',
-      }),
-      failRuntimeModelRun: vi.fn().mockResolvedValue({
-        model_run_id: 'mr_streaming_mock',
-        status: 'failed',
-      }),
-      execute: vi.fn().mockResolvedValue({ success: true }),
-    })),
-  };
-});
-
 // Mock the lane manager
 vi.mock('../../src/concurrency/index.js', () => {
   return {
@@ -114,6 +92,84 @@ describe('AgentLoop - Streaming Detection', () => {
     suggest: vi.fn().mockResolvedValue({ success: true, results: [], count: 0 }),
     updateOutcome: vi.fn().mockResolvedValue({ success: true }),
     loadCheckpoint: vi.fn().mockResolvedValue({ success: true }),
+    beginModelRun: vi.fn().mockResolvedValue({
+      model_run_id: 'mr_streaming_real_executor',
+      model_id: null,
+      model_provider: null,
+      prompt_version: null,
+      tool_manifest_version: null,
+      output_schema_version: null,
+      agent_id: null,
+      instance_id: null,
+      envelope_hash: null,
+      parent_model_run_id: null,
+      input_snapshot_ref: null,
+      input_refs_json: null,
+      input_refs: null,
+      completion_summary: null,
+      status: 'running',
+      error_summary: null,
+      token_count: 0,
+      cost_estimate: null,
+      created_at: 1,
+      completed_at: null,
+    }),
+    commitModelRun: vi.fn().mockResolvedValue({
+      model_run_id: 'mr_streaming_real_executor',
+      model_id: null,
+      model_provider: null,
+      prompt_version: null,
+      tool_manifest_version: null,
+      output_schema_version: null,
+      agent_id: null,
+      instance_id: null,
+      envelope_hash: null,
+      parent_model_run_id: null,
+      input_snapshot_ref: null,
+      input_refs_json: null,
+      input_refs: null,
+      completion_summary: 'agent_loop completed',
+      status: 'committed',
+      error_summary: null,
+      token_count: 0,
+      cost_estimate: null,
+      created_at: 1,
+      completed_at: 2,
+    }),
+    failModelRun: vi.fn().mockResolvedValue({
+      model_run_id: 'mr_streaming_real_executor',
+      model_id: null,
+      model_provider: null,
+      prompt_version: null,
+      tool_manifest_version: null,
+      output_schema_version: null,
+      agent_id: null,
+      instance_id: null,
+      envelope_hash: null,
+      parent_model_run_id: null,
+      input_snapshot_ref: null,
+      input_refs_json: null,
+      input_refs: null,
+      completion_summary: null,
+      status: 'failed',
+      error_summary: 'failed',
+      token_count: 0,
+      cost_estimate: null,
+      created_at: 1,
+      completed_at: 2,
+    }),
+    appendToolTrace: vi.fn().mockResolvedValue({
+      trace_id: 'trace_streaming_real_executor',
+      model_run_id: 'mr_streaming_real_executor',
+      gateway_call_id: null,
+      tool_name: 'noop',
+      input_summary: null,
+      output_summary: null,
+      execution_status: 'completed',
+      duration_ms: 0,
+      envelope_hash: null,
+      created_at: 1,
+    }),
   });
 
   let agentLoop: AgentLoop;

--- a/packages/standalone/tests/agent/agent-loop-streaming.test.ts
+++ b/packages/standalone/tests/agent/agent-loop-streaming.test.ts
@@ -64,6 +64,18 @@ vi.mock('../../src/agent/gateway-tool-executor.js', () => {
   return {
     GatewayToolExecutor: vi.fn().mockImplementation(() => ({
       setDiscordGateway: vi.fn(),
+      beginRuntimeModelRun: vi.fn().mockResolvedValue({
+        model_run_id: 'mr_streaming_mock',
+        status: 'running',
+      }),
+      commitRuntimeModelRun: vi.fn().mockResolvedValue({
+        model_run_id: 'mr_streaming_mock',
+        status: 'committed',
+      }),
+      failRuntimeModelRun: vi.fn().mockResolvedValue({
+        model_run_id: 'mr_streaming_mock',
+        status: 'failed',
+      }),
       execute: vi.fn().mockResolvedValue({ success: true }),
     })),
   };

--- a/packages/standalone/tests/agent/agent-loop.test.ts
+++ b/packages/standalone/tests/agent/agent-loop.test.ts
@@ -25,6 +25,18 @@ const gatewayExecutorSetUICommandQueueMock = vi.fn();
 const gatewayExecutorSetSessionsDbMock = vi.fn();
 const gatewayExecutorSetValidationServiceMock = vi.fn();
 const gatewayExecutorSetRawStoreMock = vi.fn();
+const gatewayExecutorBeginRuntimeModelRunMock = vi.fn().mockResolvedValue({
+  model_run_id: 'mr_agent_loop_mock',
+  status: 'running',
+});
+const gatewayExecutorCommitRuntimeModelRunMock = vi.fn().mockResolvedValue({
+  model_run_id: 'mr_agent_loop_mock',
+  status: 'committed',
+});
+const gatewayExecutorFailRuntimeModelRunMock = vi.fn().mockResolvedValue({
+  model_run_id: 'mr_agent_loop_mock',
+  status: 'failed',
+});
 
 // Mock the ClaudeCLIWrapper
 vi.mock('../../src/agent/claude-cli-wrapper.js', () => {
@@ -84,6 +96,9 @@ vi.mock('../../src/agent/gateway-tool-executor.js', () => {
       setSessionsDb: gatewayExecutorSetSessionsDbMock,
       setValidationService: gatewayExecutorSetValidationServiceMock,
       setRawStore: gatewayExecutorSetRawStoreMock,
+      beginRuntimeModelRun: gatewayExecutorBeginRuntimeModelRunMock,
+      commitRuntimeModelRun: gatewayExecutorCommitRuntimeModelRunMock,
+      failRuntimeModelRun: gatewayExecutorFailRuntimeModelRunMock,
       execute: vi.fn().mockResolvedValue({ success: true }),
     })),
   };
@@ -158,6 +173,9 @@ describe('AgentLoop', () => {
     gatewayExecutorSetSessionsDbMock.mockClear();
     gatewayExecutorSetValidationServiceMock.mockClear();
     gatewayExecutorSetRawStoreMock.mockClear();
+    gatewayExecutorBeginRuntimeModelRunMock.mockClear();
+    gatewayExecutorCommitRuntimeModelRunMock.mockClear();
+    gatewayExecutorFailRuntimeModelRunMock.mockClear();
     laneManagerEnqueueWithSessionMock.mockClear();
   });
 

--- a/packages/standalone/tests/agent/post-tool-handler.test.ts
+++ b/packages/standalone/tests/agent/post-tool-handler.test.ts
@@ -559,6 +559,34 @@ describe('PostToolHandler', () => {
         expect(searchCalls[0][2]).toBe(executionContext);
         expect(saveCalls[0][2]).toBe(executionContext);
       });
+
+      it('registers the original background promise so drains can observe failures', async () => {
+        handler = new PostToolHandler(executeTool, { enabled: true });
+        const registeredTasks: Promise<unknown>[] = [];
+        const circularResult: Record<string, unknown> = {};
+        circularResult.self = circularResult;
+        const executionContext: GatewayToolExecutionContext = {
+          agentId: 'chat_bot',
+          source: 'telegram',
+          channelId: 'tg:1',
+          executionSurface: 'reactive_internal',
+          backgroundTasks: {
+            register(task: Promise<unknown>): void {
+              registeredTasks.push(task);
+            },
+          },
+        };
+
+        handler.processInBackground(
+          'Write',
+          { path: 'src/api.ts' },
+          circularResult,
+          executionContext
+        );
+
+        expect(registeredTasks).toHaveLength(1);
+        await expect(registeredTasks[0]).rejects.toThrow(/circular/i);
+      });
     });
   });
 

--- a/packages/standalone/tests/agent/streaming-integration.test.ts
+++ b/packages/standalone/tests/agent/streaming-integration.test.ts
@@ -64,6 +64,18 @@ vi.mock('../../src/agent/gateway-tool-executor.js', () => {
   return {
     GatewayToolExecutor: vi.fn().mockImplementation(() => ({
       setDiscordGateway: vi.fn(),
+      beginRuntimeModelRun: vi.fn().mockResolvedValue({
+        model_run_id: 'mr_streaming_integration_mock',
+        status: 'running',
+      }),
+      commitRuntimeModelRun: vi.fn().mockResolvedValue({
+        model_run_id: 'mr_streaming_integration_mock',
+        status: 'committed',
+      }),
+      failRuntimeModelRun: vi.fn().mockResolvedValue({
+        model_run_id: 'mr_streaming_integration_mock',
+        status: 'failed',
+      }),
       execute: vi.fn().mockResolvedValue({ success: true }),
     })),
   };

--- a/packages/standalone/tests/agent/streaming-integration.test.ts
+++ b/packages/standalone/tests/agent/streaming-integration.test.ts
@@ -59,28 +59,6 @@ vi.mock('../../src/agent/session-pool.js', () => {
   };
 });
 
-// Mock the GatewayToolExecutor
-vi.mock('../../src/agent/gateway-tool-executor.js', () => {
-  return {
-    GatewayToolExecutor: vi.fn().mockImplementation(() => ({
-      setDiscordGateway: vi.fn(),
-      beginRuntimeModelRun: vi.fn().mockResolvedValue({
-        model_run_id: 'mr_streaming_integration_mock',
-        status: 'running',
-      }),
-      commitRuntimeModelRun: vi.fn().mockResolvedValue({
-        model_run_id: 'mr_streaming_integration_mock',
-        status: 'committed',
-      }),
-      failRuntimeModelRun: vi.fn().mockResolvedValue({
-        model_run_id: 'mr_streaming_integration_mock',
-        status: 'failed',
-      }),
-      execute: vi.fn().mockResolvedValue({ success: true }),
-    })),
-  };
-});
-
 // Mock the lane manager
 vi.mock('../../src/concurrency/index.js', () => {
   return {
@@ -106,6 +84,84 @@ describe('AgentLoop - Streaming Integration', () => {
     suggest: vi.fn().mockResolvedValue({ success: true, results: [], count: 0 }),
     updateOutcome: vi.fn().mockResolvedValue({ success: true }),
     loadCheckpoint: vi.fn().mockResolvedValue({ success: true }),
+    beginModelRun: vi.fn().mockResolvedValue({
+      model_run_id: 'mr_streaming_integration_real_executor',
+      model_id: null,
+      model_provider: null,
+      prompt_version: null,
+      tool_manifest_version: null,
+      output_schema_version: null,
+      agent_id: null,
+      instance_id: null,
+      envelope_hash: null,
+      parent_model_run_id: null,
+      input_snapshot_ref: null,
+      input_refs_json: null,
+      input_refs: null,
+      completion_summary: null,
+      status: 'running',
+      error_summary: null,
+      token_count: 0,
+      cost_estimate: null,
+      created_at: 1,
+      completed_at: null,
+    }),
+    commitModelRun: vi.fn().mockResolvedValue({
+      model_run_id: 'mr_streaming_integration_real_executor',
+      model_id: null,
+      model_provider: null,
+      prompt_version: null,
+      tool_manifest_version: null,
+      output_schema_version: null,
+      agent_id: null,
+      instance_id: null,
+      envelope_hash: null,
+      parent_model_run_id: null,
+      input_snapshot_ref: null,
+      input_refs_json: null,
+      input_refs: null,
+      completion_summary: 'agent_loop completed',
+      status: 'committed',
+      error_summary: null,
+      token_count: 0,
+      cost_estimate: null,
+      created_at: 1,
+      completed_at: 2,
+    }),
+    failModelRun: vi.fn().mockResolvedValue({
+      model_run_id: 'mr_streaming_integration_real_executor',
+      model_id: null,
+      model_provider: null,
+      prompt_version: null,
+      tool_manifest_version: null,
+      output_schema_version: null,
+      agent_id: null,
+      instance_id: null,
+      envelope_hash: null,
+      parent_model_run_id: null,
+      input_snapshot_ref: null,
+      input_refs_json: null,
+      input_refs: null,
+      completion_summary: null,
+      status: 'failed',
+      error_summary: 'failed',
+      token_count: 0,
+      cost_estimate: null,
+      created_at: 1,
+      completed_at: 2,
+    }),
+    appendToolTrace: vi.fn().mockResolvedValue({
+      trace_id: 'trace_streaming_integration_real_executor',
+      model_run_id: 'mr_streaming_integration_real_executor',
+      gateway_call_id: null,
+      tool_name: 'noop',
+      input_summary: null,
+      output_summary: null,
+      execution_status: 'completed',
+      duration_ms: 0,
+      envelope_hash: null,
+      created_at: 1,
+    }),
   });
 
   beforeEach(() => {

--- a/packages/standalone/tests/cli/runtime/memory-agent-init.test.ts
+++ b/packages/standalone/tests/cli/runtime/memory-agent-init.test.ts
@@ -107,7 +107,7 @@ describe('Story M2.1: Memory Agent Runtime Provenance', () => {
           expect.objectContaining({
             sourceTurnId: 'turn-1',
             sourceMessageRef: 'telegram:abc:turn-1',
-            modelRunId: 'parent-model-run-1',
+            parentModelRunId: 'parent-model-run-1',
           })
         );
       });

--- a/packages/standalone/tests/envelope/agent-loop-internal-tool-context.test.ts
+++ b/packages/standalone/tests/envelope/agent-loop-internal-tool-context.test.ts
@@ -26,6 +26,23 @@ function createMockApi(): MAMAApiInterface {
     updateOutcome: vi.fn().mockResolvedValue({ success: true, message: 'updated' }),
     loadCheckpoint: vi.fn().mockResolvedValue({ success: true }),
     ingestMemory: vi.fn().mockResolvedValue({ success: true, id: 'ingested_1' }),
+    beginModelRun: vi.fn().mockResolvedValue({
+      model_run_id: 'mr_internal_context',
+      status: 'running',
+    }),
+    commitModelRun: vi.fn().mockResolvedValue({
+      model_run_id: 'mr_internal_context',
+      status: 'committed',
+    }),
+    failModelRun: vi.fn().mockResolvedValue({
+      model_run_id: 'mr_internal_context',
+      status: 'failed',
+    }),
+    appendToolTrace: vi.fn().mockResolvedValue({
+      trace_id: 'trace_internal_context',
+      model_run_id: 'mr_internal_context',
+      tool_name: 'mama_search',
+    }),
   };
 }
 

--- a/packages/standalone/tests/envelope/executor-integration.test.ts
+++ b/packages/standalone/tests/envelope/executor-integration.test.ts
@@ -31,6 +31,23 @@ function makeMAMAApi(): MAMAApiInterface {
       search_meta: { query: 'test', scope_order: [], retrieval_sources: [] },
     }),
     ingestMemory: vi.fn().mockResolvedValue({ success: true, id: 'ingested_1' }),
+    beginModelRun: vi.fn().mockResolvedValue({
+      model_run_id: 'mr_executor_integration',
+      status: 'running',
+    }),
+    commitModelRun: vi.fn().mockResolvedValue({
+      model_run_id: 'mr_executor_integration',
+      status: 'committed',
+    }),
+    failModelRun: vi.fn().mockResolvedValue({
+      model_run_id: 'mr_executor_integration',
+      status: 'failed',
+    }),
+    appendToolTrace: vi.fn().mockResolvedValue({
+      trace_id: 'trace_executor_integration',
+      model_run_id: 'mr_executor_integration',
+      tool_name: 'mama_load_checkpoint',
+    }),
   };
 }
 

--- a/packages/standalone/tests/envelope/memory-provenance-context.test.ts
+++ b/packages/standalone/tests/envelope/memory-provenance-context.test.ts
@@ -9,6 +9,7 @@ import { makeSignedEnvelope } from './fixtures.js';
 type ProvenanceAwareApi = MAMAApiInterface & {
   saveWithTrustedProvenance: ReturnType<typeof vi.fn>;
   ingestWithTrustedProvenance: ReturnType<typeof vi.fn>;
+  appendToolTrace: ReturnType<typeof vi.fn>;
 };
 
 function createContext(): AgentContext {
@@ -51,6 +52,11 @@ function createApi(): ProvenanceAwareApi {
     loadCheckpoint: vi.fn().mockResolvedValue({ success: true }),
     ingestMemory: vi.fn().mockResolvedValue({ success: true, id: 'public_ingest' }),
     ingestWithTrustedProvenance: vi.fn().mockResolvedValue({ success: true, id: 'trusted_ingest' }),
+    appendToolTrace: vi.fn().mockResolvedValue({
+      trace_id: 'trace_1',
+      model_run_id: 'model-run-1',
+      tool_name: 'mama_save',
+    }),
   };
 }
 
@@ -200,6 +206,13 @@ describe('Story M2.1: Gateway Memory Provenance Context', () => {
     expect(options.provenance.model_run_id).toBe('model-run-1');
     expect(options.provenance.envelope_hash).toBe(envelope.envelope_hash);
     expect(options.provenance.source_message_ref).toBe('telegram:abc:turn-with-fallback');
+    expect(api.appendToolTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model_run_id: 'model-run-1',
+        tool_name: 'mama_save',
+        execution_status: 'completed',
+      })
+    );
     db.close();
   });
 });

--- a/packages/standalone/tests/envelope/model-run-context.test.ts
+++ b/packages/standalone/tests/envelope/model-run-context.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { AgentLoop } from '../../src/agent/agent-loop.js';
+import { PersistentCLIAdapter } from '../../src/agent/persistent-cli-adapter.js';
+import type { AgentContext, MAMAApiInterface } from '../../src/agent/types.js';
+import type { OAuthManager } from '../../src/auth/index.js';
+
+type TraceAwareApi = MAMAApiInterface & {
+  saveWithTrustedProvenance: ReturnType<typeof vi.fn>;
+  beginModelRun: ReturnType<typeof vi.fn>;
+  commitModelRun: ReturnType<typeof vi.fn>;
+  failModelRun: ReturnType<typeof vi.fn>;
+  appendToolTrace: ReturnType<typeof vi.fn>;
+};
+
+function createMockOAuthManager(): OAuthManager {
+  return { getToken: vi.fn().mockResolvedValue('token') } as unknown as OAuthManager;
+}
+
+function createAgentContext(): AgentContext {
+  return {
+    source: 'discord',
+    platform: 'discord',
+    roleName: 'chat_bot',
+    role: {
+      allowedTools: ['*'],
+      systemControl: false,
+      sensitiveAccess: false,
+    },
+    session: {
+      sessionId: 'discord:session',
+      channelId: 'channel-1',
+      userId: 'user-1',
+      startedAt: new Date(),
+    },
+    capabilities: ['*'],
+    limitations: [],
+    tier: 2,
+    backend: 'claude',
+  };
+}
+
+function createApi(): TraceAwareApi {
+  return {
+    save: vi.fn().mockResolvedValue({ success: true, id: 'public_save', type: 'decision' }),
+    saveWithTrustedProvenance: vi
+      .fn()
+      .mockResolvedValue({ success: true, id: 'trusted_save', type: 'decision' }),
+    saveCheckpoint: vi.fn().mockResolvedValue({ success: true, id: 'checkpoint_1' }),
+    listDecisions: vi.fn().mockResolvedValue([]),
+    suggest: vi.fn().mockResolvedValue({ success: true, results: [], count: 0 }),
+    updateOutcome: vi.fn().mockResolvedValue({ success: true }),
+    loadCheckpoint: vi.fn().mockResolvedValue({ success: true }),
+    beginModelRun: vi.fn().mockResolvedValue({
+      model_run_id: 'mr_agent_loop',
+      status: 'running',
+    }),
+    commitModelRun: vi.fn().mockResolvedValue({
+      model_run_id: 'mr_agent_loop',
+      status: 'committed',
+    }),
+    failModelRun: vi.fn().mockResolvedValue({
+      model_run_id: 'mr_agent_loop',
+      status: 'failed',
+    }),
+    appendToolTrace: vi.fn().mockResolvedValue({
+      trace_id: 'trace_agent_loop',
+      model_run_id: 'mr_agent_loop',
+      tool_name: 'mama_save',
+    }),
+  };
+}
+
+describe('Story M2.2: AgentLoop Model Run Context', () => {
+  let tempDir: string;
+  let previousHome: string | undefined;
+  let promptSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    previousHome = process.env.HOME;
+    tempDir = mkdtempSync(join(tmpdir(), 'mama-agent-loop-model-run-'));
+    process.env.HOME = tempDir;
+    promptSpy = vi.spyOn(PersistentCLIAdapter.prototype, 'prompt');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('Acceptance Criteria', () => {
+    describe('AC #1: tool-capable run owns a model run', () => {
+      it('begins a model run and forwards its id into gateway memory writes', async () => {
+        promptSpy
+          .mockResolvedValueOnce({
+            response:
+              '```tool_call\n' +
+              JSON.stringify({
+                name: 'mama_save',
+                input: {
+                  type: 'decision',
+                  topic: 'agent_loop_model_run',
+                  decision: 'AgentLoop owns model run ids',
+                  reasoning: 'Gateway memory writes need model-run provenance',
+                },
+              }) +
+              '\n```',
+            usage: { input_tokens: 10, output_tokens: 5 },
+          })
+          .mockResolvedValueOnce({
+            response: 'Done',
+            usage: { input_tokens: 3, output_tokens: 2 },
+          });
+
+        const api = createApi();
+        const agentLoop = new AgentLoop(
+          createMockOAuthManager(),
+          {},
+          {},
+          { mamaApi: api, envelopeIssuanceMode: 'off' }
+        );
+
+        await agentLoop.run('save this decision', {
+          source: 'discord',
+          channelId: 'channel-1',
+          agentContext: createAgentContext(),
+          cliSessionId: 'cli-session-1',
+          resumeSession: true,
+          sourceTurnId: 'turn-1',
+          sourceMessageRef: 'discord:channel-1:turn-1',
+        });
+
+        expect(api.beginModelRun).toHaveBeenCalledOnce();
+        expect(api.beginModelRun.mock.calls[0][0]).toMatchObject({
+          agent_id: 'chat_bot',
+          model_provider: 'claude',
+          input_refs: {
+            source: 'discord',
+            channelId: 'channel-1',
+            entrypoint: 'agent_loop',
+            sourceTurnId: 'turn-1',
+            sourceMessageRef: 'discord:channel-1:turn-1',
+            cliSessionId: 'cli-session-1',
+          },
+        });
+        expect(api.saveWithTrustedProvenance).toHaveBeenCalledOnce();
+        const [, options] = api.saveWithTrustedProvenance.mock.calls[0];
+        expect(options.provenance.model_run_id).toBe('mr_agent_loop');
+        expect(api.appendToolTrace).toHaveBeenCalledWith(
+          expect.objectContaining({
+            model_run_id: 'mr_agent_loop',
+            tool_name: 'mama_save',
+            execution_status: 'completed',
+          })
+        );
+        expect(api.commitModelRun).toHaveBeenCalledWith('mr_agent_loop', 'agent_loop completed');
+        expect(api.failModelRun).not.toHaveBeenCalled();
+      });
+
+      it('waits for audited autosaves before committing the parent model run', async () => {
+        promptSpy
+          .mockResolvedValueOnce({
+            response:
+              '```tool_call\n' +
+              JSON.stringify({
+                name: 'report_publish',
+                input: {
+                  slots: {
+                    summary: '<p>Dashboard says SQLite remains the default database.</p>',
+                  },
+                },
+              }) +
+              '\n```',
+            usage: { input_tokens: 10, output_tokens: 5 },
+          })
+          .mockResolvedValueOnce({
+            response: 'Done',
+            usage: { input_tokens: 3, output_tokens: 2 },
+          });
+
+        let saveResolved = false;
+        const api = createApi();
+        api.saveWithTrustedProvenance.mockImplementation(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          saveResolved = true;
+          return { success: true, id: 'autosave_1', type: 'decision' };
+        });
+        api.commitModelRun.mockImplementation(async () => {
+          expect(saveResolved).toBe(true);
+          return { model_run_id: 'mr_agent_loop', status: 'committed' };
+        });
+        const agentLoop = new AgentLoop(
+          createMockOAuthManager(),
+          {},
+          {},
+          { mamaApi: api, envelopeIssuanceMode: 'off' }
+        );
+        agentLoop.setReportPublisher(vi.fn());
+
+        await agentLoop.run('publish report', {
+          source: 'discord',
+          channelId: 'channel-1',
+          agentContext: createAgentContext(),
+          cliSessionId: 'cli-session-1',
+          resumeSession: true,
+        });
+
+        expect(api.saveWithTrustedProvenance).toHaveBeenCalled();
+        expect(api.commitModelRun).toHaveBeenCalledWith('mr_agent_loop', 'agent_loop completed');
+      });
+    });
+  });
+});

--- a/packages/standalone/tests/envelope/model-run-context.test.ts
+++ b/packages/standalone/tests/envelope/model-run-context.test.ts
@@ -216,6 +216,62 @@ describe('Story M2.2: AgentLoop Model Run Context', () => {
         expect(api.saveWithTrustedProvenance).toHaveBeenCalled();
         expect(api.commitModelRun).toHaveBeenCalledWith('mr_agent_loop', 'agent_loop completed');
       });
+
+      it('records the resolved CLI session id when the session pool selects it', async () => {
+        promptSpy.mockResolvedValueOnce({
+          response: 'Done',
+          usage: { input_tokens: 3, output_tokens: 2 },
+        });
+
+        const api = createApi();
+        const agentLoop = new AgentLoop(
+          createMockOAuthManager(),
+          {},
+          {},
+          { mamaApi: api, envelopeIssuanceMode: 'off' }
+        );
+
+        await agentLoop.run('respond once', {
+          source: 'discord',
+          channelId: 'channel-1',
+          agentContext: createAgentContext(),
+        });
+
+        expect(api.beginModelRun).toHaveBeenCalledOnce();
+        expect(api.beginModelRun.mock.calls[0][0].input_refs).toEqual(
+          expect.objectContaining({
+            cliSessionId: expect.any(String),
+          })
+        );
+      });
+
+      it('does not fail the model run when post-run finalization fails', async () => {
+        promptSpy.mockResolvedValueOnce({
+          response: 'Done',
+          usage: { input_tokens: 3, output_tokens: 2 },
+        });
+
+        const api = createApi();
+        api.commitModelRun.mockRejectedValueOnce(new Error('commit store unavailable'));
+        const agentLoop = new AgentLoop(
+          createMockOAuthManager(),
+          {},
+          {},
+          { mamaApi: api, envelopeIssuanceMode: 'off' }
+        );
+
+        const result = await agentLoop.run('respond once', {
+          source: 'discord',
+          channelId: 'channel-1',
+          agentContext: createAgentContext(),
+          cliSessionId: 'cli-session-1',
+          resumeSession: true,
+        });
+
+        expect(result.response).toBe('Done');
+        expect(api.commitModelRun).toHaveBeenCalledWith('mr_agent_loop', 'agent_loop completed');
+        expect(api.failModelRun).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/packages/standalone/tests/envelope/tool-trace.test.ts
+++ b/packages/standalone/tests/envelope/tool-trace.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it, vi } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import { closeDB } from '@jungjaehoon/mama-core/db-manager';
+
+import { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
+import type { MAMAApiInterface } from '../../src/agent/types.js';
+
+type TraceAwareApi = MAMAApiInterface & {
+  beginModelRun: ReturnType<typeof vi.fn>;
+  commitModelRun: ReturnType<typeof vi.fn>;
+  failModelRun: ReturnType<typeof vi.fn>;
+  appendToolTrace: ReturnType<typeof vi.fn>;
+  listToolTracesForRun: ReturnType<typeof vi.fn>;
+};
+
+function createApi(): TraceAwareApi {
+  return {
+    save: vi.fn().mockResolvedValue({ success: true, id: 'save_1' }),
+    saveCheckpoint: vi.fn().mockResolvedValue({ success: true, id: 'checkpoint_1' }),
+    listDecisions: vi.fn().mockResolvedValue([]),
+    suggest: vi.fn().mockResolvedValue({ success: true, results: [], count: 0 }),
+    updateOutcome: vi.fn().mockResolvedValue({ success: true }),
+    loadCheckpoint: vi.fn().mockResolvedValue({ success: true, summary: 'checkpoint' }),
+    beginModelRun: vi.fn().mockResolvedValue({
+      model_run_id: 'mr_direct_trace',
+      status: 'running',
+    }),
+    commitModelRun: vi.fn().mockResolvedValue({
+      model_run_id: 'mr_direct_trace',
+      status: 'committed',
+    }),
+    failModelRun: vi.fn().mockResolvedValue({
+      model_run_id: 'mr_direct_trace',
+      status: 'failed',
+    }),
+    appendToolTrace: vi.fn().mockResolvedValue({
+      trace_id: 'trace_1',
+      model_run_id: 'mr_parent_trace',
+    }),
+    listToolTracesForRun: vi.fn().mockResolvedValue([]),
+  };
+}
+
+describe('Story M2.2: Gateway Tool Trace Runtime', () => {
+  describe('Acceptance Criteria', () => {
+    describe('AC #1: active model-run trace binding', () => {
+      it('appends tool traces to the active model run without creating a direct run', async () => {
+        const api = createApi();
+        const executor = new GatewayToolExecutor({
+          mamaApi: api,
+          envelopeIssuanceMode: 'off',
+        });
+
+        const result = await executor.execute(
+          'mama_search',
+          { query: 'model run lineage' },
+          {
+            agentId: 'agent-main',
+            source: 'discord',
+            channelId: 'channel-1',
+            executionSurface: 'model_tool',
+            modelRunId: 'mr_parent_trace',
+            gatewayCallId: 'gw_parent_trace',
+          }
+        );
+
+        expect(result).toMatchObject({ success: true });
+        expect(api.beginModelRun).not.toHaveBeenCalled();
+        expect(api.commitModelRun).not.toHaveBeenCalled();
+        expect(api.appendToolTrace).toHaveBeenCalledOnce();
+        expect(api.appendToolTrace.mock.calls[0][0]).toMatchObject({
+          model_run_id: 'mr_parent_trace',
+          gateway_call_id: 'gw_parent_trace',
+          tool_name: 'mama_search',
+          input_summary: 'tool:mama_search',
+          output_summary: 'success',
+          execution_status: 'completed',
+          envelope_hash: null,
+        });
+        expect(api.appendToolTrace.mock.calls[0][0].duration_ms).toEqual(expect.any(Number));
+      });
+    });
+
+    describe('AC #2: direct model-run trace binding', () => {
+      it('creates, traces, and commits a direct model run when no model run is active', async () => {
+        const api = createApi();
+        const executor = new GatewayToolExecutor({
+          mamaApi: api,
+          envelopeIssuanceMode: 'enabled',
+        });
+
+        const result = await executor.execute(
+          'mama_search',
+          { query: 'direct lineage' },
+          {
+            agentId: 'direct-agent',
+            source: 'cli',
+            channelId: 'local',
+            executionSurface: 'direct',
+          }
+        );
+
+        expect(result).toMatchObject({ success: true });
+        expect(api.beginModelRun).toHaveBeenCalledOnce();
+        expect(api.beginModelRun.mock.calls[0][0]).toMatchObject({
+          agent_id: 'direct',
+          status: 'running',
+          envelope_hash: null,
+          input_refs: {
+            executionSurface: 'direct',
+            source: 'cli',
+            channelId: 'local',
+          },
+        });
+        const gatewayCallId = api.beginModelRun.mock.calls[0][0].input_refs.gateway_call_id;
+        expect(gatewayCallId).toMatch(/^gw_/);
+        expect(api.appendToolTrace).toHaveBeenCalledWith(
+          expect.objectContaining({
+            model_run_id: 'mr_direct_trace',
+            gateway_call_id: gatewayCallId,
+            tool_name: 'mama_search',
+            execution_status: 'completed',
+          })
+        );
+        expect(api.commitModelRun).toHaveBeenCalledWith('mr_direct_trace', 'mama_search completed');
+        expect(api.failModelRun).not.toHaveBeenCalled();
+      });
+
+      it('fails a direct model run when the tool returns success false', async () => {
+        const api = createApi();
+        const executor = new GatewayToolExecutor({
+          mamaApi: api,
+          envelopeIssuanceMode: 'enabled',
+        });
+
+        const result = await executor.execute(
+          'mama_save',
+          { type: 'decision', topic: 'missing reasoning', decision: 'Invalid save' },
+          {
+            source: 'cli',
+            channelId: 'local',
+            executionSurface: 'direct',
+          }
+        );
+
+        expect(result.success).toBe(false);
+        expect(api.appendToolTrace).toHaveBeenCalledWith(
+          expect.objectContaining({
+            model_run_id: 'mr_direct_trace',
+            tool_name: 'mama_save',
+            execution_status: 'failed',
+          })
+        );
+        expect(api.commitModelRun).not.toHaveBeenCalled();
+        expect(api.failModelRun).toHaveBeenCalledWith(
+          'mr_direct_trace',
+          'mama_save failed: Decision requires: topic, decision, reasoning'
+        );
+      });
+    });
+
+    describe('AC #3: real mama-api binding', () => {
+      it('binds real mama-api model-run helpers and writes a durable tool trace', async () => {
+        const dbPath = join(os.tmpdir(), `mama-tool-trace-real-${randomUUID()}.db`);
+        const previousDbPath = process.env.MAMA_DB_PATH;
+        const previousForceTier3 = process.env.MAMA_FORCE_TIER_3;
+        const cleanup = (): void => {
+          for (const file of [dbPath, `${dbPath}-journal`, `${dbPath}-wal`, `${dbPath}-shm`]) {
+            try {
+              fs.unlinkSync(file);
+            } catch {
+              // cleanup best effort
+            }
+          }
+        };
+        await closeDB();
+        cleanup();
+        process.env.MAMA_DB_PATH = dbPath;
+        process.env.MAMA_FORCE_TIER_3 = 'true';
+
+        try {
+          const executor = new GatewayToolExecutor({
+            mamaDbPath: dbPath,
+            envelopeIssuanceMode: 'enabled',
+          });
+
+          const result = await executor.execute(
+            'mama_search',
+            {},
+            {
+              source: 'cli',
+              channelId: 'local',
+              executionSurface: 'direct',
+            }
+          );
+
+          expect(result).toMatchObject({ success: true });
+          await closeDB();
+          const db = new Database(dbPath);
+          const run = db.prepare('SELECT model_run_id, status FROM model_runs').get() as
+            | { model_run_id: string; status: string }
+            | undefined;
+          const trace = db
+            .prepare(
+              `
+                SELECT model_run_id, tool_name, execution_status, gateway_call_id
+                FROM tool_traces
+              `
+            )
+            .get() as
+            | {
+                model_run_id: string;
+                tool_name: string;
+                execution_status: string;
+                gateway_call_id: string;
+              }
+            | undefined;
+
+          expect(run).toMatchObject({ status: 'committed' });
+          expect(trace).toMatchObject({
+            model_run_id: run?.model_run_id,
+            tool_name: 'mama_search',
+            execution_status: 'completed',
+          });
+          expect(trace?.gateway_call_id).toMatch(/^gw_/);
+          db.close();
+        } finally {
+          await closeDB();
+          if (previousDbPath === undefined) {
+            delete process.env.MAMA_DB_PATH;
+          } else {
+            process.env.MAMA_DB_PATH = previousDbPath;
+          }
+          if (previousForceTier3 === undefined) {
+            delete process.env.MAMA_FORCE_TIER_3;
+          } else {
+            process.env.MAMA_FORCE_TIER_3 = previousForceTier3;
+          }
+          cleanup();
+        }
+      });
+    });
+  });
+});

--- a/packages/standalone/tests/envelope/tool-trace.test.ts
+++ b/packages/standalone/tests/envelope/tool-trace.test.ts
@@ -10,6 +10,7 @@ import { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
 import type { MAMAApiInterface } from '../../src/agent/types.js';
 
 type TraceAwareApi = MAMAApiInterface & {
+  saveWithTrustedProvenance: ReturnType<typeof vi.fn>;
   beginModelRun: ReturnType<typeof vi.fn>;
   commitModelRun: ReturnType<typeof vi.fn>;
   failModelRun: ReturnType<typeof vi.fn>;
@@ -20,6 +21,9 @@ type TraceAwareApi = MAMAApiInterface & {
 function createApi(): TraceAwareApi {
   return {
     save: vi.fn().mockResolvedValue({ success: true, id: 'save_1' }),
+    saveWithTrustedProvenance: vi
+      .fn()
+      .mockResolvedValue({ success: true, id: 'trusted_save_1', type: 'decision' }),
     saveCheckpoint: vi.fn().mockResolvedValue({ success: true, id: 'checkpoint_1' }),
     listDecisions: vi.fn().mockResolvedValue([]),
     suggest: vi.fn().mockResolvedValue({ success: true, results: [], count: 0 }),
@@ -130,6 +134,63 @@ describe('Story M2.2: Gateway Tool Trace Runtime', () => {
         expect(api.failModelRun).not.toHaveBeenCalled();
       });
 
+      it('exposes the direct model run id to trusted memory write provenance', async () => {
+        const api = createApi();
+        api.saveWithTrustedProvenance = vi
+          .fn()
+          .mockResolvedValue({ success: true, id: 'save_1', type: 'decision' });
+        const executor = new GatewayToolExecutor({
+          mamaApi: api,
+          envelopeIssuanceMode: 'enabled',
+        });
+
+        const result = await executor.execute(
+          'mama_save',
+          {
+            type: 'decision',
+            topic: 'direct_model_run',
+            decision: 'Direct runs are visible to trusted provenance',
+            reasoning:
+              'The direct GatewayToolExecutor context should include the generated model run id.',
+          },
+          {
+            source: 'cli',
+            channelId: 'local',
+            executionSurface: 'direct',
+          }
+        );
+
+        expect(result).toMatchObject({ success: true });
+        expect(api.saveWithTrustedProvenance).toHaveBeenCalledOnce();
+        expect(api.saveWithTrustedProvenance.mock.calls[0][1].provenance.model_run_id).toBe(
+          'mr_direct_trace'
+        );
+      });
+
+      it('commits a successful direct model run even when trace insertion fails', async () => {
+        const api = createApi();
+        api.appendToolTrace.mockRejectedValueOnce(new Error('trace insert failed'));
+        const executor = new GatewayToolExecutor({
+          mamaApi: api,
+          envelopeIssuanceMode: 'enabled',
+        });
+
+        await expect(
+          executor.execute(
+            'mama_search',
+            { query: 'direct lineage' },
+            {
+              source: 'cli',
+              channelId: 'local',
+              executionSurface: 'direct',
+            }
+          )
+        ).rejects.toThrow(/trace insert failed/);
+
+        expect(api.commitModelRun).toHaveBeenCalledWith('mr_direct_trace', 'mama_search completed');
+        expect(api.failModelRun).not.toHaveBeenCalled();
+      });
+
       it('fails a direct model run when the tool returns success false', async () => {
         const api = createApi();
         const executor = new GatewayToolExecutor({
@@ -159,6 +220,32 @@ describe('Story M2.2: Gateway Tool Trace Runtime', () => {
         expect(api.failModelRun).toHaveBeenCalledWith(
           'mr_direct_trace',
           'mama_save failed: Decision requires: topic, decision, reasoning'
+        );
+      });
+
+      it('fails an errored direct model run even when failure trace insertion fails', async () => {
+        const api = createApi();
+        api.appendToolTrace.mockRejectedValueOnce(new Error('trace insert failed'));
+        const executor = new GatewayToolExecutor({
+          mamaApi: api,
+          envelopeIssuanceMode: 'enabled',
+        });
+
+        await expect(
+          executor.execute(
+            'report_publish',
+            {},
+            {
+              source: 'cli',
+              channelId: 'local',
+              executionSurface: 'direct',
+            }
+          )
+        ).rejects.toThrow(/report_publish requires slots object/);
+
+        expect(api.failModelRun).toHaveBeenCalledWith(
+          'mr_direct_trace',
+          'report_publish failed: report_publish requires slots object'
         );
       });
     });

--- a/packages/standalone/tests/gateways/message-router.test.ts
+++ b/packages/standalone/tests/gateways/message-router.test.ts
@@ -589,38 +589,42 @@ describe('MessageRouter', () => {
       });
     });
 
-    it('should pass the main model run id as the memory-agent parent model run id', async () => {
-      const agentLoop = {
-        async run(): Promise<{ response: string; modelRunId: string }> {
-          return { response: 'Saved.', modelRunId: 'mr_main_turn' };
-        },
-      };
-      const mamaApi = createMockMamaApi(mockDecisions);
-      const customRouter = new MessageRouter(sessionStore, agentLoop, mamaApi);
-      const sendMessage = vi.fn().mockResolvedValue({
-        response: 'DONE',
-        ack: { status: 'applied', action: 'save', event_ids: [], reason: 'saved' },
-      });
+    describe('Story M2.2: Memory agent model-run parentage', () => {
+      describe('Acceptance Criteria', () => {
+        it('should pass the main model run id as the memory-agent parent model run id', async () => {
+          const agentLoop = {
+            async run(): Promise<{ response: string; modelRunId: string }> {
+              return { response: 'Saved.', modelRunId: 'mr_main_turn' };
+            },
+          };
+          const mamaApi = createMockMamaApi(mockDecisions);
+          const customRouter = new MessageRouter(sessionStore, agentLoop, mamaApi);
+          const sendMessage = vi.fn().mockResolvedValue({
+            response: 'DONE',
+            ack: { status: 'applied', action: 'save', event_ids: [], reason: 'saved' },
+          });
 
-      customRouter.setMemoryAgent({
-        getSharedProcess: vi.fn().mockResolvedValue({ sendMessage }),
-      } as unknown as import('../../src/multi-agent/agent-process-manager.js').AgentProcessManager);
+          customRouter.setMemoryAgent({
+            getSharedProcess: vi.fn().mockResolvedValue({ sendMessage }),
+          } as unknown as import('../../src/multi-agent/agent-process-manager.js').AgentProcessManager);
 
-      await customRouter.process({
-        source: 'telegram',
-        channelId: '7026976631',
-        userId: '7026976631',
-        text: 'Use SQLite as the default database going forward. Remember this.',
-      });
+          await customRouter.process({
+            source: 'telegram',
+            channelId: '7026976631',
+            userId: '7026976631',
+            text: 'Use SQLite as the default database going forward. Remember this.',
+          });
 
-      await vi.waitFor(() => {
-        expect(sendMessage).toHaveBeenCalled();
+          await vi.waitFor(() => {
+            expect(sendMessage).toHaveBeenCalled();
+          });
+          expect(sendMessage.mock.calls[0][1]).toEqual(
+            expect.objectContaining({
+              parentModelRunId: 'mr_main_turn',
+            })
+          );
+        });
       });
-      expect(sendMessage.mock.calls[0][1]).toEqual(
-        expect.objectContaining({
-          parentModelRunId: 'mr_main_turn',
-        })
-      );
     });
 
     it('should only drain notices that were present at peek time', async () => {

--- a/packages/standalone/tests/gateways/message-router.test.ts
+++ b/packages/standalone/tests/gateways/message-router.test.ts
@@ -589,6 +589,40 @@ describe('MessageRouter', () => {
       });
     });
 
+    it('should pass the main model run id as the memory-agent parent model run id', async () => {
+      const agentLoop = {
+        async run(): Promise<{ response: string; modelRunId: string }> {
+          return { response: 'Saved.', modelRunId: 'mr_main_turn' };
+        },
+      };
+      const mamaApi = createMockMamaApi(mockDecisions);
+      const customRouter = new MessageRouter(sessionStore, agentLoop, mamaApi);
+      const sendMessage = vi.fn().mockResolvedValue({
+        response: 'DONE',
+        ack: { status: 'applied', action: 'save', event_ids: [], reason: 'saved' },
+      });
+
+      customRouter.setMemoryAgent({
+        getSharedProcess: vi.fn().mockResolvedValue({ sendMessage }),
+      } as unknown as import('../../src/multi-agent/agent-process-manager.js').AgentProcessManager);
+
+      await customRouter.process({
+        source: 'telegram',
+        channelId: '7026976631',
+        userId: '7026976631',
+        text: 'Use SQLite as the default database going forward. Remember this.',
+      });
+
+      await vi.waitFor(() => {
+        expect(sendMessage).toHaveBeenCalled();
+      });
+      expect(sendMessage.mock.calls[0][1]).toEqual(
+        expect.objectContaining({
+          parentModelRunId: 'mr_main_turn',
+        })
+      );
+    });
+
     it('should only drain notices that were present at peek time', async () => {
       const mamaApi = createMockMamaApi(mockDecisions);
       const agentLoop = {


### PR DESCRIPTION
## Summary
- Add durable `model_runs` and `tool_traces` ledger tables plus mama-core lifecycle/query helpers.
- Thread model-run IDs through AgentLoop, GatewayToolExecutor, memory-agent audit jobs, and trusted memory provenance.
- Record compact tool traces for active/direct gateway calls and harden trace/model-run row validation.

## Review
- CodeRabbit uncommitted review: 0 issues after fixes.

## Test Plan
- `pnpm build`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
- `pnpm -C packages/standalone exec vitest run tests/gateways/message-router.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model run tracking system with full lifecycle management (begin, commit, fail).
  * Added tool execution tracing to record per-tool execution details and metadata.
  * Introduced parent-child model run relationship tracking for improved execution lineage visibility.
  * Added background task registry for coordinated async operations during tool execution.

* **Tests**
  * Added comprehensive test coverage for model run ledger and tool trace functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->