### PR TITLE
feat: add vNext primary operator commit shell

### DIFF
--- a/packages/standalone/src/operator-vnext/no-update-ledger.ts
+++ b/packages/standalone/src/operator-vnext/no-update-ledger.ts
@@ -1,0 +1,44 @@
+import {
+  assertNonEmptySourceRefs,
+  serializeSourceRef,
+  type SourceRef,
+} from '@jungjaehoon/mama-core/provenance/source-ref';
+
+import type { SQLiteDatabase } from '../sqlite.js';
+import type {
+  OperatorNoUpdateLedgerInput,
+  OperatorNoUpdateLedgerRow,
+} from './operator-commit-result.js';
+import { requiredString } from './validation.js';
+
+export function serializeRequiredSourceRefs(refs: readonly SourceRef[]): string[] {
+  assertNonEmptySourceRefs(refs);
+  return refs.map((ref) => serializeSourceRef(ref));
+}
+
+export function recordNoUpdate(
+  db: SQLiteDatabase,
+  input: OperatorNoUpdateLedgerInput
+): OperatorNoUpdateLedgerRow {
+  const noUpdateId = requiredString(input.noUpdateId, 'noUpdateId');
+  const scopeKey = requiredString(input.scopeKey, 'scopeKey');
+  const reason = requiredString(input.reason, 'reason');
+  const idempotencyKey = requiredString(input.idempotencyKey, 'idempotencyKey');
+  const sourceRefs = serializeRequiredSourceRefs(input.sourceRefs);
+  const createdAtMs = input.nowMs ?? Date.now();
+
+  db.prepare(
+    `INSERT INTO operator_no_updates (
+      no_update_id, scope_key, reason, source_refs_json, idempotency_key, created_at_ms
+    ) VALUES (?, ?, ?, ?, ?, ?)`
+  ).run(noUpdateId, scopeKey, reason, JSON.stringify(sourceRefs), idempotencyKey, createdAtMs);
+
+  return {
+    noUpdateId,
+    scopeKey,
+    reason,
+    sourceRefs,
+    idempotencyKey,
+    createdAtMs,
+  };
+}

--- a/packages/standalone/src/operator-vnext/operator-commit-result.ts
+++ b/packages/standalone/src/operator-vnext/operator-commit-result.ts
@@ -1,0 +1,52 @@
+import type { SourceRef } from '@jungjaehoon/mama-core/provenance/source-ref';
+
+export type OperatorCommitStatus = 'changed' | 'no_update';
+export type OperatorCommitOutcome = 'committed' | 'already_committed' | 'recovered';
+
+export interface OperatorNoUpdateCommitInput {
+  noUpdateId?: string;
+  scopeKey: string;
+  reason: string;
+}
+
+export interface OperatorCursorCommitInput {
+  commitId?: string;
+  cursorName: string;
+  firstChangeSeq: number;
+  lastChangeSeq: number;
+  idempotencyKey: string;
+  status: OperatorCommitStatus;
+  changedRefs?: readonly SourceRef[];
+  sourceRefs: readonly SourceRef[];
+  noUpdate?: OperatorNoUpdateCommitInput;
+  nowMs?: number;
+}
+
+export interface OperatorCursorCommitResult {
+  outcome: OperatorCommitOutcome;
+  commitId: string;
+  cursorName: string;
+  firstChangeSeq: number;
+  lastChangeSeq: number;
+  idempotencyKey: string;
+  status: OperatorCommitStatus;
+  cursorAdvanced: boolean;
+}
+
+export interface OperatorNoUpdateLedgerInput {
+  noUpdateId: string;
+  scopeKey: string;
+  reason: string;
+  sourceRefs: readonly SourceRef[];
+  idempotencyKey: string;
+  nowMs?: number;
+}
+
+export interface OperatorNoUpdateLedgerRow {
+  noUpdateId: string;
+  scopeKey: string;
+  reason: string;
+  sourceRefs: string[];
+  idempotencyKey: string;
+  createdAtMs: number;
+}

--- a/packages/standalone/src/operator-vnext/operator-cursor-commit.ts
+++ b/packages/standalone/src/operator-vnext/operator-cursor-commit.ts
@@ -37,48 +37,15 @@ interface NormalizedNoUpdateCommit {
   reason: string;
 }
 
-export interface BusyRetryOptions {
-  maxBusyRetries?: number;
-}
-
 export interface ExistingOperatorCursorCommitInput {
   cursorName: string;
   idempotencyKey: string;
   nowMs?: number;
 }
 
-function isBusyError(error: unknown): boolean {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-  const maybeCode = (error as { code?: unknown }).code;
-  return (
-    maybeCode === 'SQLITE_BUSY' ||
-    maybeCode === 'SQLITE_LOCKED' ||
-    /SQLITE_BUSY|SQLITE_LOCKED|database is locked/i.test(error.message)
-  );
-}
-
 function assertOperatorCommitStatus(status: unknown): asserts status is OperatorCommitStatus {
   if (status !== 'changed' && status !== 'no_update') {
     throw new Error('Operator commit status must be changed or no_update');
-  }
-}
-
-export function runWithBoundedBusyRetry<T>(operation: () => T, options: BusyRetryOptions = {}): T {
-  const maxBusyRetries = options.maxBusyRetries ?? 3;
-  nonNegativeInteger(maxBusyRetries, 'maxBusyRetries');
-
-  let retries = 0;
-  for (;;) {
-    try {
-      return operation();
-    } catch (error) {
-      if (!isBusyError(error) || retries >= maxBusyRetries) {
-        throw error;
-      }
-      retries += 1;
-    }
   }
 }
 
