### PR TITLE
feat: add source-linked wiki artifacts

### DIFF
--- a/packages/standalone/src/agent/code-act/host-bridge.ts
+++ b/packages/standalone/src/agent/code-act/host-bridge.ts
@@ -126,13 +126,13 @@ const TOOL_REGISTRY: ToolMeta[] = [
     params: [
       {
         name: 'pages',
-        type: 'Array<{ path: string; title: string; type: string; content: string; confidence: string }>',
+        type: "Array<{ path: string; title: string; type: string; content: string; confidence?: 'high' | 'medium' | 'low'; sourceIds?: string[]; sourceRefs?: Array<{ kind: string; id: string; connector?: string }> }>",
         required: true,
         description:
-          'Array of wiki pages to publish. Each page has path, title, type (entity/lesson/synthesis/process), content (markdown), confidence (high/medium/low).',
+          'Array of wiki pages to publish. Path must be relative to the wiki directory. sourceRefs is canonical vNext provenance; sourceIds is legacy-compatible provenance.',
       },
     ],
-    returnType: '{ success: boolean; message: string }',
+    returnType: '{ success: boolean; message: string; artifactsStored?: number }',
     category: 'os',
   },
   // Obsidian CLI — vault management

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -114,6 +114,11 @@ import {
 } from './delegation-executor.js';
 import { EnvelopeEnforcer, EnvelopeViolation } from '../envelope/index.js';
 import type { Envelope, MemoryScope } from '../envelope/index.js';
