### PR TITLE
feat(m3): add first-class twin edge ledger

### DIFF
--- a/packages/mama-core/db/migrations/035-create-twin-edges.sql
+++ b/packages/mama-core/db/migrations/035-create-twin-edges.sql
@@ -1,0 +1,63 @@
+CREATE TABLE IF NOT EXISTS twin_edges (
+  edge_id TEXT PRIMARY KEY,
+  edge_type TEXT NOT NULL CHECK (
+    edge_type IN (
+      'supersedes',
+      'builds_on',
+      'debates',
+      'synthesizes',
+      'mentions',
+      'derived_from',
+      'case_member',
+      'alias_of',
+      'next_action_for',
+      'blocks'
+    )
+  ),
+  subject_kind TEXT NOT NULL CHECK (
+    subject_kind IN ('memory', 'case', 'entity', 'report', 'edge')
+  ),
+  subject_id TEXT NOT NULL,
+  object_kind TEXT NOT NULL CHECK (
+    object_kind IN ('memory', 'case', 'entity', 'report', 'edge', 'raw')
+  ),
+  object_id TEXT NOT NULL,
+  relation_attrs_json TEXT,
+  confidence REAL NOT NULL DEFAULT 1.0 CHECK (confidence >= 0.0 AND confidence <= 1.0),
+  source TEXT NOT NULL CHECK (source IN ('agent', 'human', 'code')),
+  agent_id TEXT,
+  model_run_id TEXT,
+  envelope_hash TEXT,
+  human_actor_id TEXT,
+  human_actor_role TEXT,
+  authority_scope_json TEXT,
+  reason_classification TEXT,
+  reason_text TEXT,
+  evidence_refs_json TEXT,
+  request_idempotency_key TEXT,
+  edge_idempotency_key TEXT,
+  content_hash BLOB NOT NULL CHECK(length(content_hash)=32),
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_twin_edges_subject
+  ON twin_edges(subject_kind, subject_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_twin_edges_object
+  ON twin_edges(object_kind, object_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_twin_edges_model_run_id
+  ON twin_edges(model_run_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_twin_edges_request_idempotency
+  ON twin_edges(model_run_id, request_idempotency_key, created_at DESC)
+  WHERE model_run_id IS NOT NULL
+    AND request_idempotency_key IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_twin_edges_model_run_edge_idempotency
+  ON twin_edges(model_run_id, edge_idempotency_key)
+  WHERE model_run_id IS NOT NULL
+    AND edge_idempotency_key IS NOT NULL;
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES (35, 'Create first-class twin edge ledger');

--- a/packages/mama-core/package.json
+++ b/packages/mama-core/package.json
@@ -45,7 +45,10 @@
     "./cases/wiki-page-index": "./dist/cases/wiki-page-index.js",
     "./connectors": "./dist/connectors/event-index.js",
     "./connectors/event-index": "./dist/connectors/event-index.js",
-    "./connectors/types": "./dist/connectors/types.js"
+    "./connectors/types": "./dist/connectors/types.js",
+    "./edges/types": "./dist/edges/types.js",
+    "./edges/store": "./dist/edges/store.js",
+    "./edges/ref-validation": "./dist/edges/ref-validation.js"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/mama-core/src/edges/ref-validation.ts
+++ b/packages/mama-core/src/edges/ref-validation.ts
@@ -1,0 +1,244 @@
+import type { DatabaseAdapter } from '../db-manager.js';
+import { getTwinEdge, listTwinEdgesForRefs } from './store.js';
+import type {
+  ListVisibleTwinEdgesOptions,
+  TwinEdgeRecord,
+  TwinRef,
+  TwinScopeRef,
+} from './types.js';
+
+type TwinRefVisibilityAdapter = Pick<DatabaseAdapter, 'prepare'>;
+
+const TABLE_COLUMN_PRAGMAS: Record<string, string> = {
+  decisions: 'PRAGMA table_info(decisions)',
+  case_truth: 'PRAGMA table_info(case_truth)',
+};
+const tableColumnCache = new WeakMap<TwinRefVisibilityAdapter, Map<string, Set<string>>>();
+
+function scopeKey(scope: TwinScopeRef): string {
+  return `${scope.kind}\0${scope.id}`;
+}
+
+function hasScopes(scopes: readonly TwinScopeRef[] | undefined): scopes is TwinScopeRef[] {
+  return Array.isArray(scopes) && scopes.length > 0;
+}
+
+function tableColumns(adapter: TwinRefVisibilityAdapter, table: string): Set<string> {
+  const pragma = TABLE_COLUMN_PRAGMAS[table];
+  if (!pragma) {
+    throw new Error(`Unsupported table for column introspection: ${table}`);
+  }
+
+  let adapterCache = tableColumnCache.get(adapter);
+  if (!adapterCache) {
+    adapterCache = new Map();
+    tableColumnCache.set(adapter, adapterCache);
+  }
+
+  const cached = adapterCache.get(table);
+  if (cached) {
+    return cached;
+  }
+
+  const rows = adapter.prepare(pragma).all() as Array<{ name: string }>;
+  const columns = new Set(rows.map((row) => row.name));
+  adapterCache.set(table, columns);
+  return columns;
+}
+
+function memoryExists(adapter: TwinRefVisibilityAdapter, id: string): boolean {
+  const row = adapter.prepare('SELECT 1 AS ok FROM decisions WHERE id = ? LIMIT 1').get(id) as
+    | { ok: number }
+    | undefined;
+  return Boolean(row?.ok);
+}
+
+function isMemoryVisible(
+  adapter: TwinRefVisibilityAdapter,
+  id: string,
+  scopes: readonly TwinScopeRef[] | undefined
+): boolean {
+  if (!memoryExists(adapter, id)) {
+    return false;
+  }
+  if (!hasScopes(scopes)) {
+    return true;
+  }
+
+  const scopeClauses = scopes.map(() => '(ms.kind = ? AND ms.external_id = ?)').join(' OR ');
+  const params = scopes.flatMap((scope) => [scope.kind, scope.id]);
+  const bindingRow = adapter
+    .prepare(
+      `
+        SELECT 1 AS ok
+        FROM memory_scope_bindings msb
+        JOIN memory_scopes ms ON ms.id = msb.scope_id
+        WHERE msb.memory_id = ?
+          AND (${scopeClauses})
+        LIMIT 1
+      `
+    )
+    .get(id, ...params) as { ok: number } | undefined;
+  if (bindingRow?.ok) {
+    return true;
+  }
+
+  const columns = tableColumns(adapter, 'decisions');
+  if (columns.has('memory_scope_kind') && columns.has('memory_scope_id')) {
+    const row = adapter
+      .prepare(
+        `
+          SELECT 1 AS ok
+          FROM decisions
+          WHERE id = ?
+            AND (${scopes.map(() => '(memory_scope_kind = ? AND memory_scope_id = ?)').join(' OR ')})
+          LIMIT 1
+        `
+      )
+      .get(id, ...params) as { ok: number } | undefined;
+    return Boolean(row?.ok);
+  }
+
+  return false;
+}
+
+function parseCaseScopeRefs(scopeRefs: unknown): TwinScopeRef[] {
+  if (typeof scopeRefs !== 'string' || scopeRefs.length === 0) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(scopeRefs) as unknown;
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter(
+      (item): item is TwinScopeRef =>
+        item !== null &&
+        typeof item === 'object' &&
+        typeof (item as Record<string, unknown>).kind === 'string' &&
+        typeof (item as Record<string, unknown>).id === 'string'
+    );
+  } catch {
+    return [];
+  }
+}
+
+function isCaseVisible(
+  adapter: TwinRefVisibilityAdapter,
+  id: string,
+  scopes: readonly TwinScopeRef[] | undefined
+): boolean {
+  const row = adapter.prepare('SELECT * FROM case_truth WHERE case_id = ? LIMIT 1').get(id) as
+    | Record<string, unknown>
+    | undefined;
+  if (!row) {
+    return false;
+  }
+  if (!hasScopes(scopes)) {
+    return true;
+  }
+
+  const requested = new Set(scopes.map(scopeKey));
+  const scopeRefs = parseCaseScopeRefs(row.scope_refs);
+  if (scopeRefs.some((scope) => requested.has(scopeKey(scope)))) {
+    return true;
+  }
+
+  const columns = tableColumns(adapter, 'case_truth');
+  if (columns.has('memory_scope_kind') && columns.has('memory_scope_id')) {
+    return scopes.some(
+      (scope) => row.memory_scope_kind === scope.kind && row.memory_scope_id === scope.id
+    );
+  }
+
+  return false;
+}
+
+function isRawVisible(
+  adapter: TwinRefVisibilityAdapter,
+  id: string,
+  scopes: readonly TwinScopeRef[] | undefined
+): boolean {
+  const row = adapter
+    .prepare('SELECT * FROM connector_event_index WHERE event_index_id = ? LIMIT 1')
+    .get(id) as Record<string, unknown> | undefined;
+  if (!row) {
+    return false;
+  }
+  if (!hasScopes(scopes)) {
+    return true;
+  }
+  return scopes.some(
+    (scope) => row.memory_scope_kind === scope.kind && row.memory_scope_id === scope.id
+  );
+}
+
+function isTwinRefVisible(
+  adapter: TwinRefVisibilityAdapter,
+  ref: TwinRef,
+  scopes: readonly TwinScopeRef[] | undefined,
+  visitedEdges: Set<string>,
+  edgeCache: Map<string, TwinEdgeRecord | null>
+): boolean {
+  if (ref.kind === 'entity' || ref.kind === 'report') {
+    return !hasScopes(scopes);
+  }
+  if (ref.kind === 'memory') {
+    return isMemoryVisible(adapter, ref.id, scopes);
+  }
+  if (ref.kind === 'case') {
+    return isCaseVisible(adapter, ref.id, scopes);
+  }
+  if (ref.kind === 'raw') {
+    return isRawVisible(adapter, ref.id, scopes);
+  }
+
+  if (visitedEdges.has(ref.id)) {
+    return false;
+  }
+  let edge = edgeCache.get(ref.id);
+  if (edge === undefined) {
+    edge = getTwinEdge(adapter, ref.id);
+    edgeCache.set(ref.id, edge);
+  }
+  if (!edge) {
+    return false;
+  }
+  const pathWithCurrent = new Set(visitedEdges);
+  pathWithCurrent.add(ref.id);
+  return (
+    isTwinRefVisible(adapter, edge.subject_ref, scopes, new Set(pathWithCurrent), edgeCache) &&
+    isTwinRefVisible(adapter, edge.object_ref, scopes, new Set(pathWithCurrent), edgeCache)
+  );
+}
+
+export function assertTwinRefsVisibleToScopes(
+  adapter: TwinRefVisibilityAdapter,
+  refs: readonly TwinRef[],
+  scopes?: TwinScopeRef[]
+): void {
+  const edgeCache = new Map<string, TwinEdgeRecord | null>();
+  for (const ref of refs) {
+    if (!isTwinRefVisible(adapter, ref, scopes, new Set(), edgeCache)) {
+      throw new Error(`Twin ref is not visible to requested scopes: ${ref.kind}:${ref.id}`);
+    }
+  }
+}
+
+export function listVisibleTwinEdgesForRefs(
+  adapter: TwinRefVisibilityAdapter,
+  refs: readonly TwinRef[],
+  options: ListVisibleTwinEdgesOptions = {}
+): TwinEdgeRecord[] {
+  const edgeCache = new Map<string, TwinEdgeRecord | null>();
+  const edges = listTwinEdgesForRefs(adapter, refs).filter(
+    (edge) =>
+      isTwinRefVisible(adapter, edge.subject_ref, options.scopes, new Set(), edgeCache) &&
+      isTwinRefVisible(adapter, edge.object_ref, options.scopes, new Set(), edgeCache)
+  );
+  const limit =
+    typeof options.limit === 'number' && Number.isFinite(options.limit)
+      ? Math.max(0, Math.floor(options.limit))
+      : edges.length;
+  return edges.slice(0, limit);
+}

--- a/packages/mama-core/src/edges/store.ts
+++ b/packages/mama-core/src/edges/store.ts
@@ -1,0 +1,456 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+import { canonicalizeJSON } from '../canonicalize.js';
+import type { DatabaseAdapter } from '../db-manager.js';
+import {
+  TWIN_EDGE_SOURCES,
+  TWIN_EDGE_TYPES,
+  TWIN_REF_KINDS,
+  type InsertTwinEdgeInput,
+  type TwinEdgeRecord,
+  type TwinEdgeSource,
+  type TwinEdgeSubjectRef,
+  type TwinEdgeType,
+  type TwinRef,
+  type TwinRefKind,
+} from './types.js';
+
+type TwinEdgeReadAdapter = Pick<DatabaseAdapter, 'prepare'>;
+type TwinEdgeAdapter = Pick<DatabaseAdapter, 'prepare' | 'transaction'>;
+
+const EDGE_TYPE_SET = new Set<string>(TWIN_EDGE_TYPES);
+const REF_KIND_SET = new Set<string>(TWIN_REF_KINDS);
+const SOURCE_SET = new Set<string>(TWIN_EDGE_SOURCES);
+const HUMAN_ACTOR_ROLES = new Set(['commander', 'configurator_elevated']);
+const HUMAN_REASON_CLASSIFICATIONS = new Set([
+  'factual_correction',
+  'agent_inference_wrong',
+  'privacy_redaction',
+  'duplicate_merge',
+  'state_override',
+  'other',
+]);
+
+function sha256Hex(input: string): string {
+  return createHash('sha256').update(input, 'utf8').digest('hex');
+}
+
+function sha256Buffer(input: string): Buffer {
+  return createHash('sha256').update(input, 'utf8').digest();
+}
+
+function generatedEdgeId(): string {
+  return `edge_${randomUUID().replace(/-/g, '')}`;
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function requireNonEmptyString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`twin_edges.${field} must be a non-empty string`);
+  }
+  return value;
+}
+
+function normalizeEdgeType(value: unknown): TwinEdgeType {
+  if (typeof value === 'string' && EDGE_TYPE_SET.has(value)) {
+    return value as TwinEdgeType;
+  }
+  throw new Error(`Unsupported twin edge type: ${String(value)}`);
+}
+
+function normalizeSource(value: unknown): TwinEdgeSource {
+  if (typeof value === 'string' && SOURCE_SET.has(value)) {
+    return value as TwinEdgeSource;
+  }
+  throw new Error(`Unsupported twin edge source: ${String(value)}`);
+}
+
+function normalizeRef(ref: TwinRef, field: string): TwinRef {
+  if (!ref || typeof ref !== 'object') {
+    throw new Error(`${field} must be a TwinRef`);
+  }
+  if (!REF_KIND_SET.has(ref.kind)) {
+    throw new Error(`${field}.kind is unsupported: ${String(ref.kind)}`);
+  }
+  return {
+    kind: ref.kind,
+    id: requireNonEmptyString(ref.id, `${field}.id`),
+  } as TwinRef;
+}
+
+function assertSubjectKindAllowed(ref: TwinRef): asserts ref is TwinEdgeSubjectRef {
+  if (ref.kind === 'raw') {
+    throw new Error('twin_edges.subject_ref.kind cannot be raw');
+  }
+}
+
+function normalizeConfidence(value: unknown): number {
+  if (value === undefined || value === null) {
+    return 1;
+  }
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1) {
+    return value;
+  }
+  throw new Error(`twin_edges.confidence must be between 0 and 1: ${String(value)}`);
+}
+
+function hasDeterministicRule(value: unknown): boolean {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    typeof (value as Record<string, unknown>).deterministic_rule === 'string' &&
+    ((value as Record<string, unknown>).deterministic_rule as string).length > 0
+  );
+}
+
+function validateSourceMetadata(input: InsertTwinEdgeInput, source: TwinEdgeSource): void {
+  if (source === 'agent') {
+    requireNonEmptyString(input.agent_id, 'agent_id');
+    requireNonEmptyString(input.model_run_id, 'model_run_id');
+    requireNonEmptyString(input.envelope_hash, 'envelope_hash');
+    return;
+  }
+
+  if (source === 'human') {
+    requireNonEmptyString(input.human_actor_id, 'human_actor_id');
+    const role = requireNonEmptyString(input.human_actor_role, 'human_actor_role');
+    if (!HUMAN_ACTOR_ROLES.has(role)) {
+      throw new Error(`Unsupported twin_edges.human_actor_role: ${role}`);
+    }
+    if (input.authority_scope_json === undefined || input.authority_scope_json === null) {
+      throw new Error('twin_edges.authority_scope_json is required for human edges');
+    }
+    const classification = requireNonEmptyString(
+      input.reason_classification,
+      'reason_classification'
+    );
+    if (!HUMAN_REASON_CLASSIFICATIONS.has(classification)) {
+      throw new Error(`Unsupported twin_edges.reason_classification: ${classification}`);
+    }
+    return;
+  }
+
+  if (!nullableString(input.reason_text) && !hasDeterministicRule(input.relation_attrs)) {
+    throw new Error(
+      'twin_edges.reason_text or relation_attrs.deterministic_rule is required for code edges'
+    );
+  }
+}
+
+function jsonField(value: unknown, field: string): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  try {
+    if (typeof value === 'string') {
+      return canonicalizeJSON(JSON.parse(value) as unknown);
+    }
+    return canonicalizeJSON(value);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid twin_edges.${field}: ${message}`);
+  }
+}
+
+function parseJsonField(value: unknown, field: string, edgeId: string): unknown | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const text = String(value);
+  if (text.length === 0) {
+    return null;
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid twin_edges.${field} for ${edgeId}: ${message}`);
+  }
+}
+
+function toBuffer(value: unknown): Buffer {
+  if (Buffer.isBuffer(value)) {
+    return value;
+  }
+  if (value instanceof Uint8Array) {
+    return Buffer.from(value);
+  }
+  throw new Error('twin_edges.content_hash must be a 32-byte Buffer');
+}
+
+function exists(adapter: TwinEdgeReadAdapter, table: string, column: string, id: string): boolean {
+  const row = adapter
+    .prepare(`SELECT 1 AS ok FROM ${table} WHERE ${column} = ? LIMIT 1`)
+    .get(id) as { ok: number } | undefined;
+  return Boolean(row?.ok);
+}
+
+function validateRefExists(adapter: TwinEdgeReadAdapter, ref: TwinRef, field: string): void {
+  if (ref.kind === 'entity' || ref.kind === 'report') {
+    throw new Error(`${field} ${ref.kind}:${ref.id} is not supported by twin_edges yet`);
+  }
+
+  const found =
+    (ref.kind === 'memory' && exists(adapter, 'decisions', 'id', ref.id)) ||
+    (ref.kind === 'case' && exists(adapter, 'case_truth', 'case_id', ref.id)) ||
+    (ref.kind === 'edge' && exists(adapter, 'twin_edges', 'edge_id', ref.id)) ||
+    (ref.kind === 'raw' && exists(adapter, 'connector_event_index', 'event_index_id', ref.id));
+
+  if (!found) {
+    throw new Error(`${field} not found: ${ref.kind}:${ref.id}`);
+  }
+}
+
+function contentHashInput(input: {
+  edge_type: TwinEdgeType;
+  subject_ref: TwinRef;
+  object_ref: TwinRef;
+  relation_attrs_json: string | null;
+  confidence: number;
+  source: TwinEdgeSource;
+  agent_id: string | null;
+  model_run_id: string | null;
+  envelope_hash: string | null;
+  human_actor_id: string | null;
+  human_actor_role: string | null;
+  authority_scope_json: string | null;
+  reason_classification: string | null;
+  reason_text: string | null;
+  evidence_refs_json: string | null;
+}): string {
+  return canonicalizeJSON(input);
+}
+
+function deriveEdgeIdempotencyKey(requestIdempotencyKey: string, contentHash: Buffer): string {
+  return `reqedge_${sha256Hex(
+    canonicalizeJSON({
+      request_idempotency_key: requestIdempotencyKey,
+      content_hash: contentHash.toString('hex'),
+    })
+  ).slice(0, 40)}`;
+}
+
+function selectByIdempotency(
+  adapter: TwinEdgeReadAdapter,
+  modelRunId: string | null,
+  edgeIdempotencyKey: string | null
+): TwinEdgeRecord | null {
+  if (!edgeIdempotencyKey) {
+    return null;
+  }
+  if (!modelRunId) {
+    const row = adapter
+      .prepare(
+        `
+          SELECT *
+          FROM twin_edges
+          WHERE model_run_id IS NULL
+            AND edge_idempotency_key = ?
+          ORDER BY created_at ASC, edge_id ASC
+          LIMIT 1
+        `
+      )
+      .get(edgeIdempotencyKey) as Record<string, unknown> | undefined;
+    return row ? mapTwinEdgeRow(row) : null;
+  }
+  const row = adapter
+    .prepare(
+      `
+        SELECT *
+        FROM twin_edges
+        WHERE model_run_id = ?
+          AND edge_idempotency_key = ?
+        LIMIT 1
+      `
+    )
+    .get(modelRunId, edgeIdempotencyKey) as Record<string, unknown> | undefined;
+  return row ? mapTwinEdgeRow(row) : null;
+}
+
+export function mapTwinEdgeRow(row: Record<string, unknown>): TwinEdgeRecord {
+  const edgeId = String(row.edge_id);
+  return {
+    edge_id: edgeId,
+    edge_type: normalizeEdgeType(row.edge_type),
+    subject_ref: {
+      kind: String(row.subject_kind) as TwinRefKind,
+      id: String(row.subject_id),
+    } as TwinRef,
+    object_ref: {
+      kind: String(row.object_kind) as TwinRefKind,
+      id: String(row.object_id),
+    } as TwinRef,
+    relation_attrs_json: nullableString(row.relation_attrs_json),
+    relation_attrs: parseJsonField(row.relation_attrs_json, 'relation_attrs_json', edgeId),
+    confidence: Number(row.confidence),
+    source: normalizeSource(row.source),
+    agent_id: nullableString(row.agent_id),
+    model_run_id: nullableString(row.model_run_id),
+    envelope_hash: nullableString(row.envelope_hash),
+    human_actor_id: nullableString(row.human_actor_id),
+    human_actor_role: nullableString(row.human_actor_role),
+    authority_scope_json: nullableString(row.authority_scope_json),
+    authority_scope: parseJsonField(row.authority_scope_json, 'authority_scope_json', edgeId),
+    reason_classification: nullableString(row.reason_classification),
+    reason_text: nullableString(row.reason_text),
+    evidence_refs_json: nullableString(row.evidence_refs_json),
+    evidence_refs: parseJsonField(row.evidence_refs_json, 'evidence_refs_json', edgeId),
+    request_idempotency_key: nullableString(row.request_idempotency_key),
+    edge_idempotency_key: nullableString(row.edge_idempotency_key),
+    content_hash: toBuffer(row.content_hash),
+    created_at: Number(row.created_at),
+  };
+}
+
+export function getTwinEdge(adapter: TwinEdgeReadAdapter, edgeId: string): TwinEdgeRecord | null {
+  const row = adapter.prepare('SELECT * FROM twin_edges WHERE edge_id = ?').get(edgeId) as
+    | Record<string, unknown>
+    | undefined;
+  return row ? mapTwinEdgeRow(row) : null;
+}
+
+export function listTwinEdgesForRefs(
+  adapter: TwinEdgeReadAdapter,
+  refs: readonly TwinRef[]
+): TwinEdgeRecord[] {
+  const normalizedRefs = refs.map((ref, index) => normalizeRef(ref, `refs[${index}]`));
+  if (normalizedRefs.length === 0) {
+    return [];
+  }
+  const clauses: string[] = [];
+  const params: string[] = [];
+  for (const ref of normalizedRefs) {
+    clauses.push('(subject_kind = ? AND subject_id = ?)');
+    params.push(ref.kind, ref.id);
+    clauses.push('(object_kind = ? AND object_id = ?)');
+    params.push(ref.kind, ref.id);
+  }
+  const rows = adapter
+    .prepare(
+      `
+        SELECT *
+        FROM twin_edges
+        WHERE ${clauses.join(' OR ')}
+        ORDER BY created_at ASC, edge_id ASC
+      `
+    )
+    .all(...params) as Array<Record<string, unknown>>;
+  return rows.map(mapTwinEdgeRow);
+}
+
+export function insertTwinEdge(
+  adapter: TwinEdgeAdapter,
+  input: InsertTwinEdgeInput
+): TwinEdgeRecord {
+  const edgeType = normalizeEdgeType(input.edge_type);
+  const subjectRef = normalizeRef(input.subject_ref, 'subject_ref');
+  const objectRef = normalizeRef(input.object_ref, 'object_ref');
+  assertSubjectKindAllowed(subjectRef);
+  const source = normalizeSource(input.source);
+  const confidence = normalizeConfidence(input.confidence);
+
+  validateSourceMetadata(input, source);
+  validateRefExists(adapter, subjectRef, 'subject_ref');
+  validateRefExists(adapter, objectRef, 'object_ref');
+
+  const relationAttrsJson = jsonField(input.relation_attrs, 'relation_attrs_json');
+  const evidenceRefsJson = jsonField(input.evidence_refs, 'evidence_refs_json');
+  const authorityScopeJson = jsonField(input.authority_scope_json, 'authority_scope_json');
+  const agentId = nullableString(input.agent_id);
+  const reasonText = nullableString(input.reason_text);
+  const envelopeHash = nullableString(input.envelope_hash);
+  const humanActorId = nullableString(input.human_actor_id);
+  const humanActorRole = nullableString(input.human_actor_role);
+  const reasonClassification = nullableString(input.reason_classification);
+  const requestIdempotencyKey = nullableString(input.request_idempotency_key);
+  const modelRunId = nullableString(input.model_run_id);
+
+  const contentHash = sha256Buffer(
+    contentHashInput({
+      edge_type: edgeType,
+      subject_ref: subjectRef,
+      object_ref: objectRef,
+      relation_attrs_json: relationAttrsJson,
+      confidence,
+      source,
+      agent_id: agentId,
+      model_run_id: modelRunId,
+      envelope_hash: envelopeHash,
+      human_actor_id: humanActorId,
+      human_actor_role: humanActorRole,
+      authority_scope_json: authorityScopeJson,
+      reason_classification: reasonClassification,
+      reason_text: reasonText,
+      evidence_refs_json: evidenceRefsJson,
+    })
+  );
+  const edgeIdempotencyKey =
+    nullableString(input.edge_idempotency_key) ??
+    (requestIdempotencyKey ? deriveEdgeIdempotencyKey(requestIdempotencyKey, contentHash) : null);
+
+  const existing = selectByIdempotency(adapter, modelRunId, edgeIdempotencyKey);
+  if (existing) {
+    return existing;
+  }
+
+  const edgeId = nullableString(input.edge_id) ?? generatedEdgeId();
+  const createdAt = Date.now();
+
+  try {
+    return adapter.transaction(() => {
+      adapter
+        .prepare(
+          `
+            INSERT INTO twin_edges (
+              edge_id, edge_type, subject_kind, subject_id, object_kind, object_id,
+              relation_attrs_json, confidence, source, agent_id, model_run_id, envelope_hash,
+              human_actor_id, human_actor_role, authority_scope_json, reason_classification,
+              reason_text, evidence_refs_json, request_idempotency_key, edge_idempotency_key,
+              content_hash, created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `
+        )
+        .run(
+          edgeId,
+          edgeType,
+          subjectRef.kind,
+          subjectRef.id,
+          objectRef.kind,
+          objectRef.id,
+          relationAttrsJson,
+          confidence,
+          source,
+          agentId,
+          modelRunId,
+          envelopeHash,
+          humanActorId,
+          humanActorRole,
+          authorityScopeJson,
+          reasonClassification,
+          reasonText,
+          evidenceRefsJson,
+          requestIdempotencyKey,
+          edgeIdempotencyKey,
+          contentHash,
+          createdAt
+        );
+
+      const inserted = getTwinEdge(adapter, edgeId);
+      if (!inserted) {
+        throw new Error(`Failed to load inserted twin edge: ${edgeId}`);
+      }
+      return inserted;
+    });
+  } catch (error) {
+    const duplicate = selectByIdempotency(adapter, modelRunId, edgeIdempotencyKey);
+    if (duplicate) {
+      return duplicate;
+    }
+    throw error;
+  }
+}