@@ -249,33 +216,29 @@ function resultFromExistingCommit(
 
 export function recoverExistingOperatorCursorCommit(
   db: SQLiteDatabase,
-  input: ExistingOperatorCursorCommitInput,
-  options: BusyRetryOptions = {}
+  input: ExistingOperatorCursorCommitInput
 ): OperatorCursorCommitResult | null {
   const nowMs = input.nowMs ?? Date.now();
   const cursorName = requiredString(input.cursorName, 'cursorName');
   const idempotencyKey = requiredString(input.idempotencyKey, 'idempotencyKey');
 
-  return runWithBoundedBusyRetry(() => {
-    const tx = db.transaction(() => {
-      const existing = getExistingCommit(db, idempotencyKey);
-      if (!existing) {
-        return null;
-      }
-      if (existing.cursor_name !== cursorName) {
-        throw new Error(`Idempotency key belongs to a different cursor: ${existing.cursor_name}`);
-      }
-      const cursor = getCursor(db, cursorName);
-      return resultFromStoredCommit(db, cursor, existing, nowMs);
-    });
-    return tx();
-  }, options);
+  const tx = db.transaction(() => {
+    const existing = getExistingCommit(db, idempotencyKey);
+    if (!existing) {
+      return null;
+    }
+    if (existing.cursor_name !== cursorName) {
+      throw new Error(`Idempotency key belongs to a different cursor: ${existing.cursor_name}`);
+    }
+    const cursor = getCursor(db, cursorName);
+    return resultFromStoredCommit(db, cursor, existing, nowMs);
+  });
+  return tx();
 }
 
 export function commitOperatorCursor(
   db: SQLiteDatabase,
-  input: OperatorCursorCommitInput,
-  options: BusyRetryOptions = {}
+  input: OperatorCursorCommitInput
 ): OperatorCursorCommitResult {
   const nowMs = input.nowMs ?? Date.now();
   const cursorName = requiredString(input.cursorName, 'cursorName');
@@ -288,10 +251,11 @@ export function commitOperatorCursor(
   }
 
   const sourceRefs = serializeRequiredSourceRefs(input.sourceRefs);
-  const changedRefs =
-    input.status === 'changed'
-      ? serializeRequiredSourceRefs(input.changedRefs ?? [])
-      : ([] as string[]);
+  const changedInputRefs = input.status === 'changed' ? input.changedRefs : undefined;
+  if (input.status === 'changed' && (!changedInputRefs || changedInputRefs.length === 0)) {
+    throw new Error('changedRefs must not be empty for changed commits');
+  }
+  const changedRefs = changedInputRefs ? serializeRequiredSourceRefs(changedInputRefs) : [];
   if (input.status === 'no_update' && !input.noUpdate) {
     throw new Error('noUpdate details are required for no_update commits');
   }
@@ -316,71 +280,69 @@ export function commitOperatorCursor(
   const changedRefsJson = JSON.stringify(changedRefs);
   const sourceRefsJson = JSON.stringify(sourceRefs);
 
-  return runWithBoundedBusyRetry(() => {
+  const tx = db.transaction(() => {
     ensureCursor(db, cursorName, nowMs);
-    const tx = db.transaction(() => {
-      const cursor = getCursor(db, cursorName);
-      const existing = getExistingCommit(db, idempotencyKey);
-      if (existing) {
-        return resultFromExistingCommit(
-          db,
-          cursor,
-          existing,
-          {
-            status: input.status,
-            firstChangeSeq,
-            lastChangeSeq,
-            changedRefsJson,
-            sourceRefsJson,
-            noUpdate,
-          },
-          nowMs
-        );
-      }
-
-      assertContiguous(cursor, firstChangeSeq);
-
-      db.prepare(
-        `INSERT INTO vnext_operator_commits (
-          commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
-          status, changed_refs_json, source_refs_json, created_at_ms
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
-      ).run(
-        commitId,
-        cursorName,
-        idempotencyKey,
-        firstChangeSeq,
-        lastChangeSeq,
-        input.status,
-        changedRefsJson,
-        sourceRefsJson,
+    const cursor = getCursor(db, cursorName);
+    const existing = getExistingCommit(db, idempotencyKey);
+    if (existing) {
+      return resultFromExistingCommit(
+        db,
+        cursor,
+        existing,
+        {
+          status: input.status,
+          firstChangeSeq,
+          lastChangeSeq,
+          changedRefsJson,
+          sourceRefsJson,
+          noUpdate,
+        },
         nowMs
       );
+    }
 
-      if (input.status === 'no_update' && noUpdate) {
-        recordNoUpdate(db, {
-          noUpdateId: noUpdate.noUpdateId,
-          scopeKey: noUpdate.scopeKey,
-          reason: noUpdate.reason,
-          sourceRefs: input.sourceRefs,
-          idempotencyKey,
-          nowMs,
-        });
-      }
+    assertContiguous(cursor, firstChangeSeq);
 
-      updateCursor(db, cursorName, lastChangeSeq, idempotencyKey, nowMs);
+    db.prepare(
+      `INSERT INTO vnext_operator_commits (
+        commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+        status, changed_refs_json, source_refs_json, created_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      commitId,
+      cursorName,
+      idempotencyKey,
+      firstChangeSeq,
+      lastChangeSeq,
+      input.status,
+      changedRefsJson,
+      sourceRefsJson,
+      nowMs
+    );
 
-      return {
-        outcome: 'committed',
-        commitId,
-        cursorName,
-        firstChangeSeq,
-        lastChangeSeq,
+    if (input.status === 'no_update' && noUpdate) {
+      recordNoUpdate(db, {
+        noUpdateId: noUpdate.noUpdateId,
+        scopeKey: noUpdate.scopeKey,
+        reason: noUpdate.reason,
+        sourceRefs: input.sourceRefs,
         idempotencyKey,
-        status: input.status,
-        cursorAdvanced: true,
-      } satisfies OperatorCursorCommitResult;
-    });
-    return tx();
-  }, options);
+        nowMs,
+      });
+    }
+
+    updateCursor(db, cursorName, lastChangeSeq, idempotencyKey, nowMs);
+
+    return {
+      outcome: 'committed',
+      commitId,
+      cursorName,
+      firstChangeSeq,
+      lastChangeSeq,
+      idempotencyKey,
+      status: input.status,
+      cursorAdvanced: true,
+    } satisfies OperatorCursorCommitResult;
+  });
+  return tx();
 }

--- a/packages/standalone/src/operator-vnext/operator-cursor-commit.ts
+++ b/packages/standalone/src/operator-vnext/operator-cursor-commit.ts
@@ -1,0 +1,386 @@
+import type { SQLiteDatabase } from '../sqlite.js';
+import { recordNoUpdate, serializeRequiredSourceRefs } from './no-update-ledger.js';
+import type {
+  OperatorCommitStatus,
+  OperatorCursorCommitInput,
+  OperatorCursorCommitResult,
+} from './operator-commit-result.js';
+import { nonNegativeInteger, requiredString } from './validation.js';
+
+interface CursorRow {
+  cursor_name: string;
+  last_change_seq: number;
+  last_idempotency_key: string | null;
+}
+
+interface CommitRow {
+  commit_id: string;
+  cursor_name: string;
+  idempotency_key: string;
+  first_change_seq: number;
+  last_change_seq: number;
+  status: OperatorCommitStatus;
+  changed_refs_json: string;
+  source_refs_json: string;
+}
+
+interface NoUpdateRow {
+  no_update_id: string;
+  scope_key: string;
+  reason: string;
+  source_refs_json: string;
+}
+
+interface NormalizedNoUpdateCommit {
+  noUpdateId: string;
+  scopeKey: string;
+  reason: string;
+}
+
+export interface BusyRetryOptions {
+  maxBusyRetries?: number;
+}
+
+export interface ExistingOperatorCursorCommitInput {
+  cursorName: string;
+  idempotencyKey: string;
+  nowMs?: number;
+}
+
+function isBusyError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const maybeCode = (error as { code?: unknown }).code;
+  return (
+    maybeCode === 'SQLITE_BUSY' ||
+    maybeCode === 'SQLITE_LOCKED' ||
+    /SQLITE_BUSY|SQLITE_LOCKED|database is locked/i.test(error.message)
+  );
+}
+
+function assertOperatorCommitStatus(status: unknown): asserts status is OperatorCommitStatus {
+  if (status !== 'changed' && status !== 'no_update') {
+    throw new Error('Operator commit status must be changed or no_update');
+  }
+}
+
+export function runWithBoundedBusyRetry<T>(operation: () => T, options: BusyRetryOptions = {}): T {
+  const maxBusyRetries = options.maxBusyRetries ?? 3;
+  nonNegativeInteger(maxBusyRetries, 'maxBusyRetries');
+
+  let retries = 0;
+  for (;;) {
+    try {
+      return operation();
+    } catch (error) {
+      if (!isBusyError(error) || retries >= maxBusyRetries) {
+        throw error;
+      }
+      retries += 1;
+    }
+  }
+}
+
+export function buildConnectorIdempotencyKey(
+  sourceConnector: string,
+  firstChangeSeq: number,
+  lastChangeSeq: number
+): string {
+  const connector = requiredString(sourceConnector, 'sourceConnector');
+  const first = nonNegativeInteger(firstChangeSeq, 'firstChangeSeq');
+  const last = nonNegativeInteger(lastChangeSeq, 'lastChangeSeq');
+  if (last < first) {
+    throw new Error('lastChangeSeq must be greater than or equal to firstChangeSeq');
+  }
+  return `connector:${connector}:seq:${first}-${last}`;
+}
+
+function ensureCursor(db: SQLiteDatabase, cursorName: string, nowMs: number): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO vnext_operator_cursors (
+      cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+    ) VALUES (?, ?, ?, ?)`
+  ).run(cursorName, 0, null, nowMs);
+}
+
+function getCursor(db: SQLiteDatabase, cursorName: string): CursorRow {
+  const row = db
+    .prepare(
+      `SELECT cursor_name, last_change_seq, last_idempotency_key
+       FROM vnext_operator_cursors
+       WHERE cursor_name = ?`
+    )
+    .get(cursorName) as CursorRow | undefined;
+  if (!row) {
+    throw new Error(`Operator cursor not found: ${cursorName}`);
+  }
+  return row;
+}
+
+function getExistingCommit(db: SQLiteDatabase, idempotencyKey: string): CommitRow | null {
+  return (
+    (db
+      .prepare(
+        `SELECT
+          commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+          status, changed_refs_json, source_refs_json
+         FROM vnext_operator_commits
+         WHERE idempotency_key = ?`
+      )
+      .get(idempotencyKey) as CommitRow | undefined) ?? null
+  );
+}
+
+function getExistingNoUpdate(db: SQLiteDatabase, idempotencyKey: string): NoUpdateRow | null {
+  return (
+    (db
+      .prepare(
+        `SELECT no_update_id, scope_key, reason, source_refs_json
+         FROM operator_no_updates
+         WHERE idempotency_key = ?`
+      )
+      .get(idempotencyKey) as NoUpdateRow | undefined) ?? null
+  );
+}
+
+function assertContiguous(cursor: CursorRow, firstChangeSeq: number): void {
+  const expected = cursor.last_change_seq + 1;
+  if (firstChangeSeq !== expected) {
+    throw new Error(
+      `Operator commit must be contiguous: expected first_change_seq ${expected}, got ${firstChangeSeq}`
+    );
+  }
+}
+
+function updateCursor(
+  db: SQLiteDatabase,
+  cursorName: string,
+  lastChangeSeq: number,
+  idempotencyKey: string,
+  nowMs: number
+): void {
+  db.prepare(
+    `UPDATE vnext_operator_cursors
+     SET last_change_seq = ?, last_idempotency_key = ?, updated_at_ms = ?
+     WHERE cursor_name = ?`
+  ).run(lastChangeSeq, idempotencyKey, nowMs, cursorName);
+}
+
+function resultFromStoredCommit(
+  db: SQLiteDatabase,
+  cursor: CursorRow,
+  existing: CommitRow,
+  nowMs: number
+): OperatorCursorCommitResult {
+  if (existing.status === 'no_update' && !getExistingNoUpdate(db, existing.idempotency_key)) {
+    throw new Error('Idempotent no-update replay is missing no-update commit details');
+  }
+  if (cursor.last_change_seq >= existing.last_change_seq) {
+    return {
+      outcome: 'already_committed',
+      commitId: existing.commit_id,
+      cursorName: existing.cursor_name,
+      firstChangeSeq: existing.first_change_seq,
+      lastChangeSeq: existing.last_change_seq,
+      idempotencyKey: existing.idempotency_key,
+      status: existing.status,
+      cursorAdvanced: false,
+    };
+  }
+
+  assertContiguous(cursor, existing.first_change_seq);
+  updateCursor(db, existing.cursor_name, existing.last_change_seq, existing.idempotency_key, nowMs);
+  return {
+    outcome: 'recovered',
+    commitId: existing.commit_id,
+    cursorName: existing.cursor_name,
+    firstChangeSeq: existing.first_change_seq,
+    lastChangeSeq: existing.last_change_seq,
+    idempotencyKey: existing.idempotency_key,
+    status: existing.status,
+    cursorAdvanced: true,
+  };
+}
+
+function resultFromExistingCommit(
+  db: SQLiteDatabase,
+  cursor: CursorRow,
+  existing: CommitRow,
+  expected: {
+    status: OperatorCommitStatus;
+    firstChangeSeq: number;
+    lastChangeSeq: number;
+    changedRefsJson: string;
+    sourceRefsJson: string;
+    noUpdate?: NormalizedNoUpdateCommit;
+  },
+  nowMs: number
+): OperatorCursorCommitResult {
+  if (existing.cursor_name !== cursor.cursor_name) {
+    throw new Error(`Idempotency key belongs to a different cursor: ${existing.cursor_name}`);
+  }
+  if (
+    existing.status !== expected.status ||
+    existing.first_change_seq !== expected.firstChangeSeq ||
+    existing.last_change_seq !== expected.lastChangeSeq ||
+    existing.changed_refs_json !== expected.changedRefsJson ||
+    existing.source_refs_json !== expected.sourceRefsJson
+  ) {
+    throw new Error('Idempotency key replay does not match the original operator commit');
+  }
+  if (existing.status === 'no_update') {
+    const existingNoUpdate = getExistingNoUpdate(db, existing.idempotency_key);
+    if (!existingNoUpdate || !expected.noUpdate) {
+      throw new Error('Idempotent no-update replay is missing no-update commit details');
+    }
+    if (
+      existingNoUpdate.no_update_id !== expected.noUpdate.noUpdateId ||
+      existingNoUpdate.scope_key !== expected.noUpdate.scopeKey ||
+      existingNoUpdate.reason !== expected.noUpdate.reason ||
+      existingNoUpdate.source_refs_json !== expected.sourceRefsJson
+    ) {
+      throw new Error('Idempotency key replay does not match the original no-update commit');
+    }
+  }
+
+  return resultFromStoredCommit(db, cursor, existing, nowMs);
+}
+
+export function recoverExistingOperatorCursorCommit(
+  db: SQLiteDatabase,
+  input: ExistingOperatorCursorCommitInput,
+  options: BusyRetryOptions = {}
+): OperatorCursorCommitResult | null {
+  const nowMs = input.nowMs ?? Date.now();
+  const cursorName = requiredString(input.cursorName, 'cursorName');
+  const idempotencyKey = requiredString(input.idempotencyKey, 'idempotencyKey');
+
+  return runWithBoundedBusyRetry(() => {
+    const tx = db.transaction(() => {
+      const existing = getExistingCommit(db, idempotencyKey);
+      if (!existing) {
+        return null;
+      }
+      if (existing.cursor_name !== cursorName) {
+        throw new Error(`Idempotency key belongs to a different cursor: ${existing.cursor_name}`);
+      }
+      const cursor = getCursor(db, cursorName);
+      return resultFromStoredCommit(db, cursor, existing, nowMs);
+    });
+    return tx();
+  }, options);
+}
+
+export function commitOperatorCursor(
+  db: SQLiteDatabase,
+  input: OperatorCursorCommitInput,
+  options: BusyRetryOptions = {}
+): OperatorCursorCommitResult {
+  const nowMs = input.nowMs ?? Date.now();
+  const cursorName = requiredString(input.cursorName, 'cursorName');
+  const idempotencyKey = requiredString(input.idempotencyKey, 'idempotencyKey');
+  const firstChangeSeq = nonNegativeInteger(input.firstChangeSeq, 'firstChangeSeq');
+  const lastChangeSeq = nonNegativeInteger(input.lastChangeSeq, 'lastChangeSeq');
+  assertOperatorCommitStatus(input.status);
+  if (lastChangeSeq < firstChangeSeq) {
+    throw new Error('lastChangeSeq must be greater than or equal to firstChangeSeq');
+  }
+
+  const sourceRefs = serializeRequiredSourceRefs(input.sourceRefs);
+  const changedRefs =
+    input.status === 'changed'
+      ? serializeRequiredSourceRefs(input.changedRefs ?? [])
+      : ([] as string[]);
+  if (input.status === 'no_update' && !input.noUpdate) {
+    throw new Error('noUpdate details are required for no_update commits');
+  }
+
+  const commitId = requiredString(input.commitId ?? `commit:${idempotencyKey}`, 'commitId');
+  const noUpdate: NormalizedNoUpdateCommit | undefined =
+    input.status === 'no_update' && input.noUpdate
+      ? {
+          noUpdateId: requiredString(
+            input.noUpdate.noUpdateId ?? `no-update:${idempotencyKey}`,
+            'noUpdateId'
+          ),
+          scopeKey: requiredString(input.noUpdate.scopeKey, 'scopeKey'),
+          reason: requiredString(input.noUpdate.reason, 'reason'),
+        }
+      : undefined;
+  if (noUpdate && noUpdate.scopeKey !== cursorName) {
+    throw new Error(
+      `noUpdate scopeKey must match cursorName ${cursorName}; got ${noUpdate.scopeKey}`
+    );
+  }
+  const changedRefsJson = JSON.stringify(changedRefs);
+  const sourceRefsJson = JSON.stringify(sourceRefs);
+
+  return runWithBoundedBusyRetry(() => {
+    ensureCursor(db, cursorName, nowMs);
+    const tx = db.transaction(() => {
+      const cursor = getCursor(db, cursorName);
+      const existing = getExistingCommit(db, idempotencyKey);
+      if (existing) {
+        return resultFromExistingCommit(
+          db,
+          cursor,
+          existing,
+          {
+            status: input.status,
+            firstChangeSeq,
+            lastChangeSeq,
+            changedRefsJson,
+            sourceRefsJson,
+            noUpdate,
+          },
+          nowMs
+        );
+      }
+
+      assertContiguous(cursor, firstChangeSeq);
+
+      db.prepare(
+        `INSERT INTO vnext_operator_commits (
+          commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+          status, changed_refs_json, source_refs_json, created_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        commitId,
+        cursorName,
+        idempotencyKey,
+        firstChangeSeq,
+        lastChangeSeq,
+        input.status,
+        changedRefsJson,
+        sourceRefsJson,
+        nowMs
+      );
+
+      if (input.status === 'no_update' && noUpdate) {
+        recordNoUpdate(db, {
+          noUpdateId: noUpdate.noUpdateId,
+          scopeKey: noUpdate.scopeKey,
+          reason: noUpdate.reason,
+          sourceRefs: input.sourceRefs,
+          idempotencyKey,
+          nowMs,
+        });
+      }
+
+      updateCursor(db, cursorName, lastChangeSeq, idempotencyKey, nowMs);
+
+      return {
+        outcome: 'committed',
+        commitId,
+        cursorName,
+        firstChangeSeq,
+        lastChangeSeq,
+        idempotencyKey,
+        status: input.status,
+        cursorAdvanced: true,
+      } satisfies OperatorCursorCommitResult;
+    });
+    return tx();
+  }, options);
+}

