### PR TITLE
feat: bootstrap vNext primary operator runtime

### DIFF
--- a/docs/architecture/mama-vnext-primary-operator-rebuild.md
+++ b/docs/architecture/mama-vnext-primary-operator-rebuild.md
@@ -230,14 +230,14 @@ Current `origin/main` connector polling files that PR 1 must control:
 Do not create a third provenance dialect in standalone. The canonical parser belongs
 in `mama-core`.
 
-| Surface | Current shape | Current kinds | Problem | vNext rule |
-|---------|---------------|---------------|---------|------------|
-| context compile | object refs | `memory`, `raw`, `entity`, `case` | rejects `context_packet`, `report`, `wiki_page` | keep V0 parser, add conversion to canonical `SourceRef` |
-| context provenance string | `raw:${connector}:${raw_id}` or `${kind}:${id}` | `raw`, `memory`, `entity`, `case` | string form is narrower than needed | canonical serializer must round-trip current strings |
-| verify artifact | `{ type, id }` | `decision`, `os_task`, `agent_situation_packet`, `report_slot`, `context_packet`, `model_run`, `tool_trace` | uses `type`, not `kind` | add adapter from verify artifact to canonical `SourceRef` |
-| memory provenance | `source_refs: string[]` | unconstrained strings | permits bad refs | validate strings before trusted writes |
-| legacy memory provenance | string refs | `message:*`, `conversation:*`, `raw_memory:*` | current tests allow these strings | grandfather as `legacy` refs before strict enforcement |
-| wiki current | `sourceIds: string[]` | often empty | source chain breaks | reject empty source refs in vNext |
+| Surface                   | Current shape                                   | Current kinds                                                                                               | Problem                                         | vNext rule                                                |
+| ------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
+| context compile           | object refs                                     | `memory`, `raw`, `entity`, `case`                                                                           | rejects `context_packet`, `report`, `wiki_page` | keep V0 parser, add conversion to canonical `SourceRef`   |
+| context provenance string | `raw:${connector}:${raw_id}` or `${kind}:${id}` | `raw`, `memory`, `entity`, `case`                                                                           | string form is narrower than needed             | canonical serializer must round-trip current strings      |
+| verify artifact           | `{ type, id }`                                  | `decision`, `os_task`, `agent_situation_packet`, `report_slot`, `context_packet`, `model_run`, `tool_trace` | uses `type`, not `kind`                         | add adapter from verify artifact to canonical `SourceRef` |
+| memory provenance         | `source_refs: string[]`                         | unconstrained strings                                                                                       | permits bad refs                                | validate strings before trusted writes                    |
+| legacy memory provenance  | string refs                                     | `message:*`, `conversation:*`, `raw_memory:*`                                                               | current tests allow these strings               | grandfather as `legacy` refs before strict enforcement    |
+| wiki current              | `sourceIds: string[]`                           | often empty                                                                                                 | source chain breaks                             | reject empty source refs in vNext                         |
 
 Canonical file:
 
@@ -305,15 +305,15 @@ Rules:
 
 Default in vNext: deny durable writes unless explicitly allowed.
 
-| Tool/path | Primary operator | Worker | Legacy agent | Viewer/admin | Notes |
-|-----------|------------------|--------|--------------|--------------|-------|
-| `task_create` | allow | deny | legacy-only | deny | worker returns task proposal |
-| `task_update` | allow | deny | legacy-only | deny | primary commits after verify |
-| `mama_save` | allow through memory commit path | deny | legacy-only | admin/manual allowed with refs | source refs required |
-| `wiki_publish` | allow proposal commit | proposal-only | legacy-only | admin/manual allowed with refs | no empty refs |
-| `report_publish` | deny as canonical state | deny | legacy-only | deny | dashboard reads projection |
-| `delegate` | allow | deny nested by default | legacy-only | deny | bounded depth |
-| filesystem writes | deny by default | deny by default | legacy policy | viewer policy | not part of canonical state |
+| Tool/path         | Primary operator                 | Worker                 | Legacy agent  | Viewer/admin                   | Notes                        |
+| ----------------- | -------------------------------- | ---------------------- | ------------- | ------------------------------ | ---------------------------- |
+| `task_create`     | allow                            | deny                   | legacy-only   | deny                           | worker returns task proposal |
+| `task_update`     | allow                            | deny                   | legacy-only   | deny                           | primary commits after verify |
+| `mama_save`       | allow through memory commit path | deny                   | legacy-only   | admin/manual allowed with refs | source refs required         |
+| `wiki_publish`    | allow proposal commit            | proposal-only          | legacy-only   | admin/manual allowed with refs | no empty refs                |
+| `report_publish`  | deny as canonical state          | deny                   | legacy-only   | deny                           | dashboard reads projection   |
+| `delegate`        | allow                            | deny nested by default | legacy-only   | deny                           | bounded depth                |
+| filesystem writes | deny by default                  | deny by default        | legacy policy | viewer policy                  | not part of canonical state  |
 
 Implementation hook:
 
@@ -539,30 +539,37 @@ Regression cases:
 - two operators racing on same idempotency key result in one commit
 - DB busy retry stops after bounded attempts
 
-### PR 3: Trigger-Scoped Memory Hints
+### PR 3: Primary Operator Bootstrap Runtime
 
 Goal:
 
-- Stop vNext mode from recalling memory on ordinary turns.
-- Port the reference memory hint policy shape: ordinary turns skip recall, prior-rule
-  language triggers bounded hints.
-- Keep legacy mode unchanged.
+- Replace the PR 1 `primary_operator_placeholder` startup step with explicit
+  operator schema and runtime preparation.
+- Keep legacy fanout disabled while exposing the primary operator readiness state
+  through authenticated status APIs.
+- Preserve the PR 1/PR 2-compatible `primary_operator` response field during the
+  transition; expose the new runtime payload as `primary_operator_runtime`.
 
 Files:
 
-- Create: `packages/standalone/src/memory-vnext/memory-hint-policy.ts`
-- Create: `packages/standalone/src/memory-vnext/memory-hint-renderer.ts`
-- Modify: `packages/standalone/src/gateways/message-router.ts`
-- Create: `packages/standalone/tests/memory-vnext/memory-hint-policy.test.ts`
-- Create: `packages/standalone/tests/memory-vnext/memory-hint-renderer.test.ts`
-- Create: `packages/standalone/tests/gateways/message-router-memory-hints.test.ts`
+- Create: `packages/standalone/src/operator-vnext/schema.ts`
+- Modify: `packages/standalone/src/runtime-vnext/bootstrap.ts`
+- Modify: `packages/standalone/src/cli/commands/start.ts`
+- Create: `packages/standalone/tests/operator-vnext/schema.test.ts`
+- Modify: `packages/standalone/tests/runtime-vnext/bootstrap.test.ts`
+- Modify: `packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts`
 
 Regression cases:
 
