### PR TITLE
feat(m4): add unified raw search APIs

### DIFF
--- a/packages/mama-core/package.json
+++ b/packages/mama-core/package.json
@@ -45,6 +45,7 @@
     "./cases/wiki-page-index": "./dist/cases/wiki-page-index.js",
     "./connectors": "./dist/connectors/event-index.js",
     "./connectors/event-index": "./dist/connectors/event-index.js",
+    "./connectors/raw-query": "./dist/connectors/raw-query.js",
     "./connectors/types": "./dist/connectors/types.js",
     "./edges/types": "./dist/edges/types.js",
     "./edges/store": "./dist/edges/store.js",

--- a/packages/mama-core/src/connectors/event-index.ts
+++ b/packages/mama-core/src/connectors/event-index.ts
@@ -141,6 +141,12 @@ function mapConnectorEventIndexRow(row: Record<string, unknown>): ConnectorEvent
   };
 }
 
+export function mapConnectorEventIndexRecord(
+  row: Record<string, unknown>
+): ConnectorEventIndexRecord {
+  return mapConnectorEventIndexRow(row);
+}
+
 function mapConnectorCursorRow(row: Record<string, unknown>): ConnectorEventIndexCursorRecord {
   return {
     connector_name: String(row.connector_name),

--- a/packages/mama-core/src/connectors/raw-query.ts
+++ b/packages/mama-core/src/connectors/raw-query.ts
@@ -1,0 +1,419 @@
+import type { DatabaseAdapter } from '../db-manager.js';
+import { MEMORY_SCOPE_KINDS, type MemoryScopeKind } from '../memory/types.js';
+import { mapConnectorEventIndexRecord } from './event-index.js';
+import type {
+  ConnectorEventIndexRecord,
+  RawSearchHit,
+  RawSearchInput,
+  RawSearchResult,
+  RawSearchScopeFilter,
+} from './types.js';
+
+type RawQueryAdapter = Pick<DatabaseAdapter, 'prepare'>;
+
+interface RawCursor {
+  rank: number;
+  timestampMs: number;
+  rawId: string;
+}
+
+interface RawSearchRow extends Record<string, unknown> {
+  rank: number;
+}
+
+interface RawWindowInput {
+  connectors?: string[];
+  scopes?: RawSearchScopeFilter[];
+  before?: number;
+  after?: number;
+}
+
+const DEFAULT_RAW_LIMIT = 25;
+const MAX_RAW_LIMIT = 100;
+const DEFAULT_WINDOW_SIZE = 5;
+const MAX_WINDOW_SIZE = 50;
+const VALID_SCOPE_KINDS = new Set<string>(MEMORY_SCOPE_KINDS);
+
+function placeholders(values: readonly unknown[]): string {
+  if (values.length === 0) {
+    throw new Error('Cannot build SQL placeholders for an empty list.');
+  }
+  return values.map(() => '?').join(', ');
+}
+
+function normalizeLimit(value: number | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_RAW_LIMIT;
+  }
+  return Math.min(MAX_RAW_LIMIT, Math.max(0, Math.floor(value)));
+}
+
+function normalizeWindowSize(value: number | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_WINDOW_SIZE;
+  }
+  return Math.min(MAX_WINDOW_SIZE, Math.max(0, Math.floor(value)));
+}
+
+function escapeFtsQuery(query: string): string {
+  return `"${query.replace(/"/g, '""')}"`;
+}
+
+function encodeCursor(row: {
+  rank: number;
+  source_timestamp_ms: number;
+  event_index_id: string;
+}): string {
+  return Buffer.from(
+    JSON.stringify({
+      rank: row.rank,
+      timestampMs: row.source_timestamp_ms,
+      rawId: row.event_index_id,
+    }),
+    'utf8'
+  ).toString('base64url');
+}
+
+function decodeCursor(cursor: string | undefined): RawCursor | null {
+  if (!cursor) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(
+      Buffer.from(cursor, 'base64url').toString('utf8')
+    ) as Partial<RawCursor>;
+    if (
+      typeof parsed.rank !== 'number' ||
+      !Number.isFinite(parsed.rank) ||
+      typeof parsed.timestampMs !== 'number' ||
+      !Number.isFinite(parsed.timestampMs) ||
+      typeof parsed.rawId !== 'string' ||
+      parsed.rawId.length === 0
+    ) {
+      throw new Error('invalid shape');
+    }
+    return {
+      rank: parsed.rank,
+      timestampMs: parsed.timestampMs,
+      rawId: parsed.rawId,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Invalid raw search cursor: ${message}`);
+  }
+}
+
+function normalizeConnectors(connectors: string[] | undefined): string[] {
+  return [...new Set((connectors ?? []).map((connector) => connector.trim()).filter(Boolean))];
+}
+
+function normalizeScopes(scopes: RawSearchScopeFilter[] | undefined): RawSearchScopeFilter[] {
+  return (scopes ?? [])
+    .map((scope) => {
+      const kind = scope.kind.trim();
+      if (!VALID_SCOPE_KINDS.has(kind)) {
+        throw new Error(`Invalid raw search scope kind: ${kind}`);
+      }
+      return { kind: kind as MemoryScopeKind, id: scope.id.trim() };
+    })
+    .filter((scope) => scope.id.length > 0);
+}
+
+function appendFilters(
+  clauses: string[],
+  params: unknown[],
+  input: RawSearchInput,
+  alias = 'e'
+): void {
+  const connectors = normalizeConnectors(input.connectors);
+  if (connectors.length > 0) {
+    clauses.push(`${alias}.source_connector IN (${placeholders(connectors)})`);
+    params.push(...connectors);
+  }
+
+  const scopes = normalizeScopes(input.scopes);
+  if (scopes.length > 0) {
+    clauses.push(
+      `(${scopes.map(() => `(${alias}.memory_scope_kind = ? AND ${alias}.memory_scope_id = ?)`).join(' OR ')})`
+    );
+    for (const scope of scopes) {
+      params.push(scope.kind, scope.id);
+    }
+  }
+
+  if (input.fromMs !== undefined) {
+    clauses.push(`${alias}.source_timestamp_ms >= ?`);
+    params.push(input.fromMs);
+  }
+  if (input.toMs !== undefined) {
+    clauses.push(`${alias}.source_timestamp_ms <= ?`);
+    params.push(input.toMs);
+  }
+}
+
+function appendCursorFilter(clauses: string[], params: unknown[], cursor: RawCursor | null): void {
+  if (!cursor) {
+    return;
+  }
+  clauses.push(
+    `(rank > ? OR (rank = ? AND source_timestamp_ms < ?) OR ` +
+      `(rank = ? AND source_timestamp_ms = ? AND event_index_id > ?))`
+  );
+  params.push(
+    cursor.rank,
+    cursor.rank,
+    cursor.timestampMs,
+    cursor.rank,
+    cursor.timestampMs,
+    cursor.rawId
+  );
+}
+
+function parseMetadata(metadataJson: string | null): Record<string, unknown> {
+  if (!metadataJson) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(metadataJson) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function contentPreview(content: string): string {
+  const compact = content.replace(/\s+/g, ' ').trim();
+  return compact.length > 240 ? `${compact.slice(0, 237)}...` : compact;
+}
+
+function scoreFromRank(rank: number): number {
+  return Number.isFinite(rank) ? 1 / (1 + Math.exp(rank)) : 0;
+}
+
+function timestampToIso(timestampMs: number | null): string | null {
+  if (timestampMs === null || !Number.isFinite(timestampMs)) {
+    return null;
+  }
+  return new Date(timestampMs).toISOString();
+}
+
+function toRawHit(row: RawSearchRow): RawSearchHit {
+  const record = mapConnectorEventIndexRecord(row) as ConnectorEventIndexRecord;
+  return {
+    raw_id: record.event_index_id,
+    connector: record.source_connector,
+    source_id: record.source_id,
+    channel_id: record.channel,
+    author_label: record.author,
+    created_at: timestampToIso(record.event_datetime ?? record.source_timestamp_ms),
+    content_preview: contentPreview(record.content),
+    score: scoreFromRank(Number(row.rank)),
+    source_ref: record.source_locator ?? record.artifact_locator,
+    metadata: parseMetadata(record.metadata_json),
+  };
+}
+
+function runSearch(adapter: RawQueryAdapter, input: RawSearchInput): RawSearchResult {
+  const query = input.query.trim();
+  if (query.length === 0) {
+    return { hits: [], next_cursor: null };
+  }
+
+  const limit = normalizeLimit(input.limit);
+  if (limit === 0) {
+    return { hits: [], next_cursor: null };
+  }
+
+  const params: unknown[] = [escapeFtsQuery(query)];
+  const clauses: string[] = [];
+  appendFilters(clauses, params, input);
+  const cursor = decodeCursor(input.cursor);
+
+  const outerClauses: string[] = [];
+  const outerParams: unknown[] = [];
+  appendCursorFilter(outerClauses, outerParams, cursor);
+  const whereSql = clauses.length > 0 ? `AND ${clauses.join(' AND ')}` : '';
+  const cursorSql = outerClauses.length > 0 ? `WHERE ${outerClauses.join(' AND ')}` : '';
+  const rows = adapter
+    .prepare(
+      `
+        WITH ranked AS (
+          SELECT e.*, bm25(connector_event_index_fts) AS rank
+          FROM connector_event_index_fts
+          JOIN connector_event_index e
+            ON e.event_index_id = connector_event_index_fts.event_index_id
+          WHERE connector_event_index_fts MATCH ?
+            ${whereSql}
+        )
+        SELECT *
+        FROM ranked
+        ${cursorSql}
+        ORDER BY rank ASC, source_timestamp_ms DESC, event_index_id ASC
+        LIMIT ?
+      `
+    )
+    .all(...params, ...outerParams, limit + 1) as RawSearchRow[];
+
+  const pageRows = rows.slice(0, limit);
+  const nextRow = rows.length > limit ? pageRows[pageRows.length - 1] : undefined;
+
+  return {
+    hits: pageRows.map(toRawHit),
+    next_cursor: nextRow
+      ? encodeCursor({
+          rank: Number(nextRow.rank),
+          source_timestamp_ms: Number(nextRow.source_timestamp_ms),
+          event_index_id: String(nextRow.event_index_id),
+        })
+      : null,
+  };
+}
+
+export function searchRaw(adapter: RawQueryAdapter, input: RawSearchInput): RawSearchResult {
+  const connectors = normalizeConnectors(input.connectors);
+  if (connectors.length !== 1) {
+    throw new Error('searchRaw requires exactly one connector filter.');
+  }
+  return runSearch(adapter, { ...input, connectors });
+}
+
+export function searchAllRaw(adapter: RawQueryAdapter, input: RawSearchInput): RawSearchResult {
+  return runSearch(adapter, input);
+}
+
+export function getRawById(
+  adapter: RawQueryAdapter,
+  rawId: string,
+  visibility: Pick<RawSearchInput, 'connectors' | 'scopes'>
+): RawSearchHit | null {
+  const params: unknown[] = [rawId];
+  const clauses = ['e.event_index_id = ?'];
+  appendFilters(clauses, params, { query: '*', ...visibility });
+  const row = adapter
+    .prepare(
+      `
+        SELECT e.*, 0 AS rank
+        FROM connector_event_index e
+        WHERE ${clauses.join(' AND ')}
+        LIMIT 1
+      `
+    )
+    .get(...params) as RawSearchRow | undefined;
+
+  return row ? toRawHit(row) : null;
+}
+
+export function getRawWindow(
+  adapter: RawQueryAdapter,
+  rawId: string,
+  input: RawWindowInput
+): { target: RawSearchHit; items: RawSearchHit[] } | null {
+  const targetParams: unknown[] = [rawId];
+  const targetClauses = ['e.event_index_id = ?'];
+  appendFilters(targetClauses, targetParams, {
+    query: '*',
+    connectors: input.connectors,
+    scopes: input.scopes,
+  });
+  const targetRow = adapter
+    .prepare(
+      `
+        SELECT e.*, 0 AS rank
+        FROM connector_event_index e
+        WHERE ${targetClauses.join(' AND ')}
+        LIMIT 1
+      `
+    )
+    .get(...targetParams) as RawSearchRow | undefined;
+
+  if (!targetRow) {
+    return null;
+  }
+
+  const target = mapConnectorEventIndexRecord(targetRow);
+  const before = normalizeWindowSize(input.before);
+  const after = normalizeWindowSize(input.after);
+  const beforeRows = beforeWindowRows(adapter, target, input, before);
+  const afterRows = afterWindowRows(adapter, target, input, after);
+  const targetHit = toRawHit(targetRow);
+
+  return {
+    target: targetHit,
+    items: [...beforeRows.reverse().map(toRawHit), targetHit, ...afterRows.map(toRawHit)],
+  };
+}
+
+function beforeWindowRows(
+  adapter: RawQueryAdapter,
+  target: ConnectorEventIndexRecord,
+  input: RawWindowInput,
+  limit: number
+): RawSearchRow[] {
+  if (limit === 0) {
+    return [];
+  }
+  const params: unknown[] = [target.source_connector, target.channel, target.source_timestamp_ms];
+  const clauses = [
+    'e.source_connector = ?',
+    target.channel === null ? 'e.channel IS ?' : 'e.channel = ?',
+    'e.source_timestamp_ms < ?',
+  ];
+  appendFilters(clauses, params, {
+    query: '*',
+    connectors: input.connectors,
+    scopes: input.scopes,
+  });
+  return adapter
+    .prepare(
+      `
+        SELECT e.*, 0 AS rank
+        FROM connector_event_index e
+        WHERE ${clauses.join(' AND ')}
+        ORDER BY e.source_timestamp_ms DESC, e.event_index_id DESC
+        LIMIT ?
+      `
+    )
+    .all(...params, limit) as RawSearchRow[];
+}
+
+function afterWindowRows(
+  adapter: RawQueryAdapter,
+  target: ConnectorEventIndexRecord,
+  input: RawWindowInput,
+  limit: number
+): RawSearchRow[] {
+  if (limit === 0) {
+    return [];
+  }
+  const params: unknown[] = [target.source_connector, target.channel, target.source_timestamp_ms];
+  const clauses = [
+    'e.source_connector = ?',
+    target.channel === null ? 'e.channel IS ?' : 'e.channel = ?',
+    'e.source_timestamp_ms > ?',
+  ];
+  appendFilters(clauses, params, {
+    query: '*',
+    connectors: input.connectors,
+    scopes: input.scopes,
+  });
+  return adapter
+    .prepare(
+      `
+        SELECT e.*, 0 AS rank
+        FROM connector_event_index e
+        WHERE ${clauses.join(' AND ')}
+        ORDER BY e.source_timestamp_ms ASC, e.event_index_id ASC
+        LIMIT ?
+      `
+    )
+    .all(...params, limit) as RawSearchRow[];
+}
+
+export type {
+  RawSearchHit,
+  RawSearchInput,
+  RawSearchResult,
+  RawSearchScopeFilter,
+} from './types.js';

--- a/packages/mama-core/src/connectors/types.ts
+++ b/packages/mama-core/src/connectors/types.ts
@@ -1,4 +1,5 @@
 import type { Buffer } from 'node:buffer';
+import type { MemoryScopeRef } from '../memory/types.js';
 
 export interface ConnectorEventIndexRecord {
   event_index_id: string;
@@ -79,6 +80,39 @@ export interface UpsertConnectorEventIndexCursorInput {
 export interface ConnectorEventSearchHit extends ConnectorEventIndexRecord {
   rank: number;
   score: number;
+}
+
+export interface RawSearchScopeFilter {
+  kind: MemoryScopeRef['kind'];
+  id: string;
+}
+
+export interface RawSearchInput {
+  query: string;
+  connectors?: string[];
+  scopes?: RawSearchScopeFilter[];
+  fromMs?: number;
+  toMs?: number;
+  cursor?: string;
+  limit?: number;
+}
+
+export interface RawSearchHit {
+  raw_id: string;
+  connector: string;
+  source_id: string;
+  channel_id: string | null;
+  author_label: string | null;
+  created_at: string | null;
+  content_preview: string;
+  score: number;
+  source_ref: string | null;
+  metadata: Record<string, unknown>;
+}
+
+export interface RawSearchResult {
+  hits: RawSearchHit[];
+  next_cursor: string | null;
 }
 
 export type ConnectorEventStalenessStatus =

--- a/packages/mama-core/src/index.ts
+++ b/packages/mama-core/src/index.ts
@@ -388,6 +388,7 @@ export * from './cases/composition-overrides.js';
 export * from './cases/freshness.js';
 export * from './cases/membership-explain.js';
 export * from './connectors/event-index.js';
+export * from './connectors/raw-query.js';
 export * from './connectors/types.js';
 export * from './search/question-type.js';
 export * from './search/feedback-store.js';

--- a/packages/mama-core/tests/connectors/raw-query.test.ts
+++ b/packages/mama-core/tests/connectors/raw-query.test.ts
@@ -1,0 +1,207 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { getAdapter } from '../../src/db-manager.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+import { upsertConnectorEventIndex } from '../../src/connectors/event-index.js';
+import { searchAllRaw, searchRaw } from '../../src/connectors/raw-query.js';
+
+const KOREAN_RISK_TOKEN = '\ud504\ub85c\uc81d\ud2b8\uc704\ud5d8';
+const KOREAN_MEETING_TEXT = `${KOREAN_RISK_TOKEN} \uc77c\uc815 \uc870\uc815 \ud68c\uc758\ub85d`;
+const JAPANESE_RISK_TOKEN = '\u30ea\u30ea\u30fc\u30b9\u5371\u967a';
+const JAPANESE_MEETING_TEXT = `${JAPANESE_RISK_TOKEN} \u3092\u78ba\u8a8d\u3059\u308b\u8b70\u4e8b\u9332`;
+
+function seedRawEvent(overrides: {
+  connector?: string;
+  sourceId: string;
+  channel?: string;
+  author?: string;
+  content: string;
+  timestampMs: number;
+  scopeKind?: string | null;
+  scopeId?: string | null;
+  metadata?: Record<string, unknown>;
+}): void {
+  upsertConnectorEventIndex(getAdapter(), {
+    source_connector: overrides.connector ?? 'slack',
+    source_type: 'message',
+    source_id: overrides.sourceId,
+    source_locator: `${overrides.connector ?? 'slack'}:${overrides.channel ?? 'general'}:${overrides.sourceId}`,
+    channel: overrides.channel ?? 'general',
+    author: overrides.author ?? 'alice',
+    content: overrides.content,
+    event_datetime: overrides.timestampMs,
+    source_timestamp_ms: overrides.timestampMs,
+    memory_scope_kind: overrides.scopeKind ?? 'project',
+    memory_scope_id: overrides.scopeId ?? 'alpha',
+    metadata: overrides.metadata ?? { seeded: true },
+  });
+}
+
+describe('Story M4: Raw unified search over connector_event_index', () => {
+  let testDbPath = '';
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('raw-query');
+  });
+
+  beforeEach(() => {
+    const adapter = getAdapter();
+    adapter.prepare('DELETE FROM connector_event_index_cursors').run();
+    adapter.prepare('DELETE FROM connector_event_index').run();
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  describe('AC #1: raw.search searches one connector through FTS', () => {
+    it('returns Korean and Japanese FTS hits with raw hit fields', () => {
+      const koreanTime = Date.parse('2026-04-20T10:00:00.000Z');
+      const japaneseTime = Date.parse('2026-04-20T09:00:00.000Z');
+      seedRawEvent({
+        sourceId: 'slack-ko',
+        content: KOREAN_MEETING_TEXT,
+        timestampMs: koreanTime,
+        metadata: { language: 'ko' },
+      });
+      seedRawEvent({
+        sourceId: 'slack-ja',
+        content: JAPANESE_MEETING_TEXT,
+        timestampMs: japaneseTime,
+        metadata: { language: 'ja' },
+      });
+
+      const korean = searchRaw(getAdapter(), {
+        query: KOREAN_RISK_TOKEN,
+        connectors: ['slack'],
+        limit: 5,
+      });
+      const japanese = searchRaw(getAdapter(), {
+        query: JAPANESE_RISK_TOKEN,
+        connectors: ['slack'],
+        limit: 5,
+      });
+
+      expect(korean.hits).toHaveLength(1);
+      expect(korean.hits[0]).toMatchObject({
+        connector: 'slack',
+        source_id: 'slack-ko',
+        channel_id: 'general',
+        author_label: 'alice',
+        created_at: new Date(koreanTime).toISOString(),
+        metadata: { language: 'ko' },
+      });
+      expect(korean.hits[0]?.content_preview).toContain(KOREAN_RISK_TOKEN);
+      expect(korean.hits[0]?.score).toBeGreaterThan(0);
+      expect(korean.next_cursor).toBeNull();
+
+      expect(japanese.hits).toHaveLength(1);
+      expect(japanese.hits[0]?.source_id).toBe('slack-ja');
+    });
+
+    it('treats FTS query syntax as literal content', () => {
+      seedRawEvent({
+        sourceId: 'literal-special-syntax',
+        content: 'owner:alice escalation note',
+        timestampMs: Date.parse('2026-04-20T10:00:00.000Z'),
+      });
+
+      expect(() =>
+        searchRaw(getAdapter(), {
+          query: 'owner:alice',
+          connectors: ['slack'],
+          limit: 5,
+        })
+      ).not.toThrow();
+
+      const results = searchRaw(getAdapter(), {
+        query: 'owner:alice',
+        connectors: ['slack'],
+        limit: 5,
+      });
+
+      expect(results.hits.map((hit) => hit.source_id)).toEqual(['literal-special-syntax']);
+    });
+  });
+
+  describe('AC #2: raw.searchAll merges connector results with stable cursors', () => {
+    it('sorts multi-connector hits by score then recency and resumes after the cursor', () => {
+      seedRawEvent({
+        connector: 'slack',
+        sourceId: 'slack-newer',
+        content: 'needle shared term',
+        timestampMs: Date.parse('2026-04-20T12:00:00.000Z'),
+      });
+      seedRawEvent({
+        connector: 'discord',
+        sourceId: 'discord-older',
+        content: 'needle shared term',
+        timestampMs: Date.parse('2026-04-20T11:00:00.000Z'),
+      });
+      seedRawEvent({
+        connector: 'notion',
+        sourceId: 'notion-strong',
+        content: 'needle needle needle shared term',
+        timestampMs: Date.parse('2026-04-20T10:00:00.000Z'),
+      });
+
+      const firstPage = searchAllRaw(getAdapter(), {
+        query: 'needle',
+        connectors: ['slack', 'discord', 'notion'],
+        limit: 2,
+      });
+
+      expect(firstPage.hits.map((hit) => hit.source_id)).toEqual(['notion-strong', 'slack-newer']);
+      expect(firstPage.next_cursor).toEqual(expect.any(String));
+
+      const secondPage = searchAllRaw(getAdapter(), {
+        query: 'needle',
+        connectors: ['slack', 'discord', 'notion'],
+        cursor: firstPage.next_cursor ?? undefined,
+        limit: 2,
+      });
+
+      expect(secondPage.hits.map((hit) => hit.source_id)).toEqual(['discord-older']);
+      expect(secondPage.next_cursor).toBeNull();
+    });
+  });
+
+  describe('AC #3: connector, scope, time, and cursor filters happen before LIMIT', () => {
+    it('does not lose in-scope rows behind earlier out-of-scope rows', () => {
+      for (let i = 0; i < 8; i += 1) {
+        seedRawEvent({
+          sourceId: `out-${i}`,
+          content: 'limitneedle out of scope',
+          timestampMs: Date.parse('2026-04-20T12:00:00.000Z') - i,
+          scopeKind: 'project',
+          scopeId: 'other',
+        });
+      }
+      seedRawEvent({
+        sourceId: 'in-scope',
+        content: 'limitneedle in scope',
+        timestampMs: Date.parse('2026-04-20T10:00:00.000Z'),
+        scopeKind: 'project',
+        scopeId: 'alpha',
+      });
+
+      const results = searchAllRaw(getAdapter(), {
+        query: 'limitneedle',
+        connectors: ['slack'],
+        scopes: [{ kind: 'project', id: 'alpha' }],
+        limit: 1,
+      });
+
+      expect(results.hits.map((hit) => hit.source_id)).toEqual(['in-scope']);
+    });
+
+    it('rejects invalid scope kinds before building the SQL filter', () => {
+      expect(() =>
+        searchAllRaw(getAdapter(), {
+          query: 'limitneedle',
+          scopes: [{ kind: 'workspace' as never, id: 'alpha' }],
+        })
+      ).toThrow('Invalid raw search scope kind');
+    });
+  });
+});

--- a/packages/standalone/src/api/agent-raw-handler.ts
+++ b/packages/standalone/src/api/agent-raw-handler.ts
@@ -1,0 +1,314 @@
+import express, { type Request, type Response, type Router } from 'express';
+import * as debugLogger from '@jungjaehoon/mama-core/debug-logger';
+
+import type { EnvelopeAuthority } from '../envelope/authority.js';
+import type { MemoryScope } from '../envelope/types.js';
+import {
+  deriveWorkerEnvelopeVisibility,
+  loadWorkerEnvelope,
+  WorkerEnvelopeError,
+} from './worker-envelope.js';
+
+const { DebugLogger } = debugLogger as unknown as {
+  DebugLogger: new (context?: string) => {
+    error: (...args: unknown[]) => void;
+  };
+};
+const rawApiLogger = new DebugLogger('AgentRawAPI');
+
+interface RawQueryStatement {
+  all: (...params: unknown[]) => unknown[];
+  get: (...params: unknown[]) => unknown;
+  run: (...params: unknown[]) => unknown;
+}
+
+interface RawQueryAdapter {
+  prepare: (sql: string) => RawQueryStatement;
+}
+
+interface RawQueryModule {
+  searchRaw: (adapter: RawQueryAdapter, input: RawSearchInput) => RawSearchResult;
+  searchAllRaw: (adapter: RawQueryAdapter, input: RawSearchInput) => RawSearchResult;
+  getRawById: (
+    adapter: RawQueryAdapter,
+    rawId: string,
+    visibility: Pick<RawSearchInput, 'connectors' | 'scopes'>
+  ) => RawSearchHit | null;
+  getRawWindow: (
+    adapter: RawQueryAdapter,
+    rawId: string,
+    input: Pick<RawSearchInput, 'connectors' | 'scopes'> & { before?: number; after?: number }
+  ) => { target: RawSearchHit; items: RawSearchHit[] } | null;
+}
+
+interface RawSearchInput {
+  query: string;
+  connectors?: string[];
+  scopes?: MemoryScope[];
+  fromMs?: number;
+  toMs?: number;
+  cursor?: string;
+  limit?: number;
+}
+
+interface RawSearchHit {
+  raw_id: string;
+  connector: string;
+  source_id: string;
+  channel_id: string | null;
+  author_label: string | null;
+  created_at: string | null;
+  content_preview: string;
+  score: number;
+  source_ref: string | null;
+  metadata: Record<string, unknown>;
+}
+
+interface RawSearchResult {
+  hits: RawSearchHit[];
+  next_cursor: string | null;
+}
+
+export interface AgentRawRouterOptions {
+  memoryDb: RawQueryAdapter;
+  envelopeAuthority?: EnvelopeAuthority;
+  rawQuery?: RawQueryModule;
+}
+
+export function createAgentRawRouter(options: AgentRawRouterOptions): Router {
+  const router = express.Router();
+
+  router.get('/search', async (req, res) => {
+    await handleRawRequest(req, res, options, async (rawQuery, visibility) => {
+      const input = parseSearchInput(req, visibility);
+      if (!input.connectors || input.connectors.length !== 1) {
+        throw new WorkerEnvelopeError(
+          400,
+          'raw_connector_required',
+          'raw.search requires exactly one connector.'
+        );
+      }
+      return rawQuery.searchRaw(options.memoryDb, input);
+    });
+  });
+
+  router.get('/search-all', async (req, res) => {
+    await handleRawRequest(req, res, options, async (rawQuery, visibility) => {
+      const input = parseSearchInput(req, visibility);
+      return rawQuery.searchAllRaw(options.memoryDb, input);
+    });
+  });
+
+  router.get('/:rawId/window', async (req, res) => {
+    await handleRawRequest(req, res, options, async (rawQuery, visibility) => {
+      const before = parseBoundedInteger(req.query.before, 'before');
+      const after = parseBoundedInteger(req.query.after, 'after');
+      const result = rawQuery.getRawWindow(options.memoryDb, req.params.rawId, {
+        connectors: visibility.connectors,
+        scopes: visibility.scopes,
+        before,
+        after,
+      });
+      if (!result) {
+        res.status(404).json({
+          error: true,
+          code: 'raw_not_found',
+          message: 'Raw event is not visible to this worker envelope.',
+        });
+        return undefined;
+      }
+      return result;
+    });
+  });
+
+  router.get('/:rawId', async (req, res) => {
+    await handleRawRequest(req, res, options, async (rawQuery, visibility) => {
+      const hit = rawQuery.getRawById(options.memoryDb, req.params.rawId, {
+        connectors: visibility.connectors,
+        scopes: visibility.scopes,
+      });
+      if (!hit) {
+        res.status(404).json({
+          error: true,
+          code: 'raw_not_found',
+          message: 'Raw event is not visible to this worker envelope.',
+        });
+        return undefined;
+      }
+      return hit;
+    });
+  });
+
+  return router;
+}
+
+async function handleRawRequest(
+  req: Request,
+  res: Response,
+  options: AgentRawRouterOptions,
+  handler: (
+    rawQuery: RawQueryModule,
+    visibility: { connectors: string[]; scopes: MemoryScope[] }
+  ) => Promise<unknown>
+): Promise<void> {
+  try {
+    const envelope = loadWorkerEnvelope(req, options.envelopeAuthority);
+    const visibility = deriveWorkerEnvelopeVisibility(envelope, {
+      connectors: parseConnectors(req),
+      scopes: parseScopes(req),
+    });
+    const rawQuery = await loadRawQueryModule(options.rawQuery);
+    const payload = await handler(rawQuery, visibility);
+    if (payload !== undefined) {
+      res.json(payload);
+    }
+  } catch (err) {
+    sendRawError(res, err);
+  }
+}
+
+function parseSearchInput(
+  req: Request,
+  visibility: { connectors: string[]; scopes: MemoryScope[] }
+): RawSearchInput {
+  const query = firstString(req.query.query)?.trim();
+  if (!query) {
+    throw new WorkerEnvelopeError(400, 'raw_query_required', 'query is required.');
+  }
+  return {
+    query,
+    connectors: visibility.connectors,
+    scopes: visibility.scopes,
+    fromMs: parseOptionalNumber(req.query.fromMs, 'fromMs'),
+    toMs: parseOptionalNumber(req.query.toMs, 'toMs'),
+    cursor: firstString(req.query.cursor),
+    limit: parseBoundedInteger(req.query.limit, 'limit'),
+  };
+}
+
+function parseConnectors(req: Request): string[] | undefined {
+  const connectorValues = [
+    ...stringValues(req.query.connector),
+    ...stringValues(req.query.connectors).flatMap((value) => value.split(',')),
+  ]
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return connectorValues.length > 0 ? [...new Set(connectorValues)] : undefined;
+}
+
+function parseScopes(req: Request): MemoryScope[] | undefined {
+  const rawValues = stringValues(req.query.scope).concat(stringValues(req.query.scopes));
+  if (rawValues.length === 0) {
+    const kind = firstString(req.query.scope_kind);
+    const id = firstString(req.query.scope_id);
+    return kind && id ? [{ kind: parseScopeKind(kind), id }] : undefined;
+  }
+
+  const scopes: MemoryScope[] = [];
+  for (const rawValue of rawValues) {
+    const pieces = rawValue.trim().startsWith('[')
+      ? parseJsonScopes(rawValue)
+      : rawValue
+          .split(',')
+          .map((value) => value.trim())
+          .filter(Boolean);
+    for (const piece of pieces) {
+      const [kind, ...idParts] = piece.split(':');
+      const id = idParts.join(':');
+      if (kind && id) {
+        scopes.push({ kind: parseScopeKind(kind), id });
+      }
+    }
+  }
+  return scopes.length > 0 ? scopes : undefined;
+}
+
+function parseJsonScopes(value: string): string[] {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!Array.isArray(parsed)) {
+      throw new Error('expected array');
+    }
+    return parsed.map((scope) => {
+      if (
+        scope === null ||
+        typeof scope !== 'object' ||
+        typeof (scope as Record<string, unknown>).kind !== 'string' ||
+        typeof (scope as Record<string, unknown>).id !== 'string'
+      ) {
+        throw new Error('expected {kind,id} objects');
+      }
+      return `${(scope as { kind: string }).kind}:${(scope as { id: string }).id}`;
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new WorkerEnvelopeError(400, 'raw_scope_invalid', `Invalid scopes JSON: ${message}`);
+  }
+}
+
+function parseScopeKind(value: string): MemoryScope['kind'] {
+  if (value === 'global' || value === 'user' || value === 'channel' || value === 'project') {
+    return value;
+  }
+  throw new WorkerEnvelopeError(400, 'raw_scope_invalid', `Invalid scope kind: ${value}`);
+}
+
+function parseOptionalNumber(value: unknown, name: string): number | undefined {
+  const raw = firstString(value);
+  if (raw === undefined || raw.length === 0) {
+    return undefined;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    throw new WorkerEnvelopeError(400, 'raw_query_invalid', `${name} must be numeric.`);
+  }
+  return parsed;
+}
+
+function parseBoundedInteger(value: unknown, name: string): number | undefined {
+  const parsed = parseOptionalNumber(value, name);
+  if (parsed === undefined) {
+    return undefined;
+  }
+  return Math.max(0, Math.floor(parsed));
+}
+
+function firstString(value: unknown): string | undefined {
+  if (Array.isArray(value)) {
+    const first = value[0];
+    return typeof first === 'string' ? first : undefined;
+  }
+  return typeof value === 'string' ? value : undefined;
+}
+
+function stringValues(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string');
+  }
+  return typeof value === 'string' ? [value] : [];
+}
+
+async function loadRawQueryModule(rawQuery: RawQueryModule | undefined): Promise<RawQueryModule> {
+  if (rawQuery) {
+    return rawQuery;
+  }
+  return (await import('@jungjaehoon/mama-core/connectors/raw-query')) as RawQueryModule;
+}
+
+function sendRawError(res: Response, err: unknown): void {
+  if (err instanceof WorkerEnvelopeError) {
+    res.status(err.status).json({
+      error: true,
+      code: err.code,
+      message: err.message,
+    });
+    return;
+  }
+
+  rawApiLogger.error('Unexpected raw API error:', err);
+  res.status(500).json({
+    error: true,
+    code: 'raw_api_error',
+    message: 'Internal server error',
+  });
+}

--- a/packages/standalone/src/api/index.ts
+++ b/packages/standalone/src/api/index.ts
@@ -29,6 +29,7 @@ import { createWikiRouter } from './wiki-handler.js';
 import { createIntelligenceRouter } from './intelligence-handler.js';
 import { createConnectorFeedRouter } from './connector-feed-handler.js';
 import { createMemoryProvenanceRouter } from './memory-provenance-handler.js';
+import { createAgentRawRouter, type AgentRawRouterOptions } from './agent-raw-handler.js';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
@@ -86,6 +87,10 @@ export interface ApiServerOptions {
   };
   /** Runtime envelope bootstrap metadata for authenticated status reporting */
   envelope?: ApiEnvelopeMetadata;
+  /** Runtime envelope authority for worker-scoped raw evidence reads */
+  envelopeAuthority?: import('../envelope/authority.js').EnvelopeAuthority;
+  /** Test seam for raw query functions; production loads mama-core raw-query lazily */
+  rawQuery?: AgentRawRouterOptions['rawQuery'];
 }
 
 export type ApiEnvelopeMetadata = {
@@ -134,6 +139,8 @@ export function createApiServer(options: ApiServerOptions): ApiServer {
     enabledConnectors,
     eventBus,
     envelope = { issuance: 'off' },
+    envelopeAuthority,
+    rawQuery,
   } = options;
 
   const app = express();
@@ -161,7 +168,10 @@ export function createApiServer(options: ApiServerOptions): ApiServer {
     if (origin && /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) {
       res.setHeader('Access-Control-Allow-Origin', origin);
       res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
-      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+      res.setHeader(
+        'Access-Control-Allow-Headers',
+        'Content-Type, Authorization, x-mama-envelope-hash'
+      );
     }
     if (req.method === 'OPTIONS') {
       res.status(204).end();
@@ -198,6 +208,17 @@ export function createApiServer(options: ApiServerOptions): ApiServer {
 
   app.use('/api/cron', cronRouter);
   app.use('/api/heartbeat', heartbeatRouter);
+
+  if (memoryDb) {
+    app.use(
+      '/api/agent/raw',
+      createAgentRawRouter({
+        memoryDb,
+        envelopeAuthority,
+        rawQuery,
+      })
+    );
+  }
 
   // Mount report store (created early so intelligence router can reference it)
   const reportSseClients = new Set<ServerResponse>();

--- a/packages/standalone/src/api/worker-envelope.ts
+++ b/packages/standalone/src/api/worker-envelope.ts
@@ -1,0 +1,111 @@
+import type { Request } from 'express';
+
+import type { EnvelopeAuthority } from '../envelope/authority.js';
+import type { Envelope, MemoryScope } from '../envelope/types.js';
+
+export interface WorkerEnvelopeVisibility {
+  envelope: Envelope;
+  connectors: string[];
+  scopes: MemoryScope[];
+}
+
+export class WorkerEnvelopeError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(status: number, code: string, message: string) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export function loadWorkerEnvelope(
+  req: Request,
+  authority: EnvelopeAuthority | undefined
+): Envelope {
+  if (!authority) {
+    throw new WorkerEnvelopeError(
+      503,
+      'worker_envelope_unavailable',
+      'Worker envelope authority is unavailable.'
+    );
+  }
+
+  const envelopeHash = req.header('x-mama-envelope-hash')?.trim();
+  if (!envelopeHash) {
+    throw new WorkerEnvelopeError(
+      401,
+      'worker_envelope_missing',
+      'x-mama-envelope-hash is required.'
+    );
+  }
+
+  let envelope: Envelope | undefined;
+  try {
+    envelope = authority.loadVerified(envelopeHash);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new WorkerEnvelopeError(
+      403,
+      'worker_envelope_invalid',
+      `Worker envelope could not be verified: ${message}`
+    );
+  }
+
+  if (!envelope) {
+    throw new WorkerEnvelopeError(403, 'worker_envelope_invalid', 'Worker envelope was not found.');
+  }
+
+  const expiresMs = Date.parse(envelope.expires_at);
+  if (!Number.isFinite(expiresMs) || expiresMs <= Date.now()) {
+    throw new WorkerEnvelopeError(403, 'worker_envelope_expired', 'Worker envelope is expired.');
+  }
+
+  return envelope;
+}
+
+export function deriveWorkerEnvelopeVisibility(
+  envelope: Envelope,
+  requested: {
+    connectors?: string[];
+    scopes?: MemoryScope[];
+  }
+): WorkerEnvelopeVisibility {
+  const envelopeConnectors = uniqueStrings(envelope.scope.raw_connectors);
+  const requestedConnectors = requested.connectors
+    ? uniqueStrings(requested.connectors)
+    : envelopeConnectors;
+
+  for (const connector of requestedConnectors) {
+    if (!envelopeConnectors.includes(connector)) {
+      throw new WorkerEnvelopeError(
+        403,
+        'worker_envelope_connector_denied',
+        `Connector ${connector} is outside the worker envelope.`
+      );
+    }
+  }
+
+  const envelopeScopes = envelope.scope.memory_scopes;
+  const requestedScopes = requested.scopes ?? envelopeScopes;
+  for (const scope of requestedScopes) {
+    if (!envelopeScopes.some((allowed) => allowed.kind === scope.kind && allowed.id === scope.id)) {
+      throw new WorkerEnvelopeError(
+        403,
+        'worker_envelope_scope_denied',
+        `Scope ${scope.kind}:${scope.id} is outside the worker envelope.`
+      );
+    }
+  }
+
+  return {
+    envelope,
+    connectors: requestedConnectors,
+    scopes: requestedScopes,
+  };
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+}

--- a/packages/standalone/src/api/worker-envelope.ts
+++ b/packages/standalone/src/api/worker-envelope.ts
@@ -2,6 +2,7 @@ import type { Request } from 'express';
 
 import type { EnvelopeAuthority } from '../envelope/authority.js';
 import type { Envelope, MemoryScope } from '../envelope/types.js';
+import { parseEnvelopeExpiresAt } from '../envelope/expiry.js';
 
 export interface WorkerEnvelopeVisibility {
   envelope: Envelope;
@@ -57,8 +58,13 @@ export function loadWorkerEnvelope(
     throw new WorkerEnvelopeError(403, 'worker_envelope_invalid', 'Worker envelope was not found.');
   }
 
-  const expiresMs = Date.parse(envelope.expires_at);
-  if (!Number.isFinite(expiresMs) || expiresMs <= Date.now()) {
+  let expiresMs: number;
+  try {
+    expiresMs = parseEnvelopeExpiresAt(envelope.expires_at);
+  } catch {
+    throw new WorkerEnvelopeError(403, 'worker_envelope_expired', 'Worker envelope is expired.');
+  }
+  if (expiresMs <= Date.now()) {
     throw new WorkerEnvelopeError(403, 'worker_envelope_expired', 'Worker envelope is expired.');
   }
 

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -699,6 +699,7 @@ export async function runAgentLoop(
     agentLoop,
     getAdapter,
     envelopeMetadata: envelopeBootstrap.metadata,
+    envelopeAuthority: envelopeBootstrap.envelopeAuthority,
   });
 
   await registerApiRoutes({

--- a/packages/standalone/src/cli/runtime/api-server-init.ts
+++ b/packages/standalone/src/cli/runtime/api-server-init.ts
@@ -34,6 +34,7 @@ export interface InitApiServerParams {
   enabledConnectors: string[];
   agentLoop: AgentLoop;
   envelopeMetadata?: RuntimeEnvelopeBootstrap['metadata'];
+  envelopeAuthority?: RuntimeEnvelopeBootstrap['envelopeAuthority'];
   /** mama-core getAdapter() — used to create the memoryDb shim */
   getAdapter: () => {
     prepare: (sql: string) => unknown;
@@ -59,6 +60,7 @@ export async function initApiServer(params: InitApiServerParams): Promise<InitAp
     agentLoop,
     getAdapter,
     envelopeMetadata,
+    envelopeAuthority,
   } = params;
 
   // ── SkillRegistry + MCP config migration ──────────────────────────────
@@ -111,6 +113,7 @@ export async function initApiServer(params: InitApiServerParams): Promise<InitAp
     enabledConnectors,
     eventBus,
     envelope: envelopeMetadata,
+    envelopeAuthority,
     onHeartbeat: async (prompt) => {
       try {
         const result = await agentLoop.run(prompt);

--- a/packages/standalone/src/cli/runtime/connector-init.ts
+++ b/packages/standalone/src/cli/runtime/connector-init.ts
@@ -24,7 +24,11 @@ import { join } from 'node:path';
 
 import { DebugLogger } from '@jungjaehoon/mama-core/debug-logger';
 
-import type { RawStore } from '../../connectors/framework/raw-store.js';
+import {
+  mapNormalizedItemsToConnectorEventIndexInputs,
+  type RawIndexSink,
+  type RawStore,
+} from '../../connectors/framework/raw-store.js';
 
 const logger = new DebugLogger('connector-init');
 
@@ -60,9 +64,14 @@ export async function initConnectors(
   const { buildProjectTruth, groupByChannel, buildEntityObservations } =
     await import('../../memory/history-extractor.js');
   const { MODEL_NAME } = await import('@jungjaehoon/mama-core');
-  const entityObservationStore = (await import('@jungjaehoon/mama-core')) as unknown as {
+  const mamaCore = (await import('@jungjaehoon/mama-core')) as unknown as {
+    getAdapter?: () => Parameters<
+      typeof import('@jungjaehoon/mama-core/connectors/event-index').upsertConnectorEventIndex
+    >[0];
+    upsertConnectorEventIndex?: typeof import('@jungjaehoon/mama-core/connectors/event-index').upsertConnectorEventIndex;
     upsertEntityObservations?: (inputs: EntityObservationDraft[]) => Promise<unknown>;
   };
+  const entityObservationStore = mamaCore;
   type ConnectorsJson = import('../../connectors/framework/types.js').ConnectorsConfig;
   type ChannelConfigMap = import('../../connectors/framework/types.js').ChannelConfig;
   type NormalizedItem = import('../../connectors/framework/types.js').NormalizedItem;
@@ -93,6 +102,19 @@ export async function initConnectors(
 
   const connectorRegistry = new ConnectorRegistry();
   const rawStore = new RawStore(join(homedir(), '.mama', 'connectors'));
+  const rawIndexSink: RawIndexSink | undefined =
+    typeof mamaCore.getAdapter === 'function' &&
+    typeof mamaCore.upsertConnectorEventIndex === 'function'
+      ? async (connectorName, items) => {
+          const adapter = mamaCore.getAdapter?.();
+          if (!adapter || typeof mamaCore.upsertConnectorEventIndex !== 'function') {
+            throw new Error('[connector] unified raw index unavailable from mama-core');
+          }
+          for (const input of mapNormalizedItemsToConnectorEventIndexInputs(connectorName, items)) {
+            mamaCore.upsertConnectorEventIndex(adapter, input);
+          }
+        }
+      : undefined;
 
   // Build channel configs for role classification
   // For kagemusha connector, channels are keyed as "source:channelId" (e.g., "chatwork:ROOM_ID")
@@ -131,7 +153,8 @@ export async function initConnectors(
   if (connectorRegistry.getActive().size > 0) {
     const connectorScheduler = new PollingScheduler(
       rawStore,
-      join(homedir(), '.mama', 'connectors')
+      join(homedir(), '.mama', 'connectors'),
+      { rawIndexSink }
     );
 
     const observationExtractorVersion = 'history-extractor@v1';

--- a/packages/standalone/src/connectors/framework/polling-scheduler.ts
+++ b/packages/standalone/src/connectors/framework/polling-scheduler.ts
@@ -8,7 +8,7 @@ import { join } from 'path';
 
 import type { ConnectorRegistry } from './connector-registry.js';
 import type { ChannelConfig, NormalizedItem } from './types.js';
-import type { RawStore } from './raw-store.js';
+import type { RawIndexSink, RawStore } from './raw-store.js';
 import { classifyItemsByRole } from '../../memory/history-extractor.js';
 import type { ClassifiedItems } from '../../memory/history-extractor.js';
 
@@ -20,6 +20,7 @@ interface PollState {
 
 export class PollingScheduler {
   private readonly rawStore: RawStore;
+  private readonly rawIndexSink?: RawIndexSink;
   private lastPollTimes = new Map<string, Date>();
   private timers = new Map<string, ReturnType<typeof setInterval>>();
   private readonly stateFile: string;
@@ -27,8 +28,13 @@ export class PollingScheduler {
   /** Initial lookback for connectors with no saved state (default: 24h). Set to 0 for all history. */
   initialLookbackMs: number;
 
-  constructor(rawStore: RawStore, basePath: string, options?: { initialLookbackMs?: number }) {
+  constructor(
+    rawStore: RawStore,
+    basePath: string,
+    options?: { initialLookbackMs?: number; rawIndexSink?: RawIndexSink }
+  ) {
     this.rawStore = rawStore;
+    this.rawIndexSink = options?.rawIndexSink;
     this.stateFile = join(basePath, 'poll-state.json');
     this.initialLookbackMs = options?.initialLookbackMs ?? 24 * 60 * 60 * 1000;
     this.restoreState();
@@ -80,9 +86,12 @@ export class PollingScheduler {
           );
           if (items.length > 0) {
             this.rawStore.save(name, items);
+            if (this.rawIndexSink) {
+              await this.rawIndexSink(name, items);
+            }
             allItems.push(...items);
           }
-          // Only advance the cursor after a successful poll+save
+          // Only advance the cursor after a successful poll+save+index.
           this.lastPollTimes.set(name, new Date());
         } catch (err) {
           console.error(`[connector:${name}] poll error:`, err);

--- a/packages/standalone/src/connectors/framework/raw-store.ts
+++ b/packages/standalone/src/connectors/framework/raw-store.ts
@@ -11,6 +11,25 @@ import { join } from 'path';
 import Database from '../../sqlite.js';
 import type { NormalizedItem } from './types.js';
 
+interface ConnectorEventIndexInput {
+  source_connector: string;
+  source_type: string;
+  source_id: string;
+  source_locator: string;
+  channel: string;
+  author: string;
+  content: string;
+  event_datetime: number;
+  source_timestamp_ms: number;
+  source_cursor: string | null;
+  tenant_id: string | null;
+  project_id: string | null;
+  memory_scope_kind: string | null;
+  memory_scope_id: string | null;
+  metadata: Record<string, unknown> | null;
+  content_hash: Buffer;
+}
+
 interface RawRow {
   id: number;
   source_id: string;
@@ -62,6 +81,8 @@ export interface RawStoreBackfillOptions {
   memoryScopeId?: string;
 }
 
+export type RawIndexSink = (connectorName: string, items: NormalizedItem[]) => void | Promise<void>;
+
 function ensureRawItemsProvenanceColumns(db: Database): void {
   const columns = new Set(
     (db.prepare('PRAGMA table_info(raw_items)').all() as Array<{ name: string }>).map(
@@ -104,6 +125,30 @@ function normalizeContentHash(item: NormalizedItem): string {
     return item.contentHash;
   }
   return createHash('sha256').update(canonicalizeRawContent(item), 'utf8').digest('hex');
+}
+
+export function mapNormalizedItemsToConnectorEventIndexInputs(
+  connectorName: string,
+  items: NormalizedItem[]
+): ConnectorEventIndexInput[] {
+  return items.map((item) => ({
+    source_connector: connectorName,
+    source_type: item.type,
+    source_id: item.sourceId,
+    source_locator: `${connectorName}:${item.channel}:${item.sourceId}`,
+    channel: item.channel,
+    author: item.author,
+    content: item.content,
+    event_datetime: item.timestamp.getTime(),
+    source_timestamp_ms: item.timestamp.getTime(),
+    source_cursor: item.sourceCursor ?? null,
+    tenant_id: item.tenantId ?? null,
+    project_id: item.projectId ?? null,
+    memory_scope_kind: item.memoryScopeKind ?? null,
+    memory_scope_id: item.memoryScopeId ?? null,
+    metadata: item.metadata ?? null,
+    content_hash: Buffer.from(normalizeContentHash(item), 'hex'),
+  }));
 }
 
 export class RawStore {

--- a/packages/standalone/src/envelope/authority.ts
+++ b/packages/standalone/src/envelope/authority.ts
@@ -6,6 +6,7 @@ import {
 } from './signature.js';
 import type { Envelope } from './types.js';
 import type { EnvelopeStore } from './store.js';
+import { parseEnvelopeExpiresAt } from './expiry.js';
 
 export type EnvelopeBuildInput = Omit<Envelope, 'envelope_hash' | 'signature'>;
 
@@ -76,10 +77,7 @@ function validateBuildInput(input: EnvelopeBuildInput): void {
     throw new Error('EnvelopeAuthority.build: budget.cost_cap must be >= 0 if set');
   }
 
-  const expiresMs = Date.parse(input.expires_at);
-  if (Number.isNaN(expiresMs)) {
-    throw new Error(`EnvelopeAuthority.build: expires_at not parseable: ${input.expires_at}`);
-  }
+  const expiresMs = parseEnvelopeBuildExpiry(input.expires_at);
   if (expiresMs <= Date.now()) {
     throw new Error(`EnvelopeAuthority.build: expires_at already past: ${input.expires_at}`);
   }
@@ -95,5 +93,14 @@ function validateBuildInput(input: EnvelopeBuildInput): void {
   }
   if (!Array.isArray(input.scope.allowed_destinations)) {
     throw new Error('EnvelopeAuthority.build: scope.allowed_destinations required');
+  }
+}
+
+function parseEnvelopeBuildExpiry(expiresAt: string): number {
+  try {
+    return parseEnvelopeExpiresAt(expiresAt);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`EnvelopeAuthority.build: ${message}`);
   }
 }

--- a/packages/standalone/src/envelope/enforcer.ts
+++ b/packages/standalone/src/envelope/enforcer.ts
@@ -1,4 +1,5 @@
 import type { Envelope } from './types.js';
+import { parseEnvelopeExpiresAt } from './expiry.js';
 
 export class EnvelopeViolation extends Error {
   constructor(
@@ -51,8 +52,10 @@ export class EnvelopeEnforcer {
   }
 
   private checkExpiry(envelope: Envelope): void {
-    const expiresAt = new Date(envelope.expires_at).getTime();
-    if (Number.isNaN(expiresAt)) {
+    let expiresAt: number;
+    try {
+      expiresAt = parseEnvelopeExpiresAt(envelope.expires_at);
+    } catch {
       throw new EnvelopeViolation(
         `Envelope ${envelope.instance_id} has invalid expires_at ${envelope.expires_at}`,
         'invalid_expiry'

--- a/packages/standalone/src/envelope/expiry.ts
+++ b/packages/standalone/src/envelope/expiry.ts
@@ -1,0 +1,15 @@
+const ISO_8601_TIMESTAMP_WITH_TIMEZONE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
+
+export function parseEnvelopeExpiresAt(expiresAt: string): number {
+  if (!ISO_8601_TIMESTAMP_WITH_TIMEZONE.test(expiresAt)) {
+    throw new Error(`expires_at must be an ISO 8601 timestamp with timezone, got: ${expiresAt}`);
+  }
+
+  const expiresMs = Date.parse(expiresAt);
+  if (!Number.isFinite(expiresMs)) {
+    throw new Error(`expires_at is not parseable as an ISO 8601 timestamp: ${expiresAt}`);
+  }
+
+  return expiresMs;
+}

--- a/packages/standalone/tests/api/agent-raw-api.test.ts
+++ b/packages/standalone/tests/api/agent-raw-api.test.ts
@@ -1,0 +1,394 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+import { getAdapter } from '../../../mama-core/src/db-manager.js';
+import { upsertConnectorEventIndex } from '../../../mama-core/src/connectors/event-index.js';
+import * as rawQuery from '../../../mama-core/src/connectors/raw-query.js';
+import { cleanupTestDB, initTestDB } from '../../../mama-core/src/test-utils.js';
+
+import Database from '../../src/sqlite.js';
+import { createApiServer } from '../../src/api/index.js';
+import {
+  createAgentRawRouter,
+  type AgentRawRouterOptions,
+} from '../../src/api/agent-raw-handler.js';
+import { requireAuth } from '../../src/api/auth-middleware.js';
+import { CronScheduler } from '../../src/scheduler/index.js';
+import { applyEnvelopeTablesMigration } from '../../src/db/migrations/envelope-tables.js';
+import { EnvelopeAuthority } from '../../src/envelope/authority.js';
+import { EnvelopeStore } from '../../src/envelope/store.js';
+import { signEnvelope } from '../../src/envelope/signature.js';
+import type { Envelope } from '../../src/envelope/types.js';
+
+vi.mock('@jungjaehoon/mama-core/debug-logger', () => ({
+  DebugLogger: class {
+    warn(): void {}
+    debug(): void {}
+    info(): void {}
+    error(): void {}
+  },
+}));
+
+const TUNNEL_HEADERS = {
+  'cf-connecting-ip': '198.51.100.7',
+  'x-forwarded-for': '198.51.100.7',
+};
+
+const SIGNING_KEY = {
+  key_id: 'test',
+  key_version: 1,
+  key: Buffer.from('agent-raw-api-test-key-32-bytes!'),
+};
+
+function makeEnvelope(overrides: Partial<Envelope> = {}): Envelope {
+  return signEnvelope(
+    {
+      agent_id: 'worker-m4',
+      instance_id: `inst_${Math.random().toString(36).slice(2)}`,
+      source: 'telegram',
+      channel_id: 'tg:1',
+      trigger_context: {},
+      scope: {
+        project_refs: [{ kind: 'project', id: 'alpha' }],
+        raw_connectors: ['slack'],
+        memory_scopes: [{ kind: 'project', id: 'alpha' }],
+        allowed_destinations: [{ kind: 'telegram', id: 'tg:1' }],
+      },
+      tier: 1,
+      budget: { wall_seconds: 60 },
+      expires_at: new Date(Date.now() + 60_000).toISOString(),
+      envelope_hash: '',
+      ...overrides,
+    },
+    SIGNING_KEY
+  );
+}
+
+function seedRaw(overrides: {
+  connector?: string;
+  sourceId: string;
+  channel?: string;
+  content?: string;
+  timestampMs: number;
+  scopeId?: string;
+}): string {
+  const saved = upsertConnectorEventIndex(getAdapter(), {
+    source_connector: overrides.connector ?? 'slack',
+    source_type: 'message',
+    source_id: overrides.sourceId,
+    source_locator: `${overrides.connector ?? 'slack'}:${overrides.channel ?? 'general'}:${overrides.sourceId}`,
+    channel: overrides.channel ?? 'general',
+    author: 'alice',
+    content: overrides.content ?? 'rawapi searchable content',
+    event_datetime: overrides.timestampMs,
+    source_timestamp_ms: overrides.timestampMs,
+    memory_scope_kind: 'project',
+    memory_scope_id: overrides.scopeId ?? 'alpha',
+    metadata: { seeded: overrides.sourceId },
+  });
+  return saved.event_index_id;
+}
+
+describe('Story M4: /api/agent/raw worker envelope API', () => {
+  const originalAuthToken = process.env.MAMA_AUTH_TOKEN;
+  let testDbPath = '';
+  let sessionsDb: Database;
+  let authority: EnvelopeAuthority;
+  let validEnvelope: Envelope;
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('agent-raw-api');
+  });
+
+  beforeEach(() => {
+    process.env.MAMA_AUTH_TOKEN = 'agent-raw-token';
+    const adapter = getAdapter();
+    adapter.prepare('DELETE FROM connector_event_index_cursors').run();
+    adapter.prepare('DELETE FROM connector_event_index').run();
+
+    sessionsDb = new Database(':memory:');
+    applyEnvelopeTablesMigration(sessionsDb);
+    authority = new EnvelopeAuthority(
+      new EnvelopeStore(sessionsDb),
+      SIGNING_KEY,
+      (keyId, keyVersion) =>
+        keyId === SIGNING_KEY.key_id && keyVersion === SIGNING_KEY.key_version
+          ? SIGNING_KEY.key
+          : undefined
+    );
+    validEnvelope = makeEnvelope();
+    authority.persist(validEnvelope);
+  });
+
+  afterEach(() => {
+    sessionsDb.close();
+    if (originalAuthToken === undefined) {
+      delete process.env.MAMA_AUTH_TOKEN;
+    } else {
+      process.env.MAMA_AUTH_TOKEN = originalAuthToken;
+    }
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  function makeServer(rawQueryOverrides: Partial<AgentRawRouterOptions['rawQuery']> = {}) {
+    const app = express();
+    app.use('/api', requireAuth);
+    app.use(
+      '/api/agent/raw',
+      createAgentRawRouter({
+        memoryDb: getAdapter(),
+        envelopeAuthority: authority,
+        rawQuery: { ...rawQuery, ...rawQueryOverrides },
+      })
+    );
+    return {
+      app,
+    };
+  }
+
+  function authed(req: request.Test): request.Test {
+    return req
+      .set(TUNNEL_HEADERS)
+      .set('Authorization', 'Bearer agent-raw-token')
+      .set('x-mama-envelope-hash', validEnvelope.envelope_hash);
+  }
+
+  describe('AC #1: route-local worker envelope gate is stricter than perimeter auth', () => {
+    it('rejects missing, invalid, and expired envelopes even when requireAuth passes', async () => {
+      const expired = makeEnvelope({
+        expires_at: new Date(Date.now() - 60_000).toISOString(),
+      });
+      authority.persist(expired);
+      const apiServer = makeServer();
+
+      const missing = await request(apiServer.app)
+        .get('/api/agent/raw/search-all?query=rawapi')
+        .set(TUNNEL_HEADERS)
+        .set('Authorization', 'Bearer agent-raw-token');
+      expect(missing.status).toBe(401);
+
+      const invalid = await request(apiServer.app)
+        .get('/api/agent/raw/search-all?query=rawapi')
+        .set(TUNNEL_HEADERS)
+        .set('Authorization', 'Bearer agent-raw-token')
+        .set('x-mama-envelope-hash', 'not-present');
+      expect(invalid.status).toBe(403);
+
+      const expiredResponse = await request(apiServer.app)
+        .get('/api/agent/raw/search-all?query=rawapi')
+        .set(TUNNEL_HEADERS)
+        .set('Authorization', 'Bearer agent-raw-token')
+        .set('x-mama-envelope-hash', expired.envelope_hash);
+      expect(expiredResponse.status).toBe(403);
+    });
+
+    it('rejects envelopes with unparsable expires_at values', async () => {
+      const invalidExpiry = makeEnvelope({
+        expires_at: 'not-a-date',
+      });
+      authority.persist(invalidExpiry);
+      const apiServer = makeServer();
+
+      const response = await request(apiServer.app)
+        .get('/api/agent/raw/search-all?query=rawapi')
+        .set(TUNNEL_HEADERS)
+        .set('Authorization', 'Bearer agent-raw-token')
+        .set('x-mama-envelope-hash', invalidExpiry.envelope_hash);
+
+      expect(response.status).toBe(403);
+      expect(response.body.code).toBe('worker_envelope_expired');
+    });
+
+    it('rejects requested connector or scope filters outside the envelope', async () => {
+      const apiServer = makeServer();
+
+      const connectorOutside = await authed(
+        request(apiServer.app).get('/api/agent/raw/search-all?query=rawapi&connectors=discord')
+      );
+      expect(connectorOutside.status).toBe(403);
+
+      const scopeOutside = await authed(
+        request(apiServer.app).get('/api/agent/raw/search-all?query=rawapi&scopes=project%3Abeta')
+      );
+      expect(scopeOutside.status).toBe(403);
+    });
+
+    it('preserves colon-containing scope ids in string and JSON scope filters', async () => {
+      const colonScopeId = 'repo:alpha:service';
+      validEnvelope = makeEnvelope({
+        scope: {
+          project_refs: [{ kind: 'project', id: colonScopeId }],
+          raw_connectors: ['slack'],
+          memory_scopes: [{ kind: 'project', id: colonScopeId }],
+          allowed_destinations: [{ kind: 'telegram', id: 'tg:1' }],
+        },
+      });
+      authority.persist(validEnvelope);
+      seedRaw({
+        sourceId: 'colon-scope',
+        content: 'colonneedle scoped content',
+        timestampMs: Date.parse('2026-04-20T10:00:00.000Z'),
+        scopeId: colonScopeId,
+      });
+      const apiServer = makeServer();
+
+      const stringScope = await authed(
+        request(apiServer.app).get(
+          `/api/agent/raw/search-all?query=colonneedle&scopes=${encodeURIComponent(
+            `project:${colonScopeId}`
+          )}`
+        )
+      );
+      const jsonScope = await authed(
+        request(apiServer.app).get(
+          `/api/agent/raw/search-all?query=colonneedle&scopes=${encodeURIComponent(
+            JSON.stringify([{ kind: 'project', id: colonScopeId }])
+          )}`
+        )
+      );
+
+      expect(stringScope.status).toBe(200);
+      expect(stringScope.body.hits.map((hit: { source_id: string }) => hit.source_id)).toEqual([
+        'colon-scope',
+      ]);
+      expect(jsonScope.status).toBe(200);
+      expect(jsonScope.body.hits.map((hit: { source_id: string }) => hit.source_id)).toEqual([
+        'colon-scope',
+      ]);
+    });
+
+    it('returns a validation error when raw.search cannot resolve one connector', async () => {
+      validEnvelope = makeEnvelope({
+        scope: {
+          project_refs: [{ kind: 'project', id: 'alpha' }],
+          raw_connectors: ['slack', 'discord'],
+          memory_scopes: [{ kind: 'project', id: 'alpha' }],
+          allowed_destinations: [{ kind: 'telegram', id: 'tg:1' }],
+        },
+      });
+      authority.persist(validEnvelope);
+      const apiServer = makeServer();
+
+      const response = await authed(
+        request(apiServer.app).get('/api/agent/raw/search?query=rawapi')
+      );
+
+      expect(response.status).toBe(400);
+      expect(response.body.code).toBe('raw_connector_required');
+    });
+
+    it('sanitizes unexpected raw query errors', async () => {
+      const apiServer = makeServer({
+        searchAllRaw: () => {
+          throw new Error('sensitive sqlite path /tmp/private.db');
+        },
+      });
+
+      const response = await authed(
+        request(apiServer.app).get('/api/agent/raw/search-all?query=rawapi')
+      );
+
+      expect(response.status).toBe(500);
+      expect(response.body).toMatchObject({
+        error: true,
+        code: 'raw_api_error',
+        message: 'Internal server error',
+      });
+    });
+  });
+
+  describe('AC #2: omitted filters derive connector and scope visibility from envelope', () => {
+    it('search-all applies envelope connectors and scopes when query filters are omitted', async () => {
+      seedRaw({
+        sourceId: 'slack-alpha',
+        timestampMs: Date.parse('2026-04-20T10:00:00.000Z'),
+      });
+      seedRaw({
+        connector: 'discord',
+        sourceId: 'discord-alpha',
+        timestampMs: Date.parse('2026-04-20T11:00:00.000Z'),
+      });
+      seedRaw({
+        sourceId: 'slack-beta',
+        timestampMs: Date.parse('2026-04-20T12:00:00.000Z'),
+        scopeId: 'beta',
+      });
+      const apiServer = makeServer();
+
+      const response = await authed(
+        request(apiServer.app).get('/api/agent/raw/search-all?query=rawapi&limit=10')
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.hits.map((hit: { source_id: string }) => hit.source_id)).toEqual([
+        'slack-alpha',
+      ]);
+    });
+  });
+
+  describe('AC #3: raw detail and window stay inside envelope visibility', () => {
+    it('returns a target raw row and same-channel context window after visibility checks', async () => {
+      seedRaw({
+        sourceId: 'before',
+        channel: 'C1',
+        content: 'rawapi context before',
+        timestampMs: Date.parse('2026-04-20T09:59:00.000Z'),
+      });
+      const targetRawId = seedRaw({
+        sourceId: 'target',
+        channel: 'C1',
+        content: 'rawapi target',
+        timestampMs: Date.parse('2026-04-20T10:00:00.000Z'),
+      });
+      seedRaw({
+        sourceId: 'after',
+        channel: 'C1',
+        content: 'rawapi context after',
+        timestampMs: Date.parse('2026-04-20T10:01:00.000Z'),
+      });
+      seedRaw({
+        sourceId: 'other-channel',
+        channel: 'C2',
+        content: 'rawapi other channel',
+        timestampMs: Date.parse('2026-04-20T10:00:30.000Z'),
+      });
+      const apiServer = makeServer();
+
+      const detail = await authed(request(apiServer.app).get(`/api/agent/raw/${targetRawId}`));
+      expect(detail.status).toBe(200);
+      expect(detail.body.source_id).toBe('target');
+
+      const windowResponse = await authed(
+        request(apiServer.app).get(`/api/agent/raw/${targetRawId}/window?before=1&after=1`)
+      );
+      expect(windowResponse.status).toBe(200);
+      expect(
+        windowResponse.body.items.map((item: { source_id: string }) => item.source_id)
+      ).toEqual(['before', 'target', 'after']);
+    });
+  });
+
+  describe('AC #4: browser preflight can carry worker envelope headers', () => {
+    it('allows x-mama-envelope-hash in localhost CORS preflight requests', async () => {
+      const scheduler = new CronScheduler();
+      try {
+        const apiServer = createApiServer({ scheduler, port: 0 });
+
+        const response = await request(apiServer.app)
+          .options('/api/agent/raw/search-all?query=rawapi')
+          .set('Origin', 'http://localhost:5173')
+          .set('Access-Control-Request-Method', 'GET')
+          .set('Access-Control-Request-Headers', 'x-mama-envelope-hash, authorization');
+
+        expect(response.status).toBe(204);
+        expect(response.headers['access-control-allow-headers']).toContain('x-mama-envelope-hash');
+      } finally {
+        scheduler.shutdown();
+      }
+    });
+  });
+});

--- a/packages/standalone/tests/api/agent-raw-api.test.ts
+++ b/packages/standalone/tests/api/agent-raw-api.test.ts
@@ -203,6 +203,23 @@ describe('Story M4: /api/agent/raw worker envelope API', () => {
       expect(response.body.code).toBe('worker_envelope_expired');
     });
 
+    it('rejects parseable non-ISO expires_at values', async () => {
+      const invalidExpiry = makeEnvelope({
+        expires_at: '2099-01-01 00:00:00',
+      });
+      authority.persist(invalidExpiry);
+      const apiServer = makeServer();
+
+      const response = await request(apiServer.app)
+        .get('/api/agent/raw/search-all?query=rawapi')
+        .set(TUNNEL_HEADERS)
+        .set('Authorization', 'Bearer agent-raw-token')
+        .set('x-mama-envelope-hash', invalidExpiry.envelope_hash);
+
+      expect(response.status).toBe(403);
+      expect(response.body.code).toBe('worker_envelope_expired');
+    });
+
     it('rejects requested connector or scope filters outside the envelope', async () => {
       const apiServer = makeServer();
 

--- a/packages/standalone/tests/connectors/raw-store-unified-index.test.ts
+++ b/packages/standalone/tests/connectors/raw-store-unified-index.test.ts
@@ -1,0 +1,134 @@
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getAdapter } from '../../../mama-core/src/db-manager.js';
+import { searchAllRaw } from '../../../mama-core/src/connectors/raw-query.js';
+import { upsertConnectorEventIndex } from '../../../mama-core/src/connectors/event-index.js';
+import { cleanupTestDB, initTestDB } from '../../../mama-core/src/test-utils.js';
+
+import { ConnectorRegistry } from '../../src/connectors/framework/connector-registry.js';
+import { PollingScheduler } from '../../src/connectors/framework/polling-scheduler.js';
+import {
+  RawStore,
+  mapNormalizedItemsToConnectorEventIndexInputs,
+} from '../../src/connectors/framework/raw-store.js';
+import type { IConnector, NormalizedItem } from '../../src/connectors/framework/types.js';
+
+function makeItem(overrides: Partial<NormalizedItem> = {}): NormalizedItem {
+  return {
+    source: 'slack',
+    sourceId: 'msg-1',
+    channel: 'C123',
+    author: 'alice',
+    content: 'unifiedindex searchable body',
+    timestamp: new Date('2026-04-20T10:00:00.000Z'),
+    sourceCursor: 'cursor-1',
+    tenantId: 'tenant-a',
+    projectId: 'project-a',
+    memoryScopeKind: 'project',
+    memoryScopeId: 'project-a',
+    type: 'message',
+    metadata: { thread: 'T1' },
+    ...overrides,
+  };
+}
+
+function makeConnector(name: string, items: NormalizedItem[]): IConnector {
+  return {
+    name,
+    type: 'api',
+    init: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn().mockResolvedValue(undefined),
+    healthCheck: vi.fn().mockResolvedValue({ healthy: true, lastPollTime: null, lastPollCount: 0 }),
+    getAuthRequirements: vi.fn().mockReturnValue([]),
+    authenticate: vi.fn().mockResolvedValue(true),
+    poll: vi.fn().mockResolvedValue(items),
+  };
+}
+
+describe('Story M4: RawStore to unified connector_event_index indexing', () => {
+  let testDbPath = '';
+  let tmpDir = '';
+  let rawStore: RawStore;
+
+  beforeAll(async () => {
+    testDbPath = await initTestDB('raw-store-unified-index');
+  });
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'raw-unified-index-'));
+    rawStore = new RawStore(tmpDir);
+    const adapter = getAdapter();
+    adapter.prepare('DELETE FROM connector_event_index_cursors').run();
+    adapter.prepare('DELETE FROM connector_event_index').run();
+  });
+
+  afterEach(() => {
+    rawStore.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  afterAll(async () => {
+    await cleanupTestDB(testDbPath);
+  });
+
+  describe('AC #1: PollingScheduler can index saved raw rows into the unified index', () => {
+    it('maps NormalizedItem provenance fields and indexes after RawStore.save succeeds', async () => {
+      const scheduler = new PollingScheduler(rawStore, tmpDir, {
+        rawIndexSink: async (connectorName, items) => {
+          for (const input of mapNormalizedItemsToConnectorEventIndexInputs(connectorName, items)) {
+            upsertConnectorEventIndex(getAdapter(), input);
+          }
+        },
+      });
+      const registry = new ConnectorRegistry();
+      registry.register('slack', makeConnector('slack', [makeItem()]));
+
+      await scheduler.pollAll(registry, { slack: { C123: { role: 'hub' } } }, vi.fn());
+
+      const hits = searchAllRaw(getAdapter(), {
+        query: 'unifiedindex',
+        connectors: ['slack'],
+        scopes: [{ kind: 'project', id: 'project-a' }],
+        limit: 5,
+      }).hits;
+      expect(hits).toHaveLength(1);
+      expect(hits[0]).toMatchObject({
+        connector: 'slack',
+        source_id: 'msg-1',
+        channel_id: 'C123',
+        author_label: 'alice',
+        source_ref: 'slack:C123:msg-1',
+      });
+      expect(hits[0]?.metadata).toEqual({ thread: 'T1' });
+      expect(scheduler.getLastPollTime('slack')).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('AC #2: index sink failure keeps cursor unchanged for idempotent retry', () => {
+    it('does not advance lastPollTimes until poll, raw save, and index sink all succeed', async () => {
+      const onExtract = vi.fn();
+      const indexError = new Error('index unavailable');
+      const sink = vi.fn().mockRejectedValueOnce(indexError).mockResolvedValueOnce(undefined);
+      const scheduler = new PollingScheduler(rawStore, tmpDir, { rawIndexSink: sink });
+      const registry = new ConnectorRegistry();
+      const connector = makeConnector('slack', [makeItem()]);
+      registry.register('slack', connector);
+
+      await scheduler.pollAll(registry, { slack: { C123: { role: 'hub' } } }, onExtract);
+
+      expect(rawStore.query('slack', new Date(0))).toHaveLength(1);
+      expect(scheduler.getLastPollTime('slack')).toBeUndefined();
+      expect(onExtract).not.toHaveBeenCalled();
+
+      await scheduler.pollAll(registry, { slack: { C123: { role: 'hub' } } }, onExtract);
+
+      expect(rawStore.query('slack', new Date(0))).toHaveLength(1);
+      expect(sink).toHaveBeenCalledTimes(2);
+      expect(scheduler.getLastPollTime('slack')).toBeInstanceOf(Date);
+      expect(onExtract).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/packages/standalone/tests/envelope/authority.test.ts
+++ b/packages/standalone/tests/envelope/authority.test.ts
@@ -116,6 +116,9 @@ describe('EnvelopeAuthority', () => {
       expect(() =>
         auth.build(buildInput({ expires_at: new Date(Date.now() - 1_000).toISOString() }))
       ).toThrow(/past/);
+      expect(() => auth.build(buildInput({ expires_at: '2099-01-01 00:00:00' }))).toThrow(
+        /ISO 8601/
+      );
     } finally {
       closeDb(db, dir);
     }

--- a/packages/standalone/tests/envelope/enforcer.test.ts
+++ b/packages/standalone/tests/envelope/enforcer.test.ts
@@ -41,6 +41,12 @@ describe('EnvelopeEnforcer', () => {
     expect(() => enforcer.check(env, 'mama_search', { query: 'x' })).toThrow(/invalid_expiry/);
   });
 
+  it('rejects parseable non-ISO expires_at values', () => {
+    const env = makeEnvelope({ expires_at: '2099-01-01 00:00:00' });
+
+    expect(() => enforcer.check(env, 'mama_search', { query: 'x' })).toThrow(/invalid_expiry/);
+  });
+
   it('rejects raw access outside envelope.scope.raw_connectors', () => {
     const env = makeEnvelope();
 


### PR DESCRIPTION
## Summary
- Add unified raw search APIs over connector event index with worker-envelope visibility checks.
- Escape raw FTS5 search text as literal queries and sanitize unexpected raw API errors.
- Add regression coverage for literal FTS syntax, raw API error sanitization, and raw-store indexing.

## CodeRabbit
- coderabbit review --agent -t committed --base main -c CLAUDE.md
- Result: 0 issues

## Verification
- MAMA_FORCE_TIER_3=true pnpm -C packages/mama-core exec vitest run tests/connectors/raw-query.test.ts
- MAMA_FORCE_TIER_3=true pnpm -C packages/standalone exec vitest run tests/api/agent-raw-api.test.ts tests/connectors/raw-store-unified-index.test.ts
- pnpm typecheck
- pnpm lint
- pnpm build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added raw data search across indexed events with full-text search, connector and scope filtering, time-range constraints, and cursor-based pagination.
  * Added authenticated API endpoints for raw data retrieval with visibility enforcement based on allowed scopes.

* **Chores**
  * Extended module exports and type definitions to support raw query operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->