--- a/packages/standalone/src/operator-vnext/operator-cursor-commit.ts
+++ b/packages/standalone/src/operator-vnext/operator-cursor-commit.ts
@@ -1,3 +1,5 @@
+import type { SourceRef } from '@jungjaehoon/mama-core/provenance/source-ref';
+
 import type { SQLiteDatabase } from '../sqlite.js';
 import { recordNoUpdate, serializeRequiredSourceRefs } from './no-update-ledger.js';
 import type {
@@ -40,6 +42,7 @@ interface NormalizedNoUpdateCommit {
 export interface ExistingOperatorCursorCommitInput {
   cursorName: string;
   idempotencyKey: string;
+  sourceRefs: readonly SourceRef[];
   nowMs?: number;
 }
 
@@ -221,6 +224,7 @@ export function recoverExistingOperatorCursorCommit(
   const nowMs = input.nowMs ?? Date.now();
   const cursorName = requiredString(input.cursorName, 'cursorName');
   const idempotencyKey = requiredString(input.idempotencyKey, 'idempotencyKey');
+  const expectedSourceRefsJson = JSON.stringify(serializeRequiredSourceRefs(input.sourceRefs));
 
   const tx = db.transaction(() => {
     const existing = getExistingCommit(db, idempotencyKey);
@@ -229,6 +233,9 @@ export function recoverExistingOperatorCursorCommit(
     }
     if (existing.cursor_name !== cursorName) {
       throw new Error(`Idempotency key belongs to a different cursor: ${existing.cursor_name}`);
+    }
+    if (existing.source_refs_json !== expectedSourceRefsJson) {
+      throw new Error('Idempotent replay source refs do not match the original operator commit');
     }
     const cursor = getCursor(db, cursorName);
     return resultFromStoredCommit(db, cursor, existing, nowMs);

--- a/packages/standalone/src/operator-vnext/primary-operator-runtime.ts
+++ b/packages/standalone/src/operator-vnext/primary-operator-runtime.ts
@@ -1,0 +1,218 @@
+import type { SourceRef } from '@jungjaehoon/mama-core/provenance/source-ref';
+
+import type { SQLiteDatabase } from '../sqlite.js';
+import {
+  buildConnectorIdempotencyKey,
+  commitOperatorCursor,
+  recoverExistingOperatorCursorCommit,
+} from './operator-cursor-commit.js';
+import type { OperatorCursorCommitResult } from './operator-commit-result.js';
+import { nonNegativeInteger, requiredString } from './validation.js';
+
+export interface PrimaryOperatorEvent {
+  seq: number;
+  sourceRef: SourceRef;
+  payload?: unknown;
+}
+
+export type PrimaryOperatorDecision =
+  | {
+      status: 'changed';
+      changedRefs: readonly SourceRef[];
+    }
+  | {
+      status: 'no_update';
+      reason: string;
+      scopeKey?: string;
+    };
+
+export interface PrimaryOperatorRuntimeOptions {
+  db: SQLiteDatabase;
+  cursorName: string;
+  connector: string;
+  nowMs?: () => number;
+}
+
+export type PrimaryOperatorBatchResult =
+  | {
+      status: 'idle';
+      processed: 0;
+      advancedThroughSeq: number;
+      commits: OperatorCursorCommitResult[];
+    }
+  | {
+      status: 'committed';
+      processed: number;
+      advancedThroughSeq: number;
+      commits: OperatorCursorCommitResult[];
+    }
+  | {
+      status: 'partial_failure';
+      processed: number;
+      advancedThroughSeq: number;
+      failedSeq: number;
+      error: Error;
+      commits: OperatorCursorCommitResult[];
+    };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function parseDecision(value: unknown): PrimaryOperatorDecision {
+  if (!isRecord(value)) {
+    throw new Error('Primary operator decision must be an object');
+  }
+  if (value.status === 'changed') {
+    if (!Array.isArray(value.changedRefs)) {
+      throw new Error('Changed primary operator decisions require changedRefs');
+    }
+    return {
+      status: 'changed',
+      changedRefs: value.changedRefs as SourceRef[],
+    };
+  }
+  if (value.status === 'no_update') {
+    if (typeof value.reason !== 'string' || value.reason.trim().length === 0) {
+      throw new Error('No-update primary operator decisions require reason');
+    }
+    return {
+      status: 'no_update',
+      reason: value.reason,
+      scopeKey:
+        value.scopeKey === undefined ? undefined : requiredString(value.scopeKey, 'scopeKey'),
+    };
+  }
+  throw new Error('Primary operator decision must be changed or no_update');
+}
+
+function assertRawEventSourceBoundToConnector(sourceRef: SourceRef, connector: string): void {
+  if (sourceRef.kind !== 'raw') {
+    throw new Error('Primary operator events require a raw source ref');
+  }
+  if (sourceRef.connector !== connector) {
+    throw new Error(
+      `Primary operator event source connector mismatch: expected ${connector}, got ${sourceRef.connector}`
+    );
+  }
+}
+
+function readCursorSeq(db: SQLiteDatabase, cursorName: string): number {
+  const row = db
+    .prepare('SELECT last_change_seq FROM vnext_operator_cursors WHERE cursor_name = ?')
+    .get(cursorName) as { last_change_seq: number } | undefined;
+  return row?.last_change_seq ?? 0;
+}
+
+export class PrimaryOperatorRuntime {
+  private readonly db: SQLiteDatabase;
+  private readonly cursorName: string;
+  private readonly connector: string;
+  private readonly nowMs: () => number;
+
+  constructor(options: PrimaryOperatorRuntimeOptions) {
+    this.db = options.db;
+    this.cursorName = options.cursorName.trim();
+    this.connector = options.connector.trim();
+    this.nowMs = options.nowMs ?? Date.now;
+    if (this.cursorName.length === 0) {
+      throw new Error('cursorName must not be empty');
+    }
+    if (this.connector.length === 0) {
+      throw new Error('connector must not be empty');
+    }
+  }
+
+  async processBatch(
+    events: readonly PrimaryOperatorEvent[],
+    decide: (event: PrimaryOperatorEvent) => Promise<unknown> | unknown
+  ): Promise<PrimaryOperatorBatchResult> {
+    if (events.length === 0) {
+      return {
+        status: 'idle',
+        processed: 0,
+        advancedThroughSeq: readCursorSeq(this.db, this.cursorName),
+        commits: [],
+      };
+    }
+
+    const commits: OperatorCursorCommitResult[] = [];
+    let advancedThroughSeq = readCursorSeq(this.db, this.cursorName);
+
+    for (const event of events) {
+      try {
+        const seq = nonNegativeInteger(event.seq, 'event.seq');
+        assertRawEventSourceBoundToConnector(event.sourceRef, this.connector);
+        const idempotencyKey = buildConnectorIdempotencyKey(this.connector, seq, seq);
+        const existingCommit = recoverExistingOperatorCursorCommit(this.db, {
+          cursorName: this.cursorName,
+          idempotencyKey,
+          nowMs: this.nowMs(),
+        });
+        if (existingCommit) {
+          commits.push(existingCommit);
+          advancedThroughSeq = Math.max(advancedThroughSeq, existingCommit.lastChangeSeq);
+          continue;
+        }
+        const decision = parseDecision(await decide(event));
+        const sourceRefs = [event.sourceRef];
+        const commit =
+          decision.status === 'changed'
+            ? commitOperatorCursor(this.db, {
+                cursorName: this.cursorName,
+                firstChangeSeq: seq,
+                lastChangeSeq: seq,
+                idempotencyKey,
+                status: 'changed',
+                changedRefs: decision.changedRefs,
+                sourceRefs,
+                nowMs: this.nowMs(),
+              })
+            : commitOperatorCursor(this.db, {
+                cursorName: this.cursorName,
+                firstChangeSeq: seq,
+                lastChangeSeq: seq,
+                idempotencyKey,
+                status: 'no_update',
+                sourceRefs,
+                noUpdate: {
+                  scopeKey: this.resolveNoUpdateScope(decision.scopeKey),
+                  reason: decision.reason,
+                },
+                nowMs: this.nowMs(),
+              });
+        commits.push(commit);
+        advancedThroughSeq = Math.max(advancedThroughSeq, commit.lastChangeSeq);
+      } catch (error) {
+        return {
+          status: 'partial_failure',
+          processed: commits.length,
+          advancedThroughSeq,
+          failedSeq: event.seq,
+          error: asError(error),
+          commits,
+        };
+      }
+    }
+
+    return {
+      status: 'committed',
+      processed: commits.length,
+      advancedThroughSeq,
+      commits,
+    };
+  }
+
+  private resolveNoUpdateScope(candidateScopeKey: string | undefined): string {
+    if (candidateScopeKey !== undefined && candidateScopeKey !== this.cursorName) {
+      throw new Error(
+        `No-update scopeKey must match primary operator cursor ${this.cursorName}; got ${candidateScopeKey}`
+      );
+    }
+    return this.cursorName;
+  }
+}

--- a/packages/standalone/src/operator-vnext/primary-operator-runtime.ts
+++ b/packages/standalone/src/operator-vnext/primary-operator-runtime.ts
@@ -177,9 +177,11 @@ export class PrimaryOperatorRuntime {
         const seq = nonNegativeInteger(event.seq, 'event.seq');
         assertRawEventSourceBoundToConnector(event.sourceRef, this.connector);
         const idempotencyKey = buildConnectorIdempotencyKey(this.connector, seq, seq);
+        const sourceRefs = [event.sourceRef];
         const existingCommit = recoverExistingOperatorCursorCommit(this.db, {
           cursorName: this.cursorName,
           idempotencyKey,
+          sourceRefs,
           nowMs: this.nowMs(),
         });
         if (existingCommit) {
@@ -187,8 +189,12 @@ export class PrimaryOperatorRuntime {
           advancedThroughSeq = Math.max(advancedThroughSeq, existingCommit.lastChangeSeq);
           continue;
         }
+        if (seq !== advancedThroughSeq + 1) {
+          throw new Error(
+            `Operator events must be contiguous; expected seq ${advancedThroughSeq + 1}, got ${seq}`
+          );
+        }
         const decision = parseDecision(await decide(event));
-        const sourceRefs = [event.sourceRef];
         const commit =
           decision.status === 'changed'
             ? commitOperatorCursor(this.db, {

--- a/packages/standalone/src/operator-vnext/primary-operator-runtime.ts
+++ b/packages/standalone/src/operator-vnext/primary-operator-runtime.ts
@@ -55,6 +55,28 @@ export type PrimaryOperatorBatchResult =
       commits: OperatorCursorCommitResult[];
     };
 
+const cursorLocks = new Map<string, Promise<void>>();
+
+async function withCursorLock<T>(cursorName: string, operation: () => Promise<T>): Promise<T> {
+  const previous = cursorLocks.get(cursorName) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const chained = previous.catch(() => undefined).then(() => current);
+  cursorLocks.set(cursorName, chained);
+
+  await previous.catch(() => undefined);
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (cursorLocks.get(cursorName) === chained) {
+      cursorLocks.delete(cursorName);
+    }
+  }
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -128,6 +150,13 @@ export class PrimaryOperatorRuntime {
   }
 
   async processBatch(
+    events: readonly PrimaryOperatorEvent[],
+    decide: (event: PrimaryOperatorEvent) => Promise<unknown> | unknown
+  ): Promise<PrimaryOperatorBatchResult> {
+    return withCursorLock(this.cursorName, () => this.processBatchLocked(events, decide));
+  }
+
+  private async processBatchLocked(
     events: readonly PrimaryOperatorEvent[],
     decide: (event: PrimaryOperatorEvent) => Promise<unknown> | unknown
   ): Promise<PrimaryOperatorBatchResult> {

--- a/packages/standalone/src/operator-vnext/validation.ts
+++ b/packages/standalone/src/operator-vnext/validation.ts
@@ -9,8 +9,8 @@ export function requiredString(value: unknown, field: string): string {
   return trimmed;
 }
 
-export function nonNegativeInteger(value: number, field: string): number {
-  if (!Number.isInteger(value) || value < 0) {
+export function nonNegativeInteger(value: unknown, field: string): number {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
     throw new Error(`${field} must be a non-negative integer`);
   }
   return value;

--- a/packages/standalone/src/operator-vnext/validation.ts
+++ b/packages/standalone/src/operator-vnext/validation.ts
@@ -1,0 +1,17 @@
+export function requiredString(value: unknown, field: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`${field} must be a string`);
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`${field} must not be empty`);
+  }
+  return trimmed;
+}
+
+export function nonNegativeInteger(value: number, field: string): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${field} must be a non-negative integer`);
+  }
+  return value;
+}

--- a/packages/standalone/tests/operator-vnext/fixtures.ts
+++ b/packages/standalone/tests/operator-vnext/fixtures.ts
@@ -1,0 +1,14 @@
+import { applyMigrationsThrough } from '@jungjaehoon/mama-core/test-utils';
+
+import Database, { type SQLiteDatabase } from '../../src/sqlite.js';
+
+export function makeOperatorVNextDb(): SQLiteDatabase {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 38);
+  return db;
+}
+
+export function countRows(db: SQLiteDatabase, table: string): number {
+  return (db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get() as { count: number }).count;
+}

--- a/packages/standalone/tests/operator-vnext/fixtures.ts
+++ b/packages/standalone/tests/operator-vnext/fixtures.ts
@@ -5,6 +5,7 @@ import Database, { type SQLiteDatabase } from '../../src/sqlite.js';
 export function makeOperatorVNextDb(): SQLiteDatabase {
   const db = new Database(':memory:');
   db.pragma('foreign_keys = ON');
+  // The standalone SQLite wrapper exposes the migration helper's required better-sqlite3 surface.
   applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 38);
   return db;
 }

--- a/packages/standalone/tests/operator-vnext/no-update-ledger.test.ts
+++ b/packages/standalone/tests/operator-vnext/no-update-ledger.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { recordNoUpdate } from '../../src/operator-vnext/no-update-ledger.js';
+import { makeOperatorVNextDb } from './fixtures.js';
+
+describe('STORY-VNEXT-PR2-NO-UPDATE-LEDGER: no-update ledger writes', () => {
+  describe('AC: no-update rows require source refs and idempotency', () => {
+    it('records no-update decisions with serialized source refs', () => {
+      const db = makeOperatorVNextDb();
+
+      const row = recordNoUpdate(db, {
+        noUpdateId: 'no-update-1',
+        scopeKey: 'connector:slack',
+        reason: 'no durable state changed',
+        sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+        idempotencyKey: 'connector:slack:seq:1-1',
+        nowMs: 1710000000000,
+      });
+
+      expect(row).toEqual({
+        noUpdateId: 'no-update-1',
+        scopeKey: 'connector:slack',
+        reason: 'no durable state changed',
+        sourceRefs: ['raw:slack:event-1'],
+        idempotencyKey: 'connector:slack:seq:1-1',
+        createdAtMs: 1710000000000,
+      });
+      expect(
+        db
+          .prepare('SELECT source_refs_json FROM operator_no_updates WHERE no_update_id = ?')
+          .get('no-update-1')
+      ).toEqual({ source_refs_json: '["raw:slack:event-1"]' });
+
+      db.close();
+    });
+
+    it('rejects empty source refs before inserting no-update rows', () => {
+      const db = makeOperatorVNextDb();
+
+      expect(() =>
+        recordNoUpdate(db, {
+          noUpdateId: 'no-update-empty',
+          scopeKey: 'connector:slack',
+          reason: 'unchanged',
+          sourceRefs: [],
+          idempotencyKey: 'connector:slack:seq:1-1',
+          nowMs: 1710000000000,
+        })
+      ).toThrow(/source refs/i);
+      expect(db.prepare('SELECT COUNT(*) AS count FROM operator_no_updates').get()).toEqual({
+        count: 0,
+      });
+
+      db.close();
+    });
+  });
+});

--- a/packages/standalone/tests/operator-vnext/operator-cursor-commit.test.ts
+++ b/packages/standalone/tests/operator-vnext/operator-cursor-commit.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import {
   buildConnectorIdempotencyKey,
   commitOperatorCursor,
-  runWithBoundedBusyRetry,
 } from '../../src/operator-vnext/operator-cursor-commit.js';
 import { countRows, makeOperatorVNextDb } from './fixtures.js';
 
@@ -122,7 +121,7 @@ describe('STORY-VNEXT-PR2-CURSOR-COMMIT: atomic cursor commits', () => {
         db
           .prepare('SELECT last_change_seq FROM vnext_operator_cursors WHERE cursor_name = ?')
           .get('connector:slack')
-      ).toEqual({ last_change_seq: 0 });
+      ).toBeUndefined();
       expect(countRows(db, 'vnext_operator_commits')).toBe(0);
 
       db.close();
@@ -144,6 +143,28 @@ describe('STORY-VNEXT-PR2-CURSOR-COMMIT: atomic cursor commits', () => {
           nowMs: 1710000000000,
         })
       ).toThrow(/status/i);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(countRows(db, 'vnext_operator_cursors')).toBe(0);
+
+      db.close();
+    });
+
+    it('rejects changed commits without changed refs using a clear error', () => {
+      const db = makeOperatorVNextDb();
+
+      expect(() =>
+        commitOperatorCursor(db, {
+          commitId: 'commit-empty-changed-refs',
+          cursorName: 'connector:slack',
+          firstChangeSeq: 1,
+          lastChangeSeq: 1,
+          idempotencyKey: buildConnectorIdempotencyKey('slack', 1, 1),
+          status: 'changed',
+          changedRefs: [],
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          nowMs: 1710000000000,
+        })
+      ).toThrow(/changedRefs must not be empty/i);
       expect(countRows(db, 'vnext_operator_commits')).toBe(0);
       expect(countRows(db, 'vnext_operator_cursors')).toBe(0);
 
@@ -189,7 +210,7 @@ describe('STORY-VNEXT-PR2-CURSOR-COMMIT: atomic cursor commits', () => {
         db
           .prepare('SELECT last_change_seq FROM vnext_operator_cursors WHERE cursor_name = ?')
           .get('connector:slack')
-      ).toEqual({ last_change_seq: 0 });
+      ).toBeUndefined();
 
       db.close();
     });
@@ -307,7 +328,7 @@ describe('STORY-VNEXT-PR2-CURSOR-COMMIT: atomic cursor commits', () => {
         db
           .prepare('SELECT last_change_seq FROM vnext_operator_cursors WHERE cursor_name = ?')
           .get('connector:discord')
-      ).toEqual({ last_change_seq: 0 });
+      ).toBeUndefined();
 
       db.close();
     });
@@ -486,23 +507,6 @@ describe('STORY-VNEXT-PR2-CURSOR-COMMIT: atomic cursor commits', () => {
       expect(countRows(db, 'operator_no_updates')).toBe(1);
 
       db.close();
-    });
-
-    it('stops retrying SQLITE_BUSY after the configured attempt budget', () => {
-      let attempts = 0;
-
-      expect(() =>
-        runWithBoundedBusyRetry(
-          () => {
-            attempts += 1;
-            const error = new Error('database is locked');
-            Object.assign(error, { code: 'SQLITE_BUSY' });
-            throw error;
-          },
-          { maxBusyRetries: 2 }
-        )
-      ).toThrow(/database is locked/i);
-      expect(attempts).toBe(3);
     });
   });
 });

--- a/packages/standalone/tests/operator-vnext/operator-cursor-commit.test.ts
+++ b/packages/standalone/tests/operator-vnext/operator-cursor-commit.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+process.env.MAMA_FORCE_TIER_3 ||= 'true';
+
 import {
   buildConnectorIdempotencyKey,
   commitOperatorCursor,

--- a/packages/standalone/tests/operator-vnext/operator-cursor-commit.test.ts
+++ b/packages/standalone/tests/operator-vnext/operator-cursor-commit.test.ts
@@ -1,0 +1,508 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildConnectorIdempotencyKey,
+  commitOperatorCursor,
+  runWithBoundedBusyRetry,
+} from '../../src/operator-vnext/operator-cursor-commit.js';
+import { countRows, makeOperatorVNextDb } from './fixtures.js';
+
+describe('STORY-VNEXT-PR2-CURSOR-COMMIT: atomic cursor commits', () => {
+  describe('AC: cursor and durable commit move together', () => {
+    it('commits changed refs and advances the cursor in one transaction', () => {
+      const db = makeOperatorVNextDb();
+
+      const result = commitOperatorCursor(db, {
+        commitId: 'commit-1',
+        cursorName: 'connector:slack',
+        firstChangeSeq: 1,
+        lastChangeSeq: 2,
+        idempotencyKey: buildConnectorIdempotencyKey('slack', 1, 2),
+        status: 'changed',
+        changedRefs: [{ kind: 'os_task', id: 'task-1' }],
+        sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+        nowMs: 1710000000000,
+      });
+
+      expect(result.outcome).toBe('committed');
+      expect(result.cursorAdvanced).toBe(true);
+      expect(
+        db.prepare('SELECT last_change_seq, last_idempotency_key FROM vnext_operator_cursors').get()
+      ).toEqual({
+        last_change_seq: 2,
+        last_idempotency_key: 'connector:slack:seq:1-2',
+      });
+      expect(
+        db
+          .prepare('SELECT status, changed_refs_json, source_refs_json FROM vnext_operator_commits')
+          .get()
+      ).toEqual({
+        status: 'changed',
+        changed_refs_json: '["os_task:task-1"]',
+        source_refs_json: '["raw:slack:event-1"]',
+      });
+
+      db.close();
+    });
+
+    it('commits no-update rows and advances the cursor atomically', () => {
+      const db = makeOperatorVNextDb();
+
+      const result = commitOperatorCursor(db, {
+        commitId: 'commit-no-update-1',
+        cursorName: 'connector:slack',
+        firstChangeSeq: 1,
+        lastChangeSeq: 1,
+        idempotencyKey: buildConnectorIdempotencyKey('slack', 1, 1),
+        status: 'no_update',
+        noUpdate: {
+          noUpdateId: 'no-update-1',
+          scopeKey: 'connector:slack',
+          reason: 'event did not change canonical state',
+        },
+        sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+        nowMs: 1710000000000,
+      });
+
+      expect(result.outcome).toBe('committed');
+      expect(countRows(db, 'vnext_operator_commits')).toBe(1);
+      expect(countRows(db, 'operator_no_updates')).toBe(1);
+      expect(
+        db
+          .prepare('SELECT last_change_seq FROM vnext_operator_cursors WHERE cursor_name = ?')
+          .get('connector:slack')
+      ).toEqual({ last_change_seq: 1 });
+
+      db.close();
+    });
+
+    it('rejects no-update scopes that do not match the cursor', () => {
+      const db = makeOperatorVNextDb();
+
+      expect(() =>
+        commitOperatorCursor(db, {
+          commitId: 'commit-no-update-wrong-scope',
+          cursorName: 'connector:slack',
+          firstChangeSeq: 1,
+          lastChangeSeq: 1,
+          idempotencyKey: buildConnectorIdempotencyKey('slack', 1, 1),
+          status: 'no_update',
+          noUpdate: {
+            noUpdateId: 'no-update-wrong-scope',
+            scopeKey: 'connector:discord',
+            reason: 'event did not change canonical state',
+          },
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          nowMs: 1710000000000,
+        })
+      ).toThrow(/scopeKey/i);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(countRows(db, 'operator_no_updates')).toBe(0);
+
+      db.close();
+    });
+
+    it('rejects non-contiguous commits without advancing the cursor', () => {
+      const db = makeOperatorVNextDb();
+
+      expect(() =>
+        commitOperatorCursor(db, {
+          commitId: 'commit-gap',
+          cursorName: 'connector:slack',
+          firstChangeSeq: 2,
+          lastChangeSeq: 2,
+          idempotencyKey: buildConnectorIdempotencyKey('slack', 2, 2),
+          status: 'changed',
+          changedRefs: [{ kind: 'os_task', id: 'task-2' }],
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
+          nowMs: 1710000000000,
+        })
+      ).toThrow(/contiguous/i);
+      expect(
+        db
+          .prepare('SELECT last_change_seq FROM vnext_operator_cursors WHERE cursor_name = ?')
+          .get('connector:slack')
+      ).toEqual({ last_change_seq: 0 });
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+
+      db.close();
+    });
+
+    it('rejects invalid runtime statuses without inserting commits', () => {
+      const db = makeOperatorVNextDb();
+
+      expect(() =>
+        commitOperatorCursor(db, {
+          commitId: 'commit-invalid-status',
+          cursorName: 'connector:slack',
+          firstChangeSeq: 1,
+          lastChangeSeq: 1,
+          idempotencyKey: buildConnectorIdempotencyKey('slack', 1, 1),
+          status: 'invalid' as never,
+          changedRefs: [{ kind: 'os_task', id: 'task-1' }],
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          nowMs: 1710000000000,
+        })
+      ).toThrow(/status/i);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(countRows(db, 'vnext_operator_cursors')).toBe(0);
+
+      db.close();
+    });
+
+    it('rolls back commit rows when the no-update ledger insert fails', () => {
+      const db = makeOperatorVNextDb();
+      db.prepare(
+        `INSERT INTO operator_no_updates (
+          no_update_id, scope_key, reason, source_refs_json, idempotency_key, created_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?)`
+      ).run(
+        'no-update-duplicate',
+        'connector:slack',
+        'preexisting no-update',
+        '["raw:slack:event-0"]',
+        'connector:slack:seq:0-0',
+        1710000000000
+      );
+
+      expect(() =>
+        commitOperatorCursor(db, {
+          commitId: 'commit-no-update-duplicate',
+          cursorName: 'connector:slack',
+          firstChangeSeq: 1,
+          lastChangeSeq: 1,
+          idempotencyKey: buildConnectorIdempotencyKey('slack', 1, 1),
+          status: 'no_update',
+          noUpdate: {
+            noUpdateId: 'no-update-duplicate',
+            scopeKey: 'connector:slack',
+            reason: 'event did not change canonical state',
+          },
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          nowMs: 1710000000001,
+        })
+      ).toThrow(/UNIQUE constraint/i);
+
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(countRows(db, 'operator_no_updates')).toBe(1);
+      expect(
+        db
+          .prepare('SELECT last_change_seq FROM vnext_operator_cursors WHERE cursor_name = ?')
+          .get('connector:slack')
+      ).toEqual({ last_change_seq: 0 });
+
+      db.close();
+    });
+  });
+
+  describe('AC: idempotency recovers crash boundaries', () => {
+    it('rejects idempotency keys with inverted change ranges', () => {
+      expect(() => buildConnectorIdempotencyKey('slack', 3, 2)).toThrow(/lastChangeSeq/i);
+    });
+
+    it('recovers a cursor when a commit row exists but cursor was not advanced', () => {
+      const db = makeOperatorVNextDb();
+      db.prepare(
+        `INSERT INTO vnext_operator_cursors (
+          cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+        ) VALUES (?, ?, ?, ?)`
+      ).run('connector:slack', 0, null, 1710000000000);
+      db.prepare(
+        `INSERT INTO vnext_operator_commits (
+          commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+          status, changed_refs_json, source_refs_json, created_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        'commit-orphaned',
+        'connector:slack',
+        'connector:slack:seq:1-1',
+        1,
+        1,
+        'changed',
+        '["os_task:task-1"]',
+        '["raw:slack:event-1"]',
+        1710000000000
+      );
+
+      const result = commitOperatorCursor(db, {
+        commitId: 'commit-orphaned',
+        cursorName: 'connector:slack',
+        firstChangeSeq: 1,
+        lastChangeSeq: 1,
+        idempotencyKey: buildConnectorIdempotencyKey('slack', 1, 1),
+        status: 'changed',
+        changedRefs: [{ kind: 'os_task', id: 'task-1' }],
+        sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+        nowMs: 1710000000001,
+      });
+
+      expect(result.outcome).toBe('recovered');
+      expect(result.cursorAdvanced).toBe(true);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(1);
+      expect(
+        db.prepare('SELECT last_change_seq, last_idempotency_key FROM vnext_operator_cursors').get()
+      ).toEqual({
+        last_change_seq: 1,
+        last_idempotency_key: 'connector:slack:seq:1-1',
+      });
+
+      db.close();
+    });
+
+    it('does not duplicate commits after the cursor already advanced', () => {
+      const db = makeOperatorVNextDb();
+      const input = {
+        commitId: 'commit-once',
+        cursorName: 'connector:slack',
+        firstChangeSeq: 1,
+        lastChangeSeq: 1,
+        idempotencyKey: buildConnectorIdempotencyKey('slack', 1, 1),
+        status: 'changed' as const,
+        changedRefs: [{ kind: 'os_task' as const, id: 'task-1' }],
+        sourceRefs: [{ kind: 'raw' as const, connector: 'slack', id: 'event-1' }],
+        nowMs: 1710000000000,
+      };
+
+      expect(commitOperatorCursor(db, input).outcome).toBe('committed');
+      expect(commitOperatorCursor(db, input).outcome).toBe('already_committed');
+      expect(countRows(db, 'vnext_operator_commits')).toBe(1);
+
+      db.close();
+    });
+
+    it('rejects idempotency-key reuse across different cursors without advancing the new cursor', () => {
+      const db = makeOperatorVNextDb();
+      const idempotencyKey = buildConnectorIdempotencyKey('slack', 1, 1);
+
+      expect(
+        commitOperatorCursor(db, {
+          commitId: 'commit-slack',
+          cursorName: 'connector:slack',
+          firstChangeSeq: 1,
+          lastChangeSeq: 1,
+          idempotencyKey,
+          status: 'changed',
+          changedRefs: [{ kind: 'os_task', id: 'task-1' }],
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          nowMs: 1710000000000,
+        }).outcome
+      ).toBe('committed');
+
+      expect(() =>
+        commitOperatorCursor(db, {
+          commitId: 'commit-discord',
+          cursorName: 'connector:discord',
+          firstChangeSeq: 1,
+          lastChangeSeq: 1,
+          idempotencyKey,
+          status: 'changed',
+          changedRefs: [{ kind: 'os_task', id: 'task-2' }],
+          sourceRefs: [{ kind: 'raw', connector: 'discord', id: 'event-1' }],
+          nowMs: 1710000000001,
+        })
+      ).toThrow(/different cursor/i);
+
+      expect(countRows(db, 'vnext_operator_commits')).toBe(1);
+      expect(
+        db
+          .prepare('SELECT last_change_seq FROM vnext_operator_cursors WHERE cursor_name = ?')
+          .get('connector:discord')
+      ).toEqual({ last_change_seq: 0 });
+
+      db.close();
+    });
+
+    it('rejects divergent idempotency-key replays for the same cursor', () => {
+      const db = makeOperatorVNextDb();
+      const idempotencyKey = buildConnectorIdempotencyKey('slack', 1, 1);
+
+      expect(
+        commitOperatorCursor(db, {
+          commitId: 'commit-original',
+          cursorName: 'connector:slack',
+          firstChangeSeq: 1,
+          lastChangeSeq: 1,
+          idempotencyKey,
+          status: 'changed',
+          changedRefs: [{ kind: 'os_task', id: 'task-1' }],
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          nowMs: 1710000000000,
+        }).outcome
+      ).toBe('committed');
+
+      expect(() =>
+        commitOperatorCursor(db, {
+          commitId: 'commit-replay',
+          cursorName: 'connector:slack',
+          firstChangeSeq: 1,
+          lastChangeSeq: 1,
+          idempotencyKey,
+          status: 'changed',
+          changedRefs: [{ kind: 'os_task', id: 'task-2' }],
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          nowMs: 1710000000001,
+        })
+      ).toThrow(/Idempotency key replay/i);
+
+      expect(countRows(db, 'vnext_operator_commits')).toBe(1);
+
+      db.close();
+    });
+
+    it('normalizes no-update details before comparing idempotent replays', () => {
+      const db = makeOperatorVNextDb();
+      const input = {
+        commitId: 'commit-no-update-trimmed',
+        cursorName: 'connector:slack',
+        firstChangeSeq: 1,
+        lastChangeSeq: 1,
+        idempotencyKey: buildConnectorIdempotencyKey('slack', 1, 1),
+        status: 'no_update' as const,
+        noUpdate: {
+          noUpdateId: ' no-update-trimmed ',
+          scopeKey: ' connector:slack ',
+          reason: ' unchanged ',
+        },
+        sourceRefs: [{ kind: 'raw' as const, connector: 'slack', id: 'event-1' }],
+        nowMs: 1710000000000,
+      };
+
+      expect(commitOperatorCursor(db, input).outcome).toBe('committed');
+      expect(commitOperatorCursor(db, input).outcome).toBe('already_committed');
+      expect(
+        db.prepare('SELECT no_update_id, scope_key, reason FROM operator_no_updates').get()
+      ).toEqual({
+        no_update_id: 'no-update-trimmed',
+        scope_key: 'connector:slack',
+        reason: 'unchanged',
+      });
+
+      db.close();
+    });
+
+    it('rejects divergent no-update ids on idempotent replays', () => {
+      const db = makeOperatorVNextDb();
+      const idempotencyKey = buildConnectorIdempotencyKey('slack', 1, 1);
+
+      expect(
+        commitOperatorCursor(db, {
+          commitId: 'commit-no-update-original',
+          cursorName: 'connector:slack',
+          firstChangeSeq: 1,
+          lastChangeSeq: 1,
+          idempotencyKey,
+          status: 'no_update',
+          noUpdate: {
+            noUpdateId: 'no-update-original',
+            scopeKey: 'connector:slack',
+            reason: 'unchanged',
+          },
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          nowMs: 1710000000000,
+        }).outcome
+      ).toBe('committed');
+
+      expect(() =>
+        commitOperatorCursor(db, {
+          commitId: 'commit-no-update-replay',
+          cursorName: 'connector:slack',
+          firstChangeSeq: 1,
+          lastChangeSeq: 1,
+          idempotencyKey,
+          status: 'no_update',
+          noUpdate: {
+            noUpdateId: 'no-update-different',
+            scopeKey: 'connector:slack',
+            reason: 'unchanged',
+          },
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          nowMs: 1710000000001,
+        })
+      ).toThrow(/Idempotency key replay/i);
+
+      expect(countRows(db, 'operator_no_updates')).toBe(1);
+
+      db.close();
+    });
+
+    it('rejects divergent no-update details on idempotent replays', () => {
+      const db = makeOperatorVNextDb();
+      const idempotencyKey = buildConnectorIdempotencyKey('slack', 1, 1);
+
+      expect(
+        commitOperatorCursor(db, {
+          commitId: 'commit-no-update-original',
+          cursorName: 'connector:slack',
+          firstChangeSeq: 1,
+          lastChangeSeq: 1,
+          idempotencyKey,
+          status: 'no_update',
+          noUpdate: {
+            noUpdateId: 'no-update-original',
+            scopeKey: 'connector:slack',
+            reason: 'unchanged',
+          },
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          nowMs: 1710000000000,
+        }).outcome
+      ).toBe('committed');
+
+      expect(() =>
+        commitOperatorCursor(db, {
+          commitId: 'commit-no-update-reason-replay',
+          cursorName: 'connector:slack',
+          firstChangeSeq: 1,
+          lastChangeSeq: 1,
+          idempotencyKey,
+          status: 'no_update',
+          noUpdate: {
+            noUpdateId: 'no-update-original',
+            scopeKey: 'connector:slack',
+            reason: 'different reason',
+          },
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          nowMs: 1710000000001,
+        })
+      ).toThrow(/Idempotency key replay/i);
+
+      expect(() =>
+        commitOperatorCursor(db, {
+          commitId: 'commit-no-update-source-replay',
+          cursorName: 'connector:slack',
+          firstChangeSeq: 1,
+          lastChangeSeq: 1,
+          idempotencyKey,
+          status: 'no_update',
+          noUpdate: {
+            noUpdateId: 'no-update-original',
+            scopeKey: 'connector:slack',
+            reason: 'unchanged',
+          },
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
+          nowMs: 1710000000002,
+        })
+      ).toThrow(/Idempotency key replay/i);
+
+      expect(countRows(db, 'operator_no_updates')).toBe(1);
+
+      db.close();
+    });
+
+    it('stops retrying SQLITE_BUSY after the configured attempt budget', () => {
+      let attempts = 0;
+
+      expect(() =>
+        runWithBoundedBusyRetry(
+          () => {
+            attempts += 1;
+            const error = new Error('database is locked');
+            Object.assign(error, { code: 'SQLITE_BUSY' });
+            throw error;
+          },
+          { maxBusyRetries: 2 }
+        )
+      ).toThrow(/database is locked/i);
+      expect(attempts).toBe(3);
+    });
+  });
+});

--- a/packages/standalone/tests/operator-vnext/primary-operator-runtime.test.ts
+++ b/packages/standalone/tests/operator-vnext/primary-operator-runtime.test.ts
@@ -1,0 +1,401 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { SQLiteDatabase } from '../../src/sqlite.js';
+import { PrimaryOperatorRuntime } from '../../src/operator-vnext/primary-operator-runtime.js';
+import { countRows, makeOperatorVNextDb } from './fixtures.js';
+
+function lastCursorSeq(db: SQLiteDatabase, cursorName = 'connector:slack'): number {
+  const row = db
+    .prepare('SELECT last_change_seq FROM vnext_operator_cursors WHERE cursor_name = ?')
+    .get(cursorName) as { last_change_seq: number } | undefined;
+  return row?.last_change_seq ?? 0;
+}
+
+describe('STORY-VNEXT-PR2-PRIMARY-OPERATOR: primary operator commit shell', () => {
+  describe('AC: only delivered changed/no-update decisions advance the cursor', () => {
+    it('advances only the contiguous prefix before a channel failure', async () => {
+      const db = makeOperatorVNextDb();
+      const runtime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000000,
+      });
+
+      const result = await runtime.processBatch(
+        [
+          { seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } },
+          { seq: 2, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-2' } },
+          { seq: 3, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-3' } },
+        ],
+        async (event) => {
+          if (event.seq === 3) {
+            throw new Error('worker failed');
+          }
+          return {
+            status: 'no_update',
+            reason: `event ${event.seq} did not change state`,
+            scopeKey: 'connector:slack',
+          };
+        }
+      );
+
+      expect(result).toMatchObject({
+        status: 'partial_failure',
+        processed: 2,
+        advancedThroughSeq: 2,
+        failedSeq: 3,
+      });
+      expect(lastCursorSeq(db)).toBe(2);
+      expect(db.prepare('SELECT COUNT(*) AS count FROM operator_no_updates').get()).toEqual({
+        count: 2,
+      });
+
+      db.close();
+    });
+
+    it('treats model output without changed or no-update as a failed commit', async () => {
+      const db = makeOperatorVNextDb();
+      const runtime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000000,
+      });
+
+      const result = await runtime.processBatch(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } }],
+        async () => ({ message: 'looks fine' }) as never
+      );
+
+      expect(result).toMatchObject({
+        status: 'partial_failure',
+        processed: 0,
+        advancedThroughSeq: 0,
+        failedSeq: 1,
+      });
+      expect(lastCursorSeq(db)).toBe(0);
+
+      db.close();
+    });
+
+    it('commits changed decisions through the primary operator only', async () => {
+      const db = makeOperatorVNextDb();
+      const runtime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000000,
+      });
+
+      const result = await runtime.processBatch(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } }],
+        async () => ({
+          status: 'changed',
+          changedRefs: [{ kind: 'os_task', id: 'task-1' }],
+        })
+      );
+
+      expect(result).toMatchObject({
+        status: 'committed',
+        processed: 1,
+        advancedThroughSeq: 1,
+      });
+      expect(
+        db.prepare('SELECT status, changed_refs_json FROM vnext_operator_commits').get()
+      ).toEqual({
+        status: 'changed',
+        changed_refs_json: '["os_task:task-1"]',
+      });
+
+      db.close();
+    });
+
+    it('ignores model-supplied supplemental source refs', async () => {
+      const db = makeOperatorVNextDb();
+      const runtime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000000,
+      });
+
+      const result = await runtime.processBatch(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } }],
+        async () => ({
+          status: 'changed',
+          changedRefs: [{ kind: 'os_task', id: 'task-1' }],
+          sourceRefs: [{ kind: 'memory', id: 'memory-1' }],
+        })
+      );
+
+      expect(result.status).toBe('committed');
+      expect(db.prepare('SELECT source_refs_json FROM vnext_operator_commits').get()).toEqual({
+        source_refs_json: '["raw:slack:event-1"]',
+      });
+
+      db.close();
+    });
+
+    it('rejects raw event source refs from a different connector before cursor advancement', async () => {
+      const db = makeOperatorVNextDb();
+      const runtime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000000,
+      });
+
+      const result = await runtime.processBatch(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'discord', id: 'event-1' } }],
+        async () => ({
+          status: 'changed',
+          changedRefs: [{ kind: 'os_task', id: 'task-1' }],
+        })
+      );
+
+      expect(result).toMatchObject({
+        status: 'partial_failure',
+        processed: 0,
+        advancedThroughSeq: 0,
+        failedSeq: 1,
+      });
+      expect(result.error.message).toMatch(/connector mismatch/i);
+      expect(lastCursorSeq(db)).toBe(0);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+
+      db.close();
+    });
+
+    it('rejects non-raw event source refs before cursor advancement', async () => {
+      const db = makeOperatorVNextDb();
+      const runtime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000000,
+      });
+
+      const result = await runtime.processBatch(
+        [{ seq: 1, sourceRef: { kind: 'memory', id: 'memory-1' } }],
+        async () => ({
+          status: 'changed',
+          changedRefs: [{ kind: 'os_task', id: 'task-1' }],
+        })
+      );
+
+      expect(result).toMatchObject({
+        status: 'partial_failure',
+        processed: 0,
+        advancedThroughSeq: 0,
+        failedSeq: 1,
+      });
+      expect(result.error.message).toMatch(/raw source ref/i);
+      expect(lastCursorSeq(db)).toBe(0);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+
+      db.close();
+    });
+
+    it('rejects no-update scope keys that do not match the runtime cursor', async () => {
+      const db = makeOperatorVNextDb();
+      const runtime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000000,
+      });
+
+      const result = await runtime.processBatch(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } }],
+        async () => ({
+          status: 'no_update',
+          reason: 'event did not change state',
+          scopeKey: 'connector:discord',
+        })
+      );
+
+      expect(result).toMatchObject({
+        status: 'partial_failure',
+        processed: 0,
+        advancedThroughSeq: 0,
+        failedSeq: 1,
+      });
+      expect(result.error.message).toMatch(/scopeKey/i);
+      expect(lastCursorSeq(db)).toBe(0);
+
+      db.close();
+    });
+
+    it('does not regress advancedThroughSeq when replaying an already committed event', async () => {
+      const db = makeOperatorVNextDb();
+      const runtime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000000,
+      });
+
+      const first = await runtime.processBatch(
+        [
+          { seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } },
+          { seq: 2, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-2' } },
+        ],
+        async (event) => ({
+          status: 'changed',
+          changedRefs: [{ kind: 'os_task', id: `task-${event.seq}` }],
+        })
+      );
+      expect(first).toMatchObject({
+        status: 'committed',
+        processed: 2,
+        advancedThroughSeq: 2,
+      });
+
+      const replayDecide = vi.fn(() => ({
+        status: 'changed',
+        changedRefs: [{ kind: 'os_task', id: 'task-1' }],
+      }));
+
+      const replay = await runtime.processBatch(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } }],
+        replayDecide
+      );
+
+      expect(replay).toMatchObject({
+        status: 'committed',
+        processed: 1,
+        advancedThroughSeq: 2,
+      });
+      expect(replay.commits[0]?.outcome).toBe('already_committed');
+      expect(replayDecide).not.toHaveBeenCalled();
+      expect(lastCursorSeq(db)).toBe(2);
+
+      db.close();
+    });
+
+    it('recovers an orphaned stored commit without calling the decider', async () => {
+      const db = makeOperatorVNextDb();
+      db.prepare(
+        `INSERT INTO vnext_operator_cursors (
+          cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+        ) VALUES (?, ?, ?, ?)`
+      ).run('connector:slack', 0, null, 1710000000000);
+      db.prepare(
+        `INSERT INTO vnext_operator_commits (
+          commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+          status, changed_refs_json, source_refs_json, created_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        'commit-orphaned',
+        'connector:slack',
+        'connector:slack:seq:1-1',
+        1,
+        1,
+        'changed',
+        '["os_task:task-1"]',
+        '["raw:slack:event-1"]',
+        1710000000000
+      );
+      const runtime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000001,
+      });
+      const decide = vi.fn(() => {
+        throw new Error('decider must not run');
+      });
+
+      const result = await runtime.processBatch(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } }],
+        decide
+      );
+
+      expect(result).toMatchObject({
+        status: 'committed',
+        processed: 1,
+        advancedThroughSeq: 1,
+      });
+      expect(result.commits[0]?.outcome).toBe('recovered');
+      expect(decide).not.toHaveBeenCalled();
+      expect(lastCursorSeq(db)).toBe(1);
+
+      db.close();
+    });
+
+    it('rejects allowed-status decisions that omit required payload fields', async () => {
+      const changedDb = makeOperatorVNextDb();
+      const changedRuntime = new PrimaryOperatorRuntime({
+        db: changedDb,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000000,
+      });
+
+      const changedResult = await changedRuntime.processBatch(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } }],
+        async () => ({ status: 'changed' })
+      );
+      expect(changedResult).toMatchObject({
+        status: 'partial_failure',
+        processed: 0,
+        advancedThroughSeq: 0,
+        failedSeq: 1,
+      });
+      expect(lastCursorSeq(changedDb)).toBe(0);
+      changedDb.close();
+
+      const noUpdateDb = makeOperatorVNextDb();
+      const noUpdateRuntime = new PrimaryOperatorRuntime({
+        db: noUpdateDb,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000000,
+      });
+
+      const noUpdateResult = await noUpdateRuntime.processBatch(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } }],
+        async () => ({ status: 'no_update', reason: '   ' })
+      );
+      expect(noUpdateResult).toMatchObject({
+        status: 'partial_failure',
+        processed: 0,
+        advancedThroughSeq: 0,
+        failedSeq: 1,
+      });
+      expect(lastCursorSeq(noUpdateDb)).toBe(0);
+      noUpdateDb.close();
+    });
+
+    it('returns idle for an empty batch without calling the decider', async () => {
+      const db = makeOperatorVNextDb();
+      const runtime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000000,
+      });
+      await runtime.processBatch(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } }],
+        async () => ({
+          status: 'changed',
+          changedRefs: [{ kind: 'os_task', id: 'task-1' }],
+        })
+      );
+      const decide = vi.fn();
+
+      const result = await runtime.processBatch([], decide);
+
+      expect(result).toEqual({
+        status: 'idle',
+        processed: 0,
+        advancedThroughSeq: 1,
+        commits: [],
+      });
+      expect(decide).not.toHaveBeenCalled();
+
+      db.close();
+    });
+  });
+});

--- a/packages/standalone/tests/operator-vnext/primary-operator-runtime.test.ts
+++ b/packages/standalone/tests/operator-vnext/primary-operator-runtime.test.ts
@@ -11,6 +11,12 @@ function lastCursorSeq(db: SQLiteDatabase, cursorName = 'connector:slack'): numb
   return row?.last_change_seq ?? 0;
 }
 
+function waitOneTurn(): Promise<void> {
+  return new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
 describe('STORY-VNEXT-PR2-PRIMARY-OPERATOR: primary operator commit shell', () => {
   describe('AC: only delivered changed/no-update decisions advance the cursor', () => {
     it('advances only the contiguous prefix before a channel failure', async () => {
@@ -320,6 +326,55 @@ describe('STORY-VNEXT-PR2-PRIMARY-OPERATOR: primary operator commit shell', () =
       expect(result.commits[0]?.outcome).toBe('recovered');
       expect(decide).not.toHaveBeenCalled();
       expect(lastCursorSeq(db)).toBe(1);
+
+      db.close();
+    });
+
+    it('serializes concurrent batches for the same cursor before invoking the decider', async () => {
+      const db = makeOperatorVNextDb();
+      const firstRuntime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000000,
+      });
+      const secondRuntime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000001,
+      });
+      let releaseDecision!: () => void;
+      const decisionGate = new Promise<void>((resolve) => {
+        releaseDecision = resolve;
+      });
+      const decide = vi.fn(async () => {
+        await decisionGate;
+        return {
+          status: 'changed',
+          changedRefs: [{ kind: 'os_task', id: 'task-1' }],
+        };
+      });
+
+      const first = firstRuntime.processBatch(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } }],
+        decide
+      );
+      const second = secondRuntime.processBatch(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } }],
+        decide
+      );
+      await waitOneTurn();
+
+      expect(decide).toHaveBeenCalledTimes(1);
+      releaseDecision();
+      const [firstResult, secondResult] = await Promise.all([first, second]);
+
+      expect(firstResult.commits[0]?.outcome).toBe('committed');
+      expect(secondResult.commits[0]?.outcome).toBe('already_committed');
+      expect(decide).toHaveBeenCalledTimes(1);
+      expect(lastCursorSeq(db)).toBe(1);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(1);
 
       db.close();
     });

--- a/packages/standalone/tests/operator-vnext/primary-operator-runtime.test.ts
+++ b/packages/standalone/tests/operator-vnext/primary-operator-runtime.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
+process.env.MAMA_FORCE_TIER_3 ||= 'true';
+
 import type { SQLiteDatabase } from '../../src/sqlite.js';
 import { PrimaryOperatorRuntime } from '../../src/operator-vnext/primary-operator-runtime.js';
 import { countRows, makeOperatorVNextDb } from './fixtures.js';
@@ -233,6 +235,38 @@ describe('STORY-VNEXT-PR2-PRIMARY-OPERATOR: primary operator commit shell', () =
       db.close();
     });
 
+    it('rejects non-contiguous events before invoking the decider', async () => {
+      const db = makeOperatorVNextDb();
+      const runtime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000000,
+      });
+      const decide = vi.fn(() => ({
+        status: 'changed',
+        changedRefs: [{ kind: 'os_task', id: 'task-2' }],
+      }));
+
+      const result = await runtime.processBatch(
+        [{ seq: 2, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-2' } }],
+        decide
+      );
+
+      expect(result).toMatchObject({
+        status: 'partial_failure',
+        processed: 0,
+        advancedThroughSeq: 0,
+        failedSeq: 2,
+      });
+      expect(result.error.message).toMatch(/contiguous/i);
+      expect(decide).not.toHaveBeenCalled();
+      expect(lastCursorSeq(db)).toBe(0);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+
+      db.close();
+    });
+
     it('does not regress advancedThroughSeq when replaying an already committed event', async () => {
       const db = makeOperatorVNextDb();
       const runtime = new PrimaryOperatorRuntime({
@@ -326,6 +360,57 @@ describe('STORY-VNEXT-PR2-PRIMARY-OPERATOR: primary operator commit shell', () =
       expect(result.commits[0]?.outcome).toBe('recovered');
       expect(decide).not.toHaveBeenCalled();
       expect(lastCursorSeq(db)).toBe(1);
+
+      db.close();
+    });
+
+    it('rejects recovered commits with mismatched raw source provenance before invoking the decider', async () => {
+      const db = makeOperatorVNextDb();
+      db.prepare(
+        `INSERT INTO vnext_operator_cursors (
+          cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+        ) VALUES (?, ?, ?, ?)`
+      ).run('connector:slack', 0, null, 1710000000000);
+      db.prepare(
+        `INSERT INTO vnext_operator_commits (
+          commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+          status, changed_refs_json, source_refs_json, created_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        'commit-orphaned',
+        'connector:slack',
+        'connector:slack:seq:1-1',
+        1,
+        1,
+        'changed',
+        '["os_task:task-1"]',
+        '["raw:slack:event-1"]',
+        1710000000000
+      );
+      const runtime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000001,
+      });
+      const decide = vi.fn(() => {
+        throw new Error('decider must not run');
+      });
+
+      const result = await runtime.processBatch(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-tampered' } }],
+        decide
+      );
+
+      expect(result).toMatchObject({
+        status: 'partial_failure',
+        processed: 0,
+        advancedThroughSeq: 0,
+        failedSeq: 1,
+      });
+      expect(result.error.message).toMatch(/source refs/i);
+      expect(decide).not.toHaveBeenCalled();
+      expect(lastCursorSeq(db)).toBe(0);
 
       db.close();
     });