--- a/packages/mama-core/src/edges/types.ts
+++ b/packages/mama-core/src/edges/types.ts
@@ -1,0 +1,100 @@
+import type { Buffer } from 'node:buffer';
+
+export const TWIN_REF_KINDS = ['memory', 'case', 'entity', 'report', 'edge', 'raw'] as const;
+export type TwinRefKind = (typeof TWIN_REF_KINDS)[number];
+
+export const TWIN_EDGE_SOURCES = ['agent', 'human', 'code'] as const;
+export type TwinEdgeSource = (typeof TWIN_EDGE_SOURCES)[number];
+
+export const TWIN_EDGE_TYPES = [
+  'supersedes',
+  'builds_on',
+  'debates',
+  'synthesizes',
+  'mentions',
+  'derived_from',
+  'case_member',
+  'alias_of',
+  'next_action_for',
+  'blocks',
+] as const;
+export type TwinEdgeType = (typeof TWIN_EDGE_TYPES)[number];
+
+export type TwinRef = {
+  [Kind in TwinRefKind]: {
+    kind: Kind;
+    id: string;
+  };
+}[TwinRefKind];
+
+export type TwinEdgeSubjectRef = Exclude<TwinRef, { kind: 'raw' }>;
+
+export interface TwinScopeRef {
+  kind: 'global' | 'user' | 'channel' | 'project';
+  id: string;
+}
+
+export interface InsertTwinEdgeInput {
+  edge_id?: string;
+  edge_type: TwinEdgeType;
+  subject_ref: TwinEdgeSubjectRef;
+  object_ref: TwinRef;
+  relation_attrs?: unknown;
+  confidence?: number;
+  source: TwinEdgeSource;
+  agent_id?: string;
+  model_run_id?: string;
+  envelope_hash?: string;
+  request_idempotency_key?: string;
+  edge_idempotency_key?: string;
+  human_actor_id?: string;
+  human_actor_role?: 'commander' | 'configurator_elevated';
+  authority_scope_json?: unknown;
+  reason_classification?:
+    | 'factual_correction'
+    | 'agent_inference_wrong'
+    | 'privacy_redaction'
+    | 'duplicate_merge'
+    | 'state_override'
+    | 'other';
+  reason_text?: string;
+  evidence_refs?: unknown;
+}
+
+export interface TwinEdgeRecord {
+  edge_id: string;
+  edge_type: TwinEdgeType;
+  subject_ref: TwinRef;
+  object_ref: TwinRef;
+  relation_attrs_json: string | null;
+  relation_attrs: unknown | null;
+  confidence: number;
+  source: TwinEdgeSource;
+  agent_id: string | null;
+  model_run_id: string | null;
+  envelope_hash: string | null;
+  human_actor_id: string | null;
+  human_actor_role: string | null;
+  authority_scope_json: string | null;
+  authority_scope: unknown | null;
+  reason_classification: string | null;
+  reason_text: string | null;
+  evidence_refs_json: string | null;
+  evidence_refs: unknown | null;
+  request_idempotency_key: string | null;
+  edge_idempotency_key: string | null;
+  content_hash: Buffer;
+  created_at: number;
+}
+
+export interface ListVisibleTwinEdgesOptions {
+  scopes?: TwinScopeRef[];
+  limit?: number;
+}
+
+type AssertFalse<T extends false> = T;
+type IsAssignable<T, U> = T extends U ? true : false;
+type RawSubjectRef = { kind: 'raw'; id: string };
+type _RawSubjectRefIsNotAssignable = AssertFalse<
+  IsAssignable<RawSubjectRef, InsertTwinEdgeInput['subject_ref']>
+>;