-- ordinary message does not call `mamaApi.recallMemory` in vNext mode
-- trigger message calls recall once
-- recall failure is non-fatal
-- legacy mode keeps current behavior
+- empty sessions DB gets vNext operator tables before runtime creation
+- existing sessions DB skips repeated schema work
+- failed operator schema installation rolls back as one transaction
+- status endpoints keep `/health` public and `/api/*` authenticated
+- existing status clients can still parse `primary_operator.status = noop`
+- new status clients can read `primary_operator_runtime.cursor_name`,
+  `connector`, and `advanced_through_seq`
+- `createVNextPrimaryOperatorRuntime` binds the manual connector and advances
+  the `operator:primary` cursor through `processBatch`
 
 ### PR 4: Wiki Artifact Adapter And Store
 
@@ -657,12 +664,12 @@ MAMA_FORCE_TIER_3=true pnpm vitest run \
 
 Only pure contract/store work runs in parallel. Integration work is sequential.
 
-| Lane | Work | Modules | Depends on |
-|------|------|---------|------------|
-| A | PR 0 SourceRef and contracts | `mama-core/src/provenance`, migrations | none |
-| C | PR 2 commit stores | `operator-vnext` stores | A |
-| D | PR 3 memory hint policy | `memory-vnext` pure modules | A |
-| E | PR 4 wiki store/exporter pure modules | `wiki-artifacts` pure modules | A |
+| Lane | Work                                  | Modules                                | Depends on |
+| ---- | ------------------------------------- | -------------------------------------- | ---------- |
+| A    | PR 0 SourceRef and contracts          | `mama-core/src/provenance`, migrations | none       |
+| C    | PR 2 commit stores                    | `operator-vnext` stores                | A          |
+| D    | PR 3 memory hint policy               | `memory-vnext` pure modules            | A          |
+| E    | PR 4 wiki store/exporter pure modules | `wiki-artifacts` pure modules          | A          |
 
 Sequential integration:
 

--- a/docs/architecture/mama-vnext-primary-operator-rebuild.md
+++ b/docs/architecture/mama-vnext-primary-operator-rebuild.md
@@ -664,12 +664,12 @@ MAMA_FORCE_TIER_3=true pnpm vitest run \
 
 Only pure contract/store work runs in parallel. Integration work is sequential.
 
-| Lane | Work                                  | Modules                                | Depends on |
-| ---- | ------------------------------------- | -------------------------------------- | ---------- |
-| A    | PR 0 SourceRef and contracts          | `mama-core/src/provenance`, migrations | none       |
-| C    | PR 2 commit stores                    | `operator-vnext` stores                | A          |
-| D    | PR 3 memory hint policy               | `memory-vnext` pure modules            | A          |
-| E    | PR 4 wiki store/exporter pure modules | `wiki-artifacts` pure modules          | A          |
+| Lane | Work                                    | Modules                                      | Depends on |
+| ---- | --------------------------------------- | -------------------------------------------- | ---------- |
+| A    | PR 0 SourceRef and contracts            | `mama-core/src/provenance`, migrations       | none       |
+| C    | PR 2 commit stores                      | `operator-vnext` stores                      | A          |
+| D    | PR 3 primary operator bootstrap runtime | `operator-vnext`, `runtime-vnext`, start API | C          |
+| E    | PR 4 wiki store/exporter pure modules   | `wiki-artifacts` pure modules                | A          |
 
 Sequential integration:
 
@@ -677,7 +677,7 @@ Sequential integration:
 1. Merge A.
 2. Implement PR 1 sequentially. It touches startup/config/connector/scheduler files.
 3. Merge C.
-4. Integrate D into MessageRouter.
+4. Integrate D into vNext bootstrap/start API.
 5. Integrate E into GatewayToolExecutor.
 6. Add situation projection and report API adapter.
 7. Add commit authority to GatewayToolExecutor and DelegationExecutor.

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -591,7 +591,7 @@ export function createVNextPrimaryOperatorRuntime(db: Database): VNextPrimaryOpe
         status.status = 'degraded';
         status.failedSeq = result.failedSeq;
         status.errorMessage = result.error.message;
-      } else {
+      } else if (result.status === 'committed') {
         status.status = 'prepared';
         delete status.failedSeq;
         delete status.errorMessage;

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -67,12 +67,18 @@ import { buildRuntimeEnvelopeBootstrap } from '../runtime/envelope-bootstrap.js'
 import { requireAuth } from '../../api/auth-middleware.js';
 import {
   buildVNextBootstrapPlan,
+  buildVNextPrimaryOperatorReadyStatus,
+  VNEXT_PRIMARY_OPERATOR_CONNECTOR,
+  VNEXT_PRIMARY_OPERATOR_CURSOR_NAME,
   shouldSkipVNextFanout,
   startVNextBootstrapRuntime,
   type VNextBootstrapRuntimeHandles,
   type VNextBootstrapRuntimeStatus,
+  type VNextPrimaryOperatorRuntimeHandle,
 } from '../../runtime-vnext/bootstrap.js';
 import { resolveVNextRuntimeFlags } from '../../runtime-vnext/feature-flags.js';
+import { ensureVNextOperatorSchema } from '../../operator-vnext/schema.js';
+import { PrimaryOperatorRuntime } from '../../operator-vnext/primary-operator-runtime.js';
 import { resolveReactiveProjectRoot } from '../../envelope/reactive-config.js';
 import { deriveMemoryScopes, type MemoryScopeRef } from '../../memory/scope-context.js';
 import { DEFAULT_ROLES, type AgentPersonaConfig, type RoleConfig } from '../config/types.js';
@@ -520,6 +526,31 @@ export async function startCommand(options: StartOptions = {}): Promise<void> {
   }
 }
 