### PR DESCRIPTION
## Summary

Adds the PR2 vNext primary-operator commit shell for MAMA OS:

- Introduces operator commit result contracts, no-update ledger writes, cursor commit/replay helpers, and the primary operator runtime shell.
- Makes cursor advancement atomic with durable commit/no-update writes.
- Checks replay/idempotency before calling the decider, so already committed events do not re-run nondeterministic model work or side effects.
- Pins no-update scope to the runtime cursor and rejects cross-scope no-update writes.
- Treats raw event provenance as authoritative and ignores model-supplied supplemental source refs.

## Test Coverage

All new operator-vnext paths are covered by focused Vitest tests:

- Cursor commit happy path and no-update path
- Transaction rollback when no-update ledger insert fails
- Non-contiguous ranges, inverted ranges, invalid runtime status
- Idempotent replay, divergent replay, cross-cursor idempotency reuse
- Replay/recovery before decider invocation
- Wrong connector, non-raw event source ref, no-update scope mismatch
- Empty batch and allowed-status malformed model outputs

Tests added: 3 operator-vnext test files, 28 focused tests.

## Pre-Landing Review

GStack review was run before PR creation with testing, maintainability, and red-team specialists.

Resolved findings:

- Replay now checks stored commits before invoking the decider.
- Model-supplied provenance is not persisted as source refs.
- No-update scope pollution is blocked at both runtime and commit boundary.
- Divergent idempotency replays are rejected.
- No-update replay details and source refs are pinned by tests.
- Shared validation and migration/test helpers reduce duplicated setup.

