### PR TITLE
feat: add MAMA vNext operator contract foundation

### DIFF
--- a/packages/mama-core/db/migrations/038-create-vnext-operator-contracts.sql
+++ b/packages/mama-core/db/migrations/038-create-vnext-operator-contracts.sql
@@ -1,0 +1,52 @@
+CREATE TABLE IF NOT EXISTS vnext_operator_cursors (
+  cursor_name TEXT PRIMARY KEY,
+  last_change_seq INTEGER NOT NULL DEFAULT 0 CHECK (last_change_seq >= 0),
+  last_idempotency_key TEXT,
+  updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS vnext_operator_commits (
+  commit_id TEXT PRIMARY KEY,
+  cursor_name TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL UNIQUE,
+  first_change_seq INTEGER NOT NULL CHECK (first_change_seq >= 0),
+  last_change_seq INTEGER NOT NULL CHECK (last_change_seq >= first_change_seq),
+  status TEXT NOT NULL CHECK (status IN ('changed', 'no_update')),
+  changed_refs_json TEXT NOT NULL,
+  source_refs_json TEXT NOT NULL,
+  created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+  FOREIGN KEY (cursor_name) REFERENCES vnext_operator_cursors(cursor_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_vnext_operator_commits_cursor_seq
+  ON vnext_operator_commits(cursor_name, last_change_seq);
+
+CREATE TABLE IF NOT EXISTS operator_no_updates (
+  no_update_id TEXT PRIMARY KEY,
+  scope_key TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  source_refs_json TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL UNIQUE,
+  created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_operator_no_updates_scope_created
+  ON operator_no_updates(scope_key, created_at_ms DESC);
+
+CREATE TABLE IF NOT EXISTS worker_proposals (
+  proposal_id TEXT PRIMARY KEY,
+  worker_id TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  source_refs_json TEXT NOT NULL,
+  confidence REAL NOT NULL CHECK (confidence >= 0 AND confidence <= 1),
+  status TEXT NOT NULL CHECK (status IN ('proposed', 'accepted', 'rejected', 'superseded')),
+  created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+  accepted_at_ms INTEGER CHECK (accepted_at_ms IS NULL OR accepted_at_ms >= created_at_ms)
+);
+
+CREATE INDEX IF NOT EXISTS idx_worker_proposals_status_kind
+  ON worker_proposals(status, kind, created_at_ms);
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES (38, 'Create vNext operator contracts');

--- a/packages/mama-core/db/migrations/038-create-vnext-operator-contracts.sql
+++ b/packages/mama-core/db/migrations/038-create-vnext-operator-contracts.sql
@@ -12,8 +12,8 @@ CREATE TABLE IF NOT EXISTS vnext_operator_commits (
   first_change_seq INTEGER NOT NULL CHECK (first_change_seq >= 0),
   last_change_seq INTEGER NOT NULL CHECK (last_change_seq >= first_change_seq),
   status TEXT NOT NULL CHECK (status IN ('changed', 'no_update')),
-  changed_refs_json TEXT NOT NULL,
-  source_refs_json TEXT NOT NULL,
+  changed_refs_json TEXT NOT NULL CHECK (json_valid(changed_refs_json)),
+  source_refs_json TEXT NOT NULL CHECK (json_valid(source_refs_json)),
   created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
   FOREIGN KEY (cursor_name) REFERENCES vnext_operator_cursors(cursor_name)
 );
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS operator_no_updates (
   no_update_id TEXT PRIMARY KEY,
   scope_key TEXT NOT NULL,
   reason TEXT NOT NULL,
-  source_refs_json TEXT NOT NULL,
+  source_refs_json TEXT NOT NULL CHECK (json_valid(source_refs_json)),
   idempotency_key TEXT NOT NULL UNIQUE,
   created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0)
 );
@@ -37,12 +37,17 @@ CREATE TABLE IF NOT EXISTS worker_proposals (
   proposal_id TEXT PRIMARY KEY,
   worker_id TEXT NOT NULL,
   kind TEXT NOT NULL,
-  payload_json TEXT NOT NULL,
-  source_refs_json TEXT NOT NULL,
+  payload_json TEXT NOT NULL CHECK (json_valid(payload_json)),
+  source_refs_json TEXT NOT NULL CHECK (json_valid(source_refs_json)),
   confidence REAL NOT NULL CHECK (confidence >= 0 AND confidence <= 1),
   status TEXT NOT NULL CHECK (status IN ('proposed', 'accepted', 'rejected', 'superseded')),
   created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
-  accepted_at_ms INTEGER CHECK (accepted_at_ms IS NULL OR accepted_at_ms >= created_at_ms)
+  accepted_at_ms INTEGER CHECK (
+    (status = 'proposed' AND accepted_at_ms IS NULL) OR
+    (status = 'accepted' AND accepted_at_ms IS NOT NULL AND accepted_at_ms >= created_at_ms) OR
+    (status = 'rejected' AND accepted_at_ms IS NULL) OR
+    (status = 'superseded' AND (accepted_at_ms IS NULL OR accepted_at_ms >= created_at_ms))
+  )
 );
 
 CREATE INDEX IF NOT EXISTS idx_worker_proposals_status_kind

--- a/packages/mama-core/package.json
+++ b/packages/mama-core/package.json
@@ -50,6 +50,7 @@
     "./agent-situation": "./dist/agent-situation/index.js",
     "./agent-graph": "./dist/agent-graph/index.js",
     "./context-compile": "./dist/context-compile/index.js",
+    "./provenance/source-ref": "./dist/provenance/source-ref.js",
     "./edges/types": "./dist/edges/types.js",
     "./edges/store": "./dist/edges/store.js",
     "./edges/ref-validation": "./dist/edges/ref-validation.js"

--- a/packages/mama-core/src/db-adapter/node-sqlite-adapter.ts
+++ b/packages/mama-core/src/db-adapter/node-sqlite-adapter.ts
@@ -556,6 +556,19 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
         'context packet store'
       );
     }
+
+    if (
+      !this.tableExists('vnext_operator_cursors') ||
+      !this.tableExists('vnext_operator_commits') ||
+      !this.tableExists('operator_no_updates') ||
+      !this.tableExists('worker_proposals')
+    ) {
+      this.applyRepairMigration(
+        migrationsDir,
+        '038-create-vnext-operator-contracts.sql',
+        'vNext operator contracts'
+      );
+    }
   }
 
   private applyRepairMigration(migrationsDir: string, fileName: string, label: string): void {

--- a/packages/mama-core/src/index.ts
+++ b/packages/mama-core/src/index.ts
@@ -200,6 +200,7 @@ export {
   listVisibleTwinEdgesForRefs,
 } from './edges/ref-validation.js';
 export * from './context-compile/index.js';
+export * from './provenance/source-ref.js';
 export * from './agent-situation/index.js';
 export * from './agent-graph/index.js';
 export * from './entities/types.js';

--- a/packages/mama-core/src/provenance/source-ref.ts
+++ b/packages/mama-core/src/provenance/source-ref.ts
@@ -1,0 +1,207 @@
+import type { ContextRef } from '../context-compile/types.js';
+
+export const STRICT_SOURCE_REF_KINDS = [
+  'memory',
+  'raw',
+  'entity',
+  'case',
+  'decision',
+  'os_task',
+  'agent_situation_packet',
+  'report_slot',
+  'context_packet',
+  'model_run',
+  'tool_trace',
+  'wiki_page',
+  'report',
+] as const;
+
+export type StrictSourceRefKind = (typeof STRICT_SOURCE_REF_KINDS)[number];
+type NonRawStrictSourceRefKind = Exclude<StrictSourceRefKind, 'raw'>;
+
+export const LEGACY_SOURCE_REF_KINDS = ['message', 'conversation', 'raw_memory'] as const;
+
+export type LegacySourceRefKind = (typeof LEGACY_SOURCE_REF_KINDS)[number];
+
+export type SourceRef =
+  | { kind: Exclude<StrictSourceRefKind, 'raw'>; id: string }
+  | {
+      kind: 'raw';
+      id: string;
+      connector: string;
+      source_id?: string;
+      channel_id?: string | null;
+    }
+  | { kind: 'legacy'; legacy_kind: LegacySourceRefKind; id: string };
+
+const STRICT_SOURCE_REF_KIND_SET = new Set<string>(STRICT_SOURCE_REF_KINDS);
+const LEGACY_SOURCE_REF_KIND_SET = new Set<string>(LEGACY_SOURCE_REF_KINDS);
+const VERIFY_ARTIFACT_KIND_SET = new Set<string>([
+  'decision',
+  'os_task',
+  'agent_situation_packet',
+  'report_slot',
+  'context_packet',
+  'model_run',
+  'tool_trace',
+]);
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`Source ref ${field} must be a string`);
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`Source ref ${field} must not be empty`);
+  }
+  return trimmed;
+}
+
+function optionalString(value: unknown, field: string): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return requiredString(value, field);
+}
+
+function optionalNullableString(value: unknown, field: string): string | null | undefined {
+  if (value === null) {
+    return null;
+  }
+  return optionalString(value, field);
+}
+
+function assertStrictSourceRefKind(kind: string): asserts kind is StrictSourceRefKind {
+  if (!STRICT_SOURCE_REF_KIND_SET.has(kind)) {
+    throw new Error(`Unsupported source ref kind: ${kind}`);
+  }
+}
+
+function assertLegacySourceRefKind(kind: string): asserts kind is LegacySourceRefKind {
+  if (!LEGACY_SOURCE_REF_KIND_SET.has(kind)) {
+    throw new Error(`Unsupported legacy source ref kind: ${kind}`);
+  }
+}
+
+export function fromContextRef(ref: ContextRef): SourceRef {
+  if (ref.kind === 'raw') {
+    const normalized: SourceRef = {
+      kind: 'raw',
+      id: requiredString(ref.raw_id, 'raw_id'),
+      connector: requiredString(ref.connector, 'connector'),
+    };
+    const sourceId = optionalString(ref.source_id, 'source_id');
+    const channelId = optionalNullableString(ref.channel_id, 'channel_id');
+    if (sourceId !== undefined) {
+      normalized.source_id = sourceId;
+    }
+    if (channelId !== undefined) {
+      normalized.channel_id = channelId;
+    }
+    return normalized;
+  }
+
+  return {
+    kind: ref.kind,
+    id: requiredString(ref.id, 'id'),
+  };
+}
+
+export function toContextRef(ref: SourceRef): ContextRef | null {
+  switch (ref.kind) {
+    case 'memory':
+    case 'entity':
+    case 'case':
+      return {
+        kind: ref.kind,
+        id: requiredString(ref.id, 'id'),
+      };
+    case 'raw': {
+      const normalized: ContextRef = {
+        kind: 'raw',
+        raw_id: requiredString(ref.id, 'id'),
+        connector: requiredString(ref.connector, 'connector'),
+      };
+      const sourceId = optionalString(ref.source_id, 'source_id');
+      const channelId = optionalNullableString(ref.channel_id, 'channel_id');
+      if (sourceId !== undefined) {
+        normalized.source_id = sourceId;
+      }
+      if (channelId !== undefined) {
+        normalized.channel_id = channelId;
+      }
+      return normalized;
+    }
+    default:
+      return null;
+  }
+}
+
+export function fromVerifyArtifact(artifact: { type: string; id: string }): SourceRef {
+  const kind = requiredString(artifact.type, 'type');
+  if (!VERIFY_ARTIFACT_KIND_SET.has(kind)) {
+    throw new Error(`Unsupported verify artifact source ref kind: ${kind}`);
+  }
+  assertStrictSourceRefKind(kind);
+  if (kind === 'raw') {
+    throw new Error('Verify artifact source refs cannot use raw kind');
+  }
+  return {
+    kind,
+    id: requiredString(artifact.id, 'id'),
+  };
+}
+
+export function parseSourceRefString(value: string): SourceRef {
+  const rawValue = requiredString(value, 'value');
+  const parts = rawValue.split(':');
+  const kind = requiredString(parts[0], 'kind');
+
+  if (kind === 'raw') {
+    const connector = requiredString(parts[1], 'connector');
+    const id = requiredString(parts.slice(2).join(':'), 'id');
+    return { kind: 'raw', connector, id };
+  }
+
+  if (LEGACY_SOURCE_REF_KIND_SET.has(kind)) {
+    assertLegacySourceRefKind(kind);
+    return {
+      kind: 'legacy',
+      legacy_kind: kind,
+      id: requiredString(parts.slice(1).join(':'), 'id'),
+    };
+  }
+
+  assertStrictSourceRefKind(kind);
+  if (kind === 'raw') {
+    throw new Error('Raw source refs must include connector and id');
+  }
+  const sourceKind: NonRawStrictSourceRefKind = kind;
+  return {
+    kind: sourceKind,
+    id: requiredString(parts.slice(1).join(':'), 'id'),
+  };
+}
+
+export function serializeSourceRef(ref: SourceRef): string {
+  switch (ref.kind) {
+    case 'raw':
+      return `raw:${requiredString(ref.connector, 'connector')}:${requiredString(ref.id, 'id')}`;
+    case 'legacy':
+      assertLegacySourceRefKind(ref.legacy_kind);
+      return `${ref.legacy_kind}:${requiredString(ref.id, 'id')}`;
+    default: {
+      assertStrictSourceRefKind(ref.kind);
+      return `${ref.kind}:${requiredString(ref.id, 'id')}`;
+    }
+  }
+}
+
+export function assertNonEmptySourceRefs(refs: readonly SourceRef[]): void {
+  if (!Array.isArray(refs) || refs.length === 0) {
+    throw new Error('Source refs must not be empty');
+  }
+  for (const ref of refs) {
+    serializeSourceRef(ref);
+  }
+}

