### PR TITLE
feat(m5-m6): add adapter-scoped model-run helpers

### DIFF
--- a/packages/mama-core/src/index.ts
+++ b/packages/mama-core/src/index.ts
@@ -165,7 +165,16 @@ export {
   type AppendToolTraceInput,
   type ToolTraceRecord,
 } from './model-runs/types.js';
-export { beginModelRun, commitModelRun, failModelRun, getModelRun } from './model-runs/store.js';
+export {
+  beginModelRun,
+  beginModelRunInAdapter,
+  commitModelRun,
+  commitModelRunInAdapter,
+  failModelRun,
+  failModelRunInAdapter,
+  getModelRun,
+  getModelRunInAdapter,
+} from './model-runs/store.js';
 export { appendToolTrace, listToolTracesForRun } from './model-runs/tool-trace-store.js';
 export {
   TWIN_EDGE_SOURCES,

--- a/packages/mama-core/src/mama-api.ts
+++ b/packages/mama-core/src/mama-api.ts
@@ -64,7 +64,16 @@ import {
   listMemoriesByGatewayCallId,
   listMemoriesByModelRunId,
 } from './memory/provenance-query.js';
-import { beginModelRun, commitModelRun, failModelRun, getModelRun } from './model-runs/store.js';
+import {
+  beginModelRun,
+  beginModelRunInAdapter,
+  commitModelRun,
+  commitModelRunInAdapter,
+  failModelRun,
+  failModelRunInAdapter,
+  getModelRun,
+  getModelRunInAdapter,
+} from './model-runs/store.js';
 import { appendToolTrace, listToolTracesForRun } from './model-runs/tool-trace-store.js';
 import {
   rollUpSearchHits,
@@ -3885,9 +3894,13 @@ const mama = {
   listMemoryEventsForMemory,
   listRecentMemoryEvents,
   beginModelRun,
+  beginModelRunInAdapter,
   commitModelRun,
+  commitModelRunInAdapter,
   failModelRun,
+  failModelRunInAdapter,
   getModelRun,
+  getModelRunInAdapter,
   appendToolTrace,
   listToolTracesForRun,
   saveCheckpoint,
@@ -3946,9 +3959,13 @@ export {
   listMemoryEventsForMemory,
   listRecentMemoryEvents,
   beginModelRun,
+  beginModelRunInAdapter,
   commitModelRun,
+  commitModelRunInAdapter,
   failModelRun,
+  failModelRunInAdapter,
   getModelRun,
+  getModelRunInAdapter,
   appendToolTrace,
   listToolTracesForRun,
   saveCheckpoint,

--- a/packages/mama-core/src/mama-api.ts
+++ b/packages/mama-core/src/mama-api.ts
@@ -3990,6 +3990,7 @@ export {
   verifyBackupExists,
   deleteAutoLinks,
   validateCleanupResult,
+  expandWithGraph,
 };
 
 // Default export for backward compatibility

--- a/packages/mama-core/src/model-runs/store.ts
+++ b/packages/mama-core/src/model-runs/store.ts
@@ -160,6 +160,14 @@ function requireModelRunStatus(value: unknown, modelRunId: string): ModelRunStat
   throw new Error(`Invalid model_runs.status for ${modelRunId}: ${formatInvalidValue(value)}`);
 }
 
+function normalizeBeginStatus(value: unknown, modelRunId: string): ModelRunStatus {
+  const status = requireModelRunStatus(value ?? 'running', modelRunId);
+  if (status !== 'running') {
+    throw new Error(`model_runs.status must begin in running status for ${modelRunId}: ${status}`);
+  }
+  return status;
+}
+
 function mapModelRunRow(row: Record<string, unknown>): ModelRunRecord {
   const model_run_id = requireString(row.model_run_id, 'model_run_id');
   const inputRefs = parseInputRefs({ model_run_id, input_refs_json: row.input_refs_json });
@@ -379,6 +387,16 @@ function assertExistingModelRunMatchesInput(
 }
 
 function isDuplicateModelRunError(error: unknown): boolean {
+  if (error && typeof error === 'object' && 'code' in error) {
+    const code = (error as { code?: unknown }).code;
+    if (
+      code === 'SQLITE_CONSTRAINT' ||
+      code === 'SQLITE_CONSTRAINT_PRIMARYKEY' ||
+      code === 'SQLITE_CONSTRAINT_UNIQUE'
+    ) {
+      return true;
+    }
+  }
   const message = error instanceof Error ? error.message : String(error);
   return /UNIQUE constraint failed: model_runs\.model_run_id|PRIMARY KEY constraint failed/i.test(
     message
@@ -427,7 +445,7 @@ export function beginModelRunInAdapter(
 ): ModelRunRecord {
   const id = nullableString(input.model_run_id) ?? modelRunId();
   const createdAt = normalizeTimestamp(input.created_at);
-  const status = input.status ?? 'running';
+  const status = normalizeBeginStatus(input.status, id);
   const inputRefsJson = normalizeInputRefsJson(input);
   const expected = normalizeBeginModelRunInput(id, input, createdAt, status, inputRefsJson);
   const replayFields = replayFieldsForInput(input);

--- a/packages/mama-core/src/model-runs/store.ts
+++ b/packages/mama-core/src/model-runs/store.ts
@@ -39,12 +39,21 @@ const BEGIN_REPLAY_FIELDS = [
   'parent_model_run_id',
   'input_snapshot_ref',
   'input_refs_json',
-  'status',
-  'error_summary',
   'token_count',
   'cost_estimate',
-  'created_at',
 ] as const satisfies ReadonlyArray<keyof NormalizedBeginModelRunInput>;
+
+const STABLE_INPUT_REF_KEYS = new Set([
+  'request_idempotency_key',
+  'gateway_call_id',
+  'source_turn_id',
+  'turn_id',
+  'message_id',
+  'event_id',
+  'raw_event_id',
+  'trace_id',
+  'cache_key',
+]);
 
 function modelRunId(): string {
   return `mr_${crypto.randomUUID().replace(/-/g, '')}`;
@@ -240,7 +249,7 @@ function normalizeBeginModelRunInput(
 }
 
 function assertReplayHasIdempotencyDiscriminator(expected: NormalizedBeginModelRunInput): void {
-  if (expected.envelope_hash || expected.input_refs_json) {
+  if (expected.envelope_hash || hasStableInputRefs(expected.input_refs_json)) {
     return;
   }
   throw new Error(
@@ -248,12 +257,59 @@ function assertReplayHasIdempotencyDiscriminator(expected: NormalizedBeginModelR
   );
 }
 
+function hasStableInputRefs(inputRefsJson: string | null): boolean {
+  if (!inputRefsJson) {
+    return false;
+  }
+  const inputRefs = JSON.parse(inputRefsJson) as unknown;
+  return hasStableInputRef(inputRefs);
+}
+
+function hasStableInputRef(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  for (const [key, item] of Object.entries(value)) {
+    if (STABLE_INPUT_REF_KEYS.has(key) && isNonEmptyStableInputRefValue(item)) {
+      return true;
+    }
+    if (hasStableInputRef(item)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isNonEmptyStableInputRefValue(value: unknown): boolean {
+  if (typeof value === 'string') {
+    return value.trim().length > 0;
+  }
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function replayFieldsForInput(
+  input: BeginModelRunInput
+): ReadonlyArray<keyof NormalizedBeginModelRunInput> {
+  const fields: Array<keyof NormalizedBeginModelRunInput> = [...BEGIN_REPLAY_FIELDS];
+  if (input.created_at !== undefined) {
+    fields.push('created_at');
+  }
+  if (input.status !== undefined && input.status !== 'running') {
+    fields.push('status');
+    if (input.error_summary !== undefined) {
+      fields.push('error_summary');
+    }
+  }
+  return fields;
+}
+
 function assertExistingModelRunMatchesInput(
   existing: ModelRunRecord,
-  expected: NormalizedBeginModelRunInput
+  expected: NormalizedBeginModelRunInput,
+  replayFields: ReadonlyArray<keyof NormalizedBeginModelRunInput>
 ): void {
   assertReplayHasIdempotencyDiscriminator(expected);
-  for (const field of BEGIN_REPLAY_FIELDS) {
+  for (const field of replayFields) {
     if (existing[field] !== expected[field]) {
       throw new Error(`Model run already exists with different ${field}: ${existing.model_run_id}`);
     }
@@ -312,10 +368,11 @@ export function beginModelRunInAdapter(
   const status = input.status ?? 'running';
   const inputRefsJson = normalizeInputRefsJson(input);
   const expected = normalizeBeginModelRunInput(id, input, createdAt, status, inputRefsJson);
+  const replayFields = replayFieldsForInput(input);
 
   const existing = selectModelRun(adapter, id);
   if (existing) {
-    assertExistingModelRunMatchesInput(existing, expected);
+    assertExistingModelRunMatchesInput(existing, expected, replayFields);
     return existing;
   }
 
@@ -359,7 +416,7 @@ export function beginModelRunInAdapter(
     }
     const duplicate = selectModelRun(adapter, id);
     if (duplicate) {
-      assertExistingModelRunMatchesInput(duplicate, expected);
+      assertExistingModelRunMatchesInput(duplicate, expected, replayFields);
       return duplicate;
     }
     throw error;

--- a/packages/mama-core/src/model-runs/store.ts
+++ b/packages/mama-core/src/model-runs/store.ts
@@ -287,20 +287,77 @@ function isNonEmptyStableInputRefValue(value: unknown): boolean {
   return typeof value === 'number' && Number.isFinite(value);
 }
 
+function pushReplayField(
+  fields: Array<keyof NormalizedBeginModelRunInput>,
+  field: keyof NormalizedBeginModelRunInput
+): void {
+  if (!fields.includes(field)) {
+    fields.push(field);
+  }
+}
+
 function replayFieldsForInput(
   input: BeginModelRunInput
 ): ReadonlyArray<keyof NormalizedBeginModelRunInput> {
-  const fields: Array<keyof NormalizedBeginModelRunInput> = [...BEGIN_REPLAY_FIELDS];
+  const fields: Array<keyof NormalizedBeginModelRunInput> = [];
+  for (const field of BEGIN_REPLAY_FIELDS) {
+    if (field === 'input_refs_json') {
+      if (input.input_refs !== undefined || input.input_refs_json !== undefined) {
+        pushReplayField(fields, field);
+      }
+    } else if (input[field] !== undefined) {
+      pushReplayField(fields, field);
+    }
+  }
   if (input.created_at !== undefined) {
-    fields.push('created_at');
+    pushReplayField(fields, 'created_at');
   }
   if (input.status !== undefined && input.status !== 'running') {
-    fields.push('status');
+    pushReplayField(fields, 'status');
     if (input.error_summary !== undefined) {
-      fields.push('error_summary');
+      pushReplayField(fields, 'error_summary');
     }
   }
   return fields;
+}
+
+function canonicalJson(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalJson(item));
+  }
+  if (value && typeof value === 'object') {
+    const object = value as Record<string, unknown>;
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(object).sort()) {
+      sorted[key] = canonicalJson(object[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+function canonicalJsonString(value: string): string {
+  return JSON.stringify(canonicalJson(JSON.parse(value) as unknown));
+}
+
+function replayFieldMatches(
+  existing: ModelRunRecord,
+  expected: NormalizedBeginModelRunInput,
+  field: keyof NormalizedBeginModelRunInput
+): boolean {
+  if (field === 'input_refs_json') {
+    if (existing.input_refs_json === expected.input_refs_json) {
+      return true;
+    }
+    if (!existing.input_refs_json || !expected.input_refs_json) {
+      return existing.input_refs_json === expected.input_refs_json;
+    }
+    return (
+      canonicalJsonString(existing.input_refs_json) ===
+      canonicalJsonString(expected.input_refs_json)
+    );
+  }
+  return existing[field] === expected[field];
 }
 
 function assertExistingModelRunMatchesInput(
@@ -310,7 +367,7 @@ function assertExistingModelRunMatchesInput(
 ): void {
   assertReplayHasIdempotencyDiscriminator(expected);
   for (const field of replayFields) {
-    if (existing[field] !== expected[field]) {
+    if (!replayFieldMatches(existing, expected, field)) {
       throw new Error(`Model run already exists with different ${field}: ${existing.model_run_id}`);
     }
   }

--- a/packages/mama-core/src/model-runs/store.ts
+++ b/packages/mama-core/src/model-runs/store.ts
@@ -314,9 +314,9 @@ function replayFieldsForInput(
   }
   if (input.status !== undefined && input.status !== 'running') {
     pushReplayField(fields, 'status');
-    if (input.error_summary !== undefined) {
-      pushReplayField(fields, 'error_summary');
-    }
+  }
+  if (input.error_summary !== undefined) {
+    pushReplayField(fields, 'error_summary');
   }
   return fields;
 }

--- a/packages/mama-core/src/model-runs/store.ts
+++ b/packages/mama-core/src/model-runs/store.ts
@@ -166,54 +166,153 @@ function requireModelRun(adapter: ModelRunAdapter, id: string): ModelRunRecord {
   return run;
 }
 
-export async function beginModelRun(input: BeginModelRunInput): Promise<ModelRunRecord> {
-  const adapter = await initializedAdapter();
+function assertNullableFieldMatches(
+  existing: ModelRunRecord,
+  input: BeginModelRunInput,
+  field: keyof Pick<
+    BeginModelRunInput,
+    | 'model_id'
+    | 'model_provider'
+    | 'prompt_version'
+    | 'tool_manifest_version'
+    | 'output_schema_version'
+    | 'agent_id'
+    | 'instance_id'
+    | 'envelope_hash'
+    | 'parent_model_run_id'
+    | 'input_snapshot_ref'
+    | 'error_summary'
+  >
+): void {
+  if (input[field] === undefined) {
+    return;
+  }
+  if (existing[field] !== nullableString(input[field])) {
+    throw new Error(`Model run already exists with different ${field}: ${existing.model_run_id}`);
+  }
+}
+
+function assertExistingModelRunMatchesInput(
+  existing: ModelRunRecord,
+  input: BeginModelRunInput,
+  inputRefsJson: string | null
+): void {
+  for (const field of [
+    'model_id',
+    'model_provider',
+    'prompt_version',
+    'tool_manifest_version',
+    'output_schema_version',
+    'agent_id',
+    'instance_id',
+    'envelope_hash',
+    'parent_model_run_id',
+    'input_snapshot_ref',
+    'error_summary',
+  ] as const) {
+    assertNullableFieldMatches(existing, input, field);
+  }
+
+  if (input.input_refs !== undefined || input.input_refs_json !== undefined) {
+    if (existing.input_refs_json !== inputRefsJson) {
+      throw new Error(
+        `Model run already exists with different input_refs_json: ${existing.model_run_id}`
+      );
+    }
+  }
+  if (input.status !== undefined && existing.status !== input.status) {
+    throw new Error(`Model run already exists with different status: ${existing.model_run_id}`);
+  }
+  if (
+    input.token_count !== undefined &&
+    existing.token_count !== normalizeNumber(input.token_count, 0)
+  ) {
+    throw new Error(
+      `Model run already exists with different token_count: ${existing.model_run_id}`
+    );
+  }
+  if (
+    input.cost_estimate !== undefined &&
+    existing.cost_estimate !== normalizeCost(input.cost_estimate)
+  ) {
+    throw new Error(
+      `Model run already exists with different cost_estimate: ${existing.model_run_id}`
+    );
+  }
+  if (
+    input.created_at !== undefined &&
+    existing.created_at !== normalizeTimestamp(input.created_at)
+  ) {
+    throw new Error(`Model run already exists with different created_at: ${existing.model_run_id}`);
+  }
+}
+
+export function beginModelRunInAdapter(
+  adapter: ModelRunAdapter,
+  input: BeginModelRunInput
+): ModelRunRecord {
   const id = nullableString(input.model_run_id) ?? modelRunId();
   const createdAt = normalizeTimestamp(input.created_at);
   const status = input.status ?? 'running';
+  const inputRefsJson = normalizeInputRefsJson(input);
 
-  adapter
-    .prepare(
-      `
-        INSERT INTO model_runs (
-          model_run_id, model_id, model_provider, prompt_version, tool_manifest_version,
-          output_schema_version, agent_id, instance_id, envelope_hash, parent_model_run_id,
-          input_snapshot_ref, input_refs_json, completion_summary, status, error_summary,
-          token_count, cost_estimate, created_at, completed_at
-        )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `
-    )
-    .run(
-      id,
-      nullableString(input.model_id),
-      nullableString(input.model_provider),
-      nullableString(input.prompt_version),
-      nullableString(input.tool_manifest_version),
-      nullableString(input.output_schema_version),
-      nullableString(input.agent_id),
-      nullableString(input.instance_id),
-      nullableString(input.envelope_hash),
-      nullableString(input.parent_model_run_id),
-      nullableString(input.input_snapshot_ref),
-      normalizeInputRefsJson(input),
-      null,
-      status,
-      nullableString(input.error_summary),
-      normalizeNumber(input.token_count, 0),
-      normalizeCost(input.cost_estimate),
-      createdAt,
-      null
-    );
+  const existing = selectModelRun(adapter, id);
+  if (existing) {
+    assertExistingModelRunMatchesInput(existing, input, inputRefsJson);
+    return existing;
+  }
+
+  try {
+    adapter
+      .prepare(
+        `
+          INSERT INTO model_runs (
+            model_run_id, model_id, model_provider, prompt_version, tool_manifest_version,
+            output_schema_version, agent_id, instance_id, envelope_hash, parent_model_run_id,
+            input_snapshot_ref, input_refs_json, completion_summary, status, error_summary,
+            token_count, cost_estimate, created_at, completed_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `
+      )
+      .run(
+        id,
+        nullableString(input.model_id),
+        nullableString(input.model_provider),
+        nullableString(input.prompt_version),
+        nullableString(input.tool_manifest_version),
+        nullableString(input.output_schema_version),
+        nullableString(input.agent_id),
+        nullableString(input.instance_id),
+        nullableString(input.envelope_hash),
+        nullableString(input.parent_model_run_id),
+        nullableString(input.input_snapshot_ref),
+        inputRefsJson,
+        null,
+        status,
+        nullableString(input.error_summary),
+        normalizeNumber(input.token_count, 0),
+        normalizeCost(input.cost_estimate),
+        createdAt,
+        null
+      );
+  } catch (error) {
+    const duplicate = selectModelRun(adapter, id);
+    if (duplicate) {
+      assertExistingModelRunMatchesInput(duplicate, input, inputRefsJson);
+      return duplicate;
+    }
+    throw error;
+  }
 
   return requireModelRun(adapter, id);
 }
 
-export async function commitModelRun(
+export function commitModelRunInAdapter(
+  adapter: ModelRunAdapter,
   modelRunId: string,
   summary?: string
-): Promise<ModelRunRecord> {
-  const adapter = await initializedAdapter();
+): ModelRunRecord {
   const completedAt = Date.now();
   adapter
     .prepare(
@@ -230,11 +329,11 @@ export async function commitModelRun(
   return requireModelRun(adapter, modelRunId);
 }
 
-export async function failModelRun(
+export function failModelRunInAdapter(
+  adapter: ModelRunAdapter,
   modelRunId: string,
   errorSummary: string
-): Promise<ModelRunRecord> {
-  const adapter = await initializedAdapter();
+): ModelRunRecord {
   const completedAt = Date.now();
   adapter
     .prepare(
@@ -251,7 +350,35 @@ export async function failModelRun(
   return requireModelRun(adapter, modelRunId);
 }
 
+export function getModelRunInAdapter(
+  adapter: ModelRunAdapter,
+  modelRunId: string
+): ModelRunRecord | null {
+  return selectModelRun(adapter, modelRunId);
+}
+
+export async function beginModelRun(input: BeginModelRunInput): Promise<ModelRunRecord> {
+  const adapter = await initializedAdapter();
+  return beginModelRunInAdapter(adapter, input);
+}
+
+export async function commitModelRun(
+  modelRunId: string,
+  summary?: string
+): Promise<ModelRunRecord> {
+  const adapter = await initializedAdapter();
+  return commitModelRunInAdapter(adapter, modelRunId, summary);
+}
+
+export async function failModelRun(
+  modelRunId: string,
+  errorSummary: string
+): Promise<ModelRunRecord> {
+  const adapter = await initializedAdapter();
+  return failModelRunInAdapter(adapter, modelRunId, errorSummary);
+}
+
 export async function getModelRun(modelRunId: string): Promise<ModelRunRecord | null> {
   const adapter = await initializedAdapter();
-  return selectModelRun(adapter, modelRunId);
+  return getModelRunInAdapter(adapter, modelRunId);
 }

--- a/packages/mama-core/src/model-runs/store.ts
+++ b/packages/mama-core/src/model-runs/store.ts
@@ -327,9 +327,14 @@ function canonicalJson(value: unknown): unknown {
   }
   if (value && typeof value === 'object') {
     const object = value as Record<string, unknown>;
-    const sorted: Record<string, unknown> = {};
+    const sorted = Object.create(null) as Record<string, unknown>;
     for (const key of Object.keys(object).sort()) {
-      sorted[key] = canonicalJson(object[key]);
+      Object.defineProperty(sorted, key, {
+        value: canonicalJson(object[key]),
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
     }
     return sorted;
   }

--- a/packages/mama-core/src/model-runs/store.ts
+++ b/packages/mama-core/src/model-runs/store.ts
@@ -6,6 +6,45 @@ import { MODEL_RUN_STATUSES } from './types.js';
 import type { BeginModelRunInput, ModelRunRecord, ModelRunStatus } from './types.js';
 
 type ModelRunAdapter = Pick<DatabaseAdapter, 'prepare'>;
+type NormalizedBeginModelRunInput = Pick<
+  ModelRunRecord,
+  | 'model_run_id'
+  | 'model_id'
+  | 'model_provider'
+  | 'prompt_version'
+  | 'tool_manifest_version'
+  | 'output_schema_version'
+  | 'agent_id'
+  | 'instance_id'
+  | 'envelope_hash'
+  | 'parent_model_run_id'
+  | 'input_snapshot_ref'
+  | 'input_refs_json'
+  | 'status'
+  | 'error_summary'
+  | 'token_count'
+  | 'cost_estimate'
+  | 'created_at'
+>;
+
+const BEGIN_REPLAY_FIELDS = [
+  'model_id',
+  'model_provider',
+  'prompt_version',
+  'tool_manifest_version',
+  'output_schema_version',
+  'agent_id',
+  'instance_id',
+  'envelope_hash',
+  'parent_model_run_id',
+  'input_snapshot_ref',
+  'input_refs_json',
+  'status',
+  'error_summary',
+  'token_count',
+  'cost_estimate',
+  'created_at',
+] as const satisfies ReadonlyArray<keyof NormalizedBeginModelRunInput>;
 
 function modelRunId(): string {
   return `mr_${crypto.randomUUID().replace(/-/g, '')}`;
@@ -27,7 +66,13 @@ function requireString(value: unknown, field: string): string {
 }
 
 function normalizeTimestamp(value: unknown): number {
-  return typeof value === 'number' && Number.isFinite(value) ? Math.floor(value) : Date.now();
+  if (value === undefined) {
+    return Date.now();
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.floor(value);
+  }
+  throw new Error(`model_runs.created_at must be a finite number: ${formatInvalidValue(value)}`);
 }
 
 function requireTimestamp(value: unknown, field: string, modelRunId: string): number {
@@ -166,85 +211,96 @@ function requireModelRun(adapter: ModelRunAdapter, id: string): ModelRunRecord {
   return run;
 }
 
-function assertNullableFieldMatches(
-  existing: ModelRunRecord,
+function normalizeBeginModelRunInput(
+  id: string,
   input: BeginModelRunInput,
-  field: keyof Pick<
-    BeginModelRunInput,
-    | 'model_id'
-    | 'model_provider'
-    | 'prompt_version'
-    | 'tool_manifest_version'
-    | 'output_schema_version'
-    | 'agent_id'
-    | 'instance_id'
-    | 'envelope_hash'
-    | 'parent_model_run_id'
-    | 'input_snapshot_ref'
-    | 'error_summary'
-  >
-): void {
-  if (input[field] === undefined) {
+  createdAt: number,
+  status: ModelRunStatus,
+  inputRefsJson: string | null
+): NormalizedBeginModelRunInput {
+  return {
+    model_run_id: id,
+    model_id: nullableString(input.model_id),
+    model_provider: nullableString(input.model_provider),
+    prompt_version: nullableString(input.prompt_version),
+    tool_manifest_version: nullableString(input.tool_manifest_version),
+    output_schema_version: nullableString(input.output_schema_version),
+    agent_id: nullableString(input.agent_id),
+    instance_id: nullableString(input.instance_id),
+    envelope_hash: nullableString(input.envelope_hash),
+    parent_model_run_id: nullableString(input.parent_model_run_id),
+    input_snapshot_ref: nullableString(input.input_snapshot_ref),
+    input_refs_json: inputRefsJson,
+    status,
+    error_summary: nullableString(input.error_summary),
+    token_count: normalizeNumber(input.token_count, 0),
+    cost_estimate: normalizeCost(input.cost_estimate),
+    created_at: createdAt,
+  };
+}
+
+function assertReplayHasIdempotencyDiscriminator(expected: NormalizedBeginModelRunInput): void {
+  if (expected.envelope_hash || expected.input_refs_json) {
     return;
   }
-  if (existing[field] !== nullableString(input[field])) {
-    throw new Error(`Model run already exists with different ${field}: ${existing.model_run_id}`);
-  }
+  throw new Error(
+    `Model run already exists and replay is missing an idempotency discriminator: ${expected.model_run_id}`
+  );
 }
 
 function assertExistingModelRunMatchesInput(
   existing: ModelRunRecord,
-  input: BeginModelRunInput,
-  inputRefsJson: string | null
+  expected: NormalizedBeginModelRunInput
 ): void {
-  for (const field of [
-    'model_id',
-    'model_provider',
-    'prompt_version',
-    'tool_manifest_version',
-    'output_schema_version',
-    'agent_id',
-    'instance_id',
-    'envelope_hash',
-    'parent_model_run_id',
-    'input_snapshot_ref',
-    'error_summary',
-  ] as const) {
-    assertNullableFieldMatches(existing, input, field);
-  }
-
-  if (input.input_refs !== undefined || input.input_refs_json !== undefined) {
-    if (existing.input_refs_json !== inputRefsJson) {
-      throw new Error(
-        `Model run already exists with different input_refs_json: ${existing.model_run_id}`
-      );
+  assertReplayHasIdempotencyDiscriminator(expected);
+  for (const field of BEGIN_REPLAY_FIELDS) {
+    if (existing[field] !== expected[field]) {
+      throw new Error(`Model run already exists with different ${field}: ${existing.model_run_id}`);
     }
   }
-  if (input.status !== undefined && existing.status !== input.status) {
-    throw new Error(`Model run already exists with different status: ${existing.model_run_id}`);
-  }
-  if (
-    input.token_count !== undefined &&
-    existing.token_count !== normalizeNumber(input.token_count, 0)
-  ) {
+}
+
+function isDuplicateModelRunError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /UNIQUE constraint failed: model_runs\.model_run_id|PRIMARY KEY constraint failed/i.test(
+    message
+  );
+}
+
+function resolveExistingCommittedRun(
+  existing: ModelRunRecord,
+  summary: string | null
+): ModelRunRecord {
+  if (existing.status === 'committed') {
+    if (existing.completion_summary === summary) {
+      return existing;
+    }
     throw new Error(
-      `Model run already exists with different token_count: ${existing.model_run_id}`
+      `Model run already committed with different completion_summary: ${existing.model_run_id}`
     );
   }
-  if (
-    input.cost_estimate !== undefined &&
-    existing.cost_estimate !== normalizeCost(input.cost_estimate)
-  ) {
+  if (existing.status === 'failed') {
+    throw new Error(`Model run already failed: ${existing.model_run_id}`);
+  }
+  throw new Error(`Cannot commit model run in ${existing.status} status: ${existing.model_run_id}`);
+}
+
+function resolveExistingFailedRun(
+  existing: ModelRunRecord,
+  errorSummary: string | null
+): ModelRunRecord {
+  if (existing.status === 'failed') {
+    if (existing.error_summary === errorSummary) {
+      return existing;
+    }
     throw new Error(
-      `Model run already exists with different cost_estimate: ${existing.model_run_id}`
+      `Model run already failed with different error_summary: ${existing.model_run_id}`
     );
   }
-  if (
-    input.created_at !== undefined &&
-    existing.created_at !== normalizeTimestamp(input.created_at)
-  ) {
-    throw new Error(`Model run already exists with different created_at: ${existing.model_run_id}`);
+  if (existing.status === 'committed') {
+    throw new Error(`Model run already committed: ${existing.model_run_id}`);
   }
+  throw new Error(`Cannot fail model run in ${existing.status} status: ${existing.model_run_id}`);
 }
 
 export function beginModelRunInAdapter(
@@ -255,10 +311,11 @@ export function beginModelRunInAdapter(
   const createdAt = normalizeTimestamp(input.created_at);
   const status = input.status ?? 'running';
   const inputRefsJson = normalizeInputRefsJson(input);
+  const expected = normalizeBeginModelRunInput(id, input, createdAt, status, inputRefsJson);
 
   const existing = selectModelRun(adapter, id);
   if (existing) {
-    assertExistingModelRunMatchesInput(existing, input, inputRefsJson);
+    assertExistingModelRunMatchesInput(existing, expected);
     return existing;
   }
 
@@ -297,9 +354,12 @@ export function beginModelRunInAdapter(
         null
       );
   } catch (error) {
+    if (!isDuplicateModelRunError(error)) {
+      throw error;
+    }
     const duplicate = selectModelRun(adapter, id);
     if (duplicate) {
-      assertExistingModelRunMatchesInput(duplicate, input, inputRefsJson);
+      assertExistingModelRunMatchesInput(duplicate, expected);
       return duplicate;
     }
     throw error;
@@ -313,18 +373,29 @@ export function commitModelRunInAdapter(
   modelRunId: string,
   summary?: string
 ): ModelRunRecord {
+  const summaryValue = nullableString(summary);
+  const existing = requireModelRun(adapter, modelRunId);
+  if (existing.status !== 'running') {
+    return resolveExistingCommittedRun(existing, summaryValue);
+  }
+
   const completedAt = Date.now();
-  adapter
+  const result = adapter
     .prepare(
       `
         UPDATE model_runs
         SET status = 'committed',
             completion_summary = ?,
+            error_summary = NULL,
             completed_at = ?
-        WHERE model_run_id = ?
+        WHERE model_run_id = ? AND status = 'running'
       `
     )
-    .run(nullableString(summary), completedAt, modelRunId);
+    .run(summaryValue, completedAt, modelRunId);
+
+  if (result.changes === 0) {
+    return resolveExistingCommittedRun(requireModelRun(adapter, modelRunId), summaryValue);
+  }
 
   return requireModelRun(adapter, modelRunId);
 }
@@ -334,18 +405,29 @@ export function failModelRunInAdapter(
   modelRunId: string,
   errorSummary: string
 ): ModelRunRecord {
+  const errorSummaryValue = nullableString(errorSummary);
+  const existing = requireModelRun(adapter, modelRunId);
+  if (existing.status !== 'running') {
+    return resolveExistingFailedRun(existing, errorSummaryValue);
+  }
+
   const completedAt = Date.now();
-  adapter
+  const result = adapter
     .prepare(
       `
         UPDATE model_runs
         SET status = 'failed',
+            completion_summary = NULL,
             error_summary = ?,
             completed_at = ?
-        WHERE model_run_id = ?
+        WHERE model_run_id = ? AND status = 'running'
       `
     )
-    .run(nullableString(errorSummary), completedAt, modelRunId);
+    .run(errorSummaryValue, completedAt, modelRunId);
+
+  if (result.changes === 0) {
+    return resolveExistingFailedRun(requireModelRun(adapter, modelRunId), errorSummaryValue);
+  }
 
   return requireModelRun(adapter, modelRunId);
 }

--- a/packages/mama-core/tests/model-runs/adapter-scoped-store.test.ts
+++ b/packages/mama-core/tests/model-runs/adapter-scoped-store.test.ts
@@ -511,6 +511,13 @@ describe('Story M5/M6: Adapter-scoped model run helpers', () => {
             error_summary: 'changed failure',
           })
         ).toThrow(/different error_summary/);
+        expect(() =>
+          beginModelRunInAdapter(scopedAdapter, {
+            model_run_id: input.model_run_id,
+            envelope_hash: input.envelope_hash,
+            error_summary: 'changed failure without status',
+          })
+        ).toThrow(/different error_summary/);
       });
 
       it('rejects conflicts for every explicitly replayed stable begin field', () => {

--- a/packages/mama-core/tests/model-runs/adapter-scoped-store.test.ts
+++ b/packages/mama-core/tests/model-runs/adapter-scoped-store.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { closeDB, getAdapter, initDB, type DatabaseAdapter } from '../../src/db-manager.js';
 import { NodeSQLiteAdapter } from '../../src/db-adapter/node-sqlite-adapter.js';
@@ -19,6 +19,8 @@ import {
 const MIGRATIONS_DIR = join(__dirname, '..', '..', 'db', 'migrations');
 const tempPaths = new Set<string>();
 const scopedAdapters = new Set<DatabaseAdapter>();
+type ModelRunAdapterForTest = Parameters<typeof beginModelRunInAdapter>[0];
+type RunResultForTest = ReturnType<ReturnType<ModelRunAdapterForTest['prepare']>['run']>;
 
 function tempDbPath(label: string): string {
   const path = join(os.tmpdir(), `test-model-run-adapter-${label}-${randomUUID()}.db`);
@@ -44,10 +46,64 @@ function createAdapter(path: string): DatabaseAdapter {
   return adapter;
 }
 
+class FakeModelRunStatement {
+  constructor(
+    private readonly behavior: {
+      get?: (...params: unknown[]) => object | undefined;
+      run?: (...params: unknown[]) => RunResultForTest;
+    }
+  ) {}
+
+  all(): object[] {
+    return [];
+  }
+
+  get(...params: unknown[]): object | undefined {
+    return this.behavior.get?.(...params);
+  }
+
+  run(...params: unknown[]): RunResultForTest {
+    if (!this.behavior.run) {
+      return { changes: 0, lastInsertRowid: 0 };
+    }
+    return this.behavior.run(...params);
+  }
+
+  finalize(): void {
+    // fake statement does not hold native resources
+  }
+}
+
+function modelRunRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    model_run_id: 'mr_fake',
+    model_id: null,
+    model_provider: null,
+    prompt_version: null,
+    tool_manifest_version: null,
+    output_schema_version: null,
+    agent_id: 'agent-fake',
+    instance_id: null,
+    envelope_hash: 'env_fake',
+    parent_model_run_id: null,
+    input_snapshot_ref: null,
+    input_refs_json: JSON.stringify({ request_idempotency_key: 'fake-key' }),
+    completion_summary: null,
+    status: 'running',
+    error_summary: null,
+    token_count: 0,
+    cost_estimate: null,
+    created_at: 10_000,
+    completed_at: null,
+    ...overrides,
+  };
+}
+
 describe('Story M5/M6: Adapter-scoped model run helpers', () => {
   afterEach(async () => {
     await closeDB();
     delete process.env.MAMA_DB_PATH;
+    vi.restoreAllMocks();
     for (const adapter of scopedAdapters) {
       adapter.disconnect();
     }
@@ -150,6 +206,45 @@ describe('Story M5/M6: Adapter-scoped model run helpers', () => {
         expect(count.count).toBe(1);
       });
 
+      it('replays matching deterministic ids when created_at was omitted', () => {
+        const scopedAdapter = createAdapter(tempDbPath('no-created-at'));
+        vi.spyOn(Date, 'now').mockReturnValueOnce(10_000).mockReturnValueOnce(10_050);
+        const input = {
+          model_run_id: 'mr_direct_no_created_at',
+          agent_id: 'agent-alias',
+          envelope_hash: 'env_alias_no_created_at',
+          input_refs: {
+            tool: 'entity.alias',
+            request_idempotency_key: 'alias-key-no-created-at',
+          },
+        };
+
+        const first = beginModelRunInAdapter(scopedAdapter, input);
+        const replay = beginModelRunInAdapter(scopedAdapter, input);
+
+        expect(replay).toEqual(first);
+        expect(replay.created_at).toBe(10_000);
+      });
+
+      it('replays matching begin input after the run reaches a terminal status', () => {
+        const scopedAdapter = createAdapter(tempDbPath('terminal-replay'));
+        const input = {
+          model_run_id: 'mr_terminal_replay',
+          agent_id: 'agent-alias',
+          envelope_hash: 'env_alias_terminal_replay',
+          input_refs: {
+            tool: 'entity.alias',
+            request_idempotency_key: 'alias-key-terminal-replay',
+          },
+          created_at: 4_500,
+        };
+
+        beginModelRunInAdapter(scopedAdapter, input);
+        const committed = commitModelRunInAdapter(scopedAdapter, input.model_run_id, 'done');
+
+        expect(beginModelRunInAdapter(scopedAdapter, input)).toEqual(committed);
+      });
+
       it('rejects underspecified duplicate model run ids instead of binding to an existing run', () => {
         const scopedAdapter = createAdapter(tempDbPath('underspecified'));
         const input = {
@@ -181,6 +276,45 @@ describe('Story M5/M6: Adapter-scoped model run helpers', () => {
             request_idempotency_key: 'alias-key-existing',
           },
         });
+      });
+
+      it('rejects empty input refs as an idempotency discriminator', () => {
+        const scopedAdapter = createAdapter(tempDbPath('empty-input-refs'));
+        const input = {
+          model_run_id: 'mr_empty_input_refs',
+          input_refs: {},
+          created_at: 5_500,
+        };
+
+        beginModelRunInAdapter(scopedAdapter, input);
+
+        expect(() => beginModelRunInAdapter(scopedAdapter, input)).toThrow(
+          /idempotency discriminator/
+        );
+      });
+
+      it('rejects empty stable input ref values as idempotency discriminators', () => {
+        const scopedAdapter = createAdapter(tempDbPath('empty-stable-input-ref-values'));
+        const cases = [
+          ['empty_string', ''],
+          ['blank_string', '  '],
+          ['empty_object', {}],
+          ['empty_array', []],
+        ] as const;
+
+        for (const [label, requestIdempotencyKey] of cases) {
+          const input = {
+            model_run_id: `mr_empty_stable_input_ref_${label}`,
+            input_refs: { request_idempotency_key: requestIdempotencyKey },
+            created_at: 5_600,
+          };
+
+          beginModelRunInAdapter(scopedAdapter, input);
+
+          expect(() => beginModelRunInAdapter(scopedAdapter, input)).toThrow(
+            /idempotency discriminator/
+          );
+        }
       });
 
       it('rejects conflicting deterministic replays and preserves the original row', () => {
@@ -255,6 +389,41 @@ describe('Story M5/M6: Adapter-scoped model run helpers', () => {
             request_idempotency_key: 'legacy-key',
           },
         });
+      });
+
+      it('rethrows non-duplicate insert errors instead of treating them as replay success', () => {
+        let selectCount = 0;
+        const adapter: ModelRunAdapterForTest = {
+          prepare(sql: string) {
+            if (/FROM model_runs/i.test(sql)) {
+              return new FakeModelRunStatement({
+                get() {
+                  selectCount += 1;
+                  return selectCount === 1 ? undefined : modelRunRow();
+                },
+              });
+            }
+            if (/INSERT INTO model_runs/i.test(sql)) {
+              return new FakeModelRunStatement({
+                run() {
+                  throw new Error('SQLITE_BUSY: database is locked');
+                },
+              });
+            }
+            throw new Error(`Unexpected SQL in fake adapter: ${sql}`);
+          },
+        };
+
+        expect(() =>
+          beginModelRunInAdapter(adapter, {
+            model_run_id: 'mr_fake',
+            agent_id: 'agent-fake',
+            envelope_hash: 'env_fake',
+            input_refs: { request_idempotency_key: 'fake-key' },
+            created_at: 10_000,
+          })
+        ).toThrow(/SQLITE_BUSY/);
+        expect(selectCount).toBe(1);
       });
     });
 

--- a/packages/mama-core/tests/model-runs/adapter-scoped-store.test.ts
+++ b/packages/mama-core/tests/model-runs/adapter-scoped-store.test.ts
@@ -8,14 +8,17 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { closeDB, getAdapter, initDB, type DatabaseAdapter } from '../../src/db-manager.js';
 import { NodeSQLiteAdapter } from '../../src/db-adapter/node-sqlite-adapter.js';
 import {
+  beginModelRun,
   beginModelRunInAdapter,
   commitModelRunInAdapter,
   failModelRunInAdapter,
+  getModelRun,
   getModelRunInAdapter,
 } from '../../src/model-runs/store.js';
 
 const MIGRATIONS_DIR = join(__dirname, '..', '..', 'db', 'migrations');
 const tempPaths = new Set<string>();
+const scopedAdapters = new Set<DatabaseAdapter>();
 
 function tempDbPath(label: string): string {
   const path = join(os.tmpdir(), `test-model-run-adapter-${label}-${randomUUID()}.db`);
@@ -37,6 +40,7 @@ function createAdapter(path: string): DatabaseAdapter {
   const adapter = new NodeSQLiteAdapter({ dbPath: path }) as unknown as DatabaseAdapter;
   adapter.connect();
   adapter.runMigrations(MIGRATIONS_DIR);
+  scopedAdapters.add(adapter);
   return adapter;
 }
 
@@ -44,6 +48,10 @@ describe('Story M5/M6: Adapter-scoped model run helpers', () => {
   afterEach(async () => {
     await closeDB();
     delete process.env.MAMA_DB_PATH;
+    for (const adapter of scopedAdapters) {
+      adapter.disconnect();
+    }
+    scopedAdapters.clear();
     for (const path of tempPaths) {
       cleanupDb(path);
     }
@@ -140,6 +148,159 @@ describe('Story M5/M6: Adapter-scoped model run helpers', () => {
           .prepare('SELECT COUNT(*) AS count FROM model_runs WHERE model_run_id = ?')
           .get(input.model_run_id) as { count: number };
         expect(count.count).toBe(1);
+      });
+
+      it('rejects underspecified duplicate model run ids instead of binding to an existing run', () => {
+        const scopedAdapter = createAdapter(tempDbPath('underspecified'));
+        const input = {
+          model_run_id: 'mr_direct_alias_existing',
+          agent_id: 'agent-alias',
+          envelope_hash: 'env_alias_existing',
+          input_refs: {
+            tool: 'entity.alias',
+            entity_id: 'entity_existing',
+            request_idempotency_key: 'alias-key-existing',
+          },
+          created_at: 5_000,
+        };
+
+        beginModelRunInAdapter(scopedAdapter, input);
+
+        expect(() =>
+          beginModelRunInAdapter(scopedAdapter, {
+            model_run_id: input.model_run_id,
+            created_at: input.created_at,
+          })
+        ).toThrow(/idempotency discriminator|different/);
+        expect(getModelRunInAdapter(scopedAdapter, input.model_run_id)).toMatchObject({
+          agent_id: 'agent-alias',
+          envelope_hash: 'env_alias_existing',
+          input_refs: {
+            tool: 'entity.alias',
+            entity_id: 'entity_existing',
+            request_idempotency_key: 'alias-key-existing',
+          },
+        });
+      });
+
+      it('rejects conflicting deterministic replays and preserves the original row', () => {
+        const scopedAdapter = createAdapter(tempDbPath('conflict'));
+        const input = {
+          model_run_id: 'mr_direct_alias_conflict',
+          agent_id: 'agent-alias',
+          envelope_hash: 'env_alias_original',
+          input_refs: {
+            tool: 'entity.alias',
+            entity_id: 'entity_original',
+            request_idempotency_key: 'alias-key-conflict',
+          },
+          token_count: 12,
+          created_at: 6_000,
+        };
+
+        beginModelRunInAdapter(scopedAdapter, input);
+
+        for (const conflictingInput of [
+          { ...input, envelope_hash: 'env_alias_changed' },
+          { ...input, input_refs: { ...input.input_refs, entity_id: 'entity_changed' } },
+          { ...input, status: 'failed' as const },
+          { ...input, token_count: 13 },
+          { ...input, created_at: 6_001 },
+        ]) {
+          expect(() => beginModelRunInAdapter(scopedAdapter, conflictingInput)).toThrow(
+            /Model run already exists/
+          );
+        }
+
+        expect(getModelRunInAdapter(scopedAdapter, input.model_run_id)).toMatchObject({
+          model_run_id: input.model_run_id,
+          envelope_hash: 'env_alias_original',
+          input_refs: {
+            tool: 'entity.alias',
+            entity_id: 'entity_original',
+            request_idempotency_key: 'alias-key-conflict',
+          },
+          token_count: 12,
+          created_at: 6_000,
+        });
+      });
+
+      it('pins duplicate behavior through the legacy global begin helper', async () => {
+        const globalPath = tempDbPath('legacy-global');
+        process.env.MAMA_DB_PATH = globalPath;
+
+        const input = {
+          model_run_id: 'mr_legacy_duplicate',
+          agent_id: 'agent-legacy',
+          envelope_hash: 'env_legacy',
+          input_refs: {
+            tool: 'model.run',
+            request_idempotency_key: 'legacy-key',
+          },
+          created_at: 7_000,
+        };
+
+        const first = await beginModelRun(input);
+        await expect(beginModelRun(input)).resolves.toEqual(first);
+        await expect(
+          beginModelRun({
+            ...input,
+            envelope_hash: 'env_legacy_changed',
+          })
+        ).rejects.toThrow(/Model run already exists/);
+        await expect(getModelRun(input.model_run_id)).resolves.toMatchObject({
+          envelope_hash: 'env_legacy',
+          input_refs: {
+            tool: 'model.run',
+            request_idempotency_key: 'legacy-key',
+          },
+        });
+      });
+    });
+
+    describe('AC #4: terminal lifecycle safety', () => {
+      it('does not allow a committed run to be failed later', () => {
+        const scopedAdapter = createAdapter(tempDbPath('committed-terminal'));
+        beginModelRunInAdapter(scopedAdapter, {
+          model_run_id: 'mr_terminal_commit',
+          created_at: 8_000,
+        });
+
+        const committed = commitModelRunInAdapter(
+          scopedAdapter,
+          'mr_terminal_commit',
+          'packet generated'
+        );
+
+        expect(() =>
+          failModelRunInAdapter(scopedAdapter, 'mr_terminal_commit', 'late failure')
+        ).toThrow(/already committed/);
+        expect(getModelRunInAdapter(scopedAdapter, 'mr_terminal_commit')).toMatchObject({
+          status: 'committed',
+          completion_summary: committed.completion_summary,
+          error_summary: null,
+          completed_at: committed.completed_at,
+        });
+      });
+
+      it('does not allow a failed run to be committed later', () => {
+        const scopedAdapter = createAdapter(tempDbPath('failed-terminal'));
+        beginModelRunInAdapter(scopedAdapter, {
+          model_run_id: 'mr_terminal_fail',
+          created_at: 9_000,
+        });
+
+        const failed = failModelRunInAdapter(scopedAdapter, 'mr_terminal_fail', 'alias failed');
+
+        expect(() =>
+          commitModelRunInAdapter(scopedAdapter, 'mr_terminal_fail', 'late success')
+        ).toThrow(/already failed/);
+        expect(getModelRunInAdapter(scopedAdapter, 'mr_terminal_fail')).toMatchObject({
+          status: 'failed',
+          completion_summary: null,
+          error_summary: failed.error_summary,
+          completed_at: failed.completed_at,
+        });
       });
     });
   });

--- a/packages/mama-core/tests/model-runs/adapter-scoped-store.test.ts
+++ b/packages/mama-core/tests/model-runs/adapter-scoped-store.test.ts
@@ -627,6 +627,52 @@ describe('Story M5/M6: Adapter-scoped model run helpers', () => {
         ).toThrow(/SQLITE_BUSY/);
         expect(selectCount).toBe(1);
       });
+
+      it('recovers matching duplicate insert errors by replaying the row inserted by a race', () => {
+        let selectCount = 0;
+        let insertCount = 0;
+        const adapter: ModelRunAdapterForTest = {
+          prepare(sql: string) {
+            if (/FROM model_runs/i.test(sql)) {
+              return new FakeModelRunStatement({
+                get() {
+                  selectCount += 1;
+                  return selectCount === 1 ? undefined : modelRunRow();
+                },
+              });
+            }
+            if (/INSERT INTO model_runs/i.test(sql)) {
+              return new FakeModelRunStatement({
+                run() {
+                  insertCount += 1;
+                  throw new Error(
+                    'SQLITE_CONSTRAINT_PRIMARYKEY: UNIQUE constraint failed: model_runs.model_run_id'
+                  );
+                },
+              });
+            }
+            throw new Error(`Unexpected SQL in fake adapter: ${sql}`);
+          },
+        };
+
+        const replay = beginModelRunInAdapter(adapter, {
+          model_run_id: 'mr_fake',
+          agent_id: 'agent-fake',
+          envelope_hash: 'env_fake',
+          input_refs: { request_idempotency_key: 'fake-key' },
+          created_at: 10_000,
+        });
+
+        expect(replay).toMatchObject({
+          model_run_id: 'mr_fake',
+          agent_id: 'agent-fake',
+          envelope_hash: 'env_fake',
+          input_refs: { request_idempotency_key: 'fake-key' },
+          status: 'running',
+        });
+        expect(selectCount).toBe(2);
+        expect(insertCount).toBe(1);
+      });
     });
 
     describe('AC #4: terminal lifecycle safety', () => {

--- a/packages/mama-core/tests/model-runs/adapter-scoped-store.test.ts
+++ b/packages/mama-core/tests/model-runs/adapter-scoped-store.test.ts
@@ -1,0 +1,146 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { closeDB, getAdapter, initDB, type DatabaseAdapter } from '../../src/db-manager.js';
+import { NodeSQLiteAdapter } from '../../src/db-adapter/node-sqlite-adapter.js';
+import {
+  beginModelRunInAdapter,
+  commitModelRunInAdapter,
+  failModelRunInAdapter,
+  getModelRunInAdapter,
+} from '../../src/model-runs/store.js';
+
+const MIGRATIONS_DIR = join(__dirname, '..', '..', 'db', 'migrations');
+const tempPaths = new Set<string>();
+
+function tempDbPath(label: string): string {
+  const path = join(os.tmpdir(), `test-model-run-adapter-${label}-${randomUUID()}.db`);
+  tempPaths.add(path);
+  return path;
+}
+
+function cleanupDb(path: string): void {
+  for (const file of [path, `${path}-journal`, `${path}-wal`, `${path}-shm`]) {
+    try {
+      fs.unlinkSync(file);
+    } catch {
+      // cleanup best effort
+    }
+  }
+}
+
+function createAdapter(path: string): DatabaseAdapter {
+  const adapter = new NodeSQLiteAdapter({ dbPath: path }) as unknown as DatabaseAdapter;
+  adapter.connect();
+  adapter.runMigrations(MIGRATIONS_DIR);
+  return adapter;
+}
+
+describe('Story M5/M6: Adapter-scoped model run helpers', () => {
+  afterEach(async () => {
+    await closeDB();
+    delete process.env.MAMA_DB_PATH;
+    for (const path of tempPaths) {
+      cleanupDb(path);
+    }
+    tempPaths.clear();
+  });
+
+  describe('Acceptance Criteria', () => {
+    describe('AC #1: injected adapter isolation', () => {
+      it('begins and reads model runs from the supplied adapter without touching the global DB', async () => {
+        const globalPath = tempDbPath('global');
+        const scopedPath = tempDbPath('scoped');
+        process.env.MAMA_DB_PATH = globalPath;
+        await initDB();
+        const globalAdapter = getAdapter();
+
+        const scopedAdapter = createAdapter(scopedPath);
+        const run = beginModelRunInAdapter(scopedAdapter, {
+          model_run_id: 'mr_scoped',
+          agent_id: 'agent-scoped',
+          envelope_hash: 'env_scoped',
+          input_refs: { source: 'agent.situation', cache_key: 'cache_1' },
+          created_at: 1_000,
+        });
+
+        expect(run).toMatchObject({
+          model_run_id: 'mr_scoped',
+          agent_id: 'agent-scoped',
+          envelope_hash: 'env_scoped',
+          status: 'running',
+        });
+        expect(getModelRunInAdapter(scopedAdapter, 'mr_scoped')).toMatchObject({
+          model_run_id: 'mr_scoped',
+          input_refs: { source: 'agent.situation', cache_key: 'cache_1' },
+        });
+        expect(getModelRunInAdapter(globalAdapter, 'mr_scoped')).toBeNull();
+      });
+    });
+
+    describe('AC #2: adapter-scoped lifecycle', () => {
+      it('commits and fails runs using the supplied adapter', () => {
+        const scopedAdapter = createAdapter(tempDbPath('lifecycle'));
+        beginModelRunInAdapter(scopedAdapter, {
+          model_run_id: 'mr_commit_scoped',
+          created_at: 2_000,
+        });
+
+        const committed = commitModelRunInAdapter(
+          scopedAdapter,
+          'mr_commit_scoped',
+          'packet generated'
+        );
+
+        expect(committed).toMatchObject({
+          model_run_id: 'mr_commit_scoped',
+          status: 'committed',
+          completion_summary: 'packet generated',
+        });
+
+        beginModelRunInAdapter(scopedAdapter, {
+          model_run_id: 'mr_fail_scoped',
+          created_at: 3_000,
+        });
+
+        const failed = failModelRunInAdapter(scopedAdapter, 'mr_fail_scoped', 'alias failed');
+
+        expect(failed).toMatchObject({
+          model_run_id: 'mr_fail_scoped',
+          status: 'failed',
+          error_summary: 'alias failed',
+        });
+      });
+    });
+
+    describe('AC #3: deterministic direct run idempotency', () => {
+      it('returns an existing matching caller-supplied model run id instead of inserting a duplicate', () => {
+        const scopedAdapter = createAdapter(tempDbPath('idempotent'));
+        const input = {
+          model_run_id: 'mr_direct_alias_env_entity_key',
+          agent_id: 'agent-alias',
+          envelope_hash: 'env_alias',
+          input_refs: {
+            tool: 'entity.alias',
+            entity_id: 'entity_1',
+            request_idempotency_key: 'alias-key',
+          },
+          created_at: 4_000,
+        };
+
+        const first = beginModelRunInAdapter(scopedAdapter, input);
+        const replay = beginModelRunInAdapter(scopedAdapter, input);
+
+        expect(replay).toEqual(first);
+        const count = scopedAdapter
+          .prepare('SELECT COUNT(*) AS count FROM model_runs WHERE model_run_id = ?')
+          .get(input.model_run_id) as { count: number };
+        expect(count.count).toBe(1);
+      });
+    });
+  });
+});

--- a/packages/mama-core/tests/model-runs/adapter-scoped-store.test.ts
+++ b/packages/mama-core/tests/model-runs/adapter-scoped-store.test.ts
@@ -253,6 +253,30 @@ describe('Story M5/M6: Adapter-scoped model run helpers', () => {
         expect(replay).toEqual(first);
       });
 
+      it('allows partial deterministic replays when stable input refs are the discriminator', () => {
+        const scopedAdapter = createAdapter(tempDbPath('partial-stable-input-ref-replay'));
+        const input = {
+          model_run_id: 'mr_partial_stable_input_ref_replay',
+          model_id: 'gpt-5.4',
+          model_provider: 'openai',
+          agent_id: 'agent-alias',
+          input_refs: {
+            request_idempotency_key: 'alias-key-partial-stable-input-ref',
+          },
+          token_count: 42,
+          cost_estimate: 0.25,
+          created_at: 4_275,
+        };
+
+        const first = beginModelRunInAdapter(scopedAdapter, input);
+        const replay = beginModelRunInAdapter(scopedAdapter, {
+          model_run_id: input.model_run_id,
+          input_refs: input.input_refs,
+        });
+
+        expect(replay).toEqual(first);
+      });
+
       it('compares replay input refs canonically instead of by raw JSON text', () => {
         const scopedAdapter = createAdapter(tempDbPath('canonical-input-refs'));
         const input = {
@@ -276,6 +300,24 @@ describe('Story M5/M6: Adapter-scoped model run helpers', () => {
             ...input,
             input_refs_json:
               '{"request_idempotency_key":"alias-key-canonical","entity_id":"entity_changed"}',
+          })
+        ).toThrow(/different input_refs_json/);
+      });
+
+      it('preserves __proto__ as an own input ref key during canonical comparison', () => {
+        const scopedAdapter = createAdapter(tempDbPath('canonical-proto-input-refs'));
+        const input = {
+          model_run_id: 'mr_canonical_proto_input_refs',
+          input_refs_json: '{"__proto__":{"request_idempotency_key":"proto-key-original"}}',
+          created_at: 4_400,
+        };
+
+        beginModelRunInAdapter(scopedAdapter, input);
+
+        expect(() =>
+          beginModelRunInAdapter(scopedAdapter, {
+            ...input,
+            input_refs_json: '{"__proto__":{"request_idempotency_key":"proto-key-changed"}}',
           })
         ).toThrow(/different input_refs_json/);
       });
@@ -448,6 +490,27 @@ describe('Story M5/M6: Adapter-scoped model run helpers', () => {
           token_count: 12,
           created_at: 6_000,
         });
+      });
+
+      it('rejects explicitly replayed error summary conflicts for non-running begin rows', () => {
+        const scopedAdapter = createAdapter(tempDbPath('error-summary-conflict'));
+        const input = {
+          model_run_id: 'mr_error_summary_conflict',
+          envelope_hash: 'env_error_summary_conflict',
+          input_refs: { request_idempotency_key: 'error-summary-conflict-key' },
+          status: 'failed' as const,
+          error_summary: 'original failure',
+          created_at: 6_250,
+        };
+
+        beginModelRunInAdapter(scopedAdapter, input);
+
+        expect(() =>
+          beginModelRunInAdapter(scopedAdapter, {
+            ...input,
+            error_summary: 'changed failure',
+          })
+        ).toThrow(/different error_summary/);
       });
 
       it('rejects conflicts for every explicitly replayed stable begin field', () => {

--- a/packages/mama-core/tests/model-runs/adapter-scoped-store.test.ts
+++ b/packages/mama-core/tests/model-runs/adapter-scoped-store.test.ts
@@ -360,6 +360,29 @@ describe('Story M5/M6: Adapter-scoped model run helpers', () => {
         expect(beginModelRunInAdapter(scopedAdapter, input)).toEqual(failed);
       });
 
+      it('rejects non-running begin statuses before inserting model run rows', () => {
+        const scopedAdapter = createAdapter(tempDbPath('non-running-begin-status'));
+
+        for (const status of ['committed', 'failed', 'legacy'] as const) {
+          const modelRunId = `mr_reject_begin_${status}`;
+          expect(() =>
+            beginModelRunInAdapter(scopedAdapter, {
+              model_run_id: modelRunId,
+              envelope_hash: `env_reject_begin_${status}`,
+              input_refs: { request_idempotency_key: `reject-begin-${status}` },
+              status,
+              error_summary: status === 'failed' ? 'failed before begin' : null,
+              created_at: 4_900,
+            })
+          ).toThrow(/must begin in running status/);
+
+          const row = scopedAdapter
+            .prepare('SELECT model_run_id FROM model_runs WHERE model_run_id = ?')
+            .get(modelRunId);
+          expect(row).toBeUndefined();
+        }
+      });
+
       it('rejects underspecified duplicate model run ids instead of binding to an existing run', () => {
         const scopedAdapter = createAdapter(tempDbPath('underspecified'));
         const input = {
@@ -470,7 +493,6 @@ describe('Story M5/M6: Adapter-scoped model run helpers', () => {
         for (const conflictingInput of [
           { ...input, envelope_hash: 'env_alias_changed' },
           { ...input, input_refs: { ...input.input_refs, entity_id: 'entity_changed' } },
-          { ...input, status: 'failed' as const },
           { ...input, token_count: 13 },
           { ...input, created_at: 6_001 },
         ]) {
@@ -490,34 +512,6 @@ describe('Story M5/M6: Adapter-scoped model run helpers', () => {
           token_count: 12,
           created_at: 6_000,
         });
-      });
-
-      it('rejects explicitly replayed error summary conflicts for non-running begin rows', () => {
-        const scopedAdapter = createAdapter(tempDbPath('error-summary-conflict'));
-        const input = {
-          model_run_id: 'mr_error_summary_conflict',
-          envelope_hash: 'env_error_summary_conflict',
-          input_refs: { request_idempotency_key: 'error-summary-conflict-key' },
-          status: 'failed' as const,
-          error_summary: 'original failure',
-          created_at: 6_250,
-        };
-
-        beginModelRunInAdapter(scopedAdapter, input);
-
-        expect(() =>
-          beginModelRunInAdapter(scopedAdapter, {
-            ...input,
-            error_summary: 'changed failure',
-          })
-        ).toThrow(/different error_summary/);
-        expect(() =>
-          beginModelRunInAdapter(scopedAdapter, {
-            model_run_id: input.model_run_id,
-            envelope_hash: input.envelope_hash,
-            error_summary: 'changed failure without status',
-          })
-        ).toThrow(/different error_summary/);
       });
 
       it('rejects conflicts for every explicitly replayed stable begin field', () => {
@@ -672,6 +666,52 @@ describe('Story M5/M6: Adapter-scoped model run helpers', () => {
         });
         expect(selectCount).toBe(2);
         expect(insertCount).toBe(1);
+      });
+
+      it('recovers duplicate insert errors reported through sqlite error codes', () => {
+        let selectCount = 0;
+        const adapter: ModelRunAdapterForTest = {
+          prepare(sql: string) {
+            if (/FROM model_runs/i.test(sql)) {
+              return new FakeModelRunStatement({
+                get() {
+                  selectCount += 1;
+                  return selectCount === 1 ? undefined : modelRunRow();
+                },
+              });
+            }
+            if (/INSERT INTO model_runs/i.test(sql)) {
+              return new FakeModelRunStatement({
+                run() {
+                  const error = new Error('insert failed without constraint text');
+                  Object.defineProperty(error, 'code', {
+                    value: 'SQLITE_CONSTRAINT_PRIMARYKEY',
+                    enumerable: true,
+                  });
+                  throw error;
+                },
+              });
+            }
+            throw new Error(`Unexpected SQL in fake adapter: ${sql}`);
+          },
+        };
+
+        const replay = beginModelRunInAdapter(adapter, {
+          model_run_id: 'mr_fake',
+          agent_id: 'agent-fake',
+          envelope_hash: 'env_fake',
+          input_refs: { request_idempotency_key: 'fake-key' },
+          created_at: 10_000,
+        });
+
+        expect(replay).toMatchObject({
+          model_run_id: 'mr_fake',
+          agent_id: 'agent-fake',
+          envelope_hash: 'env_fake',
+          input_refs: { request_idempotency_key: 'fake-key' },
+          status: 'running',
+        });
+        expect(selectCount).toBe(2);
       });
     });
 

--- a/packages/mama-core/tests/model-runs/adapter-scoped-store.test.ts
+++ b/packages/mama-core/tests/model-runs/adapter-scoped-store.test.ts
@@ -226,6 +226,60 @@ describe('Story M5/M6: Adapter-scoped model run helpers', () => {
         expect(replay.created_at).toBe(10_000);
       });
 
+      it('allows partial deterministic replays when the stable envelope matches', () => {
+        const scopedAdapter = createAdapter(tempDbPath('partial-envelope-replay'));
+        const input = {
+          model_run_id: 'mr_partial_envelope_replay',
+          model_id: 'gpt-5.4',
+          model_provider: 'openai',
+          agent_id: 'agent-alias',
+          envelope_hash: 'env_alias_partial_replay',
+          input_refs: {
+            tool: 'entity.alias',
+            entity_id: 'entity_partial',
+            request_idempotency_key: 'alias-key-partial',
+          },
+          token_count: 42,
+          cost_estimate: 0.25,
+          created_at: 4_250,
+        };
+
+        const first = beginModelRunInAdapter(scopedAdapter, input);
+        const replay = beginModelRunInAdapter(scopedAdapter, {
+          model_run_id: input.model_run_id,
+          envelope_hash: input.envelope_hash,
+        });
+
+        expect(replay).toEqual(first);
+      });
+
+      it('compares replay input refs canonically instead of by raw JSON text', () => {
+        const scopedAdapter = createAdapter(tempDbPath('canonical-input-refs'));
+        const input = {
+          model_run_id: 'mr_canonical_input_refs',
+          agent_id: 'agent-alias',
+          input_refs_json:
+            '{"request_idempotency_key":"alias-key-canonical","entity_id":"entity_1"}',
+          created_at: 4_300,
+        };
+
+        const first = beginModelRunInAdapter(scopedAdapter, input);
+        const replay = beginModelRunInAdapter(scopedAdapter, {
+          ...input,
+          input_refs_json:
+            '{\n  "entity_id": "entity_1",\n  "request_idempotency_key": "alias-key-canonical"\n}',
+        });
+
+        expect(replay).toEqual(first);
+        expect(() =>
+          beginModelRunInAdapter(scopedAdapter, {
+            ...input,
+            input_refs_json:
+              '{"request_idempotency_key":"alias-key-canonical","entity_id":"entity_changed"}',
+          })
+        ).toThrow(/different input_refs_json/);
+      });
+
       it('replays matching begin input after the run reaches a terminal status', () => {
         const scopedAdapter = createAdapter(tempDbPath('terminal-replay'));
         const input = {
@@ -243,6 +297,25 @@ describe('Story M5/M6: Adapter-scoped model run helpers', () => {
         const committed = commitModelRunInAdapter(scopedAdapter, input.model_run_id, 'done');
 
         expect(beginModelRunInAdapter(scopedAdapter, input)).toEqual(committed);
+      });
+
+      it('replays matching begin input after the run fails', () => {
+        const scopedAdapter = createAdapter(tempDbPath('failed-terminal-replay'));
+        const input = {
+          model_run_id: 'mr_failed_terminal_replay',
+          agent_id: 'agent-alias',
+          envelope_hash: 'env_alias_failed_terminal_replay',
+          input_refs: {
+            tool: 'entity.alias',
+            request_idempotency_key: 'alias-key-failed-terminal-replay',
+          },
+          created_at: 4_750,
+        };
+
+        beginModelRunInAdapter(scopedAdapter, input);
+        const failed = failModelRunInAdapter(scopedAdapter, input.model_run_id, 'model failed');
+
+        expect(beginModelRunInAdapter(scopedAdapter, input)).toEqual(failed);
       });
 
       it('rejects underspecified duplicate model run ids instead of binding to an existing run', () => {
@@ -317,6 +390,24 @@ describe('Story M5/M6: Adapter-scoped model run helpers', () => {
         }
       });
 
+      it('rejects non-empty unstable input refs as idempotency discriminators', () => {
+        const scopedAdapter = createAdapter(tempDbPath('unstable-input-refs'));
+        const input = {
+          model_run_id: 'mr_unstable_input_refs',
+          input_refs: {
+            tool: 'entity.alias',
+            entity_id: 'entity_unstable',
+          },
+          created_at: 5_750,
+        };
+
+        beginModelRunInAdapter(scopedAdapter, input);
+
+        expect(() => beginModelRunInAdapter(scopedAdapter, input)).toThrow(
+          /idempotency discriminator/
+        );
+      });
+
       it('rejects conflicting deterministic replays and preserves the original row', () => {
         const scopedAdapter = createAdapter(tempDbPath('conflict'));
         const input = {
@@ -357,6 +448,47 @@ describe('Story M5/M6: Adapter-scoped model run helpers', () => {
           token_count: 12,
           created_at: 6_000,
         });
+      });
+
+      it('rejects conflicts for every explicitly replayed stable begin field', () => {
+        const scopedAdapter = createAdapter(tempDbPath('all-stable-field-conflicts'));
+        const input = {
+          model_run_id: 'mr_all_stable_field_conflicts',
+          model_id: 'model-original',
+          model_provider: 'provider-original',
+          prompt_version: 'prompt-original',
+          tool_manifest_version: 'tool-original',
+          output_schema_version: 'schema-original',
+          agent_id: 'agent-original',
+          instance_id: 'instance-original',
+          envelope_hash: 'env_all_stable_field_conflicts',
+          parent_model_run_id: 'parent-original',
+          input_snapshot_ref: 'snapshot-original',
+          input_refs_json:
+            '{"request_idempotency_key":"stable-field-key","entity_id":"entity_original"}',
+          token_count: 12,
+          cost_estimate: 0.12,
+          created_at: 6_500,
+        };
+
+        beginModelRunInAdapter(scopedAdapter, input);
+
+        for (const conflictingInput of [
+          { ...input, model_id: 'model-changed' },
+          { ...input, model_provider: 'provider-changed' },
+          { ...input, prompt_version: 'prompt-changed' },
+          { ...input, tool_manifest_version: 'tool-changed' },
+          { ...input, output_schema_version: 'schema-changed' },
+          { ...input, agent_id: 'agent-changed' },
+          { ...input, instance_id: 'instance-changed' },
+          { ...input, parent_model_run_id: 'parent-changed' },
+          { ...input, input_snapshot_ref: 'snapshot-changed' },
+          { ...input, cost_estimate: 0.13 },
+        ]) {
+          expect(() => beginModelRunInAdapter(scopedAdapter, conflictingInput)).toThrow(
+            /Model run already exists/
+          );
+        }
       });
 
       it('pins duplicate behavior through the legacy global begin helper', async () => {
@@ -450,6 +582,12 @@ describe('Story M5/M6: Adapter-scoped model run helpers', () => {
           error_summary: null,
           completed_at: committed.completed_at,
         });
+        expect(
+          commitModelRunInAdapter(scopedAdapter, 'mr_terminal_commit', 'packet generated')
+        ).toEqual(committed);
+        expect(() =>
+          commitModelRunInAdapter(scopedAdapter, 'mr_terminal_commit', 'changed summary')
+        ).toThrow(/different completion_summary/);
       });
 
       it('does not allow a failed run to be committed later', () => {
@@ -470,6 +608,12 @@ describe('Story M5/M6: Adapter-scoped model run helpers', () => {
           error_summary: failed.error_summary,
           completed_at: failed.completed_at,
         });
+        expect(failModelRunInAdapter(scopedAdapter, 'mr_terminal_fail', 'alias failed')).toEqual(
+          failed
+        );
+        expect(() =>
+          failModelRunInAdapter(scopedAdapter, 'mr_terminal_fail', 'changed failure')
+        ).toThrow(/different error_summary/);
       });
     });
   });

--- a/packages/mama-core/tests/unit/module-exports.test.js
+++ b/packages/mama-core/tests/unit/module-exports.test.js
@@ -12,6 +12,18 @@ describe('Story M1.1: Core Module Exports', () => {
   describe('mama-api.js exports', () => {
     it('should export mama object with required methods', async () => {
       const mama = await import('../../src/mama-api.js');
+      const modelRunExports = [
+        'beginModelRun',
+        'beginModelRunInAdapter',
+        'commitModelRun',
+        'commitModelRunInAdapter',
+        'failModelRun',
+        'failModelRunInAdapter',
+        'getModelRun',
+        'getModelRunInAdapter',
+        'appendToolTrace',
+        'listToolTracesForRun',
+      ];
 
       expect(mama.default).toBeDefined();
       expect(typeof mama.default.save).toBe('function');
@@ -19,19 +31,10 @@ describe('Story M1.1: Core Module Exports', () => {
       expect(typeof mama.default.list).toBe('function');
       expect(typeof mama.default.suggest).toBe('function');
       expect(typeof mama.default.updateOutcome).toBe('function');
-      expect(typeof mama.default.beginModelRun).toBe('function');
-      expect(typeof mama.default.beginModelRunInAdapter).toBe('function');
-      expect(typeof mama.default.commitModelRun).toBe('function');
-      expect(typeof mama.default.commitModelRunInAdapter).toBe('function');
-      expect(typeof mama.default.failModelRun).toBe('function');
-      expect(typeof mama.default.failModelRunInAdapter).toBe('function');
-      expect(typeof mama.default.getModelRunInAdapter).toBe('function');
-      expect(typeof mama.default.appendToolTrace).toBe('function');
-      expect(typeof mama.default.listToolTracesForRun).toBe('function');
-      expect(typeof mama.beginModelRunInAdapter).toBe('function');
-      expect(typeof mama.commitModelRunInAdapter).toBe('function');
-      expect(typeof mama.failModelRunInAdapter).toBe('function');
-      expect(typeof mama.getModelRunInAdapter).toBe('function');
+      for (const exportName of modelRunExports) {
+        expect(typeof mama.default[exportName]).toBe('function');
+        expect(typeof mama[exportName]).toBe('function');
+      }
     });
   });
 

--- a/packages/mama-core/tests/unit/module-exports.test.js
+++ b/packages/mama-core/tests/unit/module-exports.test.js
@@ -20,8 +20,12 @@ describe('Story M1.1: Core Module Exports', () => {
       expect(typeof mama.default.suggest).toBe('function');
       expect(typeof mama.default.updateOutcome).toBe('function');
       expect(typeof mama.default.beginModelRun).toBe('function');
+      expect(typeof mama.default.beginModelRunInAdapter).toBe('function');
       expect(typeof mama.default.commitModelRun).toBe('function');
+      expect(typeof mama.default.commitModelRunInAdapter).toBe('function');
       expect(typeof mama.default.failModelRun).toBe('function');
+      expect(typeof mama.default.failModelRunInAdapter).toBe('function');
+      expect(typeof mama.default.getModelRunInAdapter).toBe('function');
       expect(typeof mama.default.appendToolTrace).toBe('function');
       expect(typeof mama.default.listToolTracesForRun).toBe('function');
     });
@@ -32,9 +36,13 @@ describe('Story M1.1: Core Module Exports', () => {
       const core = await import('../../src/index.js');
 
       expect(typeof core.beginModelRun).toBe('function');
+      expect(typeof core.beginModelRunInAdapter).toBe('function');
       expect(typeof core.commitModelRun).toBe('function');
+      expect(typeof core.commitModelRunInAdapter).toBe('function');
       expect(typeof core.failModelRun).toBe('function');
+      expect(typeof core.failModelRunInAdapter).toBe('function');
       expect(typeof core.getModelRun).toBe('function');
+      expect(typeof core.getModelRunInAdapter).toBe('function');
       expect(typeof core.appendToolTrace).toBe('function');
       expect(typeof core.listToolTracesForRun).toBe('function');
     });

--- a/packages/mama-core/tests/unit/module-exports.test.js
+++ b/packages/mama-core/tests/unit/module-exports.test.js
@@ -72,6 +72,7 @@ describe('Story M1.1: Core Module Exports', () => {
         'verifyBackupExists',
         'deleteAutoLinks',
         'validateCleanupResult',
+        'expandWithGraph',
       ];
       const defaultFunctionExports = [
         ...namedFunctionExports.filter((exportName) => exportName !== 'listOpenAuditFindings'),

--- a/packages/mama-core/tests/unit/module-exports.test.js
+++ b/packages/mama-core/tests/unit/module-exports.test.js
@@ -12,7 +12,34 @@ describe('Story M1.1: Core Module Exports', () => {
   describe('mama-api.js exports', () => {
     it('should export mama object with required methods', async () => {
       const mama = await import('../../src/mama-api.js');
-      const modelRunExports = [
+      const namedFunctionExports = [
+        'save',
+        'saveWithTrustedProvenance',
+        'suggest',
+        'saveMemory',
+        'saveMemoryWithTrustedProvenance',
+        'recallMemory',
+        'list',
+        'listCheckpoints',
+        'updateOutcome',
+        'buildProfile',
+        'ingestMemory',
+        'ingestWithTrustedProvenance',
+        'ingestConversation',
+        'ingestConversationWithTrustedProvenance',
+        'evolveMemory',
+        'buildMemoryBootstrap',
+        'createAuditAck',
+        'recordMemoryAudit',
+        'upsertChannelSummary',
+        'getChannelSummary',
+        'listOpenAuditFindings',
+        'getMemoryProvenance',
+        'listMemoriesByEnvelopeHash',
+        'listMemoriesByGatewayCallId',
+        'listMemoriesByModelRunId',
+        'listMemoryEventsForMemory',
+        'listRecentMemoryEvents',
         'beginModelRun',
         'beginModelRunInAdapter',
         'commitModelRun',
@@ -23,16 +50,39 @@ describe('Story M1.1: Core Module Exports', () => {
         'getModelRunInAdapter',
         'appendToolTrace',
         'listToolTracesForRun',
+        'saveCheckpoint',
+        'loadCheckpoint',
+        'recall',
+        'proposeLink',
+        'approveLink',
+        'rejectLink',
+        'getPendingLinks',
+        'deprecateAutoLinks',
+        'calculateCoverage',
+        'calculateQuality',
+        'generateQualityReport',
+        'logRestartAttempt',
+        'calculateRestartSuccessRate',
+        'calculateRestartLatency',
+        'getRestartMetrics',
+        'scanAutoLinks',
+        'createLinkBackup',
+        'generatePreCleanupReport',
+        'restoreLinkBackup',
+        'verifyBackupExists',
+        'deleteAutoLinks',
+        'validateCleanupResult',
+      ];
+      const defaultFunctionExports = [
+        ...namedFunctionExports.filter((exportName) => exportName !== 'listOpenAuditFindings'),
+        'listAuditFindings',
       ];
 
       expect(mama.default).toBeDefined();
-      expect(typeof mama.default.save).toBe('function');
-      expect(typeof mama.default.recall).toBe('function');
-      expect(typeof mama.default.list).toBe('function');
-      expect(typeof mama.default.suggest).toBe('function');
-      expect(typeof mama.default.updateOutcome).toBe('function');
-      for (const exportName of modelRunExports) {
+      for (const exportName of defaultFunctionExports) {
         expect(typeof mama.default[exportName]).toBe('function');
+      }
+      for (const exportName of namedFunctionExports) {
         expect(typeof mama[exportName]).toBe('function');
       }
     });

--- a/packages/mama-core/tests/unit/module-exports.test.js
+++ b/packages/mama-core/tests/unit/module-exports.test.js
@@ -28,6 +28,10 @@ describe('Story M1.1: Core Module Exports', () => {
       expect(typeof mama.default.getModelRunInAdapter).toBe('function');
       expect(typeof mama.default.appendToolTrace).toBe('function');
       expect(typeof mama.default.listToolTracesForRun).toBe('function');
+      expect(typeof mama.beginModelRunInAdapter).toBe('function');
+      expect(typeof mama.commitModelRunInAdapter).toBe('function');
+      expect(typeof mama.failModelRunInAdapter).toBe('function');
+      expect(typeof mama.getModelRunInAdapter).toBe('function');
     });
   });
 


### PR DESCRIPTION
## Summary

**Model-run adapter helpers**
- Add adapter-scoped model-run helper coverage for M5/M6 worker flows.
- Harden canonical replay refs, explicit replay error comparison, replay compatibility, and duplicate insert race handling.
- Keep the helper layer as the shared foundation for the stacked M5/M6 branches.

## Test Coverage

Focused helper coverage was added for replay and duplicate insert behavior.

## Pre-Landing Review

Local review was completed before push. No open blocker is known for this PR.

## Design Review

No frontend files changed, design review skipped.

## Eval Results

No prompt-related files changed, evals skipped.

## Plan Completion

This is the prerequisite branch for the M5/M6 stack.

## Test plan

- [x] Commit hook passed when this branch was completed locally
- [x] Stack validation continued on downstream M5/M6 branches

Generated with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added adapter-scoped model run operations to the public API for managing lifecycle events (begin, commit, fail, retrieve) with independent state isolation across different contexts.
  * Introduced `expandWithGraph` as a named export for simplified importing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->