Remaining notes:

- `runWithBoundedBusyRetry` remains local to operator-vnext because this PR keeps the new commit shell self-contained. It can be unified with shared transaction helpers in a later refactor if the runtime adopts the same adapter shape.

## Design Review

No frontend files changed. Design review skipped.

## Eval Results

No prompt-related files changed. Evals skipped.

## Privacy / Public Project Check

- `./scripts/check-pii.sh` passed.
- Direct staged-file scan found no local paths, tokens, private user identifiers, or internal project data.
- `@jungjaehoon/mama-core` imports are public package-scope references and safe for this public repo.

## Scope Drift

Scope Check: CLEAN

Intent: PR2 atomic primary operator commit shell, no live gateway wiring.

Delivered: operator-vnext commit ledger/runtime shell plus crash/idempotency/trust-boundary tests. No dashboard/wiki/gateway wiring included.

## Plan Completion

PR2 scope addressed:

- [x] `operator-commit-result.ts`
- [x] `no-update-ledger.ts`
- [x] `operator-cursor-commit.ts`
- [x] `primary-operator-runtime.ts`
- [x] cursor commit idempotency and crash recovery tests
- [x] no live gateway wiring

## Verification Results

- [x] `MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run tests/operator-vnext/no-update-ledger.test.ts tests/operator-vnext/operator-cursor-commit.test.ts tests/operator-vnext/primary-operator-runtime.test.ts` — 3 files passed, 28 tests passed
- [x] `pnpm --filter @jungjaehoon/mama-os typecheck` — passed
- [x] `pnpm --filter @jungjaehoon/mama-os build` — passed
- [x] pre-commit hook — typecheck/build/changed-package tests passed, 224 files passed / 1 skipped, 3229 tests passed / 3 skipped
- [x] `git diff --cached --check` — passed before commit

## TODOs

No TODO items completed in this PR.

## Test plan

- [x] Focused operator-vnext Vitest tests pass
- [x] Standalone typecheck passes
- [x] Standalone build passes
- [x] Pre-commit changed-package suite passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recording “no update” outcomes alongside normal cursor commits.
  * Introduced batch event processing with commit recovery, replay handling, and partial-failure reporting.
  * Added stricter input validation for strings and non-negative integers.

* **Bug Fixes**
  * Improved cursor commit consistency so progress and stored results stay in sync.
  * Added safeguards for invalid source references, mismatched scopes, duplicate replays, and busy-database retry limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->