--- a/packages/mama-core/src/index.ts
+++ b/packages/mama-core/src/index.ts
@@ -167,6 +167,29 @@ export {
 } from './model-runs/types.js';
 export { beginModelRun, commitModelRun, failModelRun, getModelRun } from './model-runs/store.js';
 export { appendToolTrace, listToolTracesForRun } from './model-runs/tool-trace-store.js';
+export {
+  TWIN_EDGE_SOURCES,
+  TWIN_EDGE_TYPES,
+  TWIN_REF_KINDS,
+  type InsertTwinEdgeInput,
+  type ListVisibleTwinEdgesOptions,
+  type TwinEdgeRecord,
+  type TwinEdgeSource,
+  type TwinEdgeType,
+  type TwinRef,
+  type TwinRefKind,
+  type TwinScopeRef,
+} from './edges/types.js';
+export {
+  getTwinEdge,
+  insertTwinEdge,
+  listTwinEdgesForRefs,
+  mapTwinEdgeRow,
+} from './edges/store.js';
+export {
+  assertTwinRefsVisibleToScopes,
+  listVisibleTwinEdgesForRefs,
+} from './edges/ref-validation.js';
 export * from './entities/types.js';
 export * from './entities/errors.js';
 export * from './entities/store.js';

--- a/packages/mama-core/tests/cases/migration-chain.test.ts
+++ b/packages/mama-core/tests/cases/migration-chain.test.ts
@@ -291,4 +291,78 @@ describe('Case-First Memory Substrate (migration 030, consolidated Phase 1+2+3)'
 
     db.close();
   });