--- a/packages/mama-core/src/provenance/source-ref.ts
+++ b/packages/mama-core/src/provenance/source-ref.ts
@@ -1,4 +1,4 @@
-import type { ContextRef } from '../context-compile/types.js';
+import { CONTEXT_REF_KINDS, type ContextRef } from '../context-compile/types.js';
 
 export const STRICT_SOURCE_REF_KINDS = [
   'memory',
@@ -35,6 +35,7 @@ export type SourceRef =
   | { kind: 'legacy'; legacy_kind: LegacySourceRefKind; id: string };
 
 const STRICT_SOURCE_REF_KIND_SET = new Set<string>(STRICT_SOURCE_REF_KINDS);
+const CONTEXT_REF_KIND_SET = new Set<string>(CONTEXT_REF_KINDS);
 const LEGACY_SOURCE_REF_KIND_SET = new Set<string>(LEGACY_SOURCE_REF_KINDS);
 const VERIFY_ARTIFACT_KIND_SET = new Set<string>([
   'decision',
@@ -83,15 +84,29 @@ function assertLegacySourceRefKind(kind: string): asserts kind is LegacySourceRe
   }
 }
 
+function assertContextSourceRefKind(
+  kind: string
+): asserts kind is Exclude<ContextRef['kind'], 'raw'> {
+  if (kind === 'raw' || !CONTEXT_REF_KIND_SET.has(kind)) {
+    throw new Error(`Unsupported context source ref kind: ${kind}`);
+  }
+}
+
 export function fromContextRef(ref: ContextRef): SourceRef {
-  if (ref.kind === 'raw') {
+  if (ref === null || ref === undefined) {
+    throw new Error('Context ref must not be null or undefined');
+  }
+
+  const input = ref as Record<string, unknown>;
+  const kind = requiredString(input.kind, 'kind');
+  if (kind === 'raw') {
     const normalized: SourceRef = {
       kind: 'raw',
-      id: requiredString(ref.raw_id, 'raw_id'),
-      connector: requiredString(ref.connector, 'connector'),
+      id: requiredString(input.raw_id, 'raw_id'),
+      connector: requiredString(input.connector, 'connector'),
     };
-    const sourceId = optionalString(ref.source_id, 'source_id');
-    const channelId = optionalNullableString(ref.channel_id, 'channel_id');
+    const sourceId = optionalString(input.source_id, 'source_id');
+    const channelId = optionalNullableString(input.channel_id, 'channel_id');
     if (sourceId !== undefined) {
       normalized.source_id = sourceId;
     }
@@ -101,13 +116,19 @@ export function fromContextRef(ref: ContextRef): SourceRef {
     return normalized;
   }
 
+  assertContextSourceRefKind(kind);
+
   return {
-    kind: ref.kind,
-    id: requiredString(ref.id, 'id'),
+    kind,
+    id: requiredString(input.id, 'id'),
   };
 }
 
 export function toContextRef(ref: SourceRef): ContextRef | null {
+  if (ref === null || ref === undefined) {
+    return null;
+  }
+
   switch (ref.kind) {
     case 'memory':
     case 'entity':
@@ -138,6 +159,10 @@ export function toContextRef(ref: SourceRef): ContextRef | null {
 }
 
 export function fromVerifyArtifact(artifact: { type: string; id: string }): SourceRef {
+  if (artifact === null || artifact === undefined) {
+    throw new Error('Artifact must not be null or undefined');
+  }
+
   const kind = requiredString(artifact.type, 'type');
   if (!VERIFY_ARTIFACT_KIND_SET.has(kind)) {
     throw new Error(`Unsupported verify artifact source ref kind: ${kind}`);
@@ -184,6 +209,10 @@ export function parseSourceRefString(value: string): SourceRef {
 }
 
 export function serializeSourceRef(ref: SourceRef): string {
+  if (ref === null || ref === undefined) {
+    throw new Error('Source ref must not be null or undefined');
+  }
+
   switch (ref.kind) {
     case 'raw':
       return `raw:${requiredString(ref.connector, 'connector')}:${requiredString(ref.id, 'id')}`;

--- a/packages/mama-core/tests/cases/migration-chain.test.ts
+++ b/packages/mama-core/tests/cases/migration-chain.test.ts
@@ -12,6 +12,10 @@ function migrationFiles(): string[] {
     .sort((left, right) => left.localeCompare(right));
 }
 
+function migrationVersion(file: string): number {
+  return Number.parseInt(file.slice(0, 3), 10);
+}
+
 function applyAll(db: Database.Database): void {
   for (const file of migrationFiles()) {
     db.exec(readFileSync(join(MIGRATIONS_DIR, file), 'utf8'));
@@ -45,6 +49,11 @@ function columnExists(db: Database.Database, table: string, column: string): boo
 }
 
 describe('Case-First Memory Substrate (migration 030, consolidated Phase 1+2+3)', () => {
+  it('keeps migration filenames contiguous with no version gaps', () => {
+    const versions = migrationFiles().map(migrationVersion);
+    expect(versions).toEqual(Array.from({ length: versions.length }, (_, index) => index + 1));
+  });
+
   it('creates every Phase 1 table/index/trigger on a fresh DB', () => {
     const db = new Database(':memory:');
     db.pragma('foreign_keys = ON');

--- a/packages/mama-core/tests/cases/migration-runner-duplicate-column.test.ts
+++ b/packages/mama-core/tests/cases/migration-runner-duplicate-column.test.ts
@@ -188,6 +188,10 @@ describe('Story M2.4: Legacy high schema-version structural recovery', () => {
           'agent_situation_packets',
           'agent_situation_refresh_leases',
           'context_packets',
+          'vnext_operator_cursors',
+          'vnext_operator_commits',
+          'operator_no_updates',
+          'worker_proposals',
         ]) {
           expect(tableExists(db, table)).toBe(true);
         }
@@ -218,6 +222,14 @@ describe('Story M2.4: Legacy high schema-version structural recovery', () => {
         expect(indexExists(db, 'idx_memory_events_memory_created')).toBe(true);
         expect(indexExists(db, 'idx_connector_event_source_cursor')).toBe(true);
         expect(indexExists(db, 'idx_context_packets_scope_hash')).toBe(true);
+        expect(indexExists(db, 'idx_vnext_operator_commits_cursor_seq')).toBe(true);
+        expect(indexExists(db, 'idx_operator_no_updates_scope_created')).toBe(true);
+        expect(indexExists(db, 'idx_worker_proposals_status_kind')).toBe(true);
+
+        const row = db.prepare('SELECT version FROM schema_version WHERE version = 38').get() as
+          | { version: number }
+          | undefined;
+        expect(row?.version).toBe(38);
         db.close();
       });
     });

--- a/packages/mama-core/tests/operator-vnext/vnext-operator-contracts.test.ts
+++ b/packages/mama-core/tests/operator-vnext/vnext-operator-contracts.test.ts
@@ -112,6 +112,27 @@ describe('Story VNext PR0: operator contract migration', () => {
           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
         )
         .run(
+          'commit-bad-source-json',
+          'connector:slack',
+          'connector:slack:seq:6-6',
+          6,
+          6,
+          'changed',
+          '[]',
+          'not-json',
+          1710000000006
+        )
+    ).toThrow(/CHECK constraint/i);
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO vnext_operator_commits (
+            commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+            status, changed_refs_json, source_refs_json, created_at_ms
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
           'commit-inverted',
           'connector:slack',
           'connector:slack:seq:4-3',
@@ -144,6 +165,100 @@ describe('Story VNext PR0: operator contract migration', () => {
           1710000000004
         )
     ).toThrow(/FOREIGN KEY constraint/i);
+
+    db.close();
+  });
+
+  it('AC: rejects malformed JSON payload columns before durable operator writes', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 38);
+
+    db.prepare(
+      `INSERT INTO vnext_operator_cursors (
+        cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+      ) VALUES (?, ?, ?, ?)`
+    ).run('connector:slack', 0, null, 1710000000000);
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO vnext_operator_commits (
+            commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+            status, changed_refs_json, source_refs_json, created_at_ms
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          'commit-bad-json',
+          'connector:slack',
+          'connector:slack:seq:5-5',
+          5,
+          5,
+          'changed',
+          'not-json',
+          '["raw:slack:event-5"]',
+          1710000000005
+        )
+    ).toThrow(/CHECK constraint/i);
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO operator_no_updates (
+            no_update_id, scope_key, reason, source_refs_json, idempotency_key, created_at_ms
+          ) VALUES (?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          'no-update-bad-json',
+          'scope-1',
+          'unchanged',
+          'not-json',
+          'scope-1:seq:1',
+          1710000000006
+        )
+    ).toThrow(/CHECK constraint/i);
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO worker_proposals (
+            proposal_id, worker_id, kind, payload_json, source_refs_json, confidence,
+            status, created_at_ms, accepted_at_ms
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          'proposal-bad-json',
+          'worker-1',
+          'memory_hint',
+          '{not-json}',
+          '["context_packet:packet-1"]',
+          0.5,
+          'proposed',
+          1710000000007,
+          null
+        )
+    ).toThrow(/CHECK constraint/i);
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO worker_proposals (
+            proposal_id, worker_id, kind, payload_json, source_refs_json, confidence,
+            status, created_at_ms, accepted_at_ms
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          'proposal-bad-source-json',
+          'worker-1',
+          'memory_hint',
+          '{}',
+          'not-json',
+          0.5,
+          'proposed',
+          1710000000008,
+          null
+        )
+    ).toThrow(/CHECK constraint/i);
 
     db.close();
   });
@@ -211,6 +326,86 @@ describe('Story VNext PR0: operator contract migration', () => {
           1710000000000
         )
     ).toThrow(/CHECK constraint/i);
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO worker_proposals (
+            proposal_id, worker_id, kind, payload_json, source_refs_json, confidence,
+            status, created_at_ms, accepted_at_ms
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          'proposal-proposed-with-accepted-time',
+          'worker-1',
+          'memory_hint',
+          '{}',
+          '["context_packet:packet-1"]',
+          0.5,
+          'proposed',
+          1710000000000,
+          1710000000000
+        )
+    ).toThrow(/CHECK constraint/i);
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO worker_proposals (
+            proposal_id, worker_id, kind, payload_json, source_refs_json, confidence,
+            status, created_at_ms, accepted_at_ms
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          'proposal-accepted-without-accepted-time',
+          'worker-1',
+          'memory_hint',
+          '{}',
+          '["context_packet:packet-1"]',
+          0.5,
+          'accepted',
+          1710000000000,
+          null
+        )
+    ).toThrow(/CHECK constraint/i);
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO worker_proposals (
+            proposal_id, worker_id, kind, payload_json, source_refs_json, confidence,
+            status, created_at_ms, accepted_at_ms
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          'proposal-rejected-with-accepted-time',
+          'worker-1',
+          'memory_hint',
+          '{}',
+          '["context_packet:packet-1"]',
+          0.5,
+          'rejected',
+          1710000000000,
+          1710000000000
+        )
+    ).toThrow(/CHECK constraint/i);
+
+    db.prepare(
+      `INSERT INTO worker_proposals (
+        proposal_id, worker_id, kind, payload_json, source_refs_json, confidence,
+        status, created_at_ms, accepted_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      'proposal-superseded-after-acceptance',
+      'worker-1',
+      'memory_hint',
+      '{}',
+      '["context_packet:packet-1"]',
+      0.5,
+      'superseded',
+      1710000000000,
+      1710000000001
+    );
 
     db.close();
   });

--- a/packages/mama-core/tests/operator-vnext/vnext-operator-contracts.test.ts
+++ b/packages/mama-core/tests/operator-vnext/vnext-operator-contracts.test.ts
@@ -1,0 +1,217 @@
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+
+import { applyMigrationsThrough } from '../../src/test-utils.js';
+
+function tableExists(db: Database.Database, name: string): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?")
+    .get(name) as { name?: string } | undefined;
+  return Boolean(row?.name);
+}
+
+function indexExists(db: Database.Database, name: string): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name = ?")
+    .get(name) as { name?: string } | undefined;
+  return Boolean(row?.name);
+}
+
+function tableSql(db: Database.Database, name: string): string {
+  return (
+    db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name = ?").get(name) as {
+      sql: string;
+    }
+  ).sql;
+}
+
+describe('Story VNext PR0: operator contract migration', () => {
+  it('AC: creates vNext operator ledger tables and records migration 038', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 38);
+
+    expect(tableExists(db, 'vnext_operator_cursors')).toBe(true);
+    expect(tableExists(db, 'vnext_operator_commits')).toBe(true);
+    expect(tableExists(db, 'operator_no_updates')).toBe(true);
+    expect(tableExists(db, 'worker_proposals')).toBe(true);
+
+    expect(indexExists(db, 'idx_vnext_operator_commits_cursor_seq')).toBe(true);
+    expect(indexExists(db, 'idx_operator_no_updates_scope_created')).toBe(true);
+    expect(indexExists(db, 'idx_worker_proposals_status_kind')).toBe(true);
+
+    const row = db
+      .prepare('SELECT version, description FROM schema_version WHERE version = 38')
+      .get() as { version: number; description: string } | undefined;
+    expect(row?.version).toBe(38);
+    expect(row?.description).toContain('vNext operator contracts');
+
+    db.close();
+  });
+
+  it('AC: enforces operator commit sequence and cursor integrity', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 38);
+
+    const commitSql = tableSql(db, 'vnext_operator_commits');
+    expect(commitSql).toMatch(/first_change_seq\s+INTEGER\s+NOT\s+NULL\s+CHECK/i);
+    expect(commitSql).toMatch(/last_change_seq\s+INTEGER\s+NOT\s+NULL\s+CHECK/i);
+    expect(commitSql).toMatch(/FOREIGN KEY\s*\(\s*cursor_name\s*\)/i);
+
+    db.prepare(
+      `INSERT INTO vnext_operator_cursors (
+        cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+      ) VALUES (?, ?, ?, ?)`
+    ).run('connector:slack', 0, null, 1710000000000);
+
+    db.prepare(
+      `INSERT INTO vnext_operator_commits (
+        commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+        status, changed_refs_json, source_refs_json, created_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      'commit-1',
+      'connector:slack',
+      'connector:slack:seq:1-3',
+      1,
+      3,
+      'changed',
+      '["task:1"]',
+      '["raw:slack:event-1"]',
+      1710000000001
+    );
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO vnext_operator_commits (
+            commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+            status, changed_refs_json, source_refs_json, created_at_ms
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          'commit-negative',
+          'connector:slack',
+          'connector:slack:seq:-1-0',
+          -1,
+          0,
+          'changed',
+          '[]',
+          '["raw:slack:event-2"]',
+          1710000000002
+        )
+    ).toThrow(/CHECK constraint/i);
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO vnext_operator_commits (
+            commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+            status, changed_refs_json, source_refs_json, created_at_ms
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          'commit-inverted',
+          'connector:slack',
+          'connector:slack:seq:4-3',
+          4,
+          3,
+          'changed',
+          '[]',
+          '["raw:slack:event-3"]',
+          1710000000003
+        )
+    ).toThrow(/CHECK constraint/i);
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO vnext_operator_commits (
+            commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+            status, changed_refs_json, source_refs_json, created_at_ms
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          'commit-missing-cursor',
+          'connector:discord',
+          'connector:discord:seq:1-1',
+          1,
+          1,
+          'changed',
+          '[]',
+          '["raw:discord:event-1"]',
+          1710000000004
+        )
+    ).toThrow(/FOREIGN KEY constraint/i);
+
+    db.close();
+  });
+
+  it('AC: enforces worker proposal confidence, status, and accepted timestamp contract', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyMigrationsThrough(db, 38);
+
+    db.prepare(
+      `INSERT INTO worker_proposals (
+        proposal_id, worker_id, kind, payload_json, source_refs_json, confidence,
+        status, created_at_ms, accepted_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      'proposal-1',
+      'worker-1',
+      'memory_hint',
+      '{}',
+      '["context_packet:packet-1"]',
+      0.75,
+      'accepted',
+      1710000000000,
+      1710000000000
+    );
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO worker_proposals (
+            proposal_id, worker_id, kind, payload_json, source_refs_json, confidence,
+            status, created_at_ms, accepted_at_ms
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          'proposal-bad-confidence',
+          'worker-1',
+          'memory_hint',
+          '{}',
+          '["context_packet:packet-1"]',
+          1.5,
+          'proposed',
+          1710000000000,
+          null
+        )
+    ).toThrow(/CHECK constraint/i);
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO worker_proposals (
+            proposal_id, worker_id, kind, payload_json, source_refs_json, confidence,
+            status, created_at_ms, accepted_at_ms
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          'proposal-bad-time',
+          'worker-1',
+          'memory_hint',
+          '{}',
+          '["context_packet:packet-1"]',
+          0.5,
+          'accepted',
+          1710000000001,
+          1710000000000
+        )
+    ).toThrow(/CHECK constraint/i);
+
+    db.close();
+  });
+});

--- a/packages/mama-core/tests/provenance/source-ref.test.ts
+++ b/packages/mama-core/tests/provenance/source-ref.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertNonEmptySourceRefs,
+  fromContextRef,
+  fromVerifyArtifact,
+  parseSourceRefString,
+  serializeSourceRef,
+  toContextRef,
+} from '../../src/provenance/source-ref.js';
+
+describe('Story VNext PR0: canonical SourceRef compatibility', () => {
+  it('AC: converts current context refs without changing their provenance identity', () => {
+    expect(fromContextRef({ kind: 'memory', id: ' mem-1 ' })).toEqual({
+      kind: 'memory',
+      id: 'mem-1',
+    });
+    expect(fromContextRef({ kind: 'entity', id: ' entity-1 ' })).toEqual({
+      kind: 'entity',
+      id: 'entity-1',
+    });
+    expect(fromContextRef({ kind: 'case', id: ' case-1 ' })).toEqual({
+      kind: 'case',
+      id: 'case-1',
+    });
+
+    const raw = fromContextRef({
+      kind: 'raw',
+      raw_id: ' raw-1 ',
+      connector: ' slack ',
+      source_id: ' source-1 ',
+      channel_id: ' channel-1 ',
+    });
+
+    expect(raw).toEqual({
+      kind: 'raw',
+      id: 'raw-1',
+      connector: 'slack',
+      source_id: 'source-1',
+      channel_id: 'channel-1',
+    });
+    expect(toContextRef(raw)).toEqual({
+      kind: 'raw',
+      raw_id: 'raw-1',
+      connector: 'slack',
+      source_id: 'source-1',
+      channel_id: 'channel-1',
+    });
+  });
+
+  it('AC: adapts verify artifact refs that cannot be represented as V0 context refs', () => {
+    expect(fromVerifyArtifact({ type: 'context_packet', id: ' packet-1 ' })).toEqual({
+      kind: 'context_packet',
+      id: 'packet-1',
+    });
+    expect(fromVerifyArtifact({ type: 'model_run', id: ' run-1 ' })).toEqual({
+      kind: 'model_run',
+      id: 'run-1',
+    });
+    expect(fromVerifyArtifact({ type: 'tool_trace', id: ' trace-1 ' })).toEqual({
+      kind: 'tool_trace',
+      id: 'trace-1',
+    });
+    expect(toContextRef({ kind: 'context_packet', id: 'packet-1' })).toBeNull();
+  });
+
+  it('AC: parses and serializes current and legacy provenance strings', () => {
+    expect(parseSourceRefString('raw:slack:event-1')).toEqual({
+      kind: 'raw',
+      connector: 'slack',
+      id: 'event-1',
+    });
+    expect(serializeSourceRef({ kind: 'raw', connector: 'slack', id: 'event-1' })).toBe(
+      'raw:slack:event-1'
+    );
+
+    expect(parseSourceRefString('memory:mem-1')).toEqual({ kind: 'memory', id: 'mem-1' });
+    expect(serializeSourceRef({ kind: 'memory', id: 'mem-1' })).toBe('memory:mem-1');
+
+    expect(parseSourceRefString('message:test')).toEqual({
+      kind: 'legacy',
+      legacy_kind: 'message',
+      id: 'test',
+    });
+    expect(parseSourceRefString('conversation:test')).toEqual({
+      kind: 'legacy',
+      legacy_kind: 'conversation',
+      id: 'test',
+    });
+    expect(parseSourceRefString('raw_memory:test')).toEqual({
+      kind: 'legacy',
+      legacy_kind: 'raw_memory',
+      id: 'test',
+    });
+    expect(serializeSourceRef({ kind: 'legacy', legacy_kind: 'raw_memory', id: 'test' })).toBe(
+      'raw_memory:test'
+    );
+  });
+
+  it('AC: rejects empty refs and unknown strict refs before durable writes', () => {
+    expect(() => assertNonEmptySourceRefs([])).toThrow(/source refs/i);
+    expect(() => parseSourceRefString('')).toThrow(/source ref/i);
+    expect(() => parseSourceRefString('unknown:test')).toThrow(/unsupported/i);
+    expect(() => fromVerifyArtifact({ type: 'unknown', id: 'test' })).toThrow(/unsupported/i);
+    expect(() => assertNonEmptySourceRefs([{ kind: 'unknown', id: 'test' } as never])).toThrow(
+      /unsupported/i
+    );
+    expect(() => assertNonEmptySourceRefs([{ kind: 'message', id: 'test' } as never])).toThrow(
+      /unsupported/i
+    );
+  });
+});

--- a/packages/mama-core/tests/provenance/source-ref.test.ts
+++ b/packages/mama-core/tests/provenance/source-ref.test.ts
@@ -109,4 +109,14 @@ describe('Story VNext PR0: canonical SourceRef compatibility', () => {
       /unsupported/i
     );
   });
+
+  it('AC: rejects nullish refs and malformed context refs with explicit errors', () => {
+    expect(() => fromContextRef(null as never)).toThrow(/context ref/i);
+    expect(() => fromContextRef({ kind: 'decision', id: 'decision-1' } as never)).toThrow(
+      /unsupported/i
+    );
+    expect(toContextRef(null as never)).toBeNull();
+    expect(() => fromVerifyArtifact(null as never)).toThrow(/artifact/i);
+    expect(() => serializeSourceRef(null as never)).toThrow(/source ref/i);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds the canonical SourceRef compatibility module for context, verify, and legacy memory provenance refs.
- Adds migration 038 for vNext operator cursors, commits, no-update records, and worker proposals.
- Repairs skipped vNext contract migration for legacy high-version databases and covers it with tests.
- Strengthens operator contract validation after review: JSON columns require valid JSON, worker proposal timestamps are status-aware, and SourceRef helpers reject malformed runtime inputs explicitly.

## Review Gates
- Pre-PR code review: approved after fixing migration repair and SourceRef runtime validation.
- Post-PR Gemini review: addressed all 8 inline comments in fab7f7f9 and replied on each thread.
- Follow-up internal review: addressed the rejected-status timestamp gap and added missing JSON constraint coverage.
- Privacy/internal-info review: clear. Only synthetic fixture refs are present in the diff.
- CodeRabbit: rate-limited for this PR, no actionable CodeRabbit findings were produced.

## Test Plan
- [x] MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-core exec vitest run tests/provenance/source-ref.test.ts tests/operator-vnext/vnext-operator-contracts.test.ts tests/context-compile/ref.test.ts tests/cases/migration-chain.test.ts tests/cases/migration-runner-duplicate-column.test.ts
- [x] pnpm --filter @jungjaehoon/mama-core typecheck
- [x] pnpm --filter @jungjaehoon/mama-core build
- [x] MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-core test
- [x] git diff --check origin/main...HEAD
- [x] git diff --cached --check
- [x] ./scripts/check-pii.sh
- [x] GitHub Actions: changes, setup, lint, test-core, test-standalone, test-plugin, test-mcp-server