+function buildVNextPrimaryOperatorPayload(
+  primaryOperator: VNextBootstrapRuntimeStatus['primaryOperator']
+): Record<string, unknown> {
+  return {
+    kind: primaryOperator.kind,
+    status: primaryOperator.status,
+    mode: primaryOperator.mode,
+    ingress: primaryOperator.ingress,
+    cursor_name: primaryOperator.cursorName,
+    connector: primaryOperator.connector,
+    advanced_through_seq: primaryOperator.advancedThroughSeq,
+    last_batch_status: primaryOperator.lastBatchStatus,
+    failed_seq: primaryOperator.failedSeq,
+    error_message: primaryOperator.errorMessage,
+  };
+}
+
+function buildVNextLegacyPrimaryOperatorPayload(): Record<string, unknown> {
+  return {
+    kind: 'primary_operator',
+    status: 'noop',
+    reason: 'vNext primary operator runtime is exposed as primary_operator_runtime.',
+  };
+}
+
 function buildVNextStatusPayload(status: VNextBootstrapRuntimeStatus): Record<string, unknown> {
   return {
     ok: true,
@@ -527,8 +558,46 @@ function buildVNextStatusPayload(status: VNextBootstrapRuntimeStatus): Record<st
     mode: status.mode,
     source: status.source,
     started_at_ms: status.startedAtMs,
-    primary_operator: status.primaryOperator,
+    primary_operator: buildVNextLegacyPrimaryOperatorPayload(),
+    primary_operator_runtime: buildVNextPrimaryOperatorPayload(status.primaryOperator),
     executed_startup_steps: status.executedStartupSteps,
+  };
+}
+
+function readVNextPrimaryOperatorCursorSeq(db: Database, cursorName: string): number {
+  const row = db
+    .prepare('SELECT last_change_seq FROM vnext_operator_cursors WHERE cursor_name = ?')
+    .get(cursorName) as { last_change_seq: number } | undefined;
+  return row?.last_change_seq ?? 0;
+}
+
+export function createVNextPrimaryOperatorRuntime(db: Database): VNextPrimaryOperatorRuntimeHandle {
+  const runtime = new PrimaryOperatorRuntime({
+    db,
+    cursorName: VNEXT_PRIMARY_OPERATOR_CURSOR_NAME,
+    connector: VNEXT_PRIMARY_OPERATOR_CONNECTOR,
+  });
+  const status = buildVNextPrimaryOperatorReadyStatus(
+    readVNextPrimaryOperatorCursorSeq(db, VNEXT_PRIMARY_OPERATOR_CURSOR_NAME)
+  );
+
+  return {
+    status,
+    processBatch: async (events, decide) => {
+      const result = await runtime.processBatch(events, decide);
+      status.advancedThroughSeq = result.advancedThroughSeq;
+      status.lastBatchStatus = result.status;
+      if (result.status === 'partial_failure') {
+        status.status = 'degraded';
+        status.failedSeq = result.failedSeq;
+        status.errorMessage = result.error.message;
+      } else {
+        status.status = 'prepared';
+        delete status.failedSeq;
+        delete status.errorMessage;
+      }
+      return result;
+    },
   };
 }
 
@@ -696,6 +765,8 @@ export async function runAgentLoop(
         );
         return new Database(dbPath);
       },
+      initializeOperatorSchema: ensureVNextOperatorSchema,
+      createPrimaryOperator: createVNextPrimaryOperatorRuntime,
       createApiServer: createVNextBootstrapApiServer,
       installShutdownHandlers: installVNextBootstrapShutdownHandlers,
     });