+
+  it('records migration 035 twin edge ledger table and indexes', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyAll(db);
+
+    expect(tableExists(db, 'twin_edges')).toBe(true);
+
+    const sql = (
+      db
+        .prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='twin_edges'")
+        .get() as { sql: string }
+    ).sql;
+    for (const edgeType of [
+      'supersedes',
+      'builds_on',
+      'debates',
+      'synthesizes',
+      'mentions',
+      'derived_from',
+      'case_member',
+      'alias_of',
+      'next_action_for',
+      'blocks',
+    ]) {
+      expect(sql).toContain(edgeType);
+    }
+    expect(sql).toMatch(/subject_kind\s+TEXT\s+NOT\s+NULL\s+CHECK/i);
+    expect(sql).toMatch(/object_kind\s+TEXT\s+NOT\s+NULL\s+CHECK/i);
+    expect(sql).toMatch(
+      /content_hash\s+BLOB\s+NOT\s+NULL\s+CHECK\s*\(\s*length\s*\(\s*content_hash\s*\)\s*=\s*32\s*\)/i
+    );
+
+    for (const column of [
+      'edge_id',
+      'edge_type',
+      'subject_kind',
+      'subject_id',
+      'object_kind',
+      'object_id',
+      'relation_attrs_json',
+      'confidence',
+      'source',
+      'agent_id',
+      'model_run_id',
+      'envelope_hash',
+      'human_actor_id',
+      'human_actor_role',
+      'authority_scope_json',
+      'reason_classification',
+      'reason_text',
+      'evidence_refs_json',
+      'request_idempotency_key',
+      'edge_idempotency_key',
+      'content_hash',
+      'created_at',
+    ]) {
+      expect(columnExists(db, 'twin_edges', column)).toBe(true);
+    }
+
+    expect(indexExists(db, 'idx_twin_edges_subject')).toBe(true);
+    expect(indexExists(db, 'idx_twin_edges_object')).toBe(true);
+    expect(indexExists(db, 'idx_twin_edges_model_run_id')).toBe(true);
+    expect(indexExists(db, 'idx_twin_edges_request_idempotency')).toBe(true);
+    expect(indexExists(db, 'ux_twin_edges_model_run_edge_idempotency')).toBe(true);
+
+    const row = db
+      .prepare('SELECT version, description FROM schema_version WHERE version = 35')
+      .get() as { version: number; description: string } | undefined;
+    expect(row?.version).toBe(35);
+    expect(row?.description).toContain('twin edge ledger');
+
+    db.close();
+  });
 });