+import {
+  createWikiPublishAdapter,
+  type WikiPublishAdapter,
+} from '../wiki-artifacts/wiki-publish-adapter.js';
+import type { WikiPagePublisher, WikiPublishPageInput } from '../wiki-artifacts/types.js';
 
 const { DebugLogger } = debugLogger as unknown as {
   DebugLogger: new (context?: string) => {
@@ -332,19 +337,8 @@ export class GatewayToolExecutor {
   private currentChannelId: string = '';
   private disallowedGatewayTools: Set<string> = new Set();
   private reportPublisher: ((slots: Record<string, string>) => void) | null = null;
-  private wikiPublisher:
-    | ((
-        pages: Array<{
-          path: string;
-          title: string;
-          type: string;
-          content: string;
-          sourceIds: string[];
-          compiledAt: string;
-          confidence: string;
-        }>
-      ) => void)
-    | null = null;
+  private wikiPublisher: WikiPagePublisher | null = null;
+  private wikiPublishAdapter: WikiPublishAdapter | null = null;
   private obsidianVaultPath: string | null = null;
   setObsidianVaultPath(vaultPath: string): void {
     this.obsidianVaultPath = vaultPath;
@@ -606,20 +600,11 @@ export class GatewayToolExecutor {
   setReportPublisher(fn: (slots: Record<string, string>) => void): void {
     this.reportPublisher = fn;
   }
-  setWikiPublisher(
-    fn: (
-      pages: Array<{
-        path: string;
-        title: string;
-        type: string;
-        content: string;
-        sourceIds: string[];
-        compiledAt: string;
-        confidence: string;
-      }>
-    ) => void
-  ): void {
+  setWikiPublisher(fn: WikiPagePublisher): void {
     this.wikiPublisher = fn;
+  }
+  setWikiPublishAdapter(adapter: WikiPublishAdapter | null): void {
+    this.wikiPublishAdapter = adapter;
   }
 
   /** Check if a memory agent is available for routing memory writes. */
@@ -665,6 +650,7 @@ export class GatewayToolExecutor {
     this.envelopeIssuanceMode = options.envelopeIssuanceMode ?? 'enabled';
     this.metricsStore = options.metricsStore ?? null;
     this.contextCompileService = options.contextCompileService;
+    this.wikiPublishAdapter = options.wikiPublishAdapter ?? null;
     this.browserTool = getBrowserTool({
       screenshotDir: join(process.env.HOME || '', '.mama', 'workspace', 'media', 'outbound'),
     });
@@ -2005,13 +1991,7 @@ export class GatewayToolExecutor {
         case 'wiki_publish': {
           const pagesInput = (
             input as {
-              pages?: Array<{
-                path: string;
-                title: string;
-                type: string;
-                content: string;
-                confidence?: string;
-              }>;
+              pages?: WikiPublishPageInput[];
             }
           ).pages;
           if (!pagesInput || !Array.isArray(pagesInput)) {
@@ -2022,25 +2002,27 @@ export class GatewayToolExecutor {
               false
             );
           }
-          if (this.wikiPublisher) {
-            const now = new Date().toISOString();
-            const wikiPages = pagesInput.map((p) => ({
-              path: p.path,
-              title: p.title,
-              type: p.type || 'entity',
-              content: p.content,
-              sourceIds: [] as string[],
-              compiledAt: now,
-              confidence: p.confidence || 'medium',
-            }));
-            this.wikiPublisher(wikiPages);
-
+          const adapter =
+            this.wikiPublishAdapter ??
+            createWikiPublishAdapter({
+              mode: 'legacy',
+              publisher: this.wikiPublisher,
+            });
+          try {
+            const publishResult = adapter.publish({ pages: pagesInput });
             return {
               success: true,
-              message: `Wiki published: ${wikiPages.length} pages`,
+              message: `Wiki published: ${publishResult.pagesPublished} pages`,
+              artifactsStored: publishResult.artifactsStored,
             };
+          } catch (error) {
+            throw new AgentError(
+              error instanceof Error ? error.message : 'Wiki publish failed',
+              'TOOL_ERROR',
+              undefined,
+              false
+            );
           }
-          throw new AgentError('Wiki publisher not configured', 'TOOL_ERROR', undefined, false);
         }
         // Kagemusha query tools — progressive business data exploration
         case 'kagemusha_overview': {

--- a/packages/standalone/src/agent/gateway-tools.md
+++ b/packages/standalone/src/agent/gateway-tools.md
@@ -63,7 +63,7 @@ Call tools via JSON block:
 ## OS Monitoring (viewer-only)
 
 - **report_publish**(slots: { briefing?: html, alerts?: html, activity?: html, pipeline?: html }) — Update dashboard report slots with HTML content. Each slot is a section of the dashboard that you write as HTML.
-- **wiki_publish**(pages: [{path, title, type, content, confidence}]) — Publish compiled wiki pages to Obsidian vault. Each page becomes a markdown file with YAML frontmatter.
+- **wiki_publish**(pages: [{path, title, type, content, confidence?, sourceIds?, sourceRefs?}]) — Publish compiled wiki pages to Obsidian vault. Each page becomes a markdown file with YAML frontmatter.
 - **obsidian**(command, args?) — Execute Obsidian CLI command on the wiki vault. Search, read, create, append, move, delete pages, manage tags and backlinks.
 - **os_list_bots**() — List configured bot platforms and status
 - **os_restart_bot**() — Restart a bot platform

--- a/packages/standalone/src/agent/tool-registry.ts
+++ b/packages/standalone/src/agent/tool-registry.ts
@@ -97,7 +97,7 @@ register({
   description:
     'Publish compiled wiki pages to Obsidian vault. Each page becomes a markdown file with YAML frontmatter.',
   category: 'os_monitoring',
-  params: 'pages: [{path, title, type, content, confidence}]',
+  params: 'pages: [{path, title, type, content, confidence?, sourceIds?, sourceRefs?}]',
 });
 register({
   name: 'obsidian',

--- a/packages/standalone/src/agent/types.ts
+++ b/packages/standalone/src/agent/types.ts
@@ -11,6 +11,7 @@
 
 import type { RoleConfig } from '../cli/config/types.js';
 import type { Envelope } from '../envelope/types.js';
+import type { WikiPublishAdapter } from '../wiki-artifacts/wiki-publish-adapter.js';
 import type { ContextCompileService } from './context-compile-service.js';
 import type {
   AppendToolTraceInput,
@@ -1206,6 +1207,8 @@ export interface GatewayToolExecutorOptions {
   metricsStore?: import('../observability/metrics-store.js').MetricsStore | null;
   /** Shared context compile service for gateway context_compile calls. */
   contextCompileService?: ContextCompileService;
+  /** Optional wiki publish adapter, used by vNext callers that persist source-linked artifacts. */
+  wikiPublishAdapter?: WikiPublishAdapter | null;
 }
 
 export interface MemoryWriteProvenance {

--- a/packages/standalone/src/db/migrations/wiki-artifacts.ts
+++ b/packages/standalone/src/db/migrations/wiki-artifacts.ts
@@ -1,0 +1,22 @@
+import type { SQLiteDatabase } from '../../sqlite.js';
+
+export function applyWikiArtifactsMigration(db: SQLiteDatabase): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS wiki_artifacts (
+      artifact_id TEXT PRIMARY KEY,
+      path TEXT NOT NULL UNIQUE,
+      title TEXT NOT NULL,
+      type TEXT NOT NULL,
+      content TEXT NOT NULL,
+      confidence TEXT NOT NULL CHECK (confidence IN ('high', 'medium', 'low')),
+      compiled_at TEXT NOT NULL,
+      source_refs_json TEXT NOT NULL CHECK (json_valid(source_refs_json)),
+      source_ids_json TEXT NOT NULL CHECK (json_valid(source_ids_json)),
+      created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+      updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= 0)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_wiki_artifacts_updated_at
+    ON wiki_artifacts(updated_at_ms DESC);
+  `);
+}

--- a/packages/standalone/src/wiki-artifacts/normalization.ts
+++ b/packages/standalone/src/wiki-artifacts/normalization.ts
@@ -1,0 +1,49 @@
+import { isValidPageType, type WikiPage, type WikiPageType } from '../wiki/types.js';
+import { normalizeWikiPagePath } from '../wiki/path-safety.js';
+
+export type WikiArtifactConfidence = WikiPage['confidence'];
+
+const CONFIDENCE_VALUES = new Set<string>(['high', 'medium', 'low']);
+
+export function requiredWikiString(value: unknown, field: string, prefix: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`${prefix} ${field} must be a string`);
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`${prefix} ${field} must not be empty`);
+  }
+  return trimmed;
+}
+
+export function normalizeWikiPageType(
+  value: string | undefined,
+  prefix: string,
+  defaultType: WikiPageType = 'entity'
+): WikiPageType {
+  if (value === undefined || value.trim().length === 0) {
+    return defaultType;
+  }
+  const normalized = requiredWikiString(value, 'type', prefix);
+  if (!isValidPageType(normalized)) {
+    throw new Error(`${prefix} type is not supported: ${normalized}`);
+  }
+  return normalized;
+}
+
+export function normalizeWikiConfidence(
+  value: string | undefined,
+  prefix: string,
+  defaultConfidence: WikiArtifactConfidence = 'medium'
+): WikiArtifactConfidence {
+  if (value === undefined || value.trim().length === 0) {
+    return defaultConfidence;
+  }
+  const normalized = requiredWikiString(value, 'confidence', prefix);
+  if (!CONFIDENCE_VALUES.has(normalized)) {
+    throw new Error(`${prefix} confidence is not supported: ${normalized}`);
+  }
+  return normalized as WikiArtifactConfidence;
+}
+
+export { normalizeWikiPagePath };

--- a/packages/standalone/src/wiki-artifacts/types.ts
+++ b/packages/standalone/src/wiki-artifacts/types.ts
@@ -1,0 +1,61 @@
+import type { SourceRef } from '@jungjaehoon/mama-core/provenance/source-ref';
+
+import type { WikiPage, WikiPageType } from '../wiki/types.js';
+import type { WikiArtifactConfidence } from './normalization.js';
+
+export type { WikiArtifactConfidence };
+
+export interface WikiArtifactInput {
+  artifactId?: string;
+  path: string;
+  title: string;
+  type: WikiPageType | string;
+  content: string;
+  confidence?: WikiArtifactConfidence | string;
+  compiledAt?: string;
+  sourceRefs: readonly SourceRef[];
+  sourceIds?: readonly string[];
+  nowMs?: number;
+}
+
+export interface WikiArtifactRecord {
+  artifactId: string;
+  path: string;
+  title: string;
+  type: WikiPageType;
+  content: string;
+  confidence: WikiArtifactConfidence;
+  compiledAt: string;
+  sourceRefs: string[];
+  sourceIds: string[];
+  createdAtMs: number;
+  updatedAtMs: number;
+}
+
+export interface WikiPublishPageInput {
+  path: string;
+  title: string;
+  type?: string;
+  content: string;
+  confidence?: string;
+  sourceIds?: string[];
+  sourceRefs?: SourceRef[];
+}
+
+export type SourceLinkedWikiPage = WikiPage & {
+  sourceRefs: string[];
+};
+
+export type WikiPagePublisher = (pages: SourceLinkedWikiPage[]) => void;
+
+export interface WikiPublishResult {
+  pagesPublished: number;
+  artifactsStored: number;
+}
+
+export interface WikiArtifactListOptions {
+  limit?: number;
+  offset?: number;
+}
+
+export type WikiArtifactPathListOptions = WikiArtifactListOptions;

--- a/packages/standalone/src/wiki-artifacts/wiki-artifact-store.ts
+++ b/packages/standalone/src/wiki-artifacts/wiki-artifact-store.ts
@@ -1,0 +1,245 @@
+import { createHash } from 'crypto';
+
+import {
+  assertNonEmptySourceRefs,
+  serializeSourceRef,
+} from '@jungjaehoon/mama-core/provenance/source-ref';
+
+import type { SQLiteDatabase } from '../sqlite.js';
+import { applyWikiArtifactsMigration } from '../db/migrations/wiki-artifacts.js';
+import {
+  normalizeWikiConfidence,
+  normalizeWikiPageType,
+  normalizeWikiPagePath,
+  requiredWikiString,
+} from './normalization.js';
+import type {
+  WikiArtifactInput,
+  WikiArtifactListOptions,
+  WikiArtifactPathListOptions,
+  WikiArtifactRecord,
+} from './types.js';
+
+interface WikiArtifactRow {
+  artifact_id: string;
+  path: string;
+  title: string;
+  type: string;
+  content: string;
+  confidence: string;
+  compiled_at: string;
+  source_refs_json: string;
+  source_ids_json: string;
+  created_at_ms: number;
+  updated_at_ms: number;
+}
+
+function parseStringArrayJson(value: string, field: string): string[] {
+  const parsed = JSON.parse(value) as unknown;
+  if (!Array.isArray(parsed) || !parsed.every((item) => typeof item === 'string')) {
+    throw new Error(`Wiki artifact ${field} must be a string array`);
+  }
+  return parsed;
+}
+
+function createArtifactId(path: string): string {
+  const digest = createHash('sha256').update(path).digest('hex').slice(0, 24);
+  return `wiki_artifact:${digest}`;
+}
+
+function rowToRecord(row: WikiArtifactRow): WikiArtifactRecord {
+  return {
+    artifactId: row.artifact_id,
+    path: row.path,
+    title: row.title,
+    type: normalizeWikiPageType(row.type, 'Wiki artifact'),
+    content: row.content,
+    confidence: normalizeWikiConfidence(row.confidence, 'Wiki artifact'),
+    compiledAt: row.compiled_at,
+    sourceRefs: parseStringArrayJson(row.source_refs_json, 'sourceRefs'),
+    sourceIds: parseStringArrayJson(row.source_ids_json, 'sourceIds'),
+    createdAtMs: row.created_at_ms,
+    updatedAtMs: row.updated_at_ms,
+  };
+}
+
+export class WikiArtifactStore {
+  constructor(private readonly db: SQLiteDatabase) {}
+
+  ensureSchema(): void {
+    applyWikiArtifactsMigration(this.db);
+  }
+
+  private normalizeInput(input: WikiArtifactInput): Omit<
+    WikiArtifactRecord,
+    'artifactId' | 'createdAtMs' | 'updatedAtMs'
+  > & {
+    artifactId: string;
+    nowMs: number;
+  } {
+    const path = normalizeWikiPagePath(input.path, 'Wiki artifact path');
+    const title = requiredWikiString(input.title, 'title', 'Wiki artifact');
+    const type = normalizeWikiPageType(input.type, 'Wiki artifact');
+    const content = requiredWikiString(input.content, 'content', 'Wiki artifact');
+    const confidence = normalizeWikiConfidence(input.confidence, 'Wiki artifact');
+    const compiledAt = input.compiledAt ?? new Date().toISOString();
+    const nowMs = input.nowMs ?? Date.now();
+    const artifactId = input.artifactId ?? createArtifactId(path);
+
+    assertNonEmptySourceRefs(input.sourceRefs);
+    const sourceRefs = input.sourceRefs.map((ref) => serializeSourceRef(ref));
+    const sourceIds =
+      input.sourceIds && input.sourceIds.length > 0
+        ? input.sourceIds.map((id) => requiredWikiString(id, 'sourceIds[]', 'Wiki artifact'))
+        : sourceRefs;
+
+    return {
+      artifactId,
+      path,
+      title,
+      type,
+      content,
+      confidence,
+      compiledAt,
+      sourceRefs,
+      sourceIds,
+      nowMs,
+    };
+  }
+
+  private validateListOptions(options: WikiArtifactListOptions | WikiArtifactPathListOptions): {
+    limit: number | undefined;
+    offset: number;
+  } {
+    const limit = options.limit;
+    const offset = options.offset ?? 0;
+    if (limit !== undefined && (!Number.isInteger(limit) || limit < 0)) {
+      throw new Error('Wiki artifact limit must be a non-negative integer');
+    }
+    if (!Number.isInteger(offset) || offset < 0) {
+      throw new Error('Wiki artifact offset must be a non-negative integer');
+    }
+    return { limit, offset };
+  }
+
+  upsertArtifact(input: WikiArtifactInput): WikiArtifactRecord {
+    return this.upsertArtifacts([input])[0];
+  }
+
+  upsertArtifacts(inputs: readonly WikiArtifactInput[]): WikiArtifactRecord[] {
+    this.ensureSchema();
+
+    const normalizedByPath = new Map<string, ReturnType<WikiArtifactStore['normalizeInput']>>();
+    for (const input of inputs) {
+      const normalized = this.normalizeInput(input);
+      normalizedByPath.set(normalized.path, normalized);
+    }
+    const normalizedInputs = [...normalizedByPath.values()];
+    const upsert = this.db.prepare(
+      `INSERT INTO wiki_artifacts (
+          artifact_id, path, title, type, content, confidence, compiled_at,
+          source_refs_json, source_ids_json, created_at_ms, updated_at_ms
+        ) VALUES (
+          COALESCE((SELECT artifact_id FROM wiki_artifacts WHERE path = ?), ?),
+          ?, ?, ?, ?, ?, ?, ?, ?,
+          COALESCE((SELECT created_at_ms FROM wiki_artifacts WHERE path = ?), ?),
+          ?
+        )
+        ON CONFLICT(path) DO UPDATE SET
+          title = excluded.title,
+          type = excluded.type,
+          content = excluded.content,
+          confidence = excluded.confidence,
+          compiled_at = excluded.compiled_at,
+          source_refs_json = excluded.source_refs_json,
+          source_ids_json = excluded.source_ids_json,
+          updated_at_ms = excluded.updated_at_ms`
+    );
+    const select = this.db.prepare(
+      `SELECT
+        artifact_id, path, title, type, content, confidence, compiled_at,
+        source_refs_json, source_ids_json, created_at_ms, updated_at_ms
+      FROM wiki_artifacts
+      WHERE path = ?`
+    );
+
+    const writeBatch = this.db.transaction(() => {
+      const records: WikiArtifactRecord[] = [];
+      for (const input of normalizedInputs) {
+        upsert.run(
+          input.path,
+          input.artifactId,
+          input.path,
+          input.title,
+          input.type,
+          input.content,
+          input.confidence,
+          input.compiledAt,
+          JSON.stringify(input.sourceRefs),
+          JSON.stringify(input.sourceIds),
+          input.path,
+          input.nowMs,
+          input.nowMs
+        );
+        const row = select.get(input.path) as WikiArtifactRow | undefined;
+        if (!row) {
+          throw new Error(`Wiki artifact was not stored: ${input.path}`);
+        }
+        records.push(rowToRecord(row));
+      }
+      return records;
+    });
+
+    return writeBatch();
+  }
+
+  getByPath(path: string): WikiArtifactRecord | null {
+    this.ensureSchema();
+    const normalizedPath = normalizeWikiPagePath(path, 'Wiki artifact path');
+    const row = this.db
+      .prepare(
+        `SELECT
+          artifact_id, path, title, type, content, confidence, compiled_at,
+          source_refs_json, source_ids_json, created_at_ms, updated_at_ms
+        FROM wiki_artifacts
+        WHERE path = ?`
+      )
+      .get(normalizedPath) as WikiArtifactRow | undefined;
+    return row ? rowToRecord(row) : null;
+  }
+
+  listArtifacts(options: WikiArtifactListOptions = {}): WikiArtifactRecord[] {
+    this.ensureSchema();
+    const { limit, offset } = this.validateListOptions(options);
+
+    const sql = `SELECT
+            artifact_id, path, title, type, content, confidence, compiled_at,
+            source_refs_json, source_ids_json, created_at_ms, updated_at_ms
+          FROM wiki_artifacts
+          ORDER BY updated_at_ms DESC, path ASC`;
+    const rows =
+      limit === undefined && offset === 0
+        ? (this.db.prepare(sql).all() as WikiArtifactRow[])
+        : limit === undefined
+          ? (this.db.prepare(`${sql} LIMIT -1 OFFSET ?`).all(offset) as WikiArtifactRow[])
+          : (this.db.prepare(`${sql} LIMIT ? OFFSET ?`).all(limit, offset) as WikiArtifactRow[]);
+    return rows.map((row) => rowToRecord(row));
+  }
+
+  listArtifactPaths(options: WikiArtifactPathListOptions = {}): string[] {
+    this.ensureSchema();
+    const { limit, offset } = this.validateListOptions(options);
+    const sql = `SELECT path
+          FROM wiki_artifacts
+          ORDER BY updated_at_ms DESC, path ASC`;
+    const rows =
+      limit === undefined && offset === 0
+        ? (this.db.prepare(sql).all() as Array<{ path: string }>)
+        : limit === undefined
+          ? (this.db.prepare(`${sql} LIMIT -1 OFFSET ?`).all(offset) as Array<{ path: string }>)
+          : (this.db.prepare(`${sql} LIMIT ? OFFSET ?`).all(limit, offset) as Array<{
+              path: string;
+            }>);
+    return rows.map((row) => row.path);
+  }
+}

--- a/packages/standalone/src/wiki-artifacts/wiki-artifact-store.ts
+++ b/packages/standalone/src/wiki-artifacts/wiki-artifact-store.ts
@@ -140,10 +140,7 @@ export class WikiArtifactStore {
           artifact_id, path, title, type, content, confidence, compiled_at,
           source_refs_json, source_ids_json, created_at_ms, updated_at_ms
         ) VALUES (
-          COALESCE((SELECT artifact_id FROM wiki_artifacts WHERE path = ?), ?),
-          ?, ?, ?, ?, ?, ?, ?, ?,
-          COALESCE((SELECT created_at_ms FROM wiki_artifacts WHERE path = ?), ?),
-          ?
+          ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
         )
         ON CONFLICT(path) DO UPDATE SET
           title = excluded.title,
@@ -167,7 +164,6 @@ export class WikiArtifactStore {
       const records: WikiArtifactRecord[] = [];
       for (const input of normalizedInputs) {
         upsert.run(
-          input.path,
           input.artifactId,
           input.path,
           input.title,
@@ -177,7 +173,6 @@ export class WikiArtifactStore {
           input.compiledAt,
           JSON.stringify(input.sourceRefs),
           JSON.stringify(input.sourceIds),
-          input.path,
           input.nowMs,
           input.nowMs
         );
@@ -206,6 +201,29 @@ export class WikiArtifactStore {
       )
       .get(normalizedPath) as WikiArtifactRow | undefined;
     return row ? rowToRecord(row) : null;
+  }
+
+  getByPaths(paths: readonly string[]): WikiArtifactRecord[] {
+    this.ensureSchema();
+    if (paths.length === 0) {
+      return [];
+    }
+    const normalizedPaths = paths.map((path) => normalizeWikiPagePath(path, 'Wiki artifact path'));
+    const placeholders = normalizedPaths.map(() => '?').join(', ');
+    const rows = this.db
+      .prepare(
+        `SELECT
+          artifact_id, path, title, type, content, confidence, compiled_at,
+          source_refs_json, source_ids_json, created_at_ms, updated_at_ms
+        FROM wiki_artifacts
+        WHERE path IN (${placeholders})`
+      )
+      .all(...normalizedPaths) as WikiArtifactRow[];
+    const byPath = new Map(rows.map((row) => [row.path, rowToRecord(row)]));
+    return normalizedPaths.flatMap((path) => {
+      const record = byPath.get(path);
+      return record ? [record] : [];
+    });
   }
 
   listArtifacts(options: WikiArtifactListOptions = {}): WikiArtifactRecord[] {

--- a/packages/standalone/src/wiki-artifacts/wiki-artifact-store.ts
+++ b/packages/standalone/src/wiki-artifacts/wiki-artifact-store.ts
@@ -47,6 +47,21 @@ function createArtifactId(path: string): string {
   return `wiki_artifact:${digest}`;
 }
 
+function runPaginated<T>(
+  db: SQLiteDatabase,
+  sql: string,
+  limit: number | undefined,
+  offset: number
+): T[] {
+  if (limit === undefined && offset === 0) {
+    return db.prepare(sql).all() as T[];
+  }
+  if (limit === undefined) {
+    return db.prepare(`${sql} LIMIT -1 OFFSET ?`).all(offset) as T[];
+  }
+  return db.prepare(`${sql} LIMIT ? OFFSET ?`).all(limit, offset) as T[];
+}
+
 function rowToRecord(row: WikiArtifactRow): WikiArtifactRecord {
   return {
     artifactId: row.artifact_id,
@@ -64,10 +79,16 @@ function rowToRecord(row: WikiArtifactRow): WikiArtifactRecord {
 }
 
 export class WikiArtifactStore {
+  private schemaEnsured = false;
+
   constructor(private readonly db: SQLiteDatabase) {}
 
   ensureSchema(): void {
+    if (this.schemaEnsured) {
+      return;
+    }
     applyWikiArtifactsMigration(this.db);
+    this.schemaEnsured = true;
   }
 
   private normalizeInput(input: WikiArtifactInput): Omit<
@@ -235,12 +256,7 @@ export class WikiArtifactStore {
             source_refs_json, source_ids_json, created_at_ms, updated_at_ms
           FROM wiki_artifacts
           ORDER BY updated_at_ms DESC, path ASC`;
-    const rows =
-      limit === undefined && offset === 0
-        ? (this.db.prepare(sql).all() as WikiArtifactRow[])
-        : limit === undefined
-          ? (this.db.prepare(`${sql} LIMIT -1 OFFSET ?`).all(offset) as WikiArtifactRow[])
-          : (this.db.prepare(`${sql} LIMIT ? OFFSET ?`).all(limit, offset) as WikiArtifactRow[]);
+    const rows = runPaginated<WikiArtifactRow>(this.db, sql, limit, offset);
     return rows.map((row) => rowToRecord(row));
   }
 
@@ -250,14 +266,7 @@ export class WikiArtifactStore {
     const sql = `SELECT path
           FROM wiki_artifacts
           ORDER BY updated_at_ms DESC, path ASC`;
-    const rows =
-      limit === undefined && offset === 0
-        ? (this.db.prepare(sql).all() as Array<{ path: string }>)
-        : limit === undefined
-          ? (this.db.prepare(`${sql} LIMIT -1 OFFSET ?`).all(offset) as Array<{ path: string }>)
-          : (this.db.prepare(`${sql} LIMIT ? OFFSET ?`).all(limit, offset) as Array<{
-              path: string;
-            }>);
+    const rows = runPaginated<{ path: string }>(this.db, sql, limit, offset);
     return rows.map((row) => row.path);
   }
 }

--- a/packages/standalone/src/wiki-artifacts/wiki-exporter.ts
+++ b/packages/standalone/src/wiki-artifacts/wiki-exporter.ts
@@ -1,0 +1,67 @@
+import type { ObsidianWriter } from '../wiki/obsidian-writer.js';
+import type { WikiPage } from '../wiki/types.js';
+import type { WikiArtifactRecord } from './types.js';
+import type { WikiArtifactStore } from './wiki-artifact-store.js';
+
+export interface WikiArtifactExportInput {
+  store: WikiArtifactStore;
+  writer: ObsidianWriter;
+  batchSize?: number;
+}
+
+export interface WikiArtifactExportResult {
+  exported: number;
+  paths: string[];
+}
+
+function artifactToPage(record: WikiArtifactRecord): WikiPage {
+  return {
+    path: record.path,
+    title: record.title,
+    type: record.type,
+    content: record.content,
+    sourceIds: record.sourceIds,
+    sourceRefs: record.sourceRefs,
+    compiledAt: record.compiledAt,
+    confidence: record.confidence,
+  };
+}
+
+export function exportWikiArtifactsToObsidian(
+  input: WikiArtifactExportInput
+): WikiArtifactExportResult {
+  const batchSize = input.batchSize ?? 100;
+  if (!Number.isInteger(batchSize) || batchSize <= 0) {
+    throw new Error('Wiki artifact export batchSize must be a positive integer');
+  }
+
+  input.writer.ensureDirectories();
+  const indexPages: WikiPage[] = [];
+  const paths: string[] = [];
+  const artifactPaths = input.store.listArtifactPaths();
+  for (let offset = 0; offset < artifactPaths.length; offset += batchSize) {
+    const batch = artifactPaths.slice(offset, offset + batchSize);
+    for (const artifactPath of batch) {
+      const record = input.store.getByPath(artifactPath);
+      if (!record) {
+        continue;
+      }
+      const page = artifactToPage(record);
+      input.writer.writePage(page);
+      paths.push(page.path);
+      indexPages.push(page);
+    }
+  }
+  if (indexPages.length > 0) {
+    input.writer.updateIndex(indexPages);
+    input.writer.appendLog(
+      'compile',
+      `Published ${indexPages.length} source-linked wiki artifacts`
+    );
+  }
+
+  return {
+    exported: paths.length,
+    paths,
+  };
+}

--- a/packages/standalone/src/wiki-artifacts/wiki-exporter.ts
+++ b/packages/standalone/src/wiki-artifacts/wiki-exporter.ts
@@ -43,9 +43,9 @@ export function exportWikiArtifactsToObsidian(
     const batch = artifactPaths.slice(offset, offset + batchSize);
     for (const record of input.store.getByPaths(batch)) {
       const page = artifactToPage(record);
-      input.writer.writePage(page);
-      paths.push(page.path);
-      indexPages.push(page);
+      const writtenPath = input.writer.writePage(page);
+      paths.push(writtenPath);
+      indexPages.push({ ...page, path: writtenPath, content: '' });
     }
   }
   if (indexPages.length > 0) {

--- a/packages/standalone/src/wiki-artifacts/wiki-exporter.ts
+++ b/packages/standalone/src/wiki-artifacts/wiki-exporter.ts
@@ -41,11 +41,7 @@ export function exportWikiArtifactsToObsidian(
   const artifactPaths = input.store.listArtifactPaths();
   for (let offset = 0; offset < artifactPaths.length; offset += batchSize) {
     const batch = artifactPaths.slice(offset, offset + batchSize);
-    for (const artifactPath of batch) {
-      const record = input.store.getByPath(artifactPath);
-      if (!record) {
-        continue;
-      }
+    for (const record of input.store.getByPaths(batch)) {
       const page = artifactToPage(record);
       input.writer.writePage(page);
       paths.push(page.path);

--- a/packages/standalone/src/wiki-artifacts/wiki-publish-adapter.ts
+++ b/packages/standalone/src/wiki-artifacts/wiki-publish-adapter.ts
@@ -93,7 +93,8 @@ export function createWikiPublishAdapter(options: WikiPublishAdapterOptions): Wi
       if (input.pages.length > MAX_WIKI_PUBLISH_PAGES) {
         throw new Error(`wiki_publish accepts at most ${MAX_WIKI_PUBLISH_PAGES} pages`);
       }
-      if (options.mode === 'vnext' && !options.store) {
+      const store = options.mode === 'vnext' ? options.store : undefined;
+      if (options.mode === 'vnext' && !store) {
         throw new Error('Wiki artifact store not configured');
       }
 
@@ -102,6 +103,9 @@ export function createWikiPublishAdapter(options: WikiPublishAdapterOptions): Wi
       let artifactsStored = 0;
 
       if (options.mode === 'vnext') {
+        if (!store) {
+          throw new Error('Wiki artifact store not configured');
+        }
         const artifacts = pagePairs.map(({ page, rawPage }) => {
           return {
             path: page.path,
@@ -115,7 +119,7 @@ export function createWikiPublishAdapter(options: WikiPublishAdapterOptions): Wi
             nowMs: options.nowMs?.(),
           };
         });
-        artifactsStored = options.store!.upsertArtifacts(artifacts).length;
+        artifactsStored = store.upsertArtifacts(artifacts).length;
         if (options.publisher) {
           options.publisher(pages);
         }

--- a/packages/standalone/src/wiki-artifacts/wiki-publish-adapter.ts
+++ b/packages/standalone/src/wiki-artifacts/wiki-publish-adapter.ts
@@ -1,0 +1,134 @@
+import { serializeSourceRef } from '@jungjaehoon/mama-core/provenance/source-ref';
+
+import type { WikiPageType } from '../wiki/types.js';
+import type { WikiArtifactStore } from './wiki-artifact-store.js';
+import {
+  normalizeWikiConfidence,
+  normalizeWikiPageType,
+  normalizeWikiPagePath,
+  requiredWikiString,
+} from './normalization.js';
+import type {
+  SourceLinkedWikiPage,
+  WikiArtifactConfidence,
+  WikiPagePublisher,
+  WikiPublishPageInput,
+  WikiPublishResult,
+} from './types.js';
+
+type WikiPublishMode = 'legacy' | 'vnext';
+const MAX_WIKI_PUBLISH_PAGES = 100;
+const MAX_WIKI_PAGE_CONTENT_CHARS = 200_000;
+
+export interface WikiPublishAdapter {
+  publish(input: { pages: WikiPublishPageInput[] }): WikiPublishResult;
+}
+
+export interface WikiPublishAdapterOptions {
+  mode: WikiPublishMode;
+  publisher?: WikiPagePublisher | null;
+  store?: WikiArtifactStore | null;
+  now?: () => Date;
+  nowMs?: () => number;
+}
+
+function normalizeType(value: string | undefined): WikiPageType {
+  return normalizeWikiPageType(value, 'wiki_publish page');
+}
+
+function normalizeConfidence(value: string | undefined): WikiArtifactConfidence {
+  return normalizeWikiConfidence(value, 'wiki_publish page');
+}
+
+function normalizeSourceIds(sourceIds: string[] | undefined, fallback: string[]): string[] {
+  if (!sourceIds || sourceIds.length === 0) {
+    return fallback;
+  }
+  return sourceIds.map((id) => requiredWikiString(id, 'sourceIds[]', 'wiki_publish page'));
+}
+
+function normalizePage(page: WikiPublishPageInput, compiledAt: string): SourceLinkedWikiPage {
+  const sourceRefs = page.sourceRefs?.map((ref) => serializeSourceRef(ref)) ?? [];
+  const content = requiredWikiString(page.content, 'content', 'wiki_publish page');
+  if (content.length > MAX_WIKI_PAGE_CONTENT_CHARS) {
+    throw new Error(
+      `wiki_publish page content must not exceed ${MAX_WIKI_PAGE_CONTENT_CHARS} characters`
+    );
+  }
+  return {
+    path: normalizeWikiPagePath(page.path, 'wiki_publish page path'),
+    title: requiredWikiString(page.title, 'title', 'wiki_publish page'),
+    type: normalizeType(page.type),
+    content,
+    sourceIds: normalizeSourceIds(page.sourceIds, sourceRefs),
+    sourceRefs,
+    compiledAt,
+    confidence: normalizeConfidence(page.confidence),
+  };
+}
+
+function normalizeAndDedupePages(
+  rawPages: WikiPublishPageInput[],
+  compiledAt: string,
+  mode: WikiPublishMode
+): Array<{ page: SourceLinkedWikiPage; rawPage: WikiPublishPageInput }> {
+  const byPath = new Map<string, { page: SourceLinkedWikiPage; rawPage: WikiPublishPageInput }>();
+  for (const rawPage of rawPages) {
+    if (mode === 'vnext' && (!rawPage.sourceRefs || rawPage.sourceRefs.length === 0)) {
+      throw new Error('wiki_publish vNext pages must include source refs');
+    }
+    const page = normalizePage(rawPage, compiledAt);
+    byPath.set(page.path, { page, rawPage });
+  }
+  return [...byPath.values()];
+}
+
+export function createWikiPublishAdapter(options: WikiPublishAdapterOptions): WikiPublishAdapter {
+  return {
+    publish(input: { pages: WikiPublishPageInput[] }): WikiPublishResult {
+      const compiledAt = (options.now ?? (() => new Date()))().toISOString();
+      if (!Array.isArray(input.pages)) {
+        throw new Error('wiki_publish pages must be an array');
+      }
+      if (input.pages.length > MAX_WIKI_PUBLISH_PAGES) {
+        throw new Error(`wiki_publish accepts at most ${MAX_WIKI_PUBLISH_PAGES} pages`);
+      }
+      if (options.mode === 'vnext' && !options.store) {
+        throw new Error('Wiki artifact store not configured');
+      }
+
+      const pagePairs = normalizeAndDedupePages(input.pages, compiledAt, options.mode);
+      const pages = pagePairs.map((pair) => pair.page);
+      let artifactsStored = 0;
+
+      if (options.mode === 'vnext') {
+        const artifacts = pagePairs.map(({ page, rawPage }) => {
+          return {
+            path: page.path,
+            title: page.title,
+            type: page.type,
+            content: page.content,
+            confidence: page.confidence,
+            compiledAt: page.compiledAt,
+            sourceRefs: rawPage.sourceRefs ?? [],
+            sourceIds: page.sourceIds,
+            nowMs: options.nowMs?.(),
+          };
+        });
+        artifactsStored = options.store!.upsertArtifacts(artifacts).length;
+        if (options.publisher) {
+          options.publisher(pages);
+        }
+      } else if (options.publisher) {
+        options.publisher(pages);
+      } else {
+        throw new Error('Wiki publisher not configured');
+      }
+
+      return {
+        pagesPublished: options.publisher ? pages.length : 0,
+        artifactsStored,
+      };
+    },
+  };
+}

--- a/packages/standalone/src/wiki/obsidian-writer.ts
+++ b/packages/standalone/src/wiki/obsidian-writer.ts
@@ -8,8 +8,36 @@ import {
 } from 'fs';
 import { join, dirname, basename } from 'path';
 import type { WikiPage } from './types.js';
+import { normalizeWikiPagePath } from './path-safety.js';
 
 const HUMAN_MARKER = '<!-- human -->';
+const FRONTMATTER_LIST_UNSAFE_PATTERN = /[\r\n]/;
+
+function frontmatterScalar(value: string, field: string): string {
+  if (value.includes('\0')) {
+    throw new Error(`${field} contains characters that cannot be safely written to frontmatter`);
+  }
+  return JSON.stringify(value);
+}
+
+function frontmatterListItem(value: string, field: string): string {
+  if (value.includes('\0') || FRONTMATTER_LIST_UNSAFE_PATTERN.test(value)) {
+    throw new Error(`${field} contains characters that cannot be safely written to frontmatter`);
+  }
+  return JSON.stringify(value);
+}
+
+function parseFrontmatterScalar(value: string): string {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (typeof parsed === 'string') {
+      return parsed;
+    }
+  } catch {
+    // Legacy wiki pages wrote unquoted scalars. Keep matching those pages.
+  }
+  return value;
+}
 
 /** Word overlap ratio between two titles. Returns 0-1. */
 function titleWordOverlap(a: string, b: string): number {
@@ -67,7 +95,7 @@ export class ObsidianWriter {
         const content = readFileSync(join(dir, file), 'utf8');
         const titleMatch = content.match(/^title:\s*(.+)$/m);
         if (titleMatch) {
-          const existingTitle = titleMatch[1].trim().toLowerCase();
+          const existingTitle = parseFrontmatterScalar(titleMatch[1].trim()).toLowerCase();
           // Loose match: one title contains the other, or they share >60% of words
           if (
             existingTitle.includes(targetTitle) ||
@@ -100,21 +128,22 @@ export class ObsidianWriter {
   }
 
   writePage(page: WikiPage): void {
+    const safePage = { ...page, path: normalizeWikiPagePath(page.path) };
     // Dedup: check if a similar page already exists in the same directory
-    const existingPath = this.findExistingPage(page);
-    const effectivePath = existingPath || page.path;
+    const existingPath = this.findExistingPage(safePage);
+    const effectivePath = existingPath || safePage.path;
 
     const filePath = join(this.wikiPath, effectivePath);
     const dir = dirname(filePath);
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 
     // Strip duplicate frontmatter from LLM-generated content
-    let cleanContent = page.content;
+    let cleanContent = safePage.content;
     if (cleanContent.trimStart().startsWith('---')) {
       cleanContent = cleanContent.replace(/^[\s]*---[\s\S]*?---[\s]*/, '').trimStart();
     }
     // Strip duplicate title heading if it matches page title
-    const titlePrefix = `# ${page.title}`;
+    const titlePrefix = `# ${safePage.title}`;
     if (cleanContent.startsWith(titlePrefix)) {
       cleanContent = cleanContent.slice(titlePrefix.length).trimStart();
     }
@@ -130,16 +159,22 @@ export class ObsidianWriter {
 
     const frontmatter = [
       '---',
-      `title: ${page.title}`,
-      `type: ${page.type}`,
-      `confidence: ${page.confidence}`,
-      `compiled_at: ${page.compiledAt}`,
+      `title: ${frontmatterScalar(safePage.title, 'title')}`,
+      `type: ${frontmatterScalar(safePage.type, 'type')}`,
+      `confidence: ${frontmatterScalar(safePage.confidence, 'confidence')}`,
+      `compiled_at: ${frontmatterScalar(safePage.compiledAt, 'compiledAt')}`,
+      ...(safePage.sourceRefs && safePage.sourceRefs.length > 0
+        ? [
+            'source_refs:',
+            ...safePage.sourceRefs.map((ref) => `  - ${frontmatterListItem(ref, 'sourceRefs')}`),
+          ]
+        : []),
       `source_ids:`,
-      ...page.sourceIds.map((id) => `  - ${id}`),
+      ...safePage.sourceIds.map((id) => `  - ${frontmatterListItem(id, 'sourceIds')}`),
       '---',
     ].join('\n');
 
-    let body = `${frontmatter}\n\n# ${page.title}\n\n${cleanContent}`;
+    let body = `${frontmatter}\n\n# ${safePage.title}\n\n${cleanContent}`;
     if (humanSection) {
       body += '\n\n' + humanSection;
     }
@@ -160,9 +195,10 @@ export class ObsidianWriter {
 
     const byType = new Map<string, WikiPage[]>();
     for (const p of pages) {
-      const list = byType.get(p.type) || [];
-      list.push(p);
-      byType.set(p.type, list);
+      const safePage = { ...p, path: normalizeWikiPagePath(p.path) };
+      const list = byType.get(safePage.type) || [];
+      list.push(safePage);
+      byType.set(safePage.type, list);
     }
 
     for (const [type, typePages] of byType) {

--- a/packages/standalone/src/wiki/obsidian-writer.ts
+++ b/packages/standalone/src/wiki/obsidian-writer.ts
@@ -6,7 +6,7 @@ import {
   appendFileSync,
   readdirSync,
 } from 'fs';
-import { join, dirname, basename } from 'path';
+import { join, dirname, basename, posix } from 'path';
 import type { WikiPage } from './types.js';
 import { normalizeWikiPagePath } from './path-safety.js';
 
@@ -75,10 +75,11 @@ export class ObsidianWriter {
    * Prevents duplicates when LLM generates different filenames for the same entity.
    */
   private findExistingPage(page: WikiPage): string | null {
-    const dir = join(this.wikiPath, dirname(page.path));
+    const pageDir = posix.dirname(page.path);
+    const dir = join(this.wikiPath, pageDir);
     if (!existsSync(dir)) return null;
 
-    const targetSlug = slugify(basename(page.path, '.md'));
+    const targetSlug = slugify(posix.basename(page.path, '.md'));
     const targetTitle = page.title.toLowerCase();
 
     for (const file of readdirSync(dir)) {
@@ -87,7 +88,7 @@ export class ObsidianWriter {
 
       // Exact slug match (case-insensitive)
       if (fileSlug === targetSlug) {
-        return join(dirname(page.path), file);
+        return posix.join(pageDir, file);
       }
 
       // Title match: read frontmatter and compare
@@ -102,7 +103,7 @@ export class ObsidianWriter {
             targetTitle.includes(existingTitle) ||
             titleWordOverlap(existingTitle, targetTitle) > 0.6
           ) {
-            return join(dirname(page.path), file);
+            return posix.join(pageDir, file);
           }
         }
       } catch {
@@ -127,7 +128,7 @@ export class ObsidianWriter {
     }
   }
 
-  writePage(page: WikiPage): void {
+  writePage(page: WikiPage): string {
     const safePage = { ...page, path: normalizeWikiPagePath(page.path) };
     // Dedup: check if a similar page already exists in the same directory
     const existingPath = this.findExistingPage(safePage);
@@ -180,6 +181,7 @@ export class ObsidianWriter {
     }
 
     writeFileSync(filePath, body, 'utf8');
+    return effectivePath;
   }
 
   appendLog(action: string, message: string): void {

--- a/packages/standalone/src/wiki/path-safety.ts
+++ b/packages/standalone/src/wiki/path-safety.ts
@@ -1,0 +1,41 @@
+import { isAbsolute, posix } from 'path';
+
+const WINDOWS_DRIVE_PATH_PATTERN = /^[A-Za-z]:/;
+const RESERVED_ROOT_PATHS = new Set(['index.md', 'log.md']);
+const RESERVED_ROOT_DIRECTORIES = new Set(['projects', 'lessons', 'synthesis']);
+
+export function normalizeWikiPagePath(value: unknown, field: string = 'wiki page path'): string {
+  if (typeof value !== 'string') {
+    throw new Error(`${field} must be a string`);
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`${field} must not be empty`);
+  }
+  if (
+    trimmed.includes('\0') ||
+    trimmed.includes('\\') ||
+    isAbsolute(trimmed) ||
+    WINDOWS_DRIVE_PATH_PATTERN.test(trimmed)
+  ) {
+    throw new Error(`${field} must stay inside the wiki directory`);
+  }
+  if (trimmed.split('/').includes('..')) {
+    throw new Error(`${field} must not contain parent-directory traversal`);
+  }
+
+  const normalized = posix.normalize(trimmed);
+  if (normalized === '..' || normalized.startsWith('../') || normalized.split('/').includes('..')) {
+    throw new Error(`${field} must not contain parent-directory traversal`);
+  }
+  if (normalized === '.' || normalized === './' || normalized.endsWith('/')) {
+    throw new Error(`${field} must point to a wiki file, not a directory`);
+  }
+  if (RESERVED_ROOT_PATHS.has(normalized.toLowerCase())) {
+    throw new Error(`${field} must not overwrite reserved wiki files`);
+  }
+  if (RESERVED_ROOT_DIRECTORIES.has(normalized.toLowerCase())) {
+    throw new Error(`${field} must not overwrite reserved wiki directories`);
+  }
+  return normalized;
+}

--- a/packages/standalone/src/wiki/types.ts
+++ b/packages/standalone/src/wiki/types.ts
@@ -11,8 +11,10 @@ export interface WikiPage {
   title: string;
   type: WikiPageType;
   content: string;
-  /** Decision IDs this page was compiled from */
+  /** Legacy decision IDs or serialized source refs this page was compiled from */
   sourceIds: string[];
+  /** Canonical vNext source refs this page was compiled from */
+  sourceRefs?: string[];
   /** ISO 8601 timestamp */
   compiledAt: string;
   confidence: 'high' | 'medium' | 'low';

--- a/packages/standalone/tests/agent/agent-result-memory.test.ts
+++ b/packages/standalone/tests/agent/agent-result-memory.test.ts
@@ -8,6 +8,9 @@
 import { describe, it, expect, vi } from 'vitest';
 import { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
 import type { MAMAApiInterface } from '../../src/agent/types.js';
+import Database from '../../src/sqlite.js';
+import { WikiArtifactStore } from '../../src/wiki-artifacts/wiki-artifact-store.js';
+import { createWikiPublishAdapter } from '../../src/wiki-artifacts/wiki-publish-adapter.js';
 
 describe('STORY-AGENT-RESULT-MEMORY: Agent result publication - AC operational outputs stay out of long-term memory', () => {
   const createMockApi = (): MAMAApiInterface => ({
@@ -121,8 +124,8 @@ describe('STORY-AGENT-RESULT-MEMORY: Agent result publication - AC operational o
       executor.setWikiPublisher(publisherFn);
 
       const pages = [
-        { path: '/wiki/api', title: 'API Reference', type: 'entity', content: '# API' },
-        { path: '/wiki/arch', title: 'Architecture', type: 'entity', content: '# Arch' },
+        { path: 'wiki/api', title: 'API Reference', type: 'entity', content: '# API' },
+        { path: 'wiki/arch', title: 'Architecture', type: 'entity', content: '# Arch' },
       ];
 
       const result = await executor.execute('wiki_publish', { pages });
@@ -130,6 +133,70 @@ describe('STORY-AGENT-RESULT-MEMORY: Agent result publication - AC operational o
       expect(result).toMatchObject({ success: true });
       expect(publisherFn).toHaveBeenCalledOnce();
       expect(mockApi.save).not.toHaveBeenCalled();
+    });
+
+    it('preserves supplied source IDs when delegating wiki_publish pages', async () => {
+      const mockApi = createMockApi();
+      const executor = new GatewayToolExecutor({ mamaApi: mockApi });
+      executor.setAgentContext(createAgentContext());
+      const publisherFn = vi.fn();
+      executor.setWikiPublisher(publisherFn);
+
+      await executor.execute('wiki_publish', {
+        pages: [
+          {
+            path: 'wiki/api',
+            title: 'API Reference',
+            type: 'entity',
+            content: '# API',
+            sourceIds: ['decision:d_1'],
+          },
+        ],
+      });
+
+      expect(publisherFn).toHaveBeenCalledWith([
+        expect.objectContaining({ sourceIds: ['decision:d_1'] }),
+      ]);
+      expect(mockApi.save).not.toHaveBeenCalled();
+    });
+
+    it('uses injected vNext wiki adapter to store source-linked artifacts', async () => {
+      const mockApi = createMockApi();
+      const db = new Database(':memory:');
+      const store = new WikiArtifactStore(db);
+      const executor = new GatewayToolExecutor({
+        mamaApi: mockApi,
+        wikiPublishAdapter: createWikiPublishAdapter({
+          mode: 'vnext',
+          store,
+          now: () => new Date('2026-07-02T00:00:00.000Z'),
+          nowMs: () => 1000,
+        }),
+      });
+      executor.setAgentContext(createAgentContext());
+
+      const result = await executor.execute('wiki_publish', {
+        pages: [
+          {
+            path: 'wiki/api.md',
+            title: 'API Reference',
+            type: 'entity',
+            content: '# API',
+            sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          },
+        ],
+      });
+
+      expect(result).toEqual({
+        success: true,
+        message: 'Wiki published: 0 pages',
+        artifactsStored: 1,
+      });
+      expect(store.getByPath('wiki/api.md')).toMatchObject({
+        sourceRefs: ['raw:slack:event-1'],
+      });
+      expect(mockApi.save).not.toHaveBeenCalled();
+      db.close();
     });
 
     it('should handle empty pages array', async () => {
@@ -151,7 +218,7 @@ describe('STORY-AGENT-RESULT-MEMORY: Agent result publication - AC operational o
 
       await expect(
         executor.execute('wiki_publish', {
-          pages: [{ path: '/wiki/test', title: 'Test', type: 'entity', content: 'x' }],
+          pages: [{ path: 'wiki/test', title: 'Test', type: 'entity', content: 'x' }],
         })
       ).rejects.toThrow('Wiki publisher not configured');
 
@@ -166,7 +233,7 @@ describe('STORY-AGENT-RESULT-MEMORY: Agent result publication - AC operational o
       executor.setWikiPublisher(vi.fn());
 
       const result = await executor.execute('wiki_publish', {
-        pages: [{ path: '/wiki/test', title: 'Test', type: 'entity', content: 'Content' }],
+        pages: [{ path: 'wiki/test', title: 'Test', type: 'entity', content: 'Content' }],
       });
 
       expect(result).toMatchObject({ success: true });
@@ -180,7 +247,7 @@ describe('STORY-AGENT-RESULT-MEMORY: Agent result publication - AC operational o
       executor.setWikiPublisher(vi.fn());
 
       const pages = Array.from({ length: 30 }, (_, i) => ({
-        path: `/wiki/page-${i}`,
+        path: `wiki/page-${i}`,
         title: `Page ${i}`,
         type: 'entity',
         content: `Content ${i}`,

--- a/packages/standalone/tests/envelope/memory-scope-mismatch-logging.test.ts
+++ b/packages/standalone/tests/envelope/memory-scope-mismatch-logging.test.ts
@@ -582,7 +582,7 @@ describe('Story M1R: memory scope mismatch audit logging', () => {
     const result = await executor.execute(
       'wiki_publish',
       {
-        pages: [{ path: '/wiki/a.md', title: 'A', type: 'entity', content: 'A page' }],
+        pages: [{ path: 'wiki/a.md', title: 'A', type: 'entity', content: 'A page' }],
       } as unknown as GatewayToolInput,
       {
         agentId: 'wiki',
@@ -598,6 +598,7 @@ describe('Story M1R: memory scope mismatch audit logging', () => {
     expect(result).toEqual({
       success: true,
       message: 'Wiki published: 1 pages',
+      artifactsStored: 0,
     });
     const rows = readGatewayToolRows(db);
     expect(rows.map((row) => row.input_summary)).toEqual(['wiki_publish']);
@@ -693,7 +694,7 @@ describe('Story M1R: memory scope mismatch audit logging', () => {
         toolName === 'report_publish'
           ? ({ slots: { blocked: 'blocked' } } as unknown as GatewayToolInput)
           : ({
-              pages: [{ path: '/wiki/a.md', title: 'A', type: 'entity', content: 'A page' }],
+              pages: [{ path: 'wiki/a.md', title: 'A', type: 'entity', content: 'A page' }],
             } as unknown as GatewayToolInput);
 
       const result = (await executor.execute(toolName, input, {

--- a/packages/standalone/tests/wiki-artifacts/wiki-artifact-store.test.ts
+++ b/packages/standalone/tests/wiki-artifacts/wiki-artifact-store.test.ts
@@ -188,6 +188,40 @@ describe('STORY-VNEXT-PR4-WIKI-ARTIFACTS: wiki artifact store', () => {
     db.close();
   });
 
+  it('loads artifacts by path in the requested order', () => {
+    const db = new Database(':memory:');
+    const store = new WikiArtifactStore(db);
+
+    store.upsertArtifact({
+      path: 'projects/a.md',
+      title: 'A',
+      type: 'entity',
+      content: 'A',
+      confidence: 'medium',
+      compiledAt: '2026-07-02T00:00:00.000Z',
+      sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+      nowMs: 1000,
+    });
+    store.upsertArtifact({
+      path: 'projects/b.md',
+      title: 'B',
+      type: 'entity',
+      content: 'B',
+      confidence: 'medium',
+      compiledAt: '2026-07-02T00:00:00.000Z',
+      sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
+      nowMs: 2000,
+    });
+
+    expect(store.getByPaths(['projects/b.md', 'projects/missing.md', 'projects/a.md'])).toEqual([
+      expect.objectContaining({ path: 'projects/b.md' }),
+      expect.objectContaining({ path: 'projects/a.md' }),
+    ]);
+    expect(store.getByPaths([])).toEqual([]);
+
+    db.close();
+  });
+
   it('rejects artifacts without source refs', () => {
     const db = new Database(':memory:');
     const store = new WikiArtifactStore(db);

--- a/packages/standalone/tests/wiki-artifacts/wiki-artifact-store.test.ts
+++ b/packages/standalone/tests/wiki-artifacts/wiki-artifact-store.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from 'vitest';
+
+process.env.MAMA_FORCE_TIER_3 ||= 'true';
+
+import Database from '../../src/sqlite.js';
+import { applyWikiArtifactsMigration } from '../../src/db/migrations/wiki-artifacts.js';
+import { WikiArtifactStore } from '../../src/wiki-artifacts/wiki-artifact-store.js';
+
+function tableExists(db: Database, tableName: string): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(tableName);
+  return row !== undefined;
+}
+
+describe('STORY-VNEXT-PR4-WIKI-ARTIFACTS: wiki artifact store', () => {
+  it('exposes the wiki artifact schema through a standalone migration', () => {
+    const db = new Database(':memory:');
+
+    applyWikiArtifactsMigration(db);
+    applyWikiArtifactsMigration(db);
+
+    expect(tableExists(db, 'wiki_artifacts')).toBe(true);
+    expect(
+      db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?")
+        .get('idx_wiki_artifacts_updated_at')
+    ).toEqual({ name: 'idx_wiki_artifacts_updated_at' });
+
+    db.close();
+  });
+
+  it('creates the wiki artifact table idempotently', () => {
+    const db = new Database(':memory:');
+    const store = new WikiArtifactStore(db);
+
+    store.ensureSchema();
+    store.ensureSchema();
+
+    expect(tableExists(db, 'wiki_artifacts')).toBe(true);
+    db.close();
+  });
+
+  it('stores wiki artifacts with serialized source refs', () => {
+    const db = new Database(':memory:');
+    const store = new WikiArtifactStore(db);
+
+    const artifact = store.upsertArtifact({
+      path: 'projects/api.md',
+      title: 'API',
+      type: 'entity',
+      content: '## API\n\nContract notes.',
+      confidence: 'high',
+      compiledAt: '2026-07-02T00:00:00.000Z',
+      sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+      nowMs: 1000,
+    });
+
+    expect(artifact).toMatchObject({
+      path: 'projects/api.md',
+      title: 'API',
+      type: 'entity',
+      sourceRefs: ['raw:slack:event-1'],
+      sourceIds: ['raw:slack:event-1'],
+      compiledAt: '2026-07-02T00:00:00.000Z',
+      createdAtMs: 1000,
+      updatedAtMs: 1000,
+    });
+    expect(store.getByPath('projects/api.md')).toMatchObject({
+      path: 'projects/api.md',
+      sourceRefs: ['raw:slack:event-1'],
+    });
+
+    db.close();
+  });
+
+  it('updates same-path artifacts without changing identity or created time', () => {
+    const db = new Database(':memory:');
+    const store = new WikiArtifactStore(db);
+
+    const first = store.upsertArtifact({
+      path: 'projects/api.md',
+      title: 'API',
+      type: 'entity',
+      content: 'first content',
+      confidence: 'medium',
+      compiledAt: '2026-07-02T00:00:00.000Z',
+      sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+      nowMs: 1000,
+    });
+    const second = store.upsertArtifact({
+      path: 'projects/api.md',
+      title: 'API Updated',
+      type: 'lesson',
+      content: 'second content',
+      confidence: 'high',
+      compiledAt: '2026-07-02T01:00:00.000Z',
+      sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
+      nowMs: 2000,
+    });
+
+    expect(second).toMatchObject({
+      artifactId: first.artifactId,
+      createdAtMs: 1000,
+      updatedAtMs: 2000,
+      title: 'API Updated',
+      type: 'lesson',
+      content: 'second content',
+      sourceRefs: ['raw:slack:event-2'],
+    });
+    expect(store.listArtifacts()).toHaveLength(1);
+
+    db.close();
+  });
+
+  it('dedupes same-path artifacts in batch writes with the last artifact winning', () => {
+    const db = new Database(':memory:');
+    const store = new WikiArtifactStore(db);
+
+    const records = store.upsertArtifacts([
+      {
+        path: 'projects/api.md',
+        title: 'API',
+        type: 'entity',
+        content: 'first content',
+        confidence: 'medium',
+        compiledAt: '2026-07-02T00:00:00.000Z',
+        sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+        nowMs: 1000,
+      },
+      {
+        path: './projects/api.md',
+        title: 'API Updated',
+        type: 'lesson',
+        content: 'second content',
+        confidence: 'high',
+        compiledAt: '2026-07-02T01:00:00.000Z',
+        sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
+        nowMs: 2000,
+      },
+    ]);
+
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      path: 'projects/api.md',
+      title: 'API Updated',
+      type: 'lesson',
+      content: 'second content',
+      sourceRefs: ['raw:slack:event-2'],
+    });
+    expect(store.listArtifacts()).toHaveLength(1);
+
+    db.close();
+  });
+
+  it('lists artifact paths without materializing content', () => {
+    const db = new Database(':memory:');
+    const store = new WikiArtifactStore(db);
+
+    store.upsertArtifact({
+      path: 'projects/a.md',
+      title: 'A',
+      type: 'entity',
+      content: 'A',
+      confidence: 'medium',
+      compiledAt: '2026-07-02T00:00:00.000Z',
+      sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+      nowMs: 1000,
+    });
+    store.upsertArtifact({
+      path: 'projects/b.md',
+      title: 'B',
+      type: 'entity',
+      content: 'B',
+      confidence: 'medium',
+      compiledAt: '2026-07-02T00:00:00.000Z',
+      sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
+      nowMs: 2000,
+    });
+
+    expect(store.listArtifactPaths()).toEqual(['projects/b.md', 'projects/a.md']);
+    expect(store.listArtifacts({ offset: 1 }).map((record) => record.path)).toEqual([
+      'projects/a.md',
+    ]);
+    expect(store.listArtifactPaths({ offset: 1 })).toEqual(['projects/a.md']);
+    expect(store.listArtifactPaths({ limit: 1, offset: 1 })).toEqual(['projects/a.md']);
+
+    db.close();
+  });
+
+  it('rejects artifacts without source refs', () => {
+    const db = new Database(':memory:');
+    const store = new WikiArtifactStore(db);
+
+    expect(() =>
+      store.upsertArtifact({
+        path: 'projects/api.md',
+        title: 'API',
+        type: 'entity',
+        content: 'content',
+        confidence: 'medium',
+        compiledAt: '2026-07-02T00:00:00.000Z',
+        sourceRefs: [],
+      })
+    ).toThrow(/source refs/i);
+
+    db.close();
+  });
+
+  it('rejects artifact paths that would escape the wiki directory', () => {
+    const db = new Database(':memory:');
+    const store = new WikiArtifactStore(db);
+
+    for (const path of [
+      '../outside.md',
+      'projects/../index.md',
+      'index.md',
+      'log.md',
+      './',
+      'projects',
+      'projects/',
+      'lessons',
+      'synthesis',
+    ]) {
+      expect(() =>
+        store.upsertArtifact({
+          path,
+          title: 'API',
+          type: 'entity',
+          content: 'content',
+          confidence: 'medium',
+          compiledAt: '2026-07-02T00:00:00.000Z',
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+        })
+      ).toThrow(/parent-directory|reserved wiki files|directories|directory/i);
+    }
+
+    db.close();
+  });
+});

--- a/packages/standalone/tests/wiki-artifacts/wiki-artifact-store.test.ts
+++ b/packages/standalone/tests/wiki-artifacts/wiki-artifact-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 process.env.MAMA_FORCE_TIER_3 ||= 'true';
 
@@ -13,112 +13,96 @@ function tableExists(db: Database, tableName: string): boolean {
   return row !== undefined;
 }
 
-describe('STORY-VNEXT-PR4-WIKI-ARTIFACTS: wiki artifact store', () => {
-  it('exposes the wiki artifact schema through a standalone migration', () => {
-    const db = new Database(':memory:');
+describe('Story PR4.1: Wiki Artifact Store', () => {
+  describe('AC #1: schema, persistence, listing, and validation', () => {
+    it('exposes the wiki artifact schema through a standalone migration', () => {
+      const db = new Database(':memory:');
 
-    applyWikiArtifactsMigration(db);
-    applyWikiArtifactsMigration(db);
+      applyWikiArtifactsMigration(db);
+      applyWikiArtifactsMigration(db);
 
-    expect(tableExists(db, 'wiki_artifacts')).toBe(true);
-    expect(
-      db
-        .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?")
-        .get('idx_wiki_artifacts_updated_at')
-    ).toEqual({ name: 'idx_wiki_artifacts_updated_at' });
+      expect(tableExists(db, 'wiki_artifacts')).toBe(true);
+      expect(
+        db
+          .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?")
+          .get('idx_wiki_artifacts_updated_at')
+      ).toEqual({ name: 'idx_wiki_artifacts_updated_at' });
 
-    db.close();
-  });
-
-  it('creates the wiki artifact table idempotently', () => {
-    const db = new Database(':memory:');
-    const store = new WikiArtifactStore(db);
-
-    store.ensureSchema();
-    store.ensureSchema();
-
-    expect(tableExists(db, 'wiki_artifacts')).toBe(true);
-    db.close();
-  });
-
-  it('stores wiki artifacts with serialized source refs', () => {
-    const db = new Database(':memory:');
-    const store = new WikiArtifactStore(db);
-
-    const artifact = store.upsertArtifact({
-      path: 'projects/api.md',
-      title: 'API',
-      type: 'entity',
-      content: '## API\n\nContract notes.',
-      confidence: 'high',
-      compiledAt: '2026-07-02T00:00:00.000Z',
-      sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
-      nowMs: 1000,
+      db.close();
     });
 
-    expect(artifact).toMatchObject({
-      path: 'projects/api.md',
-      title: 'API',
-      type: 'entity',
-      sourceRefs: ['raw:slack:event-1'],
-      sourceIds: ['raw:slack:event-1'],
-      compiledAt: '2026-07-02T00:00:00.000Z',
-      createdAtMs: 1000,
-      updatedAtMs: 1000,
-    });
-    expect(store.getByPath('projects/api.md')).toMatchObject({
-      path: 'projects/api.md',
-      sourceRefs: ['raw:slack:event-1'],
+    it('creates the wiki artifact table idempotently', () => {
+      const db = new Database(':memory:');
+      const store = new WikiArtifactStore(db);
+
+      store.ensureSchema();
+      store.ensureSchema();
+
+      expect(tableExists(db, 'wiki_artifacts')).toBe(true);
+      db.close();
     });
 
-    db.close();
-  });
+    it('installs the schema only once per store instance', () => {
+      const db = new Database(':memory:');
+      const store = new WikiArtifactStore(db);
+      const execSpy = vi.spyOn(db, 'exec');
 
-  it('updates same-path artifacts without changing identity or created time', () => {
-    const db = new Database(':memory:');
-    const store = new WikiArtifactStore(db);
+      store.ensureSchema();
+      store.ensureSchema();
+      store.upsertArtifact({
+        path: 'projects/api.md',
+        title: 'API',
+        type: 'entity',
+        content: 'content',
+        confidence: 'medium',
+        compiledAt: '2026-07-02T00:00:00.000Z',
+        sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+      });
+      store.listArtifactPaths();
 
-    const first = store.upsertArtifact({
-      path: 'projects/api.md',
-      title: 'API',
-      type: 'entity',
-      content: 'first content',
-      confidence: 'medium',
-      compiledAt: '2026-07-02T00:00:00.000Z',
-      sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
-      nowMs: 1000,
-    });
-    const second = store.upsertArtifact({
-      path: 'projects/api.md',
-      title: 'API Updated',
-      type: 'lesson',
-      content: 'second content',
-      confidence: 'high',
-      compiledAt: '2026-07-02T01:00:00.000Z',
-      sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
-      nowMs: 2000,
+      expect(execSpy).toHaveBeenCalledTimes(1);
+
+      db.close();
     });
 
-    expect(second).toMatchObject({
-      artifactId: first.artifactId,
-      createdAtMs: 1000,
-      updatedAtMs: 2000,
-      title: 'API Updated',
-      type: 'lesson',
-      content: 'second content',
-      sourceRefs: ['raw:slack:event-2'],
+    it('stores wiki artifacts with serialized source refs', () => {
+      const db = new Database(':memory:');
+      const store = new WikiArtifactStore(db);
+
+      const artifact = store.upsertArtifact({
+        path: 'projects/api.md',
+        title: 'API',
+        type: 'entity',
+        content: '## API\n\nContract notes.',
+        confidence: 'high',
+        compiledAt: '2026-07-02T00:00:00.000Z',
+        sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+        nowMs: 1000,
+      });
+
+      expect(artifact).toMatchObject({
+        path: 'projects/api.md',
+        title: 'API',
+        type: 'entity',
+        sourceRefs: ['raw:slack:event-1'],
+        sourceIds: ['raw:slack:event-1'],
+        compiledAt: '2026-07-02T00:00:00.000Z',
+        createdAtMs: 1000,
+        updatedAtMs: 1000,
+      });
+      expect(store.getByPath('projects/api.md')).toMatchObject({
+        path: 'projects/api.md',
+        sourceRefs: ['raw:slack:event-1'],
+      });
+
+      db.close();
     });
-    expect(store.listArtifacts()).toHaveLength(1);
 
-    db.close();
-  });
+    it('updates same-path artifacts without changing identity or created time', () => {
+      const db = new Database(':memory:');
+      const store = new WikiArtifactStore(db);
 
-  it('dedupes same-path artifacts in batch writes with the last artifact winning', () => {
-    const db = new Database(':memory:');
-    const store = new WikiArtifactStore(db);
-
-    const records = store.upsertArtifacts([
-      {
+      const first = store.upsertArtifact({
         path: 'projects/api.md',
         title: 'API',
         type: 'entity',
@@ -127,9 +111,9 @@ describe('STORY-VNEXT-PR4-WIKI-ARTIFACTS: wiki artifact store', () => {
         compiledAt: '2026-07-02T00:00:00.000Z',
         sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
         nowMs: 1000,
-      },
-      {
-        path: './projects/api.md',
+      });
+      const second = store.upsertArtifact({
+        path: 'projects/api.md',
         title: 'API Updated',
         type: 'lesson',
         content: 'second content',
@@ -137,138 +121,179 @@ describe('STORY-VNEXT-PR4-WIKI-ARTIFACTS: wiki artifact store', () => {
         compiledAt: '2026-07-02T01:00:00.000Z',
         sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
         nowMs: 2000,
-      },
-    ]);
+      });
 
-    expect(records).toHaveLength(1);
-    expect(records[0]).toMatchObject({
-      path: 'projects/api.md',
-      title: 'API Updated',
-      type: 'lesson',
-      content: 'second content',
-      sourceRefs: ['raw:slack:event-2'],
-    });
-    expect(store.listArtifacts()).toHaveLength(1);
+      expect(second).toMatchObject({
+        artifactId: first.artifactId,
+        createdAtMs: 1000,
+        updatedAtMs: 2000,
+        title: 'API Updated',
+        type: 'lesson',
+        content: 'second content',
+        sourceRefs: ['raw:slack:event-2'],
+      });
+      expect(store.listArtifacts()).toHaveLength(1);
 
-    db.close();
-  });
-
-  it('lists artifact paths without materializing content', () => {
-    const db = new Database(':memory:');
-    const store = new WikiArtifactStore(db);
-
-    store.upsertArtifact({
-      path: 'projects/a.md',
-      title: 'A',
-      type: 'entity',
-      content: 'A',
-      confidence: 'medium',
-      compiledAt: '2026-07-02T00:00:00.000Z',
-      sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
-      nowMs: 1000,
-    });
-    store.upsertArtifact({
-      path: 'projects/b.md',
-      title: 'B',
-      type: 'entity',
-      content: 'B',
-      confidence: 'medium',
-      compiledAt: '2026-07-02T00:00:00.000Z',
-      sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
-      nowMs: 2000,
+      db.close();
     });
 
-    expect(store.listArtifactPaths()).toEqual(['projects/b.md', 'projects/a.md']);
-    expect(store.listArtifacts({ offset: 1 }).map((record) => record.path)).toEqual([
-      'projects/a.md',
-    ]);
-    expect(store.listArtifactPaths({ offset: 1 })).toEqual(['projects/a.md']);
-    expect(store.listArtifactPaths({ limit: 1, offset: 1 })).toEqual(['projects/a.md']);
+    it('dedupes same-path artifacts in batch writes with the last artifact winning', () => {
+      const db = new Database(':memory:');
+      const store = new WikiArtifactStore(db);
 
-    db.close();
-  });
+      const records = store.upsertArtifacts([
+        {
+          path: 'projects/api.md',
+          title: 'API',
+          type: 'entity',
+          content: 'first content',
+          confidence: 'medium',
+          compiledAt: '2026-07-02T00:00:00.000Z',
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          nowMs: 1000,
+        },
+        {
+          path: './projects/api.md',
+          title: 'API Updated',
+          type: 'lesson',
+          content: 'second content',
+          confidence: 'high',
+          compiledAt: '2026-07-02T01:00:00.000Z',
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
+          nowMs: 2000,
+        },
+      ]);
 
-  it('loads artifacts by path in the requested order', () => {
-    const db = new Database(':memory:');
-    const store = new WikiArtifactStore(db);
-
-    store.upsertArtifact({
-      path: 'projects/a.md',
-      title: 'A',
-      type: 'entity',
-      content: 'A',
-      confidence: 'medium',
-      compiledAt: '2026-07-02T00:00:00.000Z',
-      sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
-      nowMs: 1000,
-    });
-    store.upsertArtifact({
-      path: 'projects/b.md',
-      title: 'B',
-      type: 'entity',
-      content: 'B',
-      confidence: 'medium',
-      compiledAt: '2026-07-02T00:00:00.000Z',
-      sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
-      nowMs: 2000,
-    });
-
-    expect(store.getByPaths(['projects/b.md', 'projects/missing.md', 'projects/a.md'])).toEqual([
-      expect.objectContaining({ path: 'projects/b.md' }),
-      expect.objectContaining({ path: 'projects/a.md' }),
-    ]);
-    expect(store.getByPaths([])).toEqual([]);
-
-    db.close();
-  });
-
-  it('rejects artifacts without source refs', () => {
-    const db = new Database(':memory:');
-    const store = new WikiArtifactStore(db);
-
-    expect(() =>
-      store.upsertArtifact({
+      expect(records).toHaveLength(1);
+      expect(records[0]).toMatchObject({
         path: 'projects/api.md',
-        title: 'API',
+        title: 'API Updated',
+        type: 'lesson',
+        content: 'second content',
+        sourceRefs: ['raw:slack:event-2'],
+      });
+      expect(store.listArtifacts()).toHaveLength(1);
+
+      db.close();
+    });
+
+    it('lists artifact paths without materializing content', () => {
+      const db = new Database(':memory:');
+      const store = new WikiArtifactStore(db);
+
+      store.upsertArtifact({
+        path: 'projects/a.md',
+        title: 'A',
         type: 'entity',
-        content: 'content',
+        content: 'A',
         confidence: 'medium',
         compiledAt: '2026-07-02T00:00:00.000Z',
-        sourceRefs: [],
-      })
-    ).toThrow(/source refs/i);
+        sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+        nowMs: 1000,
+      });
+      store.upsertArtifact({
+        path: 'projects/b.md',
+        title: 'B',
+        type: 'entity',
+        content: 'B',
+        confidence: 'medium',
+        compiledAt: '2026-07-02T00:00:00.000Z',
+        sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
+        nowMs: 2000,
+      });
 
-    db.close();
-  });
+      expect(store.listArtifactPaths()).toEqual(['projects/b.md', 'projects/a.md']);
+      expect(store.listArtifacts({ offset: 1 }).map((record) => record.path)).toEqual([
+        'projects/a.md',
+      ]);
+      expect(store.listArtifactPaths({ offset: 1 })).toEqual(['projects/a.md']);
+      expect(store.listArtifactPaths({ limit: 1, offset: 1 })).toEqual(['projects/a.md']);
 
-  it('rejects artifact paths that would escape the wiki directory', () => {
-    const db = new Database(':memory:');
-    const store = new WikiArtifactStore(db);
+      db.close();
+    });
 
-    for (const path of [
-      '../outside.md',
-      'projects/../index.md',
-      'index.md',
-      'log.md',
-      './',
-      'projects',
-      'projects/',
-      'lessons',
-      'synthesis',
-    ]) {
+    it('loads artifacts by path in the requested order', () => {
+      const db = new Database(':memory:');
+      const store = new WikiArtifactStore(db);
+
+      store.upsertArtifact({
+        path: 'projects/a.md',
+        title: 'A',
+        type: 'entity',
+        content: 'A',
+        confidence: 'medium',
+        compiledAt: '2026-07-02T00:00:00.000Z',
+        sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+        nowMs: 1000,
+      });
+      store.upsertArtifact({
+        path: 'projects/b.md',
+        title: 'B',
+        type: 'entity',
+        content: 'B',
+        confidence: 'medium',
+        compiledAt: '2026-07-02T00:00:00.000Z',
+        sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
+        nowMs: 2000,
+      });
+
+      expect(store.getByPaths(['projects/b.md', 'projects/missing.md', 'projects/a.md'])).toEqual([
+        expect.objectContaining({ path: 'projects/b.md' }),
+        expect.objectContaining({ path: 'projects/a.md' }),
+      ]);
+      expect(store.getByPaths([])).toEqual([]);
+
+      db.close();
+    });
+
+    it('rejects artifacts without source refs', () => {
+      const db = new Database(':memory:');
+      const store = new WikiArtifactStore(db);
+
       expect(() =>
         store.upsertArtifact({
-          path,
+          path: 'projects/api.md',
           title: 'API',
           type: 'entity',
           content: 'content',
           confidence: 'medium',
           compiledAt: '2026-07-02T00:00:00.000Z',
-          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          sourceRefs: [],
         })
-      ).toThrow(/parent-directory|reserved wiki files|directories|directory/i);
-    }
+      ).toThrow(/source refs/i);
 
-    db.close();
+      db.close();
+    });
+
+    it('rejects artifact paths that would escape the wiki directory', () => {
+      const db = new Database(':memory:');
+      const store = new WikiArtifactStore(db);
+
+      for (const path of [
+        '../outside.md',
+        'projects/../index.md',
+        'index.md',
+        'log.md',
+        './',
+        'projects',
+        'projects/',
+        'lessons',
+        'synthesis',
+      ]) {
+        expect(() =>
+          store.upsertArtifact({
+            path,
+            title: 'API',
+            type: 'entity',
+            content: 'content',
+            confidence: 'medium',
+            compiledAt: '2026-07-02T00:00:00.000Z',
+            sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          })
+        ).toThrow(/parent-directory|reserved wiki files|directories|directory/i);
+      }
+
+      db.close();
+    });
   });
 });

--- a/packages/standalone/tests/wiki-artifacts/wiki-exporter.test.ts
+++ b/packages/standalone/tests/wiki-artifacts/wiki-exporter.test.ts
@@ -12,7 +12,7 @@ import { exportWikiArtifactsToObsidian } from '../../src/wiki-artifacts/wiki-exp
 
 let tempDir: string;
 
-describe('STORY-VNEXT-PR4-WIKI-ARTIFACTS: wiki artifact exporter', () => {
+describe('Story PR4.3: Wiki Artifact Exporter', () => {
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'wiki-artifact-exporter-test-'));
   });
@@ -21,44 +21,84 @@ describe('STORY-VNEXT-PR4-WIKI-ARTIFACTS: wiki artifact exporter', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it('exports stored artifacts to Obsidian with source refs preserved in frontmatter', () => {
-    const db = new Database(':memory:');
-    const store = new WikiArtifactStore(db);
-    store.upsertArtifact({
-      path: 'projects/api.md',
-      title: 'API',
-      type: 'entity',
-      content: '## API\n\nContract notes.',
-      confidence: 'high',
-      compiledAt: '2026-07-02T00:00:00.000Z',
-      sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
-      nowMs: 1000,
+  describe('AC #1: source-linked Obsidian export', () => {
+    it('exports stored artifacts to Obsidian with source refs preserved in frontmatter', () => {
+      const db = new Database(':memory:');
+      const store = new WikiArtifactStore(db);
+      store.upsertArtifact({
+        path: 'projects/api.md',
+        title: 'API',
+        type: 'entity',
+        content: '## API\n\nContract notes.',
+        confidence: 'high',
+        compiledAt: '2026-07-02T00:00:00.000Z',
+        sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+        nowMs: 1000,
+      });
+      store.upsertArtifact({
+        path: 'projects/queue.md',
+        title: 'Queue',
+        type: 'entity',
+        content: '## Queue\n\nAsync work notes.',
+        confidence: 'high',
+        compiledAt: '2026-07-02T00:00:00.000Z',
+        sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
+        nowMs: 2000,
+      });
+      const writer = new ObsidianWriter(tempDir, 'wiki');
+      const getByPathSpy = vi.spyOn(store, 'getByPath');
+
+      const result = exportWikiArtifactsToObsidian({ store, writer, batchSize: 1 });
+
+      expect(result).toEqual({ exported: 2, paths: ['projects/queue.md', 'projects/api.md'] });
+      expect(getByPathSpy).not.toHaveBeenCalled();
+      const content = readFileSync(join(tempDir, 'wiki', 'projects', 'api.md'), 'utf8');
+      expect(content).toContain('source_refs:');
+      expect(content).toContain('  - "raw:slack:event-1"');
+      expect(content).toContain('source_ids:');
+      const queueContent = readFileSync(join(tempDir, 'wiki', 'projects', 'queue.md'), 'utf8');
+      expect(queueContent).toContain('  - "raw:slack:event-2"');
+      expect(queueContent).toContain('source_ids:');
+
+      db.close();
     });
-    store.upsertArtifact({
-      path: 'projects/queue.md',
-      title: 'Queue',
-      type: 'entity',
-      content: '## Queue\n\nAsync work notes.',
-      confidence: 'high',
-      compiledAt: '2026-07-02T00:00:00.000Z',
-      sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
-      nowMs: 2000,
+
+    it('reports the effective path selected by ObsidianWriter dedupe', () => {
+      const db = new Database(':memory:');
+      const store = new WikiArtifactStore(db);
+      const writer = new ObsidianWriter(tempDir, 'wiki');
+      writer.ensureDirectories();
+      writer.writePage({
+        path: 'projects/api-canonical.md',
+        title: 'API',
+        type: 'entity',
+        content: 'Existing API notes.',
+        confidence: 'medium',
+        compiledAt: '2026-07-01T00:00:00.000Z',
+        sourceIds: ['decision:d_1'],
+      });
+      store.upsertArtifact({
+        path: 'projects/api-generated.md',
+        title: 'API',
+        type: 'entity',
+        content: '## API\n\nUpdated contract notes.',
+        confidence: 'high',
+        compiledAt: '2026-07-02T00:00:00.000Z',
+        sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+        nowMs: 1000,
+      });
+
+      const result = exportWikiArtifactsToObsidian({ store, writer });
+
+      expect(result).toEqual({ exported: 1, paths: ['projects/api-canonical.md'] });
+      expect(readFileSync(join(tempDir, 'wiki', 'index.md'), 'utf8')).toContain(
+        '[[projects/api-canonical|API]]'
+      );
+      expect(readFileSync(join(tempDir, 'wiki', 'index.md'), 'utf8')).not.toContain(
+        'projects/api-generated'
+      );
+
+      db.close();
     });
-    const writer = new ObsidianWriter(tempDir, 'wiki');
-    const getByPathSpy = vi.spyOn(store, 'getByPath');
-
-    const result = exportWikiArtifactsToObsidian({ store, writer, batchSize: 1 });
-
-    expect(result).toEqual({ exported: 2, paths: ['projects/queue.md', 'projects/api.md'] });
-    expect(getByPathSpy).not.toHaveBeenCalled();
-    const content = readFileSync(join(tempDir, 'wiki', 'projects', 'api.md'), 'utf8');
-    expect(content).toContain('source_refs:');
-    expect(content).toContain('  - "raw:slack:event-1"');
-    expect(content).toContain('source_ids:');
-    const queueContent = readFileSync(join(tempDir, 'wiki', 'projects', 'queue.md'), 'utf8');
-    expect(queueContent).toContain('  - "raw:slack:event-2"');
-    expect(queueContent).toContain('source_ids:');
-
-    db.close();
   });
 });

--- a/packages/standalone/tests/wiki-artifacts/wiki-exporter.test.ts
+++ b/packages/standalone/tests/wiki-artifacts/wiki-exporter.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 process.env.MAMA_FORCE_TIER_3 ||= 'true';
 
@@ -34,15 +34,30 @@ describe('STORY-VNEXT-PR4-WIKI-ARTIFACTS: wiki artifact exporter', () => {
       sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
       nowMs: 1000,
     });
+    store.upsertArtifact({
+      path: 'projects/queue.md',
+      title: 'Queue',
+      type: 'entity',
+      content: '## Queue\n\nAsync work notes.',
+      confidence: 'high',
+      compiledAt: '2026-07-02T00:00:00.000Z',
+      sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
+      nowMs: 2000,
+    });
     const writer = new ObsidianWriter(tempDir, 'wiki');
+    const getByPathSpy = vi.spyOn(store, 'getByPath');
 
-    const result = exportWikiArtifactsToObsidian({ store, writer });
+    const result = exportWikiArtifactsToObsidian({ store, writer, batchSize: 1 });
 
-    expect(result).toEqual({ exported: 1, paths: ['projects/api.md'] });
+    expect(result).toEqual({ exported: 2, paths: ['projects/queue.md', 'projects/api.md'] });
+    expect(getByPathSpy).not.toHaveBeenCalled();
     const content = readFileSync(join(tempDir, 'wiki', 'projects', 'api.md'), 'utf8');
     expect(content).toContain('source_refs:');
     expect(content).toContain('  - "raw:slack:event-1"');
     expect(content).toContain('source_ids:');
+    const queueContent = readFileSync(join(tempDir, 'wiki', 'projects', 'queue.md'), 'utf8');
+    expect(queueContent).toContain('  - "raw:slack:event-2"');
+    expect(queueContent).toContain('source_ids:');
 
     db.close();
   });

--- a/packages/standalone/tests/wiki-artifacts/wiki-exporter.test.ts
+++ b/packages/standalone/tests/wiki-artifacts/wiki-exporter.test.ts
@@ -1,0 +1,49 @@
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+process.env.MAMA_FORCE_TIER_3 ||= 'true';
+
+import Database from '../../src/sqlite.js';
+import { ObsidianWriter } from '../../src/wiki/obsidian-writer.js';
+import { WikiArtifactStore } from '../../src/wiki-artifacts/wiki-artifact-store.js';
+import { exportWikiArtifactsToObsidian } from '../../src/wiki-artifacts/wiki-exporter.js';
+
+let tempDir: string;
+
+describe('STORY-VNEXT-PR4-WIKI-ARTIFACTS: wiki artifact exporter', () => {
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'wiki-artifact-exporter-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('exports stored artifacts to Obsidian with source refs preserved in frontmatter', () => {
+    const db = new Database(':memory:');
+    const store = new WikiArtifactStore(db);
+    store.upsertArtifact({
+      path: 'projects/api.md',
+      title: 'API',
+      type: 'entity',
+      content: '## API\n\nContract notes.',
+      confidence: 'high',
+      compiledAt: '2026-07-02T00:00:00.000Z',
+      sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+      nowMs: 1000,
+    });
+    const writer = new ObsidianWriter(tempDir, 'wiki');
+
+    const result = exportWikiArtifactsToObsidian({ store, writer });
+
+    expect(result).toEqual({ exported: 1, paths: ['projects/api.md'] });
+    const content = readFileSync(join(tempDir, 'wiki', 'projects', 'api.md'), 'utf8');
+    expect(content).toContain('source_refs:');
+    expect(content).toContain('  - "raw:slack:event-1"');
+    expect(content).toContain('source_ids:');
+
+    db.close();
+  });
+});

--- a/packages/standalone/tests/wiki-artifacts/wiki-publish-adapter.test.ts
+++ b/packages/standalone/tests/wiki-artifacts/wiki-publish-adapter.test.ts
@@ -6,138 +6,93 @@ import Database from '../../src/sqlite.js';
 import { WikiArtifactStore } from '../../src/wiki-artifacts/wiki-artifact-store.js';
 import { createWikiPublishAdapter } from '../../src/wiki-artifacts/wiki-publish-adapter.js';
 
-describe('STORY-VNEXT-PR4-WIKI-ARTIFACTS: wiki publish adapter', () => {
-  it('keeps legacy wiki_publish compatible while preserving supplied source IDs', () => {
-    const publisher = vi.fn();
-    const adapter = createWikiPublishAdapter({
-      mode: 'legacy',
-      publisher,
-      now: () => new Date('2026-07-02T00:00:00.000Z'),
-    });
+describe('Story PR4.2: Wiki Publish Adapter', () => {
+  describe('AC #1: legacy compatibility, vNext storage, and validation', () => {
+    it('keeps legacy wiki_publish compatible while preserving supplied source IDs', () => {
+      const publisher = vi.fn();
+      const adapter = createWikiPublishAdapter({
+        mode: 'legacy',
+        publisher,
+        now: () => new Date('2026-07-02T00:00:00.000Z'),
+      });
 
-    const result = adapter.publish({
-      pages: [
-        {
-          path: 'projects/api.md',
-          title: 'API',
-          type: 'entity',
-          content: 'content',
-          sourceIds: ['decision:d_1'],
-        },
-      ],
-    });
-
-    expect(result).toEqual({ pagesPublished: 1, artifactsStored: 0 });
-    expect(publisher).toHaveBeenCalledWith([
-      {
-        path: 'projects/api.md',
-        title: 'API',
-        type: 'entity',
-        content: 'content',
-        sourceIds: ['decision:d_1'],
-        sourceRefs: [],
-        compiledAt: '2026-07-02T00:00:00.000Z',
-        confidence: 'medium',
-      },
-    ]);
-  });
-
-  it('rejects vNext wiki_publish pages that do not carry source refs', () => {
-    const db = new Database(':memory:');
-    const store = new WikiArtifactStore(db);
-    const adapter = createWikiPublishAdapter({ mode: 'vnext', store });
-
-    expect(() =>
-      adapter.publish({
+      const result = adapter.publish({
         pages: [
           {
             path: 'projects/api.md',
-            title: 'API',
-            type: 'entity',
-            content: 'content',
-          },
-        ],
-      })
-    ).toThrow(/source refs/i);
-
-    db.close();
-  });
-
-  it('rejects vNext publishing when no artifact store is configured', () => {
-    const publisher = vi.fn();
-    const adapter = createWikiPublishAdapter({ mode: 'vnext', publisher });
-
-    expect(() =>
-      adapter.publish({
-        pages: [
-          {
-            path: 'projects/api.md',
-            title: 'API',
-            type: 'entity',
-            content: 'content',
-            sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
-          },
-        ],
-      })
-    ).toThrow(/store not configured/i);
-    expect(publisher).not.toHaveBeenCalled();
-  });
-
-  it('rejects malformed page fields before invoking the publisher', () => {
-    const publisher = vi.fn();
-    const adapter = createWikiPublishAdapter({ mode: 'legacy', publisher });
-
-    expect(() =>
-      adapter.publish({
-        pages: [
-          {
-            path: '   ',
             title: 'API',
             type: 'entity',
             content: 'content',
             sourceIds: ['decision:d_1'],
           },
         ],
-      })
-    ).toThrow(/path must not be empty/i);
-    expect(() =>
-      adapter.publish({
-        pages: [
-          {
-            path: 'projects/api.md',
-            title: 'API',
-            type: 'entity',
-            content: 'content',
-            sourceIds: ['   '],
-          },
-        ],
-      })
-    ).toThrow(/sourceIds/i);
-    expect(publisher).not.toHaveBeenCalled();
-  });
+      });
 
-  it('rejects page paths that would escape the wiki directory', () => {
-    const publisher = vi.fn();
-    const adapter = createWikiPublishAdapter({ mode: 'legacy', publisher });
+      expect(result).toEqual({ pagesPublished: 1, artifactsStored: 0 });
+      expect(publisher).toHaveBeenCalledWith([
+        {
+          path: 'projects/api.md',
+          title: 'API',
+          type: 'entity',
+          content: 'content',
+          sourceIds: ['decision:d_1'],
+          sourceRefs: [],
+          compiledAt: '2026-07-02T00:00:00.000Z',
+          confidence: 'medium',
+        },
+      ]);
+    });
 
-    for (const path of [
-      '../outside.md',
-      'projects/../index.md',
-      'projects/../../outside.md',
-      '/tmp/outside.md',
-      'index.md',
-      'log.md',
-      './',
-      'projects',
-      'projects/',
-      'lessons',
-      'synthesis',
-    ]) {
+    it('rejects vNext wiki_publish pages that do not carry source refs', () => {
+      const db = new Database(':memory:');
+      const store = new WikiArtifactStore(db);
+      const adapter = createWikiPublishAdapter({ mode: 'vnext', store });
+
       expect(() =>
         adapter.publish({
           pages: [
             {
-              path,
+              path: 'projects/api.md',
+              title: 'API',
+              type: 'entity',
+              content: 'content',
+            },
+          ],
+        })
+      ).toThrow(/source refs/i);
+
+      db.close();
+    });
+
+    it('rejects vNext publishing when no artifact store is configured', () => {
+      const publisher = vi.fn();
+      const adapter = createWikiPublishAdapter({ mode: 'vnext', publisher });
+
+      expect(() =>
+        adapter.publish({
+          pages: [
+            {
+              path: 'projects/api.md',
+              title: 'API',
+              type: 'entity',
+              content: 'content',
+              sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+            },
+          ],
+        })
+      ).toThrow(/store not configured/i);
+      expect(publisher).not.toHaveBeenCalled();
+    });
+
+    it('rejects malformed page fields before invoking the publisher', () => {
+      const publisher = vi.fn();
+      const adapter = createWikiPublishAdapter({ mode: 'legacy', publisher });
+
+      expect(() =>
+        adapter.publish({
+          pages: [
+            {
+              path: '   ',
               title: 'API',
               type: 'entity',
               content: 'content',
@@ -145,219 +100,266 @@ describe('STORY-VNEXT-PR4-WIKI-ARTIFACTS: wiki publish adapter', () => {
             },
           ],
         })
-      ).toThrow(/wiki directory|parent-directory|reserved wiki files|directories|directory/i);
-    }
-    expect(publisher).not.toHaveBeenCalled();
-  });
-
-  it('rejects unsupported explicit type and confidence values before invoking the publisher', () => {
-    const publisher = vi.fn();
-    const adapter = createWikiPublishAdapter({ mode: 'legacy', publisher });
-
-    expect(() =>
-      adapter.publish({
-        pages: [
-          {
-            path: 'projects/api.md',
-            title: 'API',
-            type: 'not-a-type',
-            content: 'content',
-            sourceIds: ['decision:d_1'],
-          },
-        ],
-      })
-    ).toThrow(/type/i);
-    expect(() =>
-      adapter.publish({
-        pages: [
-          {
-            path: 'projects/api.md',
-            title: 'API',
-            type: 'entity',
-            content: 'content',
-            confidence: 'certain',
-            sourceIds: ['decision:d_1'],
-          },
-        ],
-      })
-    ).toThrow(/confidence/i);
-    expect(publisher).not.toHaveBeenCalled();
-  });
-
-  it('rejects non-string page fields before invoking the publisher', () => {
-    const publisher = vi.fn();
-    const adapter = createWikiPublishAdapter({ mode: 'legacy', publisher });
-
-    expect(() =>
-      adapter.publish({
-        pages: [
-          {
-            path: 123 as never,
-            title: 'API',
-            type: 'entity',
-            content: 'content',
-          },
-        ],
-      })
-    ).toThrow(/path must be a string/i);
-    expect(publisher).not.toHaveBeenCalled();
-  });
-
-  it('rejects oversized wiki_publish requests before invoking the publisher', () => {
-    const publisher = vi.fn();
-    const adapter = createWikiPublishAdapter({ mode: 'legacy', publisher });
-
-    expect(() =>
-      adapter.publish({
-        pages: Array.from({ length: 101 }, (_, index) => ({
-          path: `projects/api-${index}.md`,
-          title: `API ${index}`,
-          type: 'entity',
-          content: 'content',
-          sourceIds: [`decision:d_${index}`],
-        })),
-      })
-    ).toThrow(/at most 100 pages/i);
-    expect(() =>
-      adapter.publish({
-        pages: [
-          {
-            path: 'projects/api.md',
-            title: 'API',
-            type: 'entity',
-            content: 'x'.repeat(200_001),
-            sourceIds: ['decision:d_1'],
-          },
-        ],
-      })
-    ).toThrow(/must not exceed 200000 characters/i);
-    expect(publisher).not.toHaveBeenCalled();
-  });
-
-  it('dedupes same-path pages before publishing or storing artifacts', () => {
-    const db = new Database(':memory:');
-    const store = new WikiArtifactStore(db);
-    const publisher = vi.fn();
-    const adapter = createWikiPublishAdapter({
-      mode: 'vnext',
-      store,
-      publisher,
-      now: () => new Date('2026-07-02T00:00:00.000Z'),
-      nowMs: () => 2000,
+      ).toThrow(/path must not be empty/i);
+      expect(() =>
+        adapter.publish({
+          pages: [
+            {
+              path: 'projects/api.md',
+              title: 'API',
+              type: 'entity',
+              content: 'content',
+              sourceIds: ['   '],
+            },
+          ],
+        })
+      ).toThrow(/sourceIds/i);
+      expect(publisher).not.toHaveBeenCalled();
     });
 
-    const result = adapter.publish({
-      pages: [
-        {
+    it('rejects page paths that would escape the wiki directory', () => {
+      const publisher = vi.fn();
+      const adapter = createWikiPublishAdapter({ mode: 'legacy', publisher });
+
+      for (const path of [
+        '../outside.md',
+        'projects/../index.md',
+        'projects/../../outside.md',
+        '/tmp/outside.md',
+        'index.md',
+        'log.md',
+        './',
+        'projects',
+        'projects/',
+        'lessons',
+        'synthesis',
+      ]) {
+        expect(() =>
+          adapter.publish({
+            pages: [
+              {
+                path,
+                title: 'API',
+                type: 'entity',
+                content: 'content',
+                sourceIds: ['decision:d_1'],
+              },
+            ],
+          })
+        ).toThrow(/wiki directory|parent-directory|reserved wiki files|directories|directory/i);
+      }
+      expect(publisher).not.toHaveBeenCalled();
+    });
+
+    it('rejects unsupported explicit type and confidence values before invoking the publisher', () => {
+      const publisher = vi.fn();
+      const adapter = createWikiPublishAdapter({ mode: 'legacy', publisher });
+
+      expect(() =>
+        adapter.publish({
+          pages: [
+            {
+              path: 'projects/api.md',
+              title: 'API',
+              type: 'not-a-type',
+              content: 'content',
+              sourceIds: ['decision:d_1'],
+            },
+          ],
+        })
+      ).toThrow(/type/i);
+      expect(() =>
+        adapter.publish({
+          pages: [
+            {
+              path: 'projects/api.md',
+              title: 'API',
+              type: 'entity',
+              content: 'content',
+              confidence: 'certain',
+              sourceIds: ['decision:d_1'],
+            },
+          ],
+        })
+      ).toThrow(/confidence/i);
+      expect(publisher).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-string page fields before invoking the publisher', () => {
+      const publisher = vi.fn();
+      const adapter = createWikiPublishAdapter({ mode: 'legacy', publisher });
+
+      expect(() =>
+        adapter.publish({
+          pages: [
+            {
+              path: 123 as never,
+              title: 'API',
+              type: 'entity',
+              content: 'content',
+            },
+          ],
+        })
+      ).toThrow(/path must be a string/i);
+      expect(publisher).not.toHaveBeenCalled();
+    });
+
+    it('rejects oversized wiki_publish requests before invoking the publisher', () => {
+      const publisher = vi.fn();
+      const adapter = createWikiPublishAdapter({ mode: 'legacy', publisher });
+
+      expect(() =>
+        adapter.publish({
+          pages: Array.from({ length: 101 }, (_, index) => ({
+            path: `projects/api-${index}.md`,
+            title: `API ${index}`,
+            type: 'entity',
+            content: 'content',
+            sourceIds: [`decision:d_${index}`],
+          })),
+        })
+      ).toThrow(/at most 100 pages/i);
+      expect(() =>
+        adapter.publish({
+          pages: [
+            {
+              path: 'projects/api.md',
+              title: 'API',
+              type: 'entity',
+              content: 'x'.repeat(200_001),
+              sourceIds: ['decision:d_1'],
+            },
+          ],
+        })
+      ).toThrow(/must not exceed 200000 characters/i);
+      expect(publisher).not.toHaveBeenCalled();
+    });
+
+    it('dedupes same-path pages before publishing or storing artifacts', () => {
+      const db = new Database(':memory:');
+      const store = new WikiArtifactStore(db);
+      const publisher = vi.fn();
+      const adapter = createWikiPublishAdapter({
+        mode: 'vnext',
+        store,
+        publisher,
+        now: () => new Date('2026-07-02T00:00:00.000Z'),
+        nowMs: () => 2000,
+      });
+
+      const result = adapter.publish({
+        pages: [
+          {
+            path: 'projects/api.md',
+            title: 'API',
+            type: 'entity',
+            content: 'first content',
+            sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          },
+          {
+            path: './projects/api.md',
+            title: 'API Updated',
+            type: 'lesson',
+            content: 'second content',
+            sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
+          },
+        ],
+      });
+
+      expect(result).toEqual({ pagesPublished: 1, artifactsStored: 1 });
+      expect(publisher).toHaveBeenCalledWith([
+        expect.objectContaining({
           path: 'projects/api.md',
-          title: 'API',
-          type: 'entity',
-          content: 'first content',
-          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
-        },
-        {
-          path: './projects/api.md',
           title: 'API Updated',
-          type: 'lesson',
           content: 'second content',
-          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
-        },
-      ],
-    });
-
-    expect(result).toEqual({ pagesPublished: 1, artifactsStored: 1 });
-    expect(publisher).toHaveBeenCalledWith([
-      expect.objectContaining({
-        path: 'projects/api.md',
+          sourceRefs: ['raw:slack:event-2'],
+        }),
+      ]);
+      expect(store.getByPath('projects/api.md')).toMatchObject({
         title: 'API Updated',
+        type: 'lesson',
         content: 'second content',
         sourceRefs: ['raw:slack:event-2'],
-      }),
-    ]);
-    expect(store.getByPath('projects/api.md')).toMatchObject({
-      title: 'API Updated',
-      type: 'lesson',
-      content: 'second content',
-      sourceRefs: ['raw:slack:event-2'],
+      });
+
+      db.close();
     });
 
-    db.close();
-  });
+    it('persists vNext artifacts before publishing so failed vault writes remain retryable', () => {
+      const db = new Database(':memory:');
+      const store = new WikiArtifactStore(db);
+      const publisher = vi.fn(() => {
+        throw new Error('vault write failed');
+      });
+      const adapter = createWikiPublishAdapter({
+        mode: 'vnext',
+        store,
+        publisher,
+        now: () => new Date('2026-07-02T00:00:00.000Z'),
+        nowMs: () => 2000,
+      });
 
-  it('persists vNext artifacts before publishing so failed vault writes remain retryable', () => {
-    const db = new Database(':memory:');
-    const store = new WikiArtifactStore(db);
-    const publisher = vi.fn(() => {
-      throw new Error('vault write failed');
-    });
-    const adapter = createWikiPublishAdapter({
-      mode: 'vnext',
-      store,
-      publisher,
-      now: () => new Date('2026-07-02T00:00:00.000Z'),
-      nowMs: () => 2000,
+      expect(() =>
+        adapter.publish({
+          pages: [
+            {
+              path: 'projects/api.md',
+              title: 'API',
+              type: 'entity',
+              content: 'content',
+              sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+            },
+          ],
+        })
+      ).toThrow(/vault write failed/i);
+
+      expect(store.getByPath('projects/api.md')).toMatchObject({
+        path: 'projects/api.md',
+        sourceRefs: ['raw:slack:event-1'],
+      });
+
+      db.close();
     });
 
-    expect(() =>
-      adapter.publish({
+    it('stores vNext wiki artifacts and publishes source-linked pages', () => {
+      const db = new Database(':memory:');
+      const store = new WikiArtifactStore(db);
+      const publisher = vi.fn();
+      const adapter = createWikiPublishAdapter({
+        mode: 'vnext',
+        store,
+        publisher,
+        now: () => new Date('2026-07-02T00:00:00.000Z'),
+        nowMs: () => 2000,
+      });
+
+      const result = adapter.publish({
         pages: [
           {
             path: 'projects/api.md',
             title: 'API',
             type: 'entity',
             content: 'content',
+            confidence: 'high',
             sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
           },
         ],
-      })
-    ).toThrow(/vault write failed/i);
+      });
 
-    expect(store.getByPath('projects/api.md')).toMatchObject({
-      path: 'projects/api.md',
-      sourceRefs: ['raw:slack:event-1'],
-    });
-
-    db.close();
-  });
-
-  it('stores vNext wiki artifacts and publishes source-linked pages', () => {
-    const db = new Database(':memory:');
-    const store = new WikiArtifactStore(db);
-    const publisher = vi.fn();
-    const adapter = createWikiPublishAdapter({
-      mode: 'vnext',
-      store,
-      publisher,
-      now: () => new Date('2026-07-02T00:00:00.000Z'),
-      nowMs: () => 2000,
-    });
-
-    const result = adapter.publish({
-      pages: [
-        {
-          path: 'projects/api.md',
-          title: 'API',
-          type: 'entity',
-          content: 'content',
-          confidence: 'high',
-          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
-        },
-      ],
-    });
-
-    expect(result).toEqual({ pagesPublished: 1, artifactsStored: 1 });
-    expect(store.getByPath('projects/api.md')).toMatchObject({
-      path: 'projects/api.md',
-      sourceRefs: ['raw:slack:event-1'],
-    });
-    expect(publisher).toHaveBeenCalledWith([
-      expect.objectContaining({
+      expect(result).toEqual({ pagesPublished: 1, artifactsStored: 1 });
+      expect(store.getByPath('projects/api.md')).toMatchObject({
         path: 'projects/api.md',
-        sourceIds: ['raw:slack:event-1'],
         sourceRefs: ['raw:slack:event-1'],
-      }),
-    ]);
+      });
+      expect(publisher).toHaveBeenCalledWith([
+        expect.objectContaining({
+          path: 'projects/api.md',
+          sourceIds: ['raw:slack:event-1'],
+          sourceRefs: ['raw:slack:event-1'],
+        }),
+      ]);
 
-    db.close();
+      db.close();
+    });
   });
 });

--- a/packages/standalone/tests/wiki-artifacts/wiki-publish-adapter.test.ts
+++ b/packages/standalone/tests/wiki-artifacts/wiki-publish-adapter.test.ts
@@ -1,0 +1,363 @@
+import { describe, expect, it, vi } from 'vitest';
+
+process.env.MAMA_FORCE_TIER_3 ||= 'true';
+
+import Database from '../../src/sqlite.js';
+import { WikiArtifactStore } from '../../src/wiki-artifacts/wiki-artifact-store.js';
+import { createWikiPublishAdapter } from '../../src/wiki-artifacts/wiki-publish-adapter.js';
+
+describe('STORY-VNEXT-PR4-WIKI-ARTIFACTS: wiki publish adapter', () => {
+  it('keeps legacy wiki_publish compatible while preserving supplied source IDs', () => {
+    const publisher = vi.fn();
+    const adapter = createWikiPublishAdapter({
+      mode: 'legacy',
+      publisher,
+      now: () => new Date('2026-07-02T00:00:00.000Z'),
+    });
+
+    const result = adapter.publish({
+      pages: [
+        {
+          path: 'projects/api.md',
+          title: 'API',
+          type: 'entity',
+          content: 'content',
+          sourceIds: ['decision:d_1'],
+        },
+      ],
+    });
+
+    expect(result).toEqual({ pagesPublished: 1, artifactsStored: 0 });
+    expect(publisher).toHaveBeenCalledWith([
+      {
+        path: 'projects/api.md',
+        title: 'API',
+        type: 'entity',
+        content: 'content',
+        sourceIds: ['decision:d_1'],
+        sourceRefs: [],
+        compiledAt: '2026-07-02T00:00:00.000Z',
+        confidence: 'medium',
+      },
+    ]);
+  });
+
+  it('rejects vNext wiki_publish pages that do not carry source refs', () => {
+    const db = new Database(':memory:');
+    const store = new WikiArtifactStore(db);
+    const adapter = createWikiPublishAdapter({ mode: 'vnext', store });
+
+    expect(() =>
+      adapter.publish({
+        pages: [
+          {
+            path: 'projects/api.md',
+            title: 'API',
+            type: 'entity',
+            content: 'content',
+          },
+        ],
+      })
+    ).toThrow(/source refs/i);
+
+    db.close();
+  });
+
+  it('rejects vNext publishing when no artifact store is configured', () => {
+    const publisher = vi.fn();
+    const adapter = createWikiPublishAdapter({ mode: 'vnext', publisher });
+
+    expect(() =>
+      adapter.publish({
+        pages: [
+          {
+            path: 'projects/api.md',
+            title: 'API',
+            type: 'entity',
+            content: 'content',
+            sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          },
+        ],
+      })
+    ).toThrow(/store not configured/i);
+    expect(publisher).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed page fields before invoking the publisher', () => {
+    const publisher = vi.fn();
+    const adapter = createWikiPublishAdapter({ mode: 'legacy', publisher });
+
+    expect(() =>
+      adapter.publish({
+        pages: [
+          {
+            path: '   ',
+            title: 'API',
+            type: 'entity',
+            content: 'content',
+            sourceIds: ['decision:d_1'],
+          },
+        ],
+      })
+    ).toThrow(/path must not be empty/i);
+    expect(() =>
+      adapter.publish({
+        pages: [
+          {
+            path: 'projects/api.md',
+            title: 'API',
+            type: 'entity',
+            content: 'content',
+            sourceIds: ['   '],
+          },
+        ],
+      })
+    ).toThrow(/sourceIds/i);
+    expect(publisher).not.toHaveBeenCalled();
+  });
+
+  it('rejects page paths that would escape the wiki directory', () => {
+    const publisher = vi.fn();
+    const adapter = createWikiPublishAdapter({ mode: 'legacy', publisher });
+
+    for (const path of [
+      '../outside.md',
+      'projects/../index.md',
+      'projects/../../outside.md',
+      '/tmp/outside.md',
+      'index.md',
+      'log.md',
+      './',
+      'projects',
+      'projects/',
+      'lessons',
+      'synthesis',
+    ]) {
+      expect(() =>
+        adapter.publish({
+          pages: [
+            {
+              path,
+              title: 'API',
+              type: 'entity',
+              content: 'content',
+              sourceIds: ['decision:d_1'],
+            },
+          ],
+        })
+      ).toThrow(/wiki directory|parent-directory|reserved wiki files|directories|directory/i);
+    }
+    expect(publisher).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported explicit type and confidence values before invoking the publisher', () => {
+    const publisher = vi.fn();
+    const adapter = createWikiPublishAdapter({ mode: 'legacy', publisher });
+
+    expect(() =>
+      adapter.publish({
+        pages: [
+          {
+            path: 'projects/api.md',
+            title: 'API',
+            type: 'not-a-type',
+            content: 'content',
+            sourceIds: ['decision:d_1'],
+          },
+        ],
+      })
+    ).toThrow(/type/i);
+    expect(() =>
+      adapter.publish({
+        pages: [
+          {
+            path: 'projects/api.md',
+            title: 'API',
+            type: 'entity',
+            content: 'content',
+            confidence: 'certain',
+            sourceIds: ['decision:d_1'],
+          },
+        ],
+      })
+    ).toThrow(/confidence/i);
+    expect(publisher).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-string page fields before invoking the publisher', () => {
+    const publisher = vi.fn();
+    const adapter = createWikiPublishAdapter({ mode: 'legacy', publisher });
+
+    expect(() =>
+      adapter.publish({
+        pages: [
+          {
+            path: 123 as never,
+            title: 'API',
+            type: 'entity',
+            content: 'content',
+          },
+        ],
+      })
+    ).toThrow(/path must be a string/i);
+    expect(publisher).not.toHaveBeenCalled();
+  });
+
+  it('rejects oversized wiki_publish requests before invoking the publisher', () => {
+    const publisher = vi.fn();
+    const adapter = createWikiPublishAdapter({ mode: 'legacy', publisher });
+
+    expect(() =>
+      adapter.publish({
+        pages: Array.from({ length: 101 }, (_, index) => ({
+          path: `projects/api-${index}.md`,
+          title: `API ${index}`,
+          type: 'entity',
+          content: 'content',
+          sourceIds: [`decision:d_${index}`],
+        })),
+      })
+    ).toThrow(/at most 100 pages/i);
+    expect(() =>
+      adapter.publish({
+        pages: [
+          {
+            path: 'projects/api.md',
+            title: 'API',
+            type: 'entity',
+            content: 'x'.repeat(200_001),
+            sourceIds: ['decision:d_1'],
+          },
+        ],
+      })
+    ).toThrow(/must not exceed 200000 characters/i);
+    expect(publisher).not.toHaveBeenCalled();
+  });
+
+  it('dedupes same-path pages before publishing or storing artifacts', () => {
+    const db = new Database(':memory:');
+    const store = new WikiArtifactStore(db);
+    const publisher = vi.fn();
+    const adapter = createWikiPublishAdapter({
+      mode: 'vnext',
+      store,
+      publisher,
+      now: () => new Date('2026-07-02T00:00:00.000Z'),
+      nowMs: () => 2000,
+    });
+
+    const result = adapter.publish({
+      pages: [
+        {
+          path: 'projects/api.md',
+          title: 'API',
+          type: 'entity',
+          content: 'first content',
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+        },
+        {
+          path: './projects/api.md',
+          title: 'API Updated',
+          type: 'lesson',
+          content: 'second content',
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
+        },
+      ],
+    });
+
+    expect(result).toEqual({ pagesPublished: 1, artifactsStored: 1 });
+    expect(publisher).toHaveBeenCalledWith([
+      expect.objectContaining({
+        path: 'projects/api.md',
+        title: 'API Updated',
+        content: 'second content',
+        sourceRefs: ['raw:slack:event-2'],
+      }),
+    ]);
+    expect(store.getByPath('projects/api.md')).toMatchObject({
+      title: 'API Updated',
+      type: 'lesson',
+      content: 'second content',
+      sourceRefs: ['raw:slack:event-2'],
+    });
+
+    db.close();
+  });
+
+  it('persists vNext artifacts before publishing so failed vault writes remain retryable', () => {
+    const db = new Database(':memory:');
+    const store = new WikiArtifactStore(db);
+    const publisher = vi.fn(() => {
+      throw new Error('vault write failed');
+    });
+    const adapter = createWikiPublishAdapter({
+      mode: 'vnext',
+      store,
+      publisher,
+      now: () => new Date('2026-07-02T00:00:00.000Z'),
+      nowMs: () => 2000,
+    });
+
+    expect(() =>
+      adapter.publish({
+        pages: [
+          {
+            path: 'projects/api.md',
+            title: 'API',
+            type: 'entity',
+            content: 'content',
+            sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          },
+        ],
+      })
+    ).toThrow(/vault write failed/i);
+
+    expect(store.getByPath('projects/api.md')).toMatchObject({
+      path: 'projects/api.md',
+      sourceRefs: ['raw:slack:event-1'],
+    });
+
+    db.close();
+  });
+
+  it('stores vNext wiki artifacts and publishes source-linked pages', () => {
+    const db = new Database(':memory:');
+    const store = new WikiArtifactStore(db);
+    const publisher = vi.fn();
+    const adapter = createWikiPublishAdapter({
+      mode: 'vnext',
+      store,
+      publisher,
+      now: () => new Date('2026-07-02T00:00:00.000Z'),
+      nowMs: () => 2000,
+    });
+
+    const result = adapter.publish({
+      pages: [
+        {
+          path: 'projects/api.md',
+          title: 'API',
+          type: 'entity',
+          content: 'content',
+          confidence: 'high',
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+        },
+      ],
+    });
+
+    expect(result).toEqual({ pagesPublished: 1, artifactsStored: 1 });
+    expect(store.getByPath('projects/api.md')).toMatchObject({
+      path: 'projects/api.md',
+      sourceRefs: ['raw:slack:event-1'],
+    });
+    expect(publisher).toHaveBeenCalledWith([
+      expect.objectContaining({
+        path: 'projects/api.md',
+        sourceIds: ['raw:slack:event-1'],
+        sourceRefs: ['raw:slack:event-1'],
+      }),
+    ]);
+
+    db.close();
+  });
+});

--- a/packages/standalone/tests/wiki/integration.test.ts
+++ b/packages/standalone/tests/wiki/integration.test.ts
@@ -57,8 +57,8 @@ describe('Wiki compilation integration', () => {
     writer.appendLog('compile', result.logEntry);
 
     const pageContent = readFileSync(join(tempDir, 'wiki', 'projects', 'TestProject.md'), 'utf8');
-    expect(pageContent).toContain('title: TestProject');
-    expect(pageContent).toContain('type: entity');
+    expect(pageContent).toContain('title: "TestProject"');
+    expect(pageContent).toContain('type: "entity"');
     expect(pageContent).toContain('Chose React over Vue');
 
     const index = readFileSync(join(tempDir, 'wiki', 'index.md'), 'utf8');
@@ -103,7 +103,7 @@ describe('Wiki compilation integration', () => {
     expect(result).toContain('Completed!');
     expect(result).toContain('My Observations');
     expect(result).toContain('This project needs attention.');
-    expect(result).toContain('confidence: high');
+    expect(result).toContain('confidence: "high"');
   });
 
   it('handles multiple projects in one compilation', () => {

--- a/packages/standalone/tests/wiki/obsidian-writer.test.ts
+++ b/packages/standalone/tests/wiki/obsidian-writer.test.ts
@@ -41,11 +41,99 @@ describe('ObsidianWriter', () => {
 
     const content = readFileSync(join(wikiDir, 'projects', 'ProjectAlpha.md'), 'utf8');
     expect(content).toContain('---');
-    expect(content).toContain('title: ProjectAlpha');
-    expect(content).toContain('type: entity');
-    expect(content).toContain('confidence: high');
+    expect(content).toContain('title: "ProjectAlpha"');
+    expect(content).toContain('type: "entity"');
+    expect(content).toContain('confidence: "high"');
     expect(content).toContain('source_ids:');
+    expect(content).toContain('  - "d_123"');
     expect(content).toContain('## Current Status');
+  });
+
+  it('quotes frontmatter scalars that YAML could otherwise reinterpret', () => {
+    const writer = new ObsidianWriter(tempDir, 'wiki');
+    writer.ensureDirectories();
+    const page: WikiPage = {
+      path: 'projects/ProjectAlpha.md',
+      title: 'ProjectAlpha: true # comment',
+      type: 'entity',
+      content: 'Content.',
+      sourceIds: ['d_123: # comment'],
+      sourceRefs: ['raw:slack:event-1'],
+      compiledAt: '2026-04-08T12:00:00Z',
+      confidence: 'high',
+    };
+
+    writer.writePage(page);
+
+    const content = readFileSync(join(wikiDir, 'projects', 'ProjectAlpha.md'), 'utf8');
+    expect(content).toContain('title: "ProjectAlpha: true # comment"');
+    expect(content).toContain('  - "d_123: # comment"');
+    expect(content).toContain('  - "raw:slack:event-1"');
+  });
+
+  it('rejects source refs that would inject frontmatter keys', () => {
+    const writer = new ObsidianWriter(tempDir, 'wiki');
+    writer.ensureDirectories();
+    const page: WikiPage = {
+      path: 'projects/ProjectAlpha.md',
+      title: 'ProjectAlpha',
+      type: 'entity',
+      content: 'Content.',
+      sourceIds: ['d_123'],
+      sourceRefs: ['decision:d_123\ninjected: true'],
+      compiledAt: '2026-04-08T12:00:00Z',
+      confidence: 'high',
+    };
+
+    expect(() => writer.writePage(page)).toThrow(/frontmatter/i);
+  });
+
+  it('rejects page paths that would escape the wiki directory', () => {
+    const writer = new ObsidianWriter(tempDir, 'wiki');
+    writer.ensureDirectories();
+    const page: WikiPage = {
+      path: '../outside.md',
+      title: 'ProjectAlpha',
+      type: 'entity',
+      content: 'Content.',
+      sourceIds: ['d_123'],
+      compiledAt: '2026-04-08T12:00:00Z',
+      confidence: 'high',
+    };
+
+    expect(() => writer.writePage(page)).toThrow(/parent-directory/i);
+  });
+
+  it('rejects generated pages that would overwrite reserved wiki files', () => {
+    const writer = new ObsidianWriter(tempDir, 'wiki');
+    writer.ensureDirectories();
+    const page: WikiPage = {
+      path: 'index.md',
+      title: 'ProjectAlpha',
+      type: 'entity',
+      content: 'Content.',
+      sourceIds: ['d_123'],
+      compiledAt: '2026-04-08T12:00:00Z',
+      confidence: 'high',
+    };
+
+    expect(() => writer.writePage(page)).toThrow(/reserved wiki files/i);
+  });
+
+  it('rejects generated pages that target reserved wiki directories', () => {
+    const writer = new ObsidianWriter(tempDir, 'wiki');
+    writer.ensureDirectories();
+    const page: WikiPage = {
+      path: 'projects',
+      title: 'ProjectAlpha',
+      type: 'entity',
+      content: 'Content.',
+      sourceIds: ['d_123'],
+      compiledAt: '2026-04-08T12:00:00Z',
+      confidence: 'high',
+    };
+
+    expect(() => writer.writePage(page)).toThrow(/reserved wiki directories/i);
   });
 
   it('updates existing page preserving human sections', () => {


### PR DESCRIPTION
## Summary
- Add a source-linked `wiki_artifacts` table, migration, store, export path, and `wiki_publish` vNext adapter.
- Harden wiki page writing with shared path validation, quoted frontmatter, and `source_refs` preservation.
- Keep legacy `wiki_publish` compatible while allowing vNext callers to require source refs and persist retryable artifacts.

## Review Notes
- Codex review found and I fixed: vNext store-before-publish ordering, offset-only list pagination, and directory-like wiki paths.
- Final Codex review: no actionable regressions found.

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run tests/wiki-artifacts/wiki-artifact-store.test.ts tests/wiki-artifacts/wiki-publish-adapter.test.ts tests/wiki-artifacts/wiki-exporter.test.ts tests/wiki/obsidian-writer.test.ts tests/agent/agent-result-memory.test.ts tests/envelope/memory-scope-mismatch-logging.test.ts tests/code-act/host-bridge.test.ts tests/code-act/type-definition-generator.test.ts tests/wiki/integration.test.ts tests/wiki/wiki-compiler.test.ts tests/runtime-vnext/legacy-fanout-disabled.test.ts` (102 tests)
- `pnpm build`
- pre-commit hook: gitleaks clear, standalone typecheck clear, changed-package build clear, standalone full test suite clear (3,267 passed, 3 skipped)

## Privacy / Public Repo Check
- `./scripts/check-pii.sh` passed.
- Direct staged and unstaged diff scans found no private local paths, secrets, tokens, or internal-only identifiers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for saving and exporting wiki pages with source references and confidence levels.
  * Introduced a safer wiki publishing flow that can store published pages as artifacts for later reuse.
  * Improved wiki export to generate Obsidian-compatible pages with structured metadata.

* **Bug Fixes**
  * Strengthened path handling to block unsafe or reserved wiki paths.
  * Made generated wiki metadata safer and more consistent by quoting values and validating list fields.
  * Improved handling of duplicate page updates and publishing results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->