--- a/packages/standalone/src/operator-vnext/schema.ts
+++ b/packages/standalone/src/operator-vnext/schema.ts
@@ -1,0 +1,208 @@
+import type { SQLiteDatabase } from '../sqlite.js';
+
+const VNEXT_OPERATOR_CONTRACTS_VERSION = 38;
+const VNEXT_OPERATOR_CONTRACTS_DESCRIPTION = 'Create vNext operator contracts';
+const REQUIRED_OPERATOR_TABLES = [
+  'vnext_operator_cursors',
+  'vnext_operator_commits',
+  'operator_no_updates',
+  'worker_proposals',
+] as const;
+const REQUIRED_COLUMNS: Record<(typeof REQUIRED_OPERATOR_TABLES)[number], readonly string[]> = {
+  vnext_operator_cursors: [
+    'cursor_name',
+    'last_change_seq',
+    'last_idempotency_key',
+    'updated_at_ms',
+  ],
+  vnext_operator_commits: [
+    'commit_id',
+    'cursor_name',
+    'idempotency_key',
+    'first_change_seq',
+    'last_change_seq',
+    'status',
+    'changed_refs_json',
+    'source_refs_json',
+    'created_at_ms',
+  ],
+  operator_no_updates: [
+    'no_update_id',
+    'scope_key',
+    'reason',
+    'source_refs_json',
+    'idempotency_key',
+    'created_at_ms',
+  ],
+  worker_proposals: [
+    'proposal_id',
+    'worker_id',
+    'kind',
+    'payload_json',
+    'source_refs_json',
+    'confidence',
+    'status',
+    'created_at_ms',
+    'accepted_at_ms',
+  ],
+};
+const REQUIRED_INDEXES = [
+  'idx_vnext_operator_commits_cursor_seq',
+  'idx_operator_no_updates_scope_created',
+  'idx_worker_proposals_status_kind',
+] as const;
+
+const VNEXT_OPERATOR_CONTRACTS_SQL = `
+CREATE TABLE IF NOT EXISTS vnext_operator_cursors (
+  cursor_name TEXT PRIMARY KEY,
+  last_change_seq INTEGER NOT NULL DEFAULT 0 CHECK (last_change_seq >= 0),
+  last_idempotency_key TEXT,
+  updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS vnext_operator_commits (
+  commit_id TEXT PRIMARY KEY,
+  cursor_name TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL UNIQUE,
+  first_change_seq INTEGER NOT NULL CHECK (first_change_seq >= 0),
+  last_change_seq INTEGER NOT NULL CHECK (last_change_seq >= first_change_seq),
+  status TEXT NOT NULL CHECK (status IN ('changed', 'no_update')),
+  changed_refs_json TEXT NOT NULL CHECK (json_valid(changed_refs_json)),
+  source_refs_json TEXT NOT NULL CHECK (json_valid(source_refs_json)),
+  created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+  FOREIGN KEY (cursor_name) REFERENCES vnext_operator_cursors(cursor_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_vnext_operator_commits_cursor_seq
+  ON vnext_operator_commits(cursor_name, last_change_seq);
+
+CREATE TABLE IF NOT EXISTS operator_no_updates (
+  no_update_id TEXT PRIMARY KEY,
+  scope_key TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  source_refs_json TEXT NOT NULL CHECK (json_valid(source_refs_json)),
+  idempotency_key TEXT NOT NULL UNIQUE,
+  created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_operator_no_updates_scope_created
+  ON operator_no_updates(scope_key, created_at_ms DESC);
+
+CREATE TABLE IF NOT EXISTS worker_proposals (
+  proposal_id TEXT PRIMARY KEY,
+  worker_id TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  payload_json TEXT NOT NULL CHECK (json_valid(payload_json)),
+  source_refs_json TEXT NOT NULL CHECK (json_valid(source_refs_json)),
+  confidence REAL NOT NULL CHECK (confidence >= 0 AND confidence <= 1),
+  status TEXT NOT NULL CHECK (status IN ('proposed', 'accepted', 'rejected', 'superseded')),
+  created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+  accepted_at_ms INTEGER CHECK (
+    (status = 'proposed' AND accepted_at_ms IS NULL) OR
+    (status = 'accepted' AND accepted_at_ms IS NOT NULL AND accepted_at_ms >= created_at_ms) OR
+    (status = 'rejected' AND accepted_at_ms IS NULL) OR
+    (status = 'superseded' AND (accepted_at_ms IS NULL OR accepted_at_ms >= created_at_ms))
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_worker_proposals_status_kind
+  ON worker_proposals(status, kind, created_at_ms);
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES (${VNEXT_OPERATOR_CONTRACTS_VERSION}, '${VNEXT_OPERATOR_CONTRACTS_DESCRIPTION}');
+`;
+
+export interface VNextOperatorSchemaOptions {
+  readMigrationSql?: () => string;
+}
+
+function tableExists(db: SQLiteDatabase, tableName: string): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(tableName);
+  return row !== undefined;
+}
+
+function hasOperatorSchemaVersion(db: SQLiteDatabase): boolean {
+  if (!tableExists(db, 'schema_version')) {
+    return false;
+  }
+  const row = db
+    .prepare('SELECT 1 FROM schema_version WHERE version = ?')
+    .get(VNEXT_OPERATOR_CONTRACTS_VERSION);
+  return row !== undefined;
+}
+
+function indexExists(db: SQLiteDatabase, indexName: string): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?")
+    .get(indexName);
+  return row !== undefined;
+}
+
+function tableColumns(db: SQLiteDatabase, tableName: string): Set<string> {
+  const columns = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>;
+  return new Set(columns.map((column) => column.name));
+}
+
+function assertOperatorSchemaCompatible(db: SQLiteDatabase): void {
+  for (const table of REQUIRED_OPERATOR_TABLES) {
+    if (!tableExists(db, table)) {
+      throw new Error(`vNext operator schema is missing table ${table}`);
+    }
+    const columns = tableColumns(db, table);
+    for (const column of REQUIRED_COLUMNS[table]) {
+      if (!columns.has(column)) {
+        throw new Error(`vNext operator schema table ${table} is missing column ${column}`);
+      }
+    }
+  }
+  for (const index of REQUIRED_INDEXES) {
+    if (!indexExists(db, index)) {
+      throw new Error(`vNext operator schema is missing index ${index}`);
+    }
+  }
+}
+
+function hasInstalledOperatorSchema(db: SQLiteDatabase): boolean {
+  if (!hasOperatorSchemaVersion(db)) {
+    return false;
+  }
+  if (!REQUIRED_OPERATOR_TABLES.every((table) => tableExists(db, table))) {
+    return false;
+  }
+  assertOperatorSchemaCompatible(db);
+  return true;
+}
+
+function ensureSchemaVersionDescriptionColumn(db: SQLiteDatabase): void {
+  const columns = db.prepare('PRAGMA table_info(schema_version)').all() as Array<{ name: string }>;
+  const hasDescription = columns.some((column) => column.name === 'description');
+  if (!hasDescription) {
+    db.exec('ALTER TABLE schema_version ADD COLUMN description TEXT');
+  }
+}
+
+export function ensureVNextOperatorSchema(
+  db: SQLiteDatabase,
+  options: VNextOperatorSchemaOptions = {}
+): void {
+  if (hasInstalledOperatorSchema(db)) {
+    return;
+  }
+
+  const migrationSql = options.readMigrationSql?.() ?? VNEXT_OPERATOR_CONTRACTS_SQL;
+  const tx = db.transaction(() => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS schema_version (
+        version INTEGER PRIMARY KEY,
+        applied_at INTEGER DEFAULT (unixepoch() * 1000),
+        description TEXT
+      )
+    `);
+    ensureSchemaVersionDescriptionColumn(db);
+    db.exec(migrationSql);
+    assertOperatorSchemaCompatible(db);
+  });
+  tx();
+}

--- a/packages/standalone/src/operator-vnext/schema.ts
+++ b/packages/standalone/src/operator-vnext/schema.ts
@@ -51,6 +51,7 @@ const REQUIRED_INDEXES = [
   'idx_operator_no_updates_scope_created',
   'idx_worker_proposals_status_kind',
 ] as const;
+const SQLITE_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 const VNEXT_OPERATOR_CONTRACTS_SQL = `
 CREATE TABLE IF NOT EXISTS vnext_operator_cursors (
@@ -141,6 +142,9 @@ function indexExists(db: SQLiteDatabase, indexName: string): boolean {
 }
 
 function tableColumns(db: SQLiteDatabase, tableName: string): Set<string> {
+  if (!SQLITE_IDENTIFIER_PATTERN.test(tableName)) {
+    throw new Error(`Invalid SQLite identifier: ${tableName}`);
+  }
   const columns = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>;
   return new Set(columns.map((column) => column.name));
 }

--- a/packages/standalone/src/runtime-vnext/bootstrap.ts
+++ b/packages/standalone/src/runtime-vnext/bootstrap.ts
@@ -1,12 +1,20 @@
 import type { VNextRuntimeFlags } from './feature-flags.js';
+import type {
+  PrimaryOperatorBatchResult,
+  PrimaryOperatorEvent,
+} from '../operator-vnext/primary-operator-runtime.js';
 
 export const VNEXT_ALLOWED_STARTUP_STEPS = [
   'config_read',
   'db_initialization',
+  'primary_operator_schema',
+  'primary_operator_runtime',
   'api_server_health',
   'manual_status_endpoints',
-  'primary_operator_placeholder',
 ] as const;
+
+export const VNEXT_PRIMARY_OPERATOR_CURSOR_NAME = 'operator:primary';
+export const VNEXT_PRIMARY_OPERATOR_CONNECTOR = 'manual';
 
 export const VNEXT_FORBIDDEN_FANOUT = [
   'dashboard_agent_interval',
@@ -27,16 +35,31 @@ export const VNEXT_FORBIDDEN_FANOUT = [
 export type VNextAllowedStartupStep = (typeof VNEXT_ALLOWED_STARTUP_STEPS)[number];
 export type VNextForbiddenFanout = (typeof VNEXT_FORBIDDEN_FANOUT)[number];
 
-export interface VNextPrimaryOperatorPlaceholder {
+export interface VNextPrimaryOperatorReadyStatus {
   kind: 'primary_operator';
-  status: 'noop';
-  reason: string;
+  status: 'prepared' | 'degraded';
+  mode: 'manual_batch';
+  ingress: 'not_wired';
+  cursorName: string;
+  connector: string;
+  advancedThroughSeq: number;
+  lastBatchStatus?: PrimaryOperatorBatchResult['status'];
+  failedSeq?: number;
+  errorMessage?: string;
+}
+
+export interface VNextPrimaryOperatorRuntimeHandle {
+  status: VNextPrimaryOperatorReadyStatus;
+  processBatch: (
+    events: readonly PrimaryOperatorEvent[],
+    decide: (event: PrimaryOperatorEvent) => Promise<unknown> | unknown
+  ) => Promise<PrimaryOperatorBatchResult>;
 }
 
 export interface VNextBootstrapPlan extends VNextRuntimeFlags {
   allowedStartupSteps: VNextAllowedStartupStep[];
   forbiddenFanout: VNextForbiddenFanout[];
-  primaryOperator: VNextPrimaryOperatorPlaceholder;
+  primaryOperator: VNextPrimaryOperatorReadyStatus;
 }
 
 export interface VNextBootstrapRuntimeStatus {
@@ -44,7 +67,7 @@ export interface VNextBootstrapRuntimeStatus {
   mode: 'bootstrap';
   source: VNextBootstrapPlan['source'];
   startedAtMs: number;
-  primaryOperator: VNextPrimaryOperatorPlaceholder;
+  primaryOperator: VNextPrimaryOperatorReadyStatus;
   executedStartupSteps: VNextAllowedStartupStep[];
 }
 
@@ -56,11 +79,14 @@ export interface VNextBootstrapApiServer {
 export interface VNextBootstrapRuntimeHandles<DatabaseHandle> {
   apiServer: VNextBootstrapApiServer;
   database: DatabaseHandle;
+  primaryOperator: VNextPrimaryOperatorRuntimeHandle;
   status: VNextBootstrapRuntimeStatus;
 }
 
 export interface VNextBootstrapRuntimeDeps<DatabaseHandle> {
   openDatabase: () => DatabaseHandle;
+  initializeOperatorSchema: (database: DatabaseHandle) => void;
+  createPrimaryOperator: (database: DatabaseHandle) => VNextPrimaryOperatorRuntimeHandle;
   createApiServer: (status: VNextBootstrapRuntimeStatus) => VNextBootstrapApiServer;
   installShutdownHandlers?: (handles: VNextBootstrapRuntimeHandles<DatabaseHandle>) => void;
   now?: () => number;
@@ -91,11 +117,21 @@ export function buildVNextBootstrapPlan(flags: VNextRuntimeFlags): VNextBootstra
     ...flags,
     allowedStartupSteps: [...VNEXT_ALLOWED_STARTUP_STEPS],
     forbiddenFanout: [...VNEXT_FORBIDDEN_FANOUT],
-    primaryOperator: {
-      kind: 'primary_operator',
-      status: 'noop',
-      reason: 'PR1 only installs the startup boundary; the operator loop lands later.',
-    },
+    primaryOperator: buildVNextPrimaryOperatorReadyStatus(0),
+  };
+}
+
+export function buildVNextPrimaryOperatorReadyStatus(
+  advancedThroughSeq: number
+): VNextPrimaryOperatorReadyStatus {
+  return {
+    kind: 'primary_operator',
+    status: 'prepared',
+    mode: 'manual_batch',
+    ingress: 'not_wired',
+    cursorName: VNEXT_PRIMARY_OPERATOR_CURSOR_NAME,
+    connector: VNEXT_PRIMARY_OPERATOR_CONNECTOR,
+    advancedThroughSeq,
   };
 }
 
@@ -144,27 +180,35 @@ export async function startVNextBootstrapRuntime<DatabaseHandle>(
   executeAllowedStep('db_initialization');
   const database = deps.openDatabase();
 
-  executeAllowedStep('api_server_health');
-  executeAllowedStep('manual_status_endpoints');
-  executeAllowedStep('primary_operator_placeholder');
+  let primaryOperator: VNextPrimaryOperatorRuntimeHandle;
+  let apiServer: VNextBootstrapApiServer;
 
-  const status: VNextBootstrapRuntimeStatus = {
-    enabled: true,
-    mode: 'bootstrap',
-    source: plan.source,
-    startedAtMs: deps.now?.() ?? Date.now(),
-    primaryOperator: plan.primaryOperator,
-    executedStartupSteps: [...executedStartupSteps],
-  };
-  const apiServer = deps.createApiServer(status);
   try {
+    executeAllowedStep('primary_operator_schema');
+    deps.initializeOperatorSchema(database);
+
+    executeAllowedStep('primary_operator_runtime');
+    primaryOperator = deps.createPrimaryOperator(database);
+
+    executeAllowedStep('api_server_health');
+    executeAllowedStep('manual_status_endpoints');
+
+    const status: VNextBootstrapRuntimeStatus = {
+      enabled: true,
+      mode: 'bootstrap',
+      source: plan.source,
+      startedAtMs: deps.now?.() ?? Date.now(),
+      primaryOperator: primaryOperator.status,
+      executedStartupSteps: [...executedStartupSteps],
+    };
+    apiServer = deps.createApiServer(status);
     await apiServer.start();
+
+    const handles = { apiServer, database, primaryOperator, status };
+    deps.installShutdownHandlers?.(handles);
+    return handles;
   } catch (error) {
     closeDatabaseIfPossible(database);
     throw error;
   }
-
-  const handles = { apiServer, database, status };
-  deps.installShutdownHandlers?.(handles);
-  return handles;
 }

--- a/packages/standalone/tests/operator-vnext/schema.test.ts
+++ b/packages/standalone/tests/operator-vnext/schema.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+
+process.env.MAMA_FORCE_TIER_3 ||= 'true';
+
+import Database from '../../src/sqlite.js';
+import { ensureVNextOperatorSchema } from '../../src/operator-vnext/schema.js';
+
+function tableExists(db: Database, tableName: string): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(tableName);
+  return row !== undefined;
+}
+
+describe('STORY-VNEXT-PR3-OPERATOR-BOOTSTRAP: operator schema bootstrap', () => {
+  describe('AC: sessions DB gets the primary operator contract before runtime creation', () => {
+    it('installs the vNext operator tables into an empty sessions database idempotently', () => {
+      const db = new Database(':memory:');
+
+      ensureVNextOperatorSchema(db);
+      ensureVNextOperatorSchema(db);
+
+      expect(tableExists(db, 'schema_version')).toBe(true);
+      expect(tableExists(db, 'vnext_operator_cursors')).toBe(true);
+      expect(tableExists(db, 'vnext_operator_commits')).toBe(true);
+      expect(tableExists(db, 'operator_no_updates')).toBe(true);
+      expect(tableExists(db, 'worker_proposals')).toBe(true);
+      expect(
+        db.prepare('SELECT version, description FROM schema_version WHERE version = 38').get()
+      ).toEqual({
+        version: 38,
+        description: 'Create vNext operator contracts',
+      });
+
+      db.close();
+    });
+
+    it('repairs legacy schema_version tables before installing operator tables', () => {
+      const db = new Database(':memory:');
+      db.exec('CREATE TABLE schema_version (version INTEGER PRIMARY KEY)');
+
+      ensureVNextOperatorSchema(db);
+
+      expect(
+        db.prepare('SELECT version, description FROM schema_version WHERE version = 38').get()
+      ).toEqual({
+        version: 38,
+        description: 'Create vNext operator contracts',
+      });
+      expect(tableExists(db, 'vnext_operator_cursors')).toBe(true);
+
+      db.close();
+    });
+
+    it('skips migration file reads when the operator schema is already installed', () => {
+      const missingSchemaDb = new Database(':memory:');
+      expect(() =>
+        ensureVNextOperatorSchema(missingSchemaDb, {
+          readMigrationSql: () => 'not valid sql',
+        })
+      ).toThrow(/syntax/i);
+      missingSchemaDb.close();
+
+      const installedSchemaDb = new Database(':memory:');
+      ensureVNextOperatorSchema(installedSchemaDb);
+
+      expect(() =>
+        ensureVNextOperatorSchema(installedSchemaDb, {
+          readMigrationSql: () => {
+            throw new Error('migration file should not be read');
+          },
+        })
+      ).not.toThrow();
+
+      installedSchemaDb.close();
+    });
+
+    it('rolls back schema repairs if operator schema installation fails', () => {
+      const db = new Database(':memory:');
+      db.exec('CREATE TABLE schema_version (version INTEGER PRIMARY KEY)');
+
+      expect(() =>
+        ensureVNextOperatorSchema(db, {
+          readMigrationSql: () => 'not valid sql',
+        })
+      ).toThrow(/syntax/i);
+
+      expect(tableExists(db, 'vnext_operator_cursors')).toBe(false);
+      expect(
+        (db.prepare('PRAGMA table_info(schema_version)').all() as Array<{ name: string }>).map(
+          (column) => column.name
+        )
+      ).toEqual(['version']);
+
+      db.close();
+    });
+
+    it('rejects partial schemas that claim the operator migration version', () => {
+      const db = new Database(':memory:');
+      db.exec(`
+        CREATE TABLE schema_version (
+          version INTEGER PRIMARY KEY,
+          applied_at INTEGER DEFAULT (unixepoch() * 1000),
+          description TEXT
+        );
+        INSERT INTO schema_version (version, description)
+        VALUES (38, 'Create vNext operator contracts');
+        CREATE TABLE vnext_operator_cursors (
+          cursor_name TEXT PRIMARY KEY,
+          last_change_seq INTEGER NOT NULL DEFAULT 0,
+          updated_at_ms INTEGER NOT NULL
+        );
+        CREATE TABLE vnext_operator_commits (
+          commit_id TEXT PRIMARY KEY
+        );
+        CREATE TABLE operator_no_updates (
+          no_update_id TEXT PRIMARY KEY
+        );
+        CREATE TABLE worker_proposals (
+          proposal_id TEXT PRIMARY KEY
+        );
+      `);
+
+      expect(() => ensureVNextOperatorSchema(db)).toThrow(/vnext_operator_cursors/i);
+
+      db.close();
+    });
+  });
+});

--- a/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
+++ b/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
@@ -182,6 +182,20 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
         failedSeq: 1,
       });
 
+      const idleResult = await primaryOperator.processBatch([], () => ({
+        status: 'no_update',
+        reason: 'idle batches do not resolve failures',
+      }));
+      expect(idleResult).toMatchObject({
+        status: 'idle',
+        advancedThroughSeq: 0,
+      });
+      expect(primaryOperator.status).toMatchObject({
+        status: 'degraded',
+        lastBatchStatus: 'idle',
+        failedSeq: 1,
+      });
+
       const statusResponse = await request(apiServer.app)
         .get('/api/vnext/status')
         .set('cf-connecting-ip', '203.0.113.10')
@@ -189,7 +203,7 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
       expect(statusResponse.status).toBe(200);
       expect(statusResponse.body.primary_operator_runtime).toMatchObject({
         status: 'degraded',
-        last_batch_status: 'partial_failure',
+        last_batch_status: 'idle',
         failed_seq: 1,
       });
 

--- a/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
+++ b/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
@@ -1,8 +1,13 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import request from 'supertest';
 
-import { createVNextBootstrapApiServer } from '../../src/cli/commands/start.js';
+import {
+  createVNextBootstrapApiServer,
+  createVNextPrimaryOperatorRuntime,
+} from '../../src/cli/commands/start.js';
+import { ensureVNextOperatorSchema } from '../../src/operator-vnext/schema.js';
 import type { VNextBootstrapRuntimeStatus } from '../../src/runtime-vnext/bootstrap.js';
+import Database from '../../src/sqlite.js';
 
 function makeStatus(): VNextBootstrapRuntimeStatus {
   return {
@@ -12,15 +17,20 @@ function makeStatus(): VNextBootstrapRuntimeStatus {
     startedAtMs: 1234,
     primaryOperator: {
       kind: 'primary_operator',
-      status: 'noop',
-      reason: 'test',
+      status: 'prepared',
+      mode: 'manual_batch',
+      ingress: 'not_wired',
+      cursorName: 'operator:primary',
+      connector: 'manual',
+      advancedThroughSeq: 0,
     },
     executedStartupSteps: [
       'config_read',
       'db_initialization',
+      'primary_operator_schema',
+      'primary_operator_runtime',
       'api_server_health',
       'manual_status_endpoints',
-      'primary_operator_placeholder',
     ],
   };
 }
@@ -67,8 +77,123 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
         primary_operator: {
           kind: 'primary_operator',
           status: 'noop',
+          reason: 'vNext primary operator runtime is exposed as primary_operator_runtime.',
+        },
+        primary_operator_runtime: {
+          kind: 'primary_operator',
+          status: 'prepared',
+          mode: 'manual_batch',
+          ingress: 'not_wired',
+          cursor_name: 'operator:primary',
+          connector: 'manual',
+          advanced_through_seq: 0,
         },
       });
+      expect(authenticated.body.primary_operator).not.toHaveProperty('cursorName');
+      expect(authenticated.body.primary_operator).not.toHaveProperty('advancedThroughSeq');
+      expect(authenticated.body.primary_operator_runtime).not.toHaveProperty('cursorName');
+      expect(authenticated.body.primary_operator_runtime).not.toHaveProperty('advancedThroughSeq');
+    });
+
+    it('creates a primary operator runtime bound to the manual cursor', async () => {
+      process.env.MAMA_AUTH_TOKEN = 'vnext-status-token';
+      const db = new Database(':memory:');
+      ensureVNextOperatorSchema(db);
+      db.prepare(
+        `INSERT INTO vnext_operator_cursors (
+          cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+        ) VALUES (?, ?, ?, ?)`
+      ).run('operator:primary', 5, null, 1710000000000);
+
+      const primaryOperator = createVNextPrimaryOperatorRuntime(db);
+      const runtimeStatus = makeStatus();
+      runtimeStatus.primaryOperator = primaryOperator.status;
+      const apiServer = createVNextBootstrapApiServer(runtimeStatus);
+
+      expect(primaryOperator.status).toEqual({
+        kind: 'primary_operator',
+        status: 'prepared',
+        mode: 'manual_batch',
+        ingress: 'not_wired',
+        cursorName: 'operator:primary',
+        connector: 'manual',
+        advancedThroughSeq: 5,
+      });
+
+      const result = await primaryOperator.processBatch(
+        [{ seq: 6, sourceRef: { kind: 'raw', connector: 'manual', id: 'event-6' } }],
+        () => ({
+          status: 'no_update',
+          reason: 'manual event did not change canonical state',
+          scopeKey: 'operator:primary',
+        })
+      );
+
+      expect(result).toMatchObject({
+        status: 'committed',
+        processed: 1,
+        advancedThroughSeq: 6,
+      });
+      expect(primaryOperator.status.advancedThroughSeq).toBe(6);
+      expect(
+        db
+          .prepare('SELECT last_change_seq FROM vnext_operator_cursors WHERE cursor_name = ?')
+          .get('operator:primary')
+      ).toEqual({ last_change_seq: 6 });
+
+      const statusResponse = await request(apiServer.app)
+        .get('/api/vnext/status')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-status-token');
+      expect(statusResponse.status).toBe(200);
+      expect(statusResponse.body.primary_operator_runtime).toMatchObject({
+        cursor_name: 'operator:primary',
+        advanced_through_seq: 6,
+      });
+
+      db.close();
+    });
+
+    it('marks primary operator runtime degraded after a failed batch', async () => {
+      process.env.MAMA_AUTH_TOKEN = 'vnext-status-token';
+      const db = new Database(':memory:');
+      ensureVNextOperatorSchema(db);
+      const primaryOperator = createVNextPrimaryOperatorRuntime(db);
+      const runtimeStatus = makeStatus();
+      runtimeStatus.primaryOperator = primaryOperator.status;
+      const apiServer = createVNextBootstrapApiServer(runtimeStatus);
+
+      const result = await primaryOperator.processBatch(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } }],
+        () => ({
+          status: 'no_update',
+          reason: 'should not run',
+          scopeKey: 'operator:primary',
+        })
+      );
+
+      expect(result).toMatchObject({
+        status: 'partial_failure',
+        failedSeq: 1,
+      });
+      expect(primaryOperator.status).toMatchObject({
+        status: 'degraded',
+        lastBatchStatus: 'partial_failure',
+        failedSeq: 1,
+      });
+
+      const statusResponse = await request(apiServer.app)
+        .get('/api/vnext/status')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-status-token');
+      expect(statusResponse.status).toBe(200);
+      expect(statusResponse.body.primary_operator_runtime).toMatchObject({
+        status: 'degraded',
+        last_batch_status: 'partial_failure',
+        failed_seq: 1,
+      });
+
+      db.close();
     });
   });
 });