--- a/packages/mama-core/tests/edges/twin-edge-store.test.ts
+++ b/packages/mama-core/tests/edges/twin-edge-store.test.ts
@@ -1,0 +1,308 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { getAdapter } from '../../src/db-manager.js';
+import { insertTwinEdge } from '../../src/edges/store.js';
+import { upsertConnectorEventIndex } from '../../src/connectors/event-index.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+
+function insertMemory(id: string): void {
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO decisions (id, topic, decision, reasoning, confidence, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(id, `topic-${id}`, `decision-${id}`, `reasoning-${id}`, 0.8, 1_000, 1_000);
+}
+
+function insertRaw(id: string): string {
+  return upsertConnectorEventIndex(getAdapter(), {
+    source_connector: 'slack',
+    source_type: 'message',
+    source_id: id,
+    content: `raw content ${id}`,
+    event_datetime: 1_000,
+  }).event_index_id;
+}
+
+function twinEdgeCount(): number {
+  const row = getAdapter().prepare('SELECT COUNT(*) AS count FROM twin_edges').get() as {
+    count: number;
+  };
+  return row.count;
+}
+
+describe('Story M3.1: Twin Edge Ledger', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('twin-edge-store');
+  });
+
+  beforeEach(() => {
+    const adapter = getAdapter();
+    adapter.prepare('DELETE FROM twin_edges').run();
+    adapter.prepare('DELETE FROM connector_event_index').run();
+    adapter.prepare('DELETE FROM decisions').run();
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  describe('AC #1: typed memory->raw derived_from edge insert/read', () => {
+    it('inserts a typed edge and returns parsed JSON plus a 32-byte content hash', () => {
+      insertMemory('mem-derived');
+      const rawId = insertRaw('raw-derived');
+
+      const edge = insertTwinEdge(getAdapter(), {
+        edge_type: 'derived_from',
+        subject_ref: { kind: 'memory', id: 'mem-derived' },
+        object_ref: { kind: 'raw', id: rawId },
+        relation_attrs: { excerpt: 'source line' },
+        confidence: 0.92,
+        source: 'code',
+        reason_text: 'deterministic replay from connector payload',
+        evidence_refs: [{ kind: 'raw', id: rawId }],
+      });
+
+      expect(edge).toMatchObject({
+        edge_type: 'derived_from',
+        subject_ref: { kind: 'memory', id: 'mem-derived' },
+        object_ref: { kind: 'raw', id: rawId },
+        relation_attrs: { excerpt: 'source line' },
+        confidence: 0.92,
+        source: 'code',
+        reason_text: 'deterministic replay from connector payload',
+        evidence_refs: [{ kind: 'raw', id: rawId }],
+      });
+      expect(edge.content_hash).toBeInstanceOf(Buffer);
+      expect(edge.content_hash.byteLength).toBe(32);
+    });
+  });
+
+  describe('AC #2: model-run edge idempotency', () => {
+    it('returns the existing edge for the same model run and edge idempotency key', () => {
+      insertMemory('mem-agent');
+      const rawId = insertRaw('raw-agent');
+
+      const first = insertTwinEdge(getAdapter(), {
+        edge_id: 'edge_first',
+        edge_type: 'derived_from',
+        subject_ref: { kind: 'memory', id: 'mem-agent' },
+        object_ref: { kind: 'raw', id: rawId },
+        source: 'agent',
+        agent_id: 'agent-m3',
+        model_run_id: 'mr-1',
+        envelope_hash: 'env-1',
+        edge_idempotency_key: 'edge-key-1',
+      });
+
+      const second = insertTwinEdge(getAdapter(), {
+        edge_id: 'edge_second',
+        edge_type: 'derived_from',
+        subject_ref: { kind: 'memory', id: 'mem-agent' },
+        object_ref: { kind: 'raw', id: rawId },
+        source: 'agent',
+        agent_id: 'agent-m3',
+        model_run_id: 'mr-1',
+        envelope_hash: 'env-1',
+        edge_idempotency_key: 'edge-key-1',
+      });
+
+      expect(second.edge_id).toBe(first.edge_id);
+      expect(second.edge_id).toBe('edge_first');
+      expect(twinEdgeCount()).toBe(1);
+    });
+
+    it('returns the existing edge for a null-model-run idempotent retry', () => {
+      insertMemory('mem-null-model-run');
+      const rawId = insertRaw('raw-null-model-run');
+
+      const first = insertTwinEdge(getAdapter(), {
+        edge_id: 'edge_null_model_first',
+        edge_type: 'derived_from',
+        subject_ref: { kind: 'memory', id: 'mem-null-model-run' },
+        object_ref: { kind: 'raw', id: rawId },
+        source: 'code',
+        reason_text: 'connector replay',
+        edge_idempotency_key: 'edge-key-null-model',
+      });
+
+      const second = insertTwinEdge(getAdapter(), {
+        edge_id: 'edge_null_model_second',
+        edge_type: 'derived_from',
+        subject_ref: { kind: 'memory', id: 'mem-null-model-run' },
+        object_ref: { kind: 'raw', id: rawId },
+        source: 'code',
+        reason_text: 'connector replay',
+        edge_idempotency_key: 'edge-key-null-model',
+      });
+
+      expect(second.edge_id).toBe(first.edge_id);
+      expect(twinEdgeCount()).toBe(1);
+    });
+  });
+
+  describe('AC #3: request idempotency key derives distinct per-edge keys', () => {
+    it('allows one request idempotency key to write five distinct edges', () => {
+      insertMemory('mem-request');
+
+      const edges = Array.from({ length: 5 }, (_, index) => {
+        const rawId = insertRaw(`raw-request-${index}`);
+        return insertTwinEdge(getAdapter(), {
+          edge_type: 'derived_from',
+          subject_ref: { kind: 'memory', id: 'mem-request' },
+          object_ref: { kind: 'raw', id: rawId },
+          relation_attrs: { ordinal: index },
+          source: 'code',
+          reason_text: 'batch connector replay',
+          request_idempotency_key: 'request-1',
+        });
+      });
+
+      expect(twinEdgeCount()).toBe(5);
+      expect(new Set(edges.map((edge) => edge.edge_idempotency_key)).size).toBe(5);
+      expect(edges.map((edge) => edge.request_idempotency_key)).toEqual([
+        'request-1',
+        'request-1',
+        'request-1',
+        'request-1',
+        'request-1',
+      ]);
+    });
+
+    it('derives distinct keys when persisted agent audit metadata differs', () => {
+      insertMemory('mem-agent-audit');
+      const rawId = insertRaw('raw-agent-audit');
+
+      const first = insertTwinEdge(getAdapter(), {
+        edge_id: 'edge_agent_audit_first',
+        edge_type: 'derived_from',
+        subject_ref: { kind: 'memory', id: 'mem-agent-audit' },
+        object_ref: { kind: 'raw', id: rawId },
+        source: 'agent',
+        agent_id: 'agent-a',
+        model_run_id: 'mr-audit',
+        envelope_hash: 'env-a',
+        request_idempotency_key: 'request-audit',
+      });
+      const second = insertTwinEdge(getAdapter(), {
+        edge_id: 'edge_agent_audit_second',
+        edge_type: 'derived_from',
+        subject_ref: { kind: 'memory', id: 'mem-agent-audit' },
+        object_ref: { kind: 'raw', id: rawId },
+        source: 'agent',
+        agent_id: 'agent-b',
+        model_run_id: 'mr-audit',
+        envelope_hash: 'env-b',
+        request_idempotency_key: 'request-audit',
+      });
+
+      expect(second.edge_id).toBe('edge_agent_audit_second');
+      expect(second.edge_idempotency_key).not.toBe(first.edge_idempotency_key);
+      expect(twinEdgeCount()).toBe(2);
+    });
+
+    it('derives distinct keys when persisted human audit metadata differs', () => {
+      insertMemory('mem-human-audit');
+      const rawId = insertRaw('raw-human-audit');
+
+      const first = insertTwinEdge(getAdapter(), {
+        edge_id: 'edge_human_audit_first',
+        edge_type: 'derived_from',
+        subject_ref: { kind: 'memory', id: 'mem-human-audit' },
+        object_ref: { kind: 'raw', id: rawId },
+        source: 'human',
+        human_actor_id: 'user-a',
+        human_actor_role: 'commander',
+        authority_scope_json: { scopes: [{ kind: 'project', id: 'alpha' }] },
+        reason_classification: 'factual_correction',
+        request_idempotency_key: 'request-human-audit',
+      });
+      const second = insertTwinEdge(getAdapter(), {
+        edge_id: 'edge_human_audit_second',
+        edge_type: 'derived_from',
+        subject_ref: { kind: 'memory', id: 'mem-human-audit' },
+        object_ref: { kind: 'raw', id: rawId },
+        source: 'human',
+        human_actor_id: 'user-b',
+        human_actor_role: 'configurator_elevated',
+        authority_scope_json: { scopes: [{ kind: 'project', id: 'beta' }] },
+        reason_classification: 'state_override',
+        request_idempotency_key: 'request-human-audit',
+      });
+
+      expect(second.edge_id).toBe('edge_human_audit_second');
+      expect(second.edge_idempotency_key).not.toBe(first.edge_idempotency_key);
+      expect(twinEdgeCount()).toBe(2);
+    });
+  });
+
+  describe('AC #4: source-specific metadata validation', () => {
+    it('rejects a human edge without authority metadata before inserting a row', () => {
+      insertMemory('mem-human');
+      const rawId = insertRaw('raw-human');
+
+      expect(() =>
+        insertTwinEdge(getAdapter(), {
+          edge_type: 'derived_from',
+          subject_ref: { kind: 'memory', id: 'mem-human' },
+          object_ref: { kind: 'raw', id: rawId },
+          source: 'human',
+          human_actor_id: 'user-1',
+        })
+      ).toThrow(/human_actor_role|authority_scope_json|reason_classification/i);
+      expect(twinEdgeCount()).toBe(0);
+    });
+
+    it('rejects unknown human actor roles and reason classifications', () => {
+      insertMemory('mem-human-enum');
+      const rawId = insertRaw('raw-human-enum');
+
+      expect(() =>
+        insertTwinEdge(getAdapter(), {
+          edge_type: 'derived_from',
+          subject_ref: { kind: 'memory', id: 'mem-human-enum' },
+          object_ref: { kind: 'raw', id: rawId },
+          source: 'human',
+          human_actor_id: 'user-1',
+          human_actor_role: 'owner' as never,
+          authority_scope_json: { scopes: [{ kind: 'project', id: 'alpha' }] },
+          reason_classification: 'other',
+        })
+      ).toThrow(/human_actor_role/i);
+
+      expect(() =>
+        insertTwinEdge(getAdapter(), {
+          edge_type: 'derived_from',
+          subject_ref: { kind: 'memory', id: 'mem-human-enum' },
+          object_ref: { kind: 'raw', id: rawId },
+          source: 'human',
+          human_actor_id: 'user-1',
+          human_actor_role: 'commander',
+          authority_scope_json: { scopes: [{ kind: 'project', id: 'alpha' }] },
+          reason_classification: 'because' as never,
+        })
+      ).toThrow(/reason_classification/i);
+      expect(twinEdgeCount()).toBe(0);
+    });
+
+    it('rejects raw subjects at runtime before inserting a row', () => {
+      insertMemory('mem-raw-subject');
+      const rawId = insertRaw('raw-subject');
+
+      expect(() =>
+        insertTwinEdge(getAdapter(), {
+          edge_type: 'derived_from',
+          subject_ref: { kind: 'raw', id: rawId } as never,
+          object_ref: { kind: 'memory', id: 'mem-raw-subject' },
+          source: 'code',
+          reason_text: 'raw refs are object-only',
+        })
+      ).toThrow(/subject_ref\.kind cannot be raw/i);
+      expect(twinEdgeCount()).toBe(0);
+    });
+  });
+});

