### PR TITLE
feat: add vnext dashboard projection authority

### DIFF
--- a/packages/standalone/src/agent/delegation-executor.ts
+++ b/packages/standalone/src/agent/delegation-executor.ts
@@ -128,6 +128,17 @@ export class DelegationExecutor {
     const { agent_id } = input;
     const sample_count = Number.parseInt(String(input.sample_count ?? 2), 10);
     const resolvedAgentId = this.deps.resolveManagedAgentId(agent_id);
+    const authority = this.deps.checkDelegationAuthority?.(
+      { agentId: resolvedAgentId, task: `agent_test:${resolvedAgentId}` },
+      routing
+    );
+    if (authority && !authority.allowed) {
+      return {
+        success: false,
+        code: authority.code,
+        error: authority.reason,
+      } as GatewayToolResult;
+    }
     if (!Number.isFinite(sample_count) || sample_count < 1) {
       securityLogger.warn('[Agent test] Invalid sample_count received', {
         agent_id: resolvedAgentId,

--- a/packages/standalone/src/agent/delegation-executor.ts
+++ b/packages/standalone/src/agent/delegation-executor.ts
@@ -40,6 +40,16 @@ export type DelegateInput = {
   skill?: string;
 };
 
+export type DelegationAuthorityDecision =
+  | {
+      allowed: true;
+    }
+  | {
+      allowed: false;
+      code: string;
+      reason: string;
+    };
+
 export type DelegationExecutorDeps = {
   agentProcessManager: AgentProcessManager | null;
   delegationManagerRef: DelegationManager | null;
@@ -49,6 +59,10 @@ export type DelegationExecutorDeps = {
   retryDelayMs: number;
   resolveManagedAgentId: (id: string) => string;
   checkViewerOnly: () => string | null;
+  checkDelegationAuthority?: (
+    input: DelegateInput,
+    routing: DelegationRoutingContext
+  ) => DelegationAuthorityDecision;
 };
 
 function summarizeActivityOutput(output: unknown): string | undefined {
@@ -147,6 +161,14 @@ export class DelegationExecutor {
     input: DelegateInput,
     routing: DelegationRoutingContext
   ): Promise<GatewayToolResult> {
+    const authority = this.deps.checkDelegationAuthority?.(input, routing);
+    if (authority && !authority.allowed) {
+      return {
+        success: false,
+        code: authority.code,
+        error: authority.reason,
+      } as GatewayToolResult;
+    }
     return this.runDelegateInternal(input, routing);
   }
 

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -495,7 +495,7 @@ export class GatewayToolExecutor {
       .trim()
       .toLowerCase()
       .replace(/[_\s]+/g, '-');
-    const normalizedAgent = state.agentId.trim().toLowerCase();
+    const normalizedAgent = (state.agentId ?? '').trim().toLowerCase();
 
     if (
       normalizedAgent === 'operator:primary' ||

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -119,6 +119,12 @@ import {
   type WikiPublishAdapter,
 } from '../wiki-artifacts/wiki-publish-adapter.js';
 import type { WikiPagePublisher, WikiPublishPageInput } from '../wiki-artifacts/types.js';
+import {
+  resolveCommitAuthority,
+  type VNextCommitActor,
+  type VNextCommitAuthorityDecision,
+  type VNextCommitRuntimeMode,
+} from '../operator-vnext/commit-authority.js';
 
 const { DebugLogger } = debugLogger as unknown as {
   DebugLogger: new (context?: string) => {
@@ -328,6 +334,7 @@ export class GatewayToolExecutor {
   private readonly envelopeIssuanceMode: 'off' | 'enabled' | 'required';
   private readonly metricsStore: GatewayToolExecutorOptions['metricsStore'];
   private contextCompileService: GatewayToolExecutorOptions['contextCompileService'];
+  private readonly vNextCommitRuntimeMode: VNextCommitRuntimeMode;
   private currentContext: AgentContext | null = null;
   private memoryAgentProcessManager: AgentProcessManager | null = null;
   private agentProcessManager: AgentProcessManager | null = null;
@@ -481,6 +488,61 @@ export class GatewayToolExecutor {
     };
   }
 
+  private resolveVNextCommitActor(): VNextCommitActor {
+    const state = this.getExecutionState();
+    const roleName = state.agentContext?.roleName ?? '';
+    const normalizedRole = roleName
+      .trim()
+      .toLowerCase()
+      .replace(/[_\s]+/g, '-');
+    const normalizedAgent = state.agentId.trim().toLowerCase();
+
+    if (
+      normalizedAgent === 'operator:primary' ||
+      normalizedAgent === 'primary-operator' ||
+      normalizedRole === 'primary-operator' ||
+      normalizedRole === 'vnext-primary-operator'
+    ) {
+      return { kind: 'primary_operator', agentId: state.agentId };
+    }
+
+    if (
+      state.source === 'viewer' &&
+      state.executionSurface === 'direct' &&
+      state.agentContext?.role?.systemControl === true &&
+      state.agentContext?.role?.sensitiveAccess === true
+    ) {
+      return { kind: 'viewer_admin', agentId: state.agentId };
+    }
+
+    if (state.agentId || normalizedRole.endsWith('-agent')) {
+      return { kind: 'worker', agentId: state.agentId || roleName };
+    }
+
+    return { kind: 'unknown', agentId: state.agentId };
+  }
+
+  private resolveGatewayCommitAuthority(toolName: string): VNextCommitAuthorityDecision {
+    return resolveCommitAuthority({
+      runtimeMode: this.vNextCommitRuntimeMode,
+      toolName,
+      actor: this.resolveVNextCommitActor(),
+    });
+  }
+
+  private checkVNextCommitAuthority(toolName: string): GatewayToolResult | null {
+    const decision = this.resolveGatewayCommitAuthority(toolName);
+    if (decision.allowed) {
+      return null;
+    }
+    return {
+      success: false,
+      code: decision.code,
+      error: decision.reason,
+      effect: decision.effect,
+    } as GatewayToolResult;
+  }
+
   async withExecutionContext<T>(
     executionContext: GatewayExecutionContext | undefined,
     fn: () => Promise<T>
@@ -630,6 +692,7 @@ export class GatewayToolExecutor {
       retryDelayMs: this._retryDelayMs,
       resolveManagedAgentId: (id) => this.resolveManagedAgentId(id),
       checkViewerOnly: () => this.checkViewerOnly(),
+      checkDelegationAuthority: () => this.resolveGatewayCommitAuthority('delegate'),
     });
   }
 
@@ -651,6 +714,8 @@ export class GatewayToolExecutor {
     this.metricsStore = options.metricsStore ?? null;
     this.contextCompileService = options.contextCompileService;
     this.wikiPublishAdapter = options.wikiPublishAdapter ?? null;
+    this.vNextCommitRuntimeMode =
+      options.vNextCommitRuntimeMode ?? (options.vNextRuntimeEnabled ? 'vnext' : 'legacy');
     this.browserTool = getBrowserTool({
       screenshotDir: join(process.env.HOME || '', '.mama', 'workspace', 'media', 'outbound'),
     });
@@ -1543,6 +1608,11 @@ export class GatewayToolExecutor {
     }
 
     try {
+      const authorityDenied = this.checkVNextCommitAuthority(toolName);
+      if (authorityDenied) {
+        return authorityDenied;
+      }
+
       // Handle non-MAMA tools first
       switch (toolName) {
         case 'Read':

--- a/packages/standalone/src/agent/gateway-tools.md
+++ b/packages/standalone/src/agent/gateway-tools.md
@@ -11,7 +11,7 @@ Call tools via JSON block:
 - **mama_save**(type, topic?, decision?, reasoning?, confidence?, context_packet_id?, summary?, next_steps?) — Save decision (topic, decision, reasoning) or checkpoint (summary, next_steps?). context_packet_id is trusted provenance and is only honored when supplied from active runtime context.
 - **mama_search**(query?, type?, limit?, scopes?, strict?, strictness?, threshold?, disableRecency?, includeRelated?, topicPrefix?, minLexicalSupport?, diagnostics?) — Search decisions
 - **mama_recall**(query, scopes?, includeProfile?) — Recall memory bundle with profile, memories, and graph context
-- **context_compile**(task, scopes?, connectors?, seed_refs?, range?, as_of?, limit?, max_tool_calls?, max_ms?, max_tokens?, strictness?) — Compile and persist an append-only scoped context packet from visible memory, raw, graph, and case evidence. strictness is recall, balanced, or strict. Unavailable to Tier 3 agents.
+- **context_compile**(task, scopes?, connectors?, seed_refs?, range?, as_of?, limit?, max_tool_calls?, max_ms?, max_tokens?, strictness?) — Compile and persist an append-only scoped context packet from visible memory, raw, graph, and case evidence. strictness is recall, balanced, or strict. Unavailable to Tier 3/read-only agents.
 - **mama_update**(id, outcome, reason?) — Update outcome
 - **mama_load_checkpoint**() — Resume session. No params.
 - **mama_add**(content) — Auto-extract and save facts from conversation content via Haiku

--- a/packages/standalone/src/agent/types.ts
+++ b/packages/standalone/src/agent/types.ts
@@ -13,6 +13,7 @@ import type { RoleConfig } from '../cli/config/types.js';
 import type { Envelope } from '../envelope/types.js';
 import type { WikiPublishAdapter } from '../wiki-artifacts/wiki-publish-adapter.js';
 import type { ContextCompileService } from './context-compile-service.js';
+import type { VNextCommitRuntimeMode } from '../operator-vnext/commit-authority.js';
 import type {
   AppendToolTraceInput,
   BeginModelRunInput,
@@ -1209,6 +1210,10 @@ export interface GatewayToolExecutorOptions {
   contextCompileService?: ContextCompileService;
   /** Optional wiki publish adapter, used by vNext callers that persist source-linked artifacts. */
   wikiPublishAdapter?: WikiPublishAdapter | null;
+  /** Enables vNext commit authority checks for durable write tools. */
+  vNextRuntimeEnabled?: boolean;
+  /** Explicit vNext authority mode override for tests and staged rollout. */
+  vNextCommitRuntimeMode?: VNextCommitRuntimeMode;
 }
 
 export interface MemoryWriteProvenance {

--- a/packages/standalone/src/api/index.ts
+++ b/packages/standalone/src/api/index.ts
@@ -25,6 +25,7 @@ import { SkillRegistry } from '../skills/skill-registry.js';
 import type { SystemHealthReport } from '../observability/health-check.js';
 import { createSecurityMiddleware } from '../security/security-monitor.js';
 import { createReportRouter, createReportStore } from './report-handler.js';
+import type { VNextProjectionProvider } from '../operator-vnext/situation-projection-types.js';
 import { createWikiRouter } from './wiki-handler.js';
 import { createIntelligenceRouter } from './intelligence-handler.js';
 import { createConnectorFeedRouter } from './connector-feed-handler.js';
@@ -110,6 +111,8 @@ export interface ApiServerOptions {
   situationNow?: AgentSituationRouterOptions['now'];
   /** Shared context compile service for HTTP/gateway packet compilation */
   contextCompileService?: AgentContextRouterOptions['contextCompileService'];
+  /** Optional vNext dashboard/report projection provider. Legacy report store is used when omitted. */
+  vNextProjectionProvider?: VNextProjectionProvider;
 }
 
 export type ApiEnvelopeMetadata = {
@@ -164,6 +167,7 @@ export function createApiServer(options: ApiServerOptions): ApiServer {
     situationBuilder,
     situationNow,
     contextCompileService,
+    vNextProjectionProvider,
   } = options;
 
   const app = express();
@@ -298,7 +302,9 @@ export function createApiServer(options: ApiServerOptions): ApiServer {
   }
 
   // Mount report router (always available)
-  const reportRouter = createReportRouter(reportStore, reportSseClients);
+  const reportRouter = createReportRouter(reportStore, reportSseClients, {
+    vNextProjectionProvider,
+  });
   app.use('/api/report', reportRouter);
 
   // Mount wiki router if wiki path is configured

--- a/packages/standalone/src/api/report-handler.ts
+++ b/packages/standalone/src/api/report-handler.ts
@@ -62,7 +62,7 @@ function rejectVNextReportMutation(options: ReportRouterOptions, res: Response):
   res.status(409).json({
     ok: false,
     code: 'vnext_report_projection_only',
-    error: 'Legacy report slot mutations are disabled while vNext projections are active.',
+    error: 'Legacy report slot mutations are disabled while vNext report mode is configured.',
   });
   return true;
 }

--- a/packages/standalone/src/api/report-handler.ts
+++ b/packages/standalone/src/api/report-handler.ts
@@ -1,5 +1,11 @@
 import { Router, type Request, type Response } from 'express';
 import type { ServerResponse } from 'node:http';
+import { buildReportSlotsFromSituationProjection } from '../operator-vnext/situation-projection.js';
+import type {
+  VNextProjectionProvider,
+  VNextSituationProjection,
+  VNextTodaySituationRow,
+} from '../operator-vnext/situation-projection-types.js';
 
 export interface ReportSlot {
   slotId: string;
@@ -14,6 +20,51 @@ export interface ReportStore {
   delete(slotId: string): void;
   getAll(): Record<string, ReportSlot>;
   getAllSorted(): ReportSlot[];
+}
+
+export interface ReportRouterOptions {
+  vNextProjectionProvider?: VNextProjectionProvider;
+}
+
+type PublicVNextTodaySituationRow = Omit<VNextTodaySituationRow, 'evidence_refs' | 'owner_hint'> & {
+  evidence_refs: [];
+  owner_hint: null;
+};
+
+export interface PublicVNextProjectionPayload {
+  projection_version: VNextSituationProjection['projectionVersion'];
+  generated_at_ms: number;
+  view_model_hash: string | null;
+  status: VNextSituationProjection['status'];
+  today: PublicVNextTodaySituationRow[];
+}
+
+export function buildPublicVNextProjectionPayload(
+  projection: VNextSituationProjection
+): PublicVNextProjectionPayload {
+  return {
+    projection_version: projection.projectionVersion,
+    generated_at_ms: projection.generatedAtMs,
+    view_model_hash: projection.viewModelHash,
+    status: projection.status,
+    today: projection.today.map((row) => ({
+      ...row,
+      evidence_refs: [],
+      owner_hint: null,
+    })),
+  };
+}
+
+function rejectVNextReportMutation(options: ReportRouterOptions, res: Response): boolean {
+  if (!options.vNextProjectionProvider) {
+    return false;
+  }
+  res.status(409).json({
+    ok: false,
+    code: 'vnext_report_projection_only',
+    error: 'Legacy report slot mutations are disabled while vNext projections are active.',
+  });
+  return true;
 }
 
 export function createReportStore(): ReportStore {
@@ -67,11 +118,24 @@ export function broadcastReportUpdate(
 /**
  * Create an Express Router that exposes report slot CRUD + SSE stream.
  */
-export function createReportRouter(store: ReportStore, sseClients: Set<ServerResponse>): Router {
+export function createReportRouter(
+  store: ReportStore,
+  sseClients: Set<ServerResponse>,
+  options: ReportRouterOptions = {}
+): Router {
   const router = Router();
 
   // GET / — list all slots sorted by priority
   router.get('/', (_req: Request, res: Response) => {
+    const projection = options.vNextProjectionProvider?.();
+    if (projection) {
+      res.json({
+        mode: 'vnext',
+        projection: buildPublicVNextProjectionPayload(projection),
+        slots: buildReportSlotsFromSituationProjection(projection),
+      });
+      return;
+    }
     res.json({ slots: store.getAllSorted() });
   });
 
@@ -92,6 +156,9 @@ export function createReportRouter(store: ReportStore, sseClients: Set<ServerRes
 
   // PUT / — bulk update
   router.put('/', (req: Request, res: Response) => {
+    if (rejectVNextReportMutation(options, res)) {
+      return;
+    }
     const body = req.body as { slots?: Record<string, { html: string; priority?: number }> };
     const incoming = body?.slots ?? {};
     for (const [id, { html, priority = 0 }] of Object.entries(incoming)) {
@@ -103,6 +170,9 @@ export function createReportRouter(store: ReportStore, sseClients: Set<ServerRes
 
   // PUT /slots/:slotId — single update
   router.put('/slots/:slotId', (req: Request<{ slotId: string }>, res: Response) => {
+    if (rejectVNextReportMutation(options, res)) {
+      return;
+    }
     const slotId = req.params.slotId as string;
     const { html, priority = 0 } = req.body as { html: string; priority?: number };
     store.update(slotId, html, priority);
@@ -112,6 +182,9 @@ export function createReportRouter(store: ReportStore, sseClients: Set<ServerRes
 
   // DELETE /slots/:slotId — delete a slot
   router.delete('/slots/:slotId', (req: Request<{ slotId: string }>, res: Response) => {
+    if (rejectVNextReportMutation(options, res)) {
+      return;
+    }
     const slotId = req.params.slotId as string;
     store.delete(slotId);
     broadcastReportUpdate(sseClients, { deleted: slotId });

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -65,6 +65,7 @@ import { startServer } from '../runtime/server-start.js';
 import { installShutdownHandlers } from '../runtime/shutdown.js';
 import { buildRuntimeEnvelopeBootstrap } from '../runtime/envelope-bootstrap.js';
 import { requireAuth } from '../../api/auth-middleware.js';
+import { buildPublicVNextProjectionPayload } from '../../api/report-handler.js';
 import {
   buildVNextBootstrapPlan,
   buildVNextPrimaryOperatorReadyStatus,
@@ -79,6 +80,10 @@ import {
 import { resolveVNextRuntimeFlags } from '../../runtime-vnext/feature-flags.js';
 import { ensureVNextOperatorSchema } from '../../operator-vnext/schema.js';
 import { PrimaryOperatorRuntime } from '../../operator-vnext/primary-operator-runtime.js';
+import {
+  buildReportSlotsFromSituationProjection,
+  buildSituationProjection,
+} from '../../operator-vnext/situation-projection.js';
 import { resolveReactiveProjectRoot } from '../../envelope/reactive-config.js';
 import { deriveMemoryScopes, type MemoryScopeRef } from '../../memory/scope-context.js';
 import { DEFAULT_ROLES, type AgentPersonaConfig, type RoleConfig } from '../config/types.js';
@@ -564,6 +569,55 @@ function buildVNextStatusPayload(status: VNextBootstrapRuntimeStatus): Record<st
   };
 }
 
+function buildVNextBootstrapSituationProjection(status: VNextBootstrapRuntimeStatus) {
+  const primaryOperator = status.primaryOperator;
+  const degraded = primaryOperator.status === 'degraded';
+  const cursorSeq = primaryOperator.advancedThroughSeq;
+  const viewModelHash = [
+    'vnext-primary-operator',
+    primaryOperator.status,
+    cursorSeq,
+    primaryOperator.lastBatchStatus ?? 'none',
+    primaryOperator.failedSeq ?? 'none',
+  ].join(':');
+
+  return buildSituationProjection(
+    [
+      {
+        situationId: 'vnext_primary_operator',
+        situationVersion: cursorSeq,
+        awarenessRunId: `vnext-bootstrap-${status.startedAtMs}`,
+        title: 'Primary operator runtime',
+        status: degraded ? 'blocked' : 'in_progress',
+        summary: degraded
+          ? 'Primary operator runtime is degraded and needs manual inspection.'
+          : 'Primary operator runtime is prepared and owns vNext durable commits.',
+        nextAction: degraded
+          ? 'Inspect the failed batch and replay only verified source events.'
+          : 'Continue verified manual batches through the primary operator cursor.',
+        freshness: degraded ? 'degraded' : 'live',
+        verificationState: degraded ? 'conflicting' : 'verified',
+        confidence: degraded ? 0.4 : 1,
+        evidenceRefs: [
+          {
+            kind: 'raw',
+            connector: primaryOperator.connector,
+            id: `${primaryOperator.cursorName}:${cursorSeq}`,
+          },
+        ],
+        updatedAtMs: status.startedAtMs,
+        viewModelHash,
+        priority: degraded ? 0 : 10,
+        tags: ['vnext', 'primary_operator'],
+        pendingReason: degraded ? (primaryOperator.errorMessage ?? 'Runtime degraded.') : undefined,
+        ownerHint: primaryOperator.cursorName,
+        issueCount: degraded ? 1 : 0,
+      },
+    ],
+    Date.now()
+  );
+}
+
 function readVNextPrimaryOperatorCursorSeq(db: Database, cursorName: string): number {
   const row = db
     .prepare('SELECT last_change_seq FROM vnext_operator_cursors WHERE cursor_name = ?')
@@ -624,6 +678,14 @@ export function createVNextBootstrapApiServer(status: VNextBootstrapRuntimeStatu
   });
   app.get('/api/status', (_req, res) => {
     res.json(buildVNextStatusPayload(status));
+  });
+  app.get('/api/report', (_req, res) => {
+    const projection = buildVNextBootstrapSituationProjection(status);
+    res.json({
+      mode: 'vnext',
+      projection: buildPublicVNextProjectionPayload(projection),
+      slots: buildReportSlotsFromSituationProjection(projection),
+    });
   });
 
   let server: HttpServer | null = null;
@@ -849,6 +911,7 @@ export async function runAgentLoop(
     rolesConfig: config.roles, // Pass roles from config.yaml
     envelopeIssuanceMode: envelopeBootstrap.metadata.issuance,
     metricsStore,
+    vNextRuntimeEnabled: vNext.enabled,
   });
 
   const validBackends = ['claude', 'codex', 'codex-mcp'] as const;
@@ -869,7 +932,11 @@ export async function runAgentLoop(
     db,
     metricsStore,
     agentLoopBackend,
-    { ...options, envelopeIssuanceMode: envelopeBootstrap.metadata.issuance }
+    {
+      ...options,
+      envelopeIssuanceMode: envelopeBootstrap.metadata.issuance,
+      vNextRuntimeEnabled: vNext.enabled,
+    }
   );
 
   // ── Phase 3: MAMA Core API ────────────────────────────────────────────────

--- a/packages/standalone/src/cli/runtime/agent-loop-init.ts
+++ b/packages/standalone/src/cli/runtime/agent-loop-init.ts
@@ -65,6 +65,7 @@ export function initMainAgentLoop(
     osAgentMode?: boolean;
     envelopeIssuanceMode?: EnvelopeIssuanceMode;
     contextCompileService?: GatewayToolExecutorOptions['contextCompileService'];
+    vNextRuntimeEnabled?: boolean;
   }
 ): AgentLoopInitResult {
   // Reasoning collector for Discord display
@@ -203,6 +204,7 @@ export function initMainAgentLoop(
       envelopeIssuanceMode: options?.envelopeIssuanceMode ?? 'off',
       metricsStore,
       contextCompileService: options?.contextCompileService,
+      vNextRuntimeEnabled: options?.vNextRuntimeEnabled,
     }
   );
   console.log('✓ Lane-based concurrency enabled (reasoning collection)');

--- a/packages/standalone/src/cli/runtime/api-server-init.ts
+++ b/packages/standalone/src/cli/runtime/api-server-init.ts
@@ -22,6 +22,7 @@ import type { HealthScoreService } from '../../observability/health-score.js';
 import type { HealthCheckService } from '../../observability/health-check.js';
 import type { RawStore } from '../../connectors/framework/raw-store.js';
 import type { SQLiteDatabase } from '../../sqlite.js';
+import type { VNextProjectionProvider } from '../../operator-vnext/situation-projection-types.js';
 import type { MAMAConfig } from '../config/types.js';
 import type { RuntimeEnvelopeBootstrap } from './envelope-bootstrap.js';
 import { API_PORT } from './utilities.js';
@@ -41,6 +42,7 @@ export interface InitApiServerParams {
   envelopeMetadata?: RuntimeEnvelopeBootstrap['metadata'];
   envelopeAuthority?: RuntimeEnvelopeBootstrap['envelopeAuthority'];
   contextCompileService?: ContextCompileService;
+  vNextProjectionProvider?: VNextProjectionProvider;
   /** mama-core getAdapter() — used to create the memoryDb shim */
   getAdapter: () => AgentSituationAdapter & {
     exec: (sql: string) => void;
@@ -67,6 +69,7 @@ export async function initApiServer(params: InitApiServerParams): Promise<InitAp
     envelopeMetadata,
     envelopeAuthority,
     contextCompileService: suppliedContextCompileService,
+    vNextProjectionProvider,
   } = params;
 
   // ── SkillRegistry + MCP config migration ──────────────────────────────
@@ -127,6 +130,7 @@ export async function initApiServer(params: InitApiServerParams): Promise<InitAp
     envelope: envelopeMetadata,
     envelopeAuthority,
     contextCompileService,
+    vNextProjectionProvider,
     onHeartbeat: async (prompt) => {
       try {
         const result = await agentLoop.run(prompt);

--- a/packages/standalone/src/operator-vnext/commit-authority.ts
+++ b/packages/standalone/src/operator-vnext/commit-authority.ts
@@ -1,0 +1,143 @@
+import type { GatewayToolName } from '../agent/types.js';
+
+export type VNextCommitRuntimeMode = 'legacy' | 'vnext';
+export type VNextCommitActorKind =
+  | 'primary_operator'
+  | 'worker'
+  | 'viewer_admin'
+  | 'legacy_agent'
+  | 'unknown';
+export type VNextCommitEffect =
+  | 'legacy'
+  | 'commit'
+  | 'manual'
+  | 'delegate'
+  | 'projection'
+  | 'proposal_required'
+  | 'denied';
+
+export interface VNextCommitActor {
+  kind: VNextCommitActorKind;
+  agentId?: string;
+}
+
+export interface VNextCommitAuthorityInput {
+  runtimeMode: VNextCommitRuntimeMode;
+  toolName: GatewayToolName | string;
+  actor: VNextCommitActor;
+}
+
+export type VNextCommitAuthorityDecision =
+  | {
+      allowed: true;
+      effect: VNextCommitEffect;
+      reason: string;
+    }
+  | {
+      allowed: false;
+      effect: VNextCommitEffect;
+      code: string;
+      reason: string;
+    };
+
+const DURABLE_WRITE_TOOLS = new Set<string>([
+  'mama_save',
+  'mama_update',
+  'mama_add',
+  'mama_ingest',
+  'wiki_publish',
+  'obsidian',
+  'report_publish',
+  'task_create',
+  'task_update',
+  'delegate',
+]);
+
+const FILESYSTEM_WRITE_TOOLS = new Set<string>(['Write', 'Bash']);
+
+function allow(effect: VNextCommitEffect, reason: string): VNextCommitAuthorityDecision {
+  return { allowed: true, effect, reason };
+}
+
+function deny(
+  effect: VNextCommitEffect,
+  code: string,
+  reason: string
+): VNextCommitAuthorityDecision {
+  return { allowed: false, effect, code, reason };
+}
+
+export function resolveCommitAuthority(
+  input: VNextCommitAuthorityInput
+): VNextCommitAuthorityDecision {
+  if (input.runtimeMode === 'legacy') {
+    return allow('legacy', 'Legacy runtime preserves existing tool behavior.');
+  }
+
+  if (input.toolName === 'obsidian') {
+    return deny(
+      'denied',
+      'vnext_obsidian_disabled',
+      'Direct Obsidian mutation is disabled in vNext; use source-linked wiki_publish instead.'
+    );
+  }
+
+  if (FILESYSTEM_WRITE_TOOLS.has(input.toolName)) {
+    if (input.actor.kind === 'viewer_admin') {
+      return allow('manual', 'Viewer/admin filesystem writes continue to follow viewer policy.');
+    }
+    return deny(
+      'denied',
+      'vnext_filesystem_write_denied',
+      'vNext agents must not write files directly; workers return proposals and viewers use viewer policy.'
+    );
+  }
+
+  if (!DURABLE_WRITE_TOOLS.has(input.toolName)) {
+    return allow('legacy', 'Tool has no vNext durable-write authority rule.');
+  }
+
+  if (input.toolName === 'report_publish') {
+    return deny(
+      'projection',
+      'vnext_report_projection_only',
+      'report_publish is not canonical in vNext; dashboard state is served from projections.'
+    );
+  }
+
+  if (input.toolName === 'delegate') {
+    if (input.actor.kind === 'primary_operator') {
+      return allow('delegate', 'Primary operator may delegate bounded worker jobs.');
+    }
+    return deny(
+      'denied',
+      'vnext_worker_delegation_denied',
+      'vNext workers must return proposals instead of delegating.'
+    );
+  }
+
+  if (input.actor.kind === 'primary_operator') {
+    return allow('commit', 'Primary operator owns vNext durable writes.');
+  }
+
+  if (
+    input.actor.kind === 'viewer_admin' &&
+    (input.toolName === 'mama_save' || input.toolName === 'wiki_publish')
+  ) {
+    return allow('manual', 'Viewer/admin may manually commit source-linked artifacts.');
+  }
+
+  if (input.actor.kind === 'worker') {
+    return deny(
+      'proposal_required',
+      'vnext_worker_proposal_required',
+      'vNext workers must submit proposals; the primary operator commits durable state.'
+    );
+  }
+
+  return deny(
+    'denied',
+    'vnext_commit_authority_denied',
+    'vNext durable writes require the primary operator or an explicitly allowed admin path.'
+  );
+}

--- a/packages/standalone/src/operator-vnext/situation-projection-types.ts
+++ b/packages/standalone/src/operator-vnext/situation-projection-types.ts
@@ -1,0 +1,83 @@
+import type { SourceRef } from '@jungjaehoon/mama-core/provenance/source-ref';
+
+export type VNextSituationStatus =
+  | 'new'
+  | 'in_progress'
+  | 'blocked'
+  | 'submitted'
+  | 'done'
+  | 'stale'
+  | 'conflicting'
+  | 'needs_review';
+
+export type VNextSituationFreshness = 'live' | 'pending_verification' | 'stale' | 'degraded';
+export type VNextSituationVerificationState = 'pending' | 'verified' | 'conflicting' | 'stale';
+
+export interface VNextSituationInput {
+  situationId: string;
+  situationVersion: number;
+  awarenessRunId: string;
+  title: string;
+  status: VNextSituationStatus;
+  summary: string;
+  nextAction: string;
+  freshness: VNextSituationFreshness;
+  verificationState: VNextSituationVerificationState;
+  confidence: number;
+  evidenceRefs: readonly SourceRef[];
+  updatedAtMs: number;
+  viewModelHash: string;
+  priority?: number;
+  tags?: readonly string[];
+  pendingReason?: string;
+  ownerHint?: string;
+  issueCount?: number;
+}
+
+export interface VNextTodaySituationRow {
+  situation_id: string;
+  situation_version: number;
+  awareness_run_id: string;
+  title: string;
+  summary: string;
+  next_action: string;
+  status: VNextSituationStatus;
+  freshness: VNextSituationFreshness;
+  verification_state: VNextSituationVerificationState;
+  confidence: number;
+  evidence_count: number;
+  evidence_refs: string[];
+  updated_at_ms: number;
+  view_model_hash: string;
+  priority: number;
+  tags: string[];
+  pending_reason: string | null;
+  owner_hint: string | null;
+  issue_count: number;
+}
+
+export interface VNextSituationProjection {
+  projectionVersion: 1;
+  generatedAtMs: number;
+  viewModelHash: string | null;
+  today: VNextTodaySituationRow[];
+  status: {
+    total: number;
+    live: number;
+    stale: number;
+    degraded: number;
+    pendingVerification: number;
+    verified: number;
+    issueCount: number;
+    newestUpdatedAtMs: number | null;
+  };
+}
+
+export interface VNextReportSlot {
+  slotId: string;
+  html: string;
+  priority: number;
+  updatedAt: number;
+}
+
+export type VNextProjectionProvider = () => VNextSituationProjection | null;

--- a/packages/standalone/src/operator-vnext/situation-projection.ts
+++ b/packages/standalone/src/operator-vnext/situation-projection.ts
@@ -36,7 +36,7 @@ function nonNegativeInteger(value: number, field: string): number {
   return value;
 }
 
-function clampConfidence(value: number): number {
+function validateConfidence(value: number): number {
   const confidence = finiteNumber(value, 'confidence');
   if (confidence < 0 || confidence > 1) {
     throw new Error('confidence must be between 0 and 1');
@@ -79,7 +79,7 @@ function rowFromSituation(input: VNextSituationInput): VNextTodaySituationRow {
     status: input.status,
     freshness: input.freshness,
     verification_state: input.verificationState,
-    confidence: clampConfidence(input.confidence),
+    confidence: validateConfidence(input.confidence),
     evidence_count: evidenceRefs.length,
     evidence_refs: evidenceRefs,
     updated_at_ms: nonNegativeInteger(input.updatedAtMs, 'updatedAtMs'),

--- a/packages/standalone/src/operator-vnext/situation-projection.ts
+++ b/packages/standalone/src/operator-vnext/situation-projection.ts
@@ -1,0 +1,188 @@
+import { createHash } from 'node:crypto';
+
+import {
+  assertNonEmptySourceRefs,
+  serializeSourceRef,
+} from '@jungjaehoon/mama-core/provenance/source-ref';
+
+import type {
+  VNextReportSlot,
+  VNextSituationInput,
+  VNextSituationProjection,
+  VNextTodaySituationRow,
+} from './situation-projection-types.js';
+
+const DEFAULT_PRIORITY = 100;
+
+function requiredString(value: string, field: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${field} must not be empty`);
+  }
+  return trimmed;
+}
+
+function finiteNumber(value: number, field: string): number {
+  if (!Number.isFinite(value)) {
+    throw new Error(`${field} must be finite`);
+  }
+  return value;
+}
+
+function nonNegativeInteger(value: number, field: string): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${field} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function clampConfidence(value: number): number {
+  const confidence = finiteNumber(value, 'confidence');
+  if (confidence < 0 || confidence > 1) {
+    throw new Error('confidence must be between 0 and 1');
+  }
+  return confidence;
+}
+
+function stableProjectionHash(rows: readonly VNextTodaySituationRow[]): string | null {
+  if (rows.length === 0) {
+    return null;
+  }
+  if (rows.length === 1) {
+    return rows[0].view_model_hash;
+  }
+  return createHash('sha256')
+    .update(JSON.stringify(rows.map((row) => row.view_model_hash)))
+    .digest('hex');
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function rowFromSituation(input: VNextSituationInput): VNextTodaySituationRow {
+  assertNonEmptySourceRefs(input.evidenceRefs);
+  const evidenceRefs = input.evidenceRefs.map((ref) => serializeSourceRef(ref));
+
+  return {
+    situation_id: requiredString(input.situationId, 'situationId'),
+    situation_version: nonNegativeInteger(input.situationVersion, 'situationVersion'),
+    awareness_run_id: requiredString(input.awarenessRunId, 'awarenessRunId'),
+    title: requiredString(input.title, 'title'),
+    summary: requiredString(input.summary, 'summary'),
+    next_action: requiredString(input.nextAction, 'nextAction'),
+    status: input.status,
+    freshness: input.freshness,
+    verification_state: input.verificationState,
+    confidence: clampConfidence(input.confidence),
+    evidence_count: evidenceRefs.length,
+    evidence_refs: evidenceRefs,
+    updated_at_ms: nonNegativeInteger(input.updatedAtMs, 'updatedAtMs'),
+    view_model_hash: requiredString(input.viewModelHash, 'viewModelHash'),
+    priority: nonNegativeInteger(input.priority ?? DEFAULT_PRIORITY, 'priority'),
+    tags: [...(input.tags ?? [])].map((tag) => requiredString(tag, 'tag')),
+    pending_reason: input.pendingReason
+      ? requiredString(input.pendingReason, 'pendingReason')
+      : null,
+    owner_hint: input.ownerHint ? requiredString(input.ownerHint, 'ownerHint') : null,
+    issue_count: nonNegativeInteger(input.issueCount ?? 0, 'issueCount'),
+  };
+}
+
+export function buildSituationProjection(
+  situations: readonly VNextSituationInput[],
+  nowMs = Date.now()
+): VNextSituationProjection {
+  const generatedAtMs = nonNegativeInteger(nowMs, 'nowMs');
+  const today = situations
+    .map((situation) => rowFromSituation(situation))
+    .sort(
+      (left, right) =>
+        left.priority - right.priority ||
+        right.updated_at_ms - left.updated_at_ms ||
+        left.situation_id.localeCompare(right.situation_id)
+    );
+
+  return {
+    projectionVersion: 1,
+    generatedAtMs,
+    viewModelHash: stableProjectionHash(today),
+    today,
+    status: {
+      total: today.length,
+      live: today.filter((row) => row.freshness === 'live').length,
+      stale: today.filter((row) => row.freshness === 'stale').length,
+      degraded: today.filter((row) => row.freshness === 'degraded').length,
+      pendingVerification: today.filter((row) => row.verification_state === 'pending').length,
+      verified: today.filter((row) => row.verification_state === 'verified').length,
+      issueCount: today.reduce((sum, row) => sum + row.issue_count, 0),
+      newestUpdatedAtMs: today.reduce<number | null>(
+        (max, row) => (max === null ? row.updated_at_ms : Math.max(max, row.updated_at_ms)),
+        null
+      ),
+    },
+  };
+}
+
+export function buildReportSlotsFromSituationProjection(
+  projection: VNextSituationProjection
+): VNextReportSlot[] {
+  const updatedAt = projection.generatedAtMs;
+  const plural = projection.status.total === 1 ? 'situation' : 'situations';
+  const statusHtml = [
+    `<strong>${projection.status.total} current ${plural}</strong>`,
+    `live ${projection.status.live}`,
+    `pending ${projection.status.pendingVerification}`,
+    `degraded ${projection.status.degraded}`,
+  ].join(' · ');
+
+  const todayRows = projection.today
+    .map(
+      (row) =>
+        `<li data-situation-id="${escapeHtml(row.situation_id)}" data-view-model-hash="${escapeHtml(
+          row.view_model_hash
+        )}"><strong>${escapeHtml(row.title)}</strong><span>${escapeHtml(
+          row.next_action
+        )}</span><code>${escapeHtml(row.view_model_hash)}</code></li>`
+    )
+    .join('');
+
+  const evidenceRows = projection.today
+    .map(
+      (row) =>
+        `<li><strong>${escapeHtml(row.title)}</strong><span>${row.evidence_count} refs</span></li>`
+    )
+    .join('');
+
+  return [
+    {
+      slotId: 'briefing',
+      html: `<section data-vnext-slot="briefing">${statusHtml}<ol>${todayRows}</ol></section>`,
+      priority: 0,
+      updatedAt,
+    },
+    {
+      slotId: 'vnext-status',
+      html: `<section data-vnext-slot="status">${statusHtml}</section>`,
+      priority: 10,
+      updatedAt,
+    },
+    {
+      slotId: 'vnext-today',
+      html: `<section data-vnext-slot="today"><ol>${todayRows}</ol></section>`,
+      priority: 20,
+      updatedAt,
+    },
+    {
+      slotId: 'vnext-evidence',
+      html: `<section data-vnext-slot="evidence"><ol>${evidenceRows}</ol></section>`,
+      priority: 30,
+      updatedAt,
+    },
+  ];
+}

--- a/packages/standalone/tests/agent/gateway-tool-executor.test.ts
+++ b/packages/standalone/tests/agent/gateway-tool-executor.test.ts
@@ -389,6 +389,33 @@ describe('STORY-V019 - GatewayToolExecutor', () => {
           message: expect.stringContaining('Invalid outcome'),
         });
       });
+
+      it('should not crash vNext authority checks when agentId is null at runtime', async () => {
+        const mockApi = createMockApi();
+        const executor = new GatewayToolExecutor({
+          mamaApi: mockApi,
+          vNextRuntimeEnabled: true,
+        });
+
+        const result = await executor.execute(
+          'mama_update',
+          {
+            id: 'decision_123',
+            outcome: 'success',
+          },
+          {
+            agentId: null,
+            source: 'system',
+            channelId: 'system',
+          } as unknown as Parameters<GatewayToolExecutor['execute']>[2]
+        );
+
+        expect(result).toMatchObject({
+          success: false,
+          code: 'vnext_commit_authority_denied',
+        });
+        expect(mockApi.updateOutcome).not.toHaveBeenCalled();
+      });
     });
 
     describe('agent management tools', () => {

--- a/packages/standalone/tests/api/report-vnext.test.ts
+++ b/packages/standalone/tests/api/report-vnext.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+import { createReportRouter, createReportStore } from '../../src/api/report-handler.js';
+import { buildSituationProjection } from '../../src/operator-vnext/situation-projection.js';
+
+describe('Story PR5.2: vNext Report Projection API', () => {
+  describe('AC #1: vNext projection is selected only when explicitly configured', () => {
+    it('serves legacy report slots when no vNext provider is configured', async () => {
+      const store = createReportStore();
+      store.update('briefing', '<p>Legacy briefing</p>', 1);
+
+      const router = createReportRouter(store, new Set());
+      const app = express();
+      app.use(express.json());
+      app.use('/', router);
+      const response = await request(app).get('/');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        slots: [
+          expect.objectContaining({
+            slotId: 'briefing',
+            html: '<p>Legacy briefing</p>',
+            priority: 1,
+          }),
+        ],
+      });
+    });
+
+    it('serves deterministic vNext report slots without mutating the legacy store', async () => {
+      const store = createReportStore();
+      store.update('briefing', '<p>Legacy briefing</p>', 1);
+      const projection = buildSituationProjection([
+        {
+          situationId: 'sit_manual_report',
+          situationVersion: 2,
+          awarenessRunId: 'run_manual_report',
+          title: 'Synthetic report projection',
+          status: 'in_progress',
+          summary: 'Synthetic dashboard projection row.',
+          nextAction: 'Continue the synthetic operator flow.',
+          freshness: 'live',
+          verificationState: 'pending',
+          confidence: 0.9,
+          evidenceRefs: [{ kind: 'raw', connector: 'manual', id: 'event-report' }],
+          updatedAtMs: 1_710_000_010_000,
+          viewModelHash: 'vm_hash_report',
+          ownerHint: 'operator:primary',
+        },
+      ]);
+
+      const router = createReportRouter(store, new Set(), {
+        vNextProjectionProvider: () => projection,
+      });
+      const app = express();
+      app.use('/', router);
+      const response = await request(app).get('/');
+
+      expect(response.status).toBe(200);
+      expect(response.body.mode).toBe('vnext');
+      expect(response.body.projection.view_model_hash).toBe('vm_hash_report');
+      expect(response.body.projection.today[0]).toMatchObject({
+        evidence_count: 1,
+        evidence_refs: [],
+        owner_hint: null,
+      });
+      expect(response.body.slots.map((slot: { slotId: string }) => slot.slotId)).toEqual([
+        'briefing',
+        'vnext-status',
+        'vnext-today',
+        'vnext-evidence',
+      ]);
+      expect(response.body.slots[0].html).toContain('Synthetic report projection');
+      expect(store.get('briefing')?.html).toBe('<p>Legacy briefing</p>');
+    });
+
+    it('rejects legacy report mutations while vNext projections are active', async () => {
+      const store = createReportStore();
+      const projection = buildSituationProjection([
+        {
+          situationId: 'sit_projection_only',
+          situationVersion: 1,
+          awarenessRunId: 'run_projection_only',
+          title: 'Projection-only dashboard',
+          status: 'in_progress',
+          summary: 'Projection mode owns dashboard state.',
+          nextAction: 'Read the projected state instead of mutating legacy slots.',
+          freshness: 'live',
+          verificationState: 'verified',
+          confidence: 1,
+          evidenceRefs: [{ kind: 'raw', connector: 'manual', id: 'event-projection-only' }],
+          updatedAtMs: 1_710_000_010_000,
+          viewModelHash: 'vm_hash_projection_only',
+        },
+      ]);
+
+      const router = createReportRouter(store, new Set(), {
+        vNextProjectionProvider: () => projection,
+      });
+      const app = express();
+      app.use(express.json());
+      app.use('/', router);
+
+      for (const response of [
+        await request(app)
+          .put('/')
+          .send({ slots: { briefing: { html: '<p>Legacy</p>' } } }),
+        await request(app).put('/slots/briefing').send({ html: '<p>Legacy</p>' }),
+        await request(app).delete('/slots/briefing'),
+      ]) {
+        expect(response.status).toBe(409);
+        expect(response.body).toMatchObject({
+          ok: false,
+          code: 'vnext_report_projection_only',
+        });
+      }
+      expect(store.getAllSorted()).toEqual([]);
+
+      const nullProjectionRouter = createReportRouter(store, new Set(), {
+        vNextProjectionProvider: () => null,
+      });
+      const nullProjectionApp = express();
+      nullProjectionApp.use(express.json());
+      nullProjectionApp.use('/', nullProjectionRouter);
+      const nullProjectionWrite = await request(nullProjectionApp)
+        .put('/')
+        .send({ slots: { briefing: { html: '<p>Legacy</p>' } } });
+
+      expect(nullProjectionWrite.status).toBe(409);
+      expect(nullProjectionWrite.body).toMatchObject({
+        ok: false,
+        code: 'vnext_report_projection_only',
+      });
+      expect(store.getAllSorted()).toEqual([]);
+    });
+  });
+});

--- a/packages/standalone/tests/cli/runtime/agent-loop-init-envelope-options.test.ts
+++ b/packages/standalone/tests/cli/runtime/agent-loop-init-envelope-options.test.ts
@@ -123,5 +123,24 @@ describe('Story M1R: initMainAgentLoop envelope options', () => {
 
       expect(runWithContentSpy).toHaveBeenCalledWith(content, expect.objectContaining(options));
     });
+
+    it('passes vNext runtime mode into the gateway executor', () => {
+      const { agentLoop } = initMainAgentLoop(
+        createConfig(),
+        { getToken: vi.fn() } as unknown as OAuthManager,
+        {} as SQLiteDatabase,
+        null as MetricsStore | null,
+        'claude',
+        { vNextRuntimeEnabled: true }
+      );
+
+      const executor = (
+        agentLoop as unknown as {
+          mcpExecutor: { vNextCommitRuntimeMode: string };
+        }
+      ).mcpExecutor;
+
+      expect(executor.vNextCommitRuntimeMode).toBe('vnext');
+    });
   });
 });

--- a/packages/standalone/tests/operator-vnext/commit-authority.test.ts
+++ b/packages/standalone/tests/operator-vnext/commit-authority.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveCommitAuthority } from '../../src/operator-vnext/commit-authority.js';
+
+describe('Story PR5.3: vNext Commit Authority', () => {
+  describe('AC #1: only the primary operator can perform allowed durable writes', () => {
+    it('allows legacy mode to preserve existing behavior', () => {
+      expect(
+        resolveCommitAuthority({
+          runtimeMode: 'legacy',
+          toolName: 'report_publish',
+          actor: { kind: 'worker', agentId: 'dashboard-agent' },
+        })
+      ).toMatchObject({ allowed: true, effect: 'legacy' });
+    });
+
+    it('denies report_publish as canonical state in vNext mode', () => {
+      expect(
+        resolveCommitAuthority({
+          runtimeMode: 'vnext',
+          toolName: 'report_publish',
+          actor: { kind: 'primary_operator', agentId: 'operator:primary' },
+        })
+      ).toMatchObject({
+        allowed: false,
+        code: 'vnext_report_projection_only',
+      });
+    });
+
+    it('lets the primary operator publish source-linked wiki artifacts', () => {
+      expect(
+        resolveCommitAuthority({
+          runtimeMode: 'vnext',
+          toolName: 'wiki_publish',
+          actor: { kind: 'primary_operator', agentId: 'operator:primary' },
+        })
+      ).toMatchObject({ allowed: true, effect: 'commit' });
+    });
+
+    it('restricts workers to proposals for durable write tools', () => {
+      expect(
+        resolveCommitAuthority({
+          runtimeMode: 'vnext',
+          toolName: 'wiki_publish',
+          actor: { kind: 'worker', agentId: 'wiki-agent' },
+        })
+      ).toMatchObject({
+        allowed: false,
+        effect: 'proposal_required',
+        code: 'vnext_worker_proposal_required',
+      });
+    });
+
+    it('treats memory updates as durable writes in vNext mode', () => {
+      expect(
+        resolveCommitAuthority({
+          runtimeMode: 'vnext',
+          toolName: 'mama_update',
+          actor: { kind: 'worker', agentId: 'memory-agent' },
+        })
+      ).toMatchObject({
+        allowed: false,
+        effect: 'proposal_required',
+        code: 'vnext_worker_proposal_required',
+      });
+    });
+
+    it('lets viewer admins manually save source-linked memory through the allowed path', () => {
+      expect(
+        resolveCommitAuthority({
+          runtimeMode: 'vnext',
+          toolName: 'mama_save',
+          actor: { kind: 'viewer_admin', agentId: 'viewer-session' },
+        })
+      ).toMatchObject({ allowed: true, effect: 'manual' });
+    });
+
+    it('denies direct Obsidian mutation because vNext wiki state must be source-linked', () => {
+      expect(
+        resolveCommitAuthority({
+          runtimeMode: 'vnext',
+          toolName: 'obsidian',
+          actor: { kind: 'worker', agentId: 'wiki-agent' },
+        })
+      ).toMatchObject({
+        allowed: false,
+        effect: 'denied',
+        code: 'vnext_obsidian_disabled',
+      });
+    });
+
+    it('keeps raw filesystem writes on viewer policy instead of worker authority', () => {
+      expect(
+        resolveCommitAuthority({
+          runtimeMode: 'vnext',
+          toolName: 'Write',
+          actor: { kind: 'worker', agentId: 'dashboard-agent' },
+        })
+      ).toMatchObject({
+        allowed: false,
+        effect: 'denied',
+        code: 'vnext_filesystem_write_denied',
+      });
+
+      expect(
+        resolveCommitAuthority({
+          runtimeMode: 'vnext',
+          toolName: 'Write',
+          actor: { kind: 'viewer_admin', agentId: 'viewer-session' },
+        })
+      ).toMatchObject({ allowed: true, effect: 'manual' });
+    });
+
+    it('denies Bash for workers because shell commands can mutate files', () => {
+      expect(
+        resolveCommitAuthority({
+          runtimeMode: 'vnext',
+          toolName: 'Bash',
+          actor: { kind: 'worker', agentId: 'developer-agent' },
+        })
+      ).toMatchObject({
+        allowed: false,
+        effect: 'denied',
+        code: 'vnext_filesystem_write_denied',
+      });
+
+      expect(
+        resolveCommitAuthority({
+          runtimeMode: 'vnext',
+          toolName: 'Bash',
+          actor: { kind: 'viewer_admin', agentId: 'viewer-session' },
+        })
+      ).toMatchObject({ allowed: true, effect: 'manual' });
+    });
+  });
+});

--- a/packages/standalone/tests/operator-vnext/delegation-authority.test.ts
+++ b/packages/standalone/tests/operator-vnext/delegation-authority.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { DelegationExecutor } from '../../src/agent/delegation-executor.js';
+import { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
+
+function createMamaApiMock() {
+  return {
+    save: vi.fn().mockResolvedValue({ success: true, id: 'decision_vnext_manual' }),
+    saveCheckpoint: vi.fn().mockResolvedValue({ success: true, id: 'checkpoint_vnext_manual' }),
+    listDecisions: vi.fn(),
+    suggest: vi.fn(),
+    updateOutcome: vi.fn(),
+    loadCheckpoint: vi.fn(),
+    beginModelRun: vi.fn().mockResolvedValue({
+      model_run_id: 'mr_vnext_manual',
+      gateway_call_id: 'gw_vnext_manual',
+    }),
+    commitModelRun: vi.fn().mockResolvedValue({ model_run_id: 'mr_vnext_manual' }),
+    failModelRun: vi.fn().mockResolvedValue({ model_run_id: 'mr_vnext_manual' }),
+    appendToolTrace: vi.fn().mockResolvedValue({ ok: true }),
+  };
+}
+
+function createViewerAdminContext() {
+  return {
+    source: 'viewer',
+    platform: 'viewer' as const,
+    roleName: 'os_agent',
+    role: {
+      allowedTools: ['*'],
+      systemControl: true,
+      sensitiveAccess: true,
+    },
+    session: {
+      sessionId: 'viewer-session',
+      startedAt: new Date(),
+    },
+    capabilities: ['All tools'],
+    limitations: [],
+  };
+}
+
+describe('Story PR5.4: vNext Delegation Authority', () => {
+  describe('AC #1: workers cannot nest durable delegation in vNext mode', () => {
+    it('denies delegate at GatewayToolExecutor before spawning a sub-agent', async () => {
+      const executor = new GatewayToolExecutor({
+        mamaApi: {
+          save: vi.fn(),
+          saveCheckpoint: vi.fn(),
+          listDecisions: vi.fn(),
+          suggest: vi.fn(),
+          updateOutcome: vi.fn(),
+          loadCheckpoint: vi.fn(),
+        },
+        vNextRuntimeEnabled: true,
+      });
+
+      const result = await executor.execute(
+        'delegate',
+        { agentId: 'wiki-agent', task: 'Write durable wiki update' },
+        {
+          executionSurface: 'model_tool',
+          agentId: 'wiki-agent',
+          source: 'system',
+          channelId: 'system:wiki-agent',
+        }
+      );
+
+      expect(result).toMatchObject({
+        success: false,
+        code: 'vnext_worker_delegation_denied',
+      });
+    });
+
+    it('lets DelegationExecutor enforce an injected authority denial', async () => {
+      const executor = new DelegationExecutor({
+        agentProcessManager: null,
+        delegationManagerRef: null,
+        retryDelayMs: 1,
+        resolveManagedAgentId: (id) => id,
+        checkViewerOnly: () => null,
+        checkDelegationAuthority: () => ({
+          allowed: false,
+          code: 'vnext_worker_delegation_denied',
+          reason: 'vNext workers must return proposals instead of delegating.',
+        }),
+      });
+
+      const result = await executor.runDelegate(
+        { agentId: 'dashboard-agent', task: 'Nested worker task' },
+        { agentId: 'wiki-agent', source: 'system', channelId: 'system:wiki-agent' }
+      );
+
+      expect(result).toEqual({
+        success: false,
+        code: 'vnext_worker_delegation_denied',
+        error: 'vNext workers must return proposals instead of delegating.',
+      });
+    });
+
+    it('requires direct viewer-admin surface for manual vNext memory commits', async () => {
+      const mamaApi = createMamaApiMock();
+      const executor = new GatewayToolExecutor({
+        mamaApi,
+        vNextRuntimeEnabled: true,
+        envelopeIssuanceMode: 'off',
+      });
+      const input = {
+        type: 'decision',
+        topic: 'operator authority',
+        decision: 'Manual commits require a direct viewer-admin surface.',
+        reasoning: 'Viewer-admin roles can be present on model-tool calls.',
+      };
+      const viewerAdminContext = createViewerAdminContext();
+
+      const modelToolResult = await executor.execute('mama_save', input, {
+        executionSurface: 'model_tool',
+        source: 'viewer',
+        agentId: 'os-agent',
+        channelId: 'viewer-session',
+        agentContext: viewerAdminContext,
+      });
+
+      expect(modelToolResult).toMatchObject({
+        success: false,
+        code: 'vnext_worker_proposal_required',
+      });
+      expect(mamaApi.save).not.toHaveBeenCalled();
+
+      const directResult = await executor.execute('mama_save', input, {
+        executionSurface: 'direct',
+        source: 'viewer',
+        agentId: 'os-agent',
+        channelId: 'viewer-session',
+        agentContext: viewerAdminContext,
+      });
+
+      expect(directResult).toMatchObject({ success: true });
+      expect(mamaApi.save).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/packages/standalone/tests/operator-vnext/delegation-authority.test.ts
+++ b/packages/standalone/tests/operator-vnext/delegation-authority.test.ts
@@ -98,6 +98,35 @@ describe('Story PR5.4: vNext Delegation Authority', () => {
       });
     });
 
+    it('denies agent_test through the same injected authority gate', async () => {
+      const executor = new DelegationExecutor({
+        agentProcessManager: null,
+        delegationManagerRef: null,
+        retryDelayMs: 1,
+        resolveManagedAgentId: (id) => id,
+        checkViewerOnly: () => null,
+        checkDelegationAuthority: () => ({
+          allowed: false,
+          code: 'vnext_worker_delegation_denied',
+          reason: 'vNext workers must return proposals instead of delegating.',
+        }),
+      });
+
+      const result = await executor.runAgentTest(
+        {
+          agent_id: 'dashboard-agent',
+          test_data: [{ input: 'Run nested durable check' }],
+        },
+        { agentId: 'wiki-agent', source: 'system', channelId: 'system:wiki-agent' }
+      );
+
+      expect(result).toEqual({
+        success: false,
+        code: 'vnext_worker_delegation_denied',
+        error: 'vNext workers must return proposals instead of delegating.',
+      });
+    });
+
     it('requires direct viewer-admin surface for manual vNext memory commits', async () => {
       const mamaApi = createMamaApiMock();
       const executor = new GatewayToolExecutor({

--- a/packages/standalone/tests/operator-vnext/situation-projection.test.ts
+++ b/packages/standalone/tests/operator-vnext/situation-projection.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildSituationProjection,
+  buildReportSlotsFromSituationProjection,
+} from '../../src/operator-vnext/situation-projection.js';
+import type { VNextSituationInput } from '../../src/operator-vnext/situation-projection-types.js';
+
+const sourceRefs = [{ kind: 'raw' as const, connector: 'manual', id: 'event-42' }];
+
+function makeSituation(overrides: Partial<VNextSituationInput> = {}): VNextSituationInput {
+  return {
+    situationId: 'sit_manual_42',
+    situationVersion: 3,
+    awarenessRunId: 'run_manual_42',
+    title: 'Synthetic onboarding follow-up',
+    status: 'needs_review',
+    summary: 'Synthetic fixture needs operator review before publication.',
+    nextAction: 'Review the synthetic follow-up and commit the next operator action.',
+    freshness: 'live',
+    verificationState: 'pending',
+    confidence: 0.82,
+    evidenceRefs: sourceRefs,
+    updatedAtMs: 1_710_000_000_000,
+    priority: 7,
+    tags: ['follow_up'],
+    pendingReason: 'Memory has not verified the latest connector delta yet.',
+    ownerHint: 'operator',
+    issueCount: 1,
+    viewModelHash: 'vm_hash_manual_42',
+    ...overrides,
+  };
+}
+
+describe('Story PR5.1: vNext Situation Projection', () => {
+  describe('AC #1: deterministic dashboard projection from one situation model', () => {
+    it('keeps current state, freshness, verification, and evidence hash together', () => {
+      const projection = buildSituationProjection([makeSituation()]);
+
+      expect(projection.projectionVersion).toBe(1);
+      expect(projection.viewModelHash).toBe('vm_hash_manual_42');
+      expect(projection.today).toHaveLength(1);
+      expect(projection.today[0]).toMatchObject({
+        situation_id: 'sit_manual_42',
+        situation_version: 3,
+        awareness_run_id: 'run_manual_42',
+        title: 'Synthetic onboarding follow-up',
+        freshness: 'live',
+        verification_state: 'pending',
+        view_model_hash: 'vm_hash_manual_42',
+        next_action: 'Review the synthetic follow-up and commit the next operator action.',
+        evidence_count: 1,
+        pending_reason: 'Memory has not verified the latest connector delta yet.',
+      });
+      expect(projection.status).toMatchObject({
+        total: 1,
+        pendingVerification: 1,
+        degraded: 0,
+      });
+    });
+
+    it('sorts by priority before recency and emits stable report slots', () => {
+      const olderHighPriority = makeSituation({
+        situationId: 'sit_high',
+        title: 'High priority synthetic issue',
+        priority: 1,
+        updatedAtMs: 100,
+        viewModelHash: 'hash_high',
+      });
+      const newerLowPriority = makeSituation({
+        situationId: 'sit_low',
+        title: 'Low priority synthetic issue',
+        priority: 20,
+        updatedAtMs: 200,
+        viewModelHash: 'hash_low',
+      });
+
+      const projection = buildSituationProjection([newerLowPriority, olderHighPriority]);
+      expect(projection.today.map((row) => row.situation_id)).toEqual(['sit_high', 'sit_low']);
+
+      const slots = buildReportSlotsFromSituationProjection(projection);
+      expect(slots.map((slot) => slot.slotId)).toEqual([
+        'briefing',
+        'vnext-status',
+        'vnext-today',
+        'vnext-evidence',
+      ]);
+      expect(slots[0].html).toContain('2 current situations');
+      expect(slots[0].html).toContain('High priority synthetic issue');
+      expect(slots[2].html).toContain('High priority synthetic issue');
+      expect(slots[2].html).toContain('hash_high');
+    });
+
+    it('rejects invalid numeric projection fields before sorting or aggregation', () => {
+      expect(() => buildSituationProjection([makeSituation({ priority: Number.NaN })])).toThrow(
+        'priority must be a non-negative integer'
+      );
+      expect(() => buildSituationProjection([makeSituation({ issueCount: -1 })])).toThrow(
+        'issueCount must be a non-negative integer'
+      );
+      expect(() => buildSituationProjection([makeSituation()], Number.POSITIVE_INFINITY)).toThrow(
+        'nowMs must be a non-negative integer'
+      );
+    });
+  });
+});

--- a/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
+++ b/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
@@ -9,7 +9,7 @@ import { ensureVNextOperatorSchema } from '../../src/operator-vnext/schema.js';
 import type { VNextBootstrapRuntimeStatus } from '../../src/runtime-vnext/bootstrap.js';
 import Database from '../../src/sqlite.js';
 
-const AUTH_TOKEN_ENV = 'MAMA_' + 'AUTH_TOKEN';
+const AUTH_TOKEN_ENV = 'MAMA_AUTH_TOKEN';
 
 function makeStatus(): VNextBootstrapRuntimeStatus {
   return {

--- a/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
+++ b/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
@@ -9,6 +9,8 @@ import { ensureVNextOperatorSchema } from '../../src/operator-vnext/schema.js';
 import type { VNextBootstrapRuntimeStatus } from '../../src/runtime-vnext/bootstrap.js';
 import Database from '../../src/sqlite.js';
 
+const AUTH_TOKEN_ENV = 'MAMA_' + 'AUTH_TOKEN';
+
 function makeStatus(): VNextBootstrapRuntimeStatus {
   return {
     enabled: true,
@@ -36,19 +38,19 @@ function makeStatus(): VNextBootstrapRuntimeStatus {
 }
 
 describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
-  const originalAuthToken = process.env.MAMA_AUTH_TOKEN;
+  const originalAuthToken = process.env[AUTH_TOKEN_ENV];
 
   afterEach(() => {
     if (originalAuthToken === undefined) {
-      delete process.env.MAMA_AUTH_TOKEN;
+      delete process.env[AUTH_TOKEN_ENV];
     } else {
-      process.env.MAMA_AUTH_TOKEN = originalAuthToken;
+      process.env[AUTH_TOKEN_ENV] = originalAuthToken;
     }
   });
 
   describe('AC: vNext status endpoints keep public health separate from authenticated API', () => {
     it('keeps /health unauthenticated but protects /api status routes for tunneled requests', async () => {
-      process.env.MAMA_AUTH_TOKEN = 'vnext-status-token';
+      process.env[AUTH_TOKEN_ENV] = 'vnext-status-token';
       const apiServer = createVNextBootstrapApiServer(makeStatus());
 
       const health = await request(apiServer.app)
@@ -95,8 +97,48 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
       expect(authenticated.body.primary_operator_runtime).not.toHaveProperty('advancedThroughSeq');
     });
 
+    it('serves the Today dashboard from vNext projection slots in bootstrap mode', async () => {
+      process.env[AUTH_TOKEN_ENV] = 'vnext-status-token';
+      const status = makeStatus();
+      status.primaryOperator.advancedThroughSeq = 9;
+      const apiServer = createVNextBootstrapApiServer(status);
+
+      const response = await request(apiServer.app)
+        .get('/api/report')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-status-token');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        mode: 'vnext',
+        projection: {
+          projection_version: 1,
+          status: {
+            total: 1,
+            live: 1,
+            issueCount: 0,
+          },
+        },
+      });
+      expect(response.body.projection.today[0]).toMatchObject({
+        situation_id: 'vnext_primary_operator',
+        freshness: 'live',
+        verification_state: 'verified',
+        evidence_count: 1,
+        evidence_refs: [],
+        owner_hint: null,
+      });
+      expect(response.body.projection.today[0].evidence_refs).not.toContain('operator:primary:9');
+      expect(response.body.slots.map((slot: { slotId: string }) => slot.slotId)).toEqual([
+        'briefing',
+        'vnext-status',
+        'vnext-today',
+        'vnext-evidence',
+      ]);
+    });
+
     it('creates a primary operator runtime bound to the manual cursor', async () => {
-      process.env.MAMA_AUTH_TOKEN = 'vnext-status-token';
+      process.env[AUTH_TOKEN_ENV] = 'vnext-status-token';
       const db = new Database(':memory:');
       ensureVNextOperatorSchema(db);
       db.prepare(
@@ -155,7 +197,7 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
     });
 
     it('marks primary operator runtime degraded after a failed batch', async () => {
-      process.env.MAMA_AUTH_TOKEN = 'vnext-status-token';
+      process.env[AUTH_TOKEN_ENV] = 'vnext-status-token';
       const db = new Database(':memory:');
       ensureVNextOperatorSchema(db);
       const primaryOperator = createVNextPrimaryOperatorRuntime(db);


### PR DESCRIPTION
## Summary
- add vNext situation projection and dashboard report slots with redacted public projection payloads
- add vNext commit authority gates for durable writes, filesystem/shell mutations, Obsidian, report publishing, and nested delegation
- wire vNext mode through gateway/API/bootstrap paths and block legacy report mutations in projection mode

## Review gates
- codex review found and fixed executor wiring, mama_update gating, briefing slot compatibility, Obsidian bypass, Bash bypass, viewer-admin surface bypass, report mutation bypass, public projection redaction, and null-provider mutation bypass
- final focused codex review: No actionable findings

## Verification
- MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run tests/api/report-handler.test.ts tests/api/report-vnext.test.ts tests/operator-vnext/situation-projection.test.ts tests/operator-vnext/commit-authority.test.ts tests/operator-vnext/delegation-authority.test.ts tests/agent/gateway-tool-executor.test.ts tests/runtime-vnext/bootstrap-api.test.ts tests/cli/runtime/agent-loop-init-envelope-options.test.ts
- pnpm --filter @jungjaehoon/mama-os typecheck
- pnpm build
- pre-commit changed-package test: 232 files passed, 3290 tests passed, 1 file/3 tests skipped
- git diff --cached --check
- ./scripts/check-pii.sh
- added-line secret/internal-info scan: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new report view that can show a vNext projection when available, with updated slot content and structured summary data.
  * Introduced support for vNext-aware startup and API configuration, including optional runtime and projection settings.

* **Bug Fixes**
  * Prevented legacy report edits when vNext projections are active, returning a clear conflict response instead.
  * Added stronger authorization checks for delegation and other restricted actions, blocking disallowed operations earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->