--- a/packages/standalone/tests/runtime-vnext/bootstrap.test.ts
+++ b/packages/standalone/tests/runtime-vnext/bootstrap.test.ts
@@ -70,7 +70,7 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP: vNext bootstrap contract', () => {
       });
     });
 
-    it('publishes the PR1 startup allowlist and no-op primary operator placeholder', () => {
+    it('publishes the PR3 startup allowlist and ready primary operator contract', () => {
       const plan = buildVNextBootstrapPlan({
         enabled: true,
         mode: 'bootstrap',
@@ -80,14 +80,19 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP: vNext bootstrap contract', () => {
       expect(plan.allowedStartupSteps).toEqual([
         'config_read',
         'db_initialization',
+        'primary_operator_schema',
+        'primary_operator_runtime',
         'api_server_health',
         'manual_status_endpoints',
-        'primary_operator_placeholder',
       ]);
       expect(plan.primaryOperator).toEqual({
         kind: 'primary_operator',
-        status: 'noop',
-        reason: 'PR1 only installs the startup boundary; the operator loop lands later.',
+        status: 'prepared',
+        mode: 'manual_batch',
+        ingress: 'not_wired',
+        cursorName: 'operator:primary',
+        connector: 'manual',
+        advancedThroughSeq: 0,
       });
       expect(isVNextStartupStepAllowed(plan, 'config_read')).toBe(true);
       expect(isVNextStartupStepAllowed(plan, 'connector_polling')).toBe(false);
@@ -131,6 +136,23 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP: vNext bootstrap contract', () => {
     it('starts vNext bootstrap through the central allowlist only', async () => {
       const calls: string[] = [];
       const database = { close: () => calls.push('db.close') };
+      const primaryOperator = {
+        status: {
+          kind: 'primary_operator' as const,
+          status: 'prepared' as const,
+          mode: 'manual_batch' as const,
+          ingress: 'not_wired' as const,
+          cursorName: 'operator:primary',
+          connector: 'manual',
+          advancedThroughSeq: 7,
+        },
+        processBatch: async () => ({
+          status: 'idle' as const,
+          processed: 0,
+          advancedThroughSeq: 7,
+          commits: [],
+        }),
+      };
       const apiServer = {
         start: async () => {
           calls.push('api.start');
@@ -150,8 +172,17 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP: vNext bootstrap contract', () => {
           calls.push('db.open');
           return database;
         },
+        initializeOperatorSchema: () => {
+          calls.push('operator.schema');
+        },
+        createPrimaryOperator: () => {
+          calls.push('operator.create');
+          return primaryOperator;
+        },
         createApiServer: (status) => {
-          calls.push(`api.create:${status.primaryOperator.status}`);
+          calls.push(
+            `api.create:${status.primaryOperator.status}:${status.primaryOperator.cursorName}`
+          );
           return apiServer;
         },
         installShutdownHandlers: () => {
@@ -161,8 +192,52 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP: vNext bootstrap contract', () => {
       });
 
       expect(result.status.executedStartupSteps).toEqual(plan.allowedStartupSteps);
-      expect(result.status.primaryOperator.status).toBe('noop');
-      expect(calls).toEqual(['db.open', 'api.create:noop', 'api.start', 'shutdown.install']);
+      expect(result.primaryOperator).toBe(primaryOperator);
+      expect(result.status.primaryOperator).toEqual(primaryOperator.status);
+      expect(calls).toEqual([
+        'db.open',
+        'operator.schema',
+        'operator.create',
+        'api.create:prepared:operator:primary',
+        'api.start',
+        'shutdown.install',
+      ]);
+    });
+
+    it('closes the opened database if primary operator bootstrap fails', async () => {
+      const calls: string[] = [];
+      const database = { close: () => calls.push('db.close') };
+      const plan = buildVNextBootstrapPlan({
+        enabled: true,
+        mode: 'bootstrap',
+        source: 'env',
+      });
+
+      await expect(
+        startVNextBootstrapRuntime(plan, {
+          openDatabase: () => {
+            calls.push('db.open');
+            return database;
+          },
+          initializeOperatorSchema: () => {
+            calls.push('operator.schema');
+            throw new Error('schema unavailable');
+          },
+          createPrimaryOperator: () => {
+            throw new Error('should not create operator');
+          },
+          createApiServer: () => ({
+            start: async () => {
+              calls.push('api.start');
+            },
+            stop: async () => {
+              calls.push('api.stop');
+            },
+          }),
+        })
+      ).rejects.toThrow('schema unavailable');
+
+      expect(calls).toEqual(['db.open', 'operator.schema', 'db.close']);
     });
 
     it('closes the opened database if vNext API startup fails', async () => {
@@ -180,6 +255,26 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP: vNext bootstrap contract', () => {
             calls.push('db.open');
             return database;
           },
+          initializeOperatorSchema: () => {
+            calls.push('operator.schema');
+          },
+          createPrimaryOperator: () => ({
+            status: {
+              kind: 'primary_operator',
+              status: 'prepared',
+              mode: 'manual_batch',
+              ingress: 'not_wired',
+              cursorName: 'operator:primary',
+              connector: 'manual',
+              advancedThroughSeq: 0,
+            },
+            processBatch: async () => ({
+              status: 'idle',
+              processed: 0,
+              advancedThroughSeq: 0,
+              commits: [],
+            }),
+          }),
           createApiServer: () => ({
             start: async () => {
               calls.push('api.start');
@@ -195,7 +290,7 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP: vNext bootstrap contract', () => {
         })
       ).rejects.toThrow('bind failed');
 
-      expect(calls).toEqual(['db.open', 'api.start', 'db.close']);
+      expect(calls).toEqual(['db.open', 'operator.schema', 'api.start', 'db.close']);
     });
   });
 });


### PR DESCRIPTION
## Summary

PR3 of the MAMA vNext primary-operator rebuild.

- Replace the vNext primary-operator placeholder with a prepared manual-batch runtime bootstrap.
- Add standalone-owned vNext operator schema installation with transaction safety, fast-path validation, and incompatible-partial-schema rejection.
- Preserve the PR1/PR2-compatible `primary_operator` status field while exposing the real runtime under `primary_operator_runtime`.
- Add direct runtime, degraded-status, schema rollback, and API contract coverage.
- Update the vNext rebuild architecture doc for this stage.

## Verification

- `MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run tests/runtime-vnext/bootstrap.test.ts tests/runtime-vnext/bootstrap-api.test.ts tests/runtime-vnext/legacy-fanout-disabled.test.ts tests/operator-vnext/no-update-ledger.test.ts tests/operator-vnext/operator-cursor-commit.test.ts tests/operator-vnext/primary-operator-runtime.test.ts tests/operator-vnext/schema.test.ts`
- `pnpm --filter @jungjaehoon/mama-os typecheck`
- `pnpm exec prettier --check docs/architecture/mama-vnext-primary-operator-rebuild.md packages/standalone/src/runtime-vnext/bootstrap.ts packages/standalone/src/operator-vnext/schema.ts packages/standalone/src/cli/commands/start.ts packages/standalone/tests/runtime-vnext/bootstrap.test.ts packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts packages/standalone/tests/operator-vnext/schema.test.ts`
- `pnpm exec eslint packages/standalone/src/runtime-vnext/bootstrap.ts packages/standalone/src/operator-vnext/schema.ts packages/standalone/src/cli/commands/start.ts packages/standalone/tests/runtime-vnext/bootstrap.test.ts packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts packages/standalone/tests/operator-vnext/schema.test.ts --ext .ts`
- `pnpm --filter @jungjaehoon/mama-os build`
- `git diff --check HEAD`

## Privacy / Internal Info Audit

- `./scripts/check-pii.sh` passed.
- Direct scan of changed files found no `/Users/`, personal names, private package owner strings, private-key blocks, or real token/API-key patterns.
- `MAMA_AUTH_TOKEN` and `vnext-status-token` only appear as an environment variable name and fake test token in tests.

## Review Gates

- gstack specialist review completed for testing, maintainability, security, performance, data migration, API contract, and red-team angles.
- Codex adversarial review findings were fixed and re-tested.
- Codex structured review reported no correctness issues in the staged, unstaged, or untracked changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vNext primary-operator startup support, including schema setup, runtime initialization, and richer startup/status reporting.
  * Exposed more detailed operator progress and degraded-state information in the vNext status view.

* **Bug Fixes**
  * Improved database setup to create or repair required operator tables and keep schema checks consistent.
  * Strengthened startup behavior so operator initialization and API startup failures are handled more safely.

* **Tests**
  * Expanded coverage for operator schema bootstrapping and vNext startup/runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->