--- a/packages/mama-core/tests/edges/twin-edge-visibility.test.ts
+++ b/packages/mama-core/tests/edges/twin-edge-visibility.test.ts
@@ -1,0 +1,243 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { getAdapter } from '../../src/db-manager.js';
+import { upsertConnectorEventIndex } from '../../src/connectors/event-index.js';
+import {
+  assertTwinRefsVisibleToScopes,
+  listVisibleTwinEdgesForRefs,
+} from '../../src/edges/ref-validation.js';
+import { insertTwinEdge } from '../../src/edges/store.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+
+type ScopeKind = 'project' | 'user' | 'channel' | 'global';
+
+function insertScopedMemory(id: string, kind: ScopeKind, externalId: string): void {
+  const adapter = getAdapter();
+  const scopeId = `scope_${kind}_${externalId}`;
+  adapter
+    .prepare(
+      `
+        INSERT INTO decisions (id, topic, decision, reasoning, confidence, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+      `
+    )
+    .run(id, `topic-${id}`, `decision-${id}`, `reasoning-${id}`, 0.8, 1_000, 1_000);
+  adapter
+    .prepare(
+      `
+        INSERT OR IGNORE INTO memory_scopes (id, kind, external_id)
+        VALUES (?, ?, ?)
+      `
+    )
+    .run(scopeId, kind, externalId);
+  adapter
+    .prepare(
+      `
+        INSERT OR REPLACE INTO memory_scope_bindings (memory_id, scope_id, is_primary)
+        VALUES (?, ?, 1)
+      `
+    )
+    .run(id, scopeId);
+}
+
+function insertScopedRaw(sourceId: string, kind: ScopeKind, scopeId: string): string {
+  return upsertConnectorEventIndex(getAdapter(), {
+    source_connector: 'slack',
+    source_type: 'message',
+    source_id: sourceId,
+    content: `raw ${sourceId}`,
+    event_datetime: 1_000,
+    memory_scope_kind: kind,
+    memory_scope_id: scopeId,
+  }).event_index_id;
+}
+
+function insertOpaqueObjectEdge(id: string, objectKind: 'entity' | 'report'): void {
+  getAdapter()
+    .prepare(
+      `
+        INSERT INTO twin_edges (
+          edge_id, edge_type, subject_kind, subject_id, object_kind, object_id,
+          confidence, source, reason_text, content_hash, created_at
+        )
+        VALUES (?, 'mentions', 'memory', 'mem-alpha', ?, ?, 1, 'code', 'opaque object', ?, 1_000)
+      `
+    )
+    .run(id, objectKind, `${objectKind}-1`, Buffer.alloc(32, id.length));
+}
+
+describe('Story M3.1: Twin Edge Visibility', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('twin-edge-visibility');
+  });
+
+  beforeEach(() => {
+    const adapter = getAdapter();
+    adapter.prepare('DELETE FROM twin_edges').run();
+    adapter.prepare('DELETE FROM connector_event_index').run();
+    adapter.prepare('DELETE FROM memory_scope_bindings').run();
+    adapter.prepare('DELETE FROM memory_scopes').run();
+    adapter.prepare('DELETE FROM decisions').run();
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  describe('AC #5: endpoint visibility is fail-closed for scoped refs', () => {
+    it('rejects an edge endpoint when a raw object is outside the requested scope', () => {
+      insertScopedMemory('mem-alpha', 'project', 'alpha');
+      const betaRaw = insertScopedRaw('raw-beta', 'project', 'beta');
+
+      expect(() =>
+        assertTwinRefsVisibleToScopes(
+          getAdapter(),
+          [
+            { kind: 'memory', id: 'mem-alpha' },
+            { kind: 'raw', id: betaRaw },
+          ],
+          [{ kind: 'project', id: 'alpha' }]
+        )
+      ).toThrow(/not visible/i);
+    });
+
+    it('excludes edges whose subject or object endpoint is outside requested scopes', () => {
+      insertScopedMemory('mem-alpha', 'project', 'alpha');
+      const alphaRaw = insertScopedRaw('raw-alpha', 'project', 'alpha');
+      const betaRaw = insertScopedRaw('raw-beta', 'project', 'beta');
+
+      const visible = insertTwinEdge(getAdapter(), {
+        edge_type: 'derived_from',
+        subject_ref: { kind: 'memory', id: 'mem-alpha' },
+        object_ref: { kind: 'raw', id: alphaRaw },
+        source: 'code',
+        reason_text: 'connector replay',
+      });
+      insertTwinEdge(getAdapter(), {
+        edge_type: 'derived_from',
+        subject_ref: { kind: 'memory', id: 'mem-alpha' },
+        object_ref: { kind: 'raw', id: betaRaw },
+        source: 'code',
+        reason_text: 'connector replay',
+      });
+
+      const scoped = listVisibleTwinEdgesForRefs(
+        getAdapter(),
+        [{ kind: 'memory', id: 'mem-alpha' }],
+        { scopes: [{ kind: 'project', id: 'alpha' }] }
+      );
+      expect(scoped.map((edge) => edge.edge_id)).toEqual([visible.edge_id]);
+
+      const unscoped = listVisibleTwinEdgesForRefs(
+        getAdapter(),
+        [{ kind: 'memory', id: 'mem-alpha' }],
+        {}
+      );
+      // Matches existing mama-core read behavior: empty scopes mean no scope filter.
+      expect(unscoped).toHaveLength(2);
+    });
+
+    it('keeps entity/report endpoints visible for unscoped reads and fail-closed for scoped reads', () => {
+      insertScopedMemory('mem-alpha', 'project', 'alpha');
+      insertOpaqueObjectEdge('edge_entity_object', 'entity');
+      insertOpaqueObjectEdge('edge_report_object', 'report');
+
+      const unscoped = listVisibleTwinEdgesForRefs(
+        getAdapter(),
+        [{ kind: 'memory', id: 'mem-alpha' }],
+        {}
+      );
+      expect(unscoped.map((edge) => edge.edge_id)).toEqual([
+        'edge_entity_object',
+        'edge_report_object',
+      ]);
+
+      const scoped = listVisibleTwinEdgesForRefs(
+        getAdapter(),
+        [{ kind: 'memory', id: 'mem-alpha' }],
+        { scopes: [{ kind: 'project', id: 'alpha' }] }
+      );
+      expect(scoped).toHaveLength(0);
+    });
+
+    it('recursively validates edge refs by checking the referenced edge endpoints', () => {
+      insertScopedMemory('mem-alpha', 'project', 'alpha');
+      const alphaRaw = insertScopedRaw('raw-alpha', 'project', 'alpha');
+      const betaRaw = insertScopedRaw('raw-beta', 'project', 'beta');
+
+      const innerVisible = insertTwinEdge(getAdapter(), {
+        edge_type: 'derived_from',
+        subject_ref: { kind: 'memory', id: 'mem-alpha' },
+        object_ref: { kind: 'raw', id: alphaRaw },
+        source: 'code',
+        reason_text: 'connector replay',
+      });
+      const innerHidden = insertTwinEdge(getAdapter(), {
+        edge_type: 'derived_from',
+        subject_ref: { kind: 'memory', id: 'mem-alpha' },
+        object_ref: { kind: 'raw', id: betaRaw },
+        source: 'code',
+        reason_text: 'connector replay',
+      });
+
+      expect(() =>
+        assertTwinRefsVisibleToScopes(
+          getAdapter(),
+          [{ kind: 'edge', id: innerVisible.edge_id }],
+          [{ kind: 'project', id: 'alpha' }]
+        )
+      ).not.toThrow();
+      expect(() =>
+        assertTwinRefsVisibleToScopes(
+          getAdapter(),
+          [{ kind: 'edge', id: innerHidden.edge_id }],
+          [{ kind: 'project', id: 'alpha' }]
+        )
+      ).toThrow(/not visible/i);
+    });
+
+    it('does not mark a sibling branch cyclic when both branches share a nested edge', () => {
+      insertScopedMemory('mem-alpha', 'project', 'alpha');
+      const alphaRaw = insertScopedRaw('raw-alpha', 'project', 'alpha');
+
+      const sharedNested = insertTwinEdge(getAdapter(), {
+        edge_type: 'derived_from',
+        subject_ref: { kind: 'memory', id: 'mem-alpha' },
+        object_ref: { kind: 'raw', id: alphaRaw },
+        source: 'code',
+        reason_text: 'connector replay',
+      });
+      const leftBranch = insertTwinEdge(getAdapter(), {
+        edge_type: 'mentions',
+        subject_ref: { kind: 'memory', id: 'mem-alpha' },
+        object_ref: { kind: 'edge', id: sharedNested.edge_id },
+        source: 'code',
+        reason_text: 'left branch',
+      });
+      const rightBranch = insertTwinEdge(getAdapter(), {
+        edge_type: 'mentions',
+        subject_ref: { kind: 'memory', id: 'mem-alpha' },
+        object_ref: { kind: 'edge', id: sharedNested.edge_id },
+        source: 'code',
+        reason_text: 'right branch',
+      });
+      const root = insertTwinEdge(getAdapter(), {
+        edge_type: 'synthesizes',
+        subject_ref: { kind: 'edge', id: leftBranch.edge_id },
+        object_ref: { kind: 'edge', id: rightBranch.edge_id },
+        source: 'code',
+        reason_text: 'shared nested edge stays visible across sibling branches',
+      });
+
+      expect(() =>
+        assertTwinRefsVisibleToScopes(
+          getAdapter(),
+          [{ kind: 'edge', id: root.edge_id }],
+          [{ kind: 'project', id: 'alpha' }]
+        )
+      ).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Summary:
- Add first-class twin edge ledger storage, validation, and visibility tests.
- Address CodeRabbit follow-up fixes: allowlisted PRAGMA table introspection and Set size assertion.

CodeRabbit:
- coderabbit review --agent -t committed --base main -c CLAUDE.md
- Result: 0 issues

Verification:
- MAMA_FORCE_TIER_3=true pnpm -C packages/mama-core exec vitest run tests/cases/migration-chain.test.ts tests/edges
- pnpm typecheck
- pnpm lint
- pnpm build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced twin edges feature for creating and managing typed relationships between entities with scope-based visibility controls
  * Added idempotent edge creation with automatic deduplication and visibility validation
  * Extended package exports with new APIs for edge operations and reference validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->