### PR TITLE
feat: add vnext connector ingress preview

### DIFF
--- a/docs/architecture/mama-vnext-primary-operator-rebuild.md
+++ b/docs/architecture/mama-vnext-primary-operator-rebuild.md
@@ -638,6 +638,58 @@ MAMA_FORCE_TIER_3=true pnpm vitest run \
   packages/standalone/tests/operator-vnext/delegation-authority.test.ts
 ```
 
+### PR 6: Connector Ingress Dry-Run Rollout
+
+Goal:
+
+- Add a local, authenticated dry-run runway for one explicit connector/channel.
+- Convert `connector_event_index` rows into source-linked primary-operator event
+  candidates without advancing cursors or committing durable state.
+- Keep connector polling, dashboard/wiki agents, memory compose, and worker commits
+  disabled by default in vNext bootstrap mode.
+
+Files:
+
+- Create: `packages/standalone/src/operator-vnext/connector-event-ingress.ts`
+- Modify: `packages/standalone/src/cli/commands/start.ts`
+- Create: `packages/standalone/tests/operator-vnext/connector-event-ingress.test.ts`
+- Modify: `packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts`
+
+Runtime opt-in:
+
+```bash
+MAMA_VNEXT_RUNTIME=1 \
+MAMA_VNEXT_INGRESS_CONNECTOR=slack \
+MAMA_VNEXT_INGRESS_CHANNEL=C_PUBLIC_SYNTHETIC \
+mama start --foreground
+```
+
+Authenticated preview endpoint:
+
+```text
+GET /api/vnext/ingress/preview?connector=slack&channel=C_PUBLIC_SYNTHETIC&limit=25
+```
+
+Rules:
+
+- `MAMA_VNEXT_INGRESS_CONNECTOR` and `MAMA_VNEXT_INGRESS_CHANNEL` must be set
+  together.
+- Preview is locked to the configured connector/channel.
+- Preview returns source refs and deterministic event seq candidates only.
+- Preview must not insert `vnext_operator_commits`, `vnext_operator_cursors`, or
+  `operator_no_updates` rows.
+- Preview must not promote legacy report/wiki/memory artifacts.
+
+Verify:
+
+```bash
+MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run \
+  tests/operator-vnext/connector-event-ingress.test.ts \
+  tests/runtime-vnext/bootstrap-api.test.ts \
+  tests/runtime-vnext/bootstrap.test.ts \
+  tests/runtime-vnext/legacy-fanout-disabled.test.ts
+```
+
 ## Global Regression Checklist
 
 - legacy mode behavior unchanged
@@ -700,8 +752,8 @@ Conflict flags:
 4. Land PR 3 and dogfood ordinary chat vs prior-rule chat.
 5. Land PR 4 and import one wiki page as unverified, then commit one source-linked artifact.
 6. Land PR 5 and switch Today dashboard to existing projection extension.
-7. Enable vNext locally for one connector/channel.
-8. Run dry-run migration.
+7. Land PR 6 and enable vNext dry-run preview locally for one connector/channel.
+8. Run dry-run migration against the authenticated ingress preview.
 9. Decide whether to remove legacy self-paced agents from default config.
 
 ## Review Notes

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -596,6 +596,12 @@ function queryLimit(value: unknown): number | undefined {
   return limit;
 }
 
+function isVNextIngressPreviewClientError(error: unknown): boolean {
+  return (
+    error instanceof Error && error.message.includes('locked to the configured connector/channel')
+  );
+}
+
 function buildVNextStatusPayload(status: VNextBootstrapRuntimeStatus): Record<string, unknown> {
   return {
     ok: true,
@@ -762,9 +768,12 @@ export function createVNextBootstrapApiServer(
         preview: options.ingressPreviewProvider({ connector, channel, limit }),
       });
     } catch (error) {
-      res.status(500).json({
+      const clientError = isVNextIngressPreviewClientError(error);
+      res.status(clientError ? 400 : 500).json({
         ok: false,
-        code: 'vnext_ingress_preview_failed',
+        code: clientError
+          ? 'vnext_ingress_preview_invalid_request'
+          : 'vnext_ingress_preview_failed',
         error: error instanceof Error ? error.message : String(error),
       });
     }
@@ -913,8 +922,7 @@ export async function runAgentLoop(
     let vNextRawAdapter: ConnectorEventIngressAdapter | null = null;
     if (vNextIngressConfig.enabled) {
       process.env.MAMA_DB_PATH = expandPath(config.database.path);
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { initDB, getAdapter } = require('@jungjaehoon/mama-core/db-manager') as {
+      const { initDB, getAdapter } = (await import('@jungjaehoon/mama-core/db-manager')) as {
         initDB: () => Promise<unknown>;
         getAdapter: () => ConnectorEventIngressAdapter;
       };

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -84,6 +84,12 @@ import {
   buildReportSlotsFromSituationProjection,
   buildSituationProjection,
 } from '../../operator-vnext/situation-projection.js';
+import {
+  createConnectorEventIngressPreviewProvider,
+  resolveConnectorEventIngressConfig,
+  type ConnectorEventIngressAdapter,
+  type ConnectorEventIngressPreview,
+} from '../../operator-vnext/connector-event-ingress.js';
 import { resolveReactiveProjectRoot } from '../../envelope/reactive-config.js';
 import { deriveMemoryScopes, type MemoryScopeRef } from '../../memory/scope-context.js';
 import { DEFAULT_ROLES, type AgentPersonaConfig, type RoleConfig } from '../config/types.js';
@@ -556,6 +562,40 @@ function buildVNextLegacyPrimaryOperatorPayload(): Record<string, unknown> {
   };
 }
 
+export interface VNextIngressPreviewRequest {
+  connector: string;
+  channel: string;
+  limit?: number;
+}
+
+export interface VNextBootstrapApiServerOptions {
+  ingressPreviewProvider?: (input: VNextIngressPreviewRequest) => ConnectorEventIngressPreview;
+}
+
+function firstQueryString(value: unknown): string | null {
+  const candidate = Array.isArray(value) ? value[0] : value;
+  if (typeof candidate !== 'string') {
+    return null;
+  }
+  const trimmed = candidate.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function queryLimit(value: unknown): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const raw = firstQueryString(value);
+  if (raw === null) {
+    throw new Error('limit must be a number');
+  }
+  const limit = Number(raw);
+  if (!Number.isFinite(limit)) {
+    throw new Error('limit must be a number');
+  }
+  return limit;
+}
+
 function buildVNextStatusPayload(status: VNextBootstrapRuntimeStatus): Record<string, unknown> {
   return {
     ok: true,
@@ -655,7 +695,10 @@ export function createVNextPrimaryOperatorRuntime(db: Database): VNextPrimaryOpe
   };
 }
 
-export function createVNextBootstrapApiServer(status: VNextBootstrapRuntimeStatus): {
+export function createVNextBootstrapApiServer(
+  status: VNextBootstrapRuntimeStatus,
+  options: VNextBootstrapApiServerOptions = {}
+): {
   app: Express;
   server: HttpServer | null;
   start: () => Promise<void>;
@@ -678,6 +721,53 @@ export function createVNextBootstrapApiServer(status: VNextBootstrapRuntimeStatu
   });
   app.get('/api/status', (_req, res) => {
     res.json(buildVNextStatusPayload(status));
+  });
+  app.get('/api/vnext/ingress/preview', (req, res) => {
+    if (!options.ingressPreviewProvider) {
+      res.status(404).json({
+        ok: false,
+        code: 'vnext_ingress_preview_unavailable',
+        error: 'vNext connector ingress preview is not configured.',
+      });
+      return;
+    }
+
+    const connector = firstQueryString(req.query.connector);
+    const channel = firstQueryString(req.query.channel);
+    if (!connector || !channel) {
+      res.status(400).json({
+        ok: false,
+        code: 'vnext_ingress_preview_invalid_request',
+        error: 'connector and channel query parameters are required.',
+      });
+      return;
+    }
+
+    let limit: number | undefined;
+    try {
+      limit = queryLimit(req.query.limit);
+    } catch (error) {
+      res.status(400).json({
+        ok: false,
+        code: 'vnext_ingress_preview_invalid_request',
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+
+    try {
+      res.json({
+        ok: true,
+        mode: 'dry_run',
+        preview: options.ingressPreviewProvider({ connector, channel, limit }),
+      });
+    } catch (error) {
+      res.status(500).json({
+        ok: false,
+        code: 'vnext_ingress_preview_failed',
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   });
   app.get('/api/report', (_req, res) => {
     const projection = buildVNextBootstrapSituationProjection(status);
@@ -819,17 +909,51 @@ export async function runAgentLoop(
   const vNext = buildVNextBootstrapPlan(resolveVNextRuntimeFlags(config, process.env));
   if (vNext.enabled) {
     console.log('✓ MAMA vNext bootstrap mode enabled (legacy fanout disabled)');
+    const vNextIngressConfig = resolveConnectorEventIngressConfig(process.env);
+    let vNextRawAdapter: ConnectorEventIngressAdapter | null = null;
+    if (vNextIngressConfig.enabled) {
+      process.env.MAMA_DB_PATH = expandPath(config.database.path);
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { initDB, getAdapter } = require('@jungjaehoon/mama-core/db-manager') as {
+        initDB: () => Promise<unknown>;
+        getAdapter: () => ConnectorEventIngressAdapter;
+      };
+      await initDB();
+      vNextRawAdapter = getAdapter();
+      console.log(
+        `✓ vNext connector ingress preview enabled (${vNextIngressConfig.connector}/${vNextIngressConfig.channel})`
+      );
+    }
+    let vNextOperatorDb: Database | null = null;
     await startVNextBootstrapRuntime(vNext, {
       openDatabase: () => {
         const dbPath = expandPath(config.database.path).replace(
           'mama-memory.db',
           'mama-sessions.db'
         );
-        return new Database(dbPath);
+        vNextOperatorDb = new Database(dbPath);
+        return vNextOperatorDb;
       },
       initializeOperatorSchema: ensureVNextOperatorSchema,
       createPrimaryOperator: createVNextPrimaryOperatorRuntime,
-      createApiServer: createVNextBootstrapApiServer,
+      createApiServer: (status) => {
+        if (!vNextIngressConfig.enabled) {
+          return createVNextBootstrapApiServer(status);
+        }
+        if (!vNextRawAdapter || !vNextOperatorDb) {
+          throw new Error(
+            'vNext connector ingress preview requires initialized raw and operator DBs'
+          );
+        }
+        return createVNextBootstrapApiServer(status, {
+          ingressPreviewProvider: createConnectorEventIngressPreviewProvider({
+            rawAdapter: vNextRawAdapter,
+            operatorDb: vNextOperatorDb,
+            connector: vNextIngressConfig.connector,
+            channel: vNextIngressConfig.channel,
+          }),
+        });
+      },
       installShutdownHandlers: installVNextBootstrapShutdownHandlers,
     });
     return;

--- a/packages/standalone/src/operator-vnext/connector-event-ingress.ts
+++ b/packages/standalone/src/operator-vnext/connector-event-ingress.ts
@@ -1,0 +1,207 @@
+import type { SourceRef } from '@jungjaehoon/mama-core/provenance/source-ref';
+
+import type { PrimaryOperatorEvent } from './primary-operator-runtime.js';
+import { nonNegativeInteger, requiredString } from './validation.js';
+
+interface QueryStatement {
+  all: (...params: unknown[]) => unknown[];
+  get: (...params: unknown[]) => unknown;
+}
+
+export interface ConnectorEventIngressAdapter {
+  prepare: (sql: string) => QueryStatement;
+}
+
+export interface ConnectorEventIngressScope {
+  connector: string;
+  channel?: string;
+}
+
+export interface ConnectorEventIngressPreviewInput extends ConnectorEventIngressScope {
+  rawAdapter: ConnectorEventIngressAdapter;
+  operatorDb: ConnectorEventIngressAdapter;
+  limit?: number;
+}
+
+export type ConnectorEventIngressConfig =
+  | { enabled: false }
+  | { enabled: true; connector: string; channel: string };
+
+export type ConnectorEventIngressPreviewProvider = (
+  input: ConnectorEventIngressScope & { limit?: number }
+) => ConnectorEventIngressPreview;
+
+export interface ConnectorOperatorEventPreview extends PrimaryOperatorEvent {
+  eventIndexId: string;
+  sourceTimestampMs: number;
+  sourceId: string;
+  channel: string | null;
+}
+
+export interface ConnectorEventIngressPreview {
+  cursorName: string;
+  connector: string;
+  channel: string;
+  advancedThroughSeq: number;
+  events: ConnectorOperatorEventPreview[];
+}
+
+interface CursorSeqRow {
+  last_change_seq: number;
+}
+
+interface ConnectorEventIngressRow {
+  operator_seq: number;
+  event_index_id: string;
+  source_connector: string;
+  source_id: string;
+  channel: string | null;
+  source_timestamp_ms: number;
+}
+
+const DEFAULT_INGRESS_LIMIT = 25;
+const MAX_INGRESS_LIMIT = 100;
+const CONNECTOR_ENV = 'MAMA_VNEXT_INGRESS_CONNECTOR';
+const CHANNEL_ENV = 'MAMA_VNEXT_INGRESS_CHANNEL';
+
+function positiveLimit(value: number | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_INGRESS_LIMIT;
+  }
+  if (!Number.isFinite(value)) {
+    throw new Error('limit must be a finite number');
+  }
+  return Math.min(MAX_INGRESS_LIMIT, Math.max(0, Math.floor(value)));
+}
+
+function readCursorSeq(operatorDb: ConnectorEventIngressAdapter, cursorName: string): number {
+  const row = operatorDb
+    .prepare('SELECT last_change_seq FROM vnext_operator_cursors WHERE cursor_name = ?')
+    .get(cursorName) as CursorSeqRow | undefined;
+  return row?.last_change_seq ?? 0;
+}
+
+function mapRowToOperatorEvent(row: ConnectorEventIngressRow): ConnectorOperatorEventPreview {
+  const sourceId = requiredString(row.source_id, 'source_id');
+  const sourceRef: SourceRef = {
+    kind: 'raw',
+    connector: requiredString(row.source_connector, 'source_connector'),
+    id: requiredString(row.event_index_id, 'event_index_id'),
+    source_id: sourceId,
+    channel_id: row.channel,
+  };
+  return {
+    seq: nonNegativeInteger(row.operator_seq, 'operator_seq'),
+    sourceRef,
+    eventIndexId: sourceRef.id,
+    sourceTimestampMs: nonNegativeInteger(row.source_timestamp_ms, 'source_timestamp_ms'),
+    sourceId,
+    channel: row.channel,
+  };
+}
+
+export function buildConnectorOperatorCursorName(scope: ConnectorEventIngressScope): string {
+  const connector = requiredString(scope.connector, 'connector');
+  const channel = scope.channel === undefined ? null : requiredString(scope.channel, 'channel');
+  return channel ? `connector:${connector}:channel:${channel}` : `connector:${connector}`;
+}
+
+export function resolveConnectorEventIngressConfig(
+  env: Record<string, string | undefined> = process.env
+): ConnectorEventIngressConfig {
+  const connector = env[CONNECTOR_ENV]?.trim();
+  const channel = env[CHANNEL_ENV]?.trim();
+  if (!connector && !channel) {
+    return { enabled: false };
+  }
+  if (!connector || !channel) {
+    throw new Error(`${CONNECTOR_ENV} and ${CHANNEL_ENV} must be set together`);
+  }
+  return {
+    enabled: true,
+    connector,
+    channel,
+  };
+}
+
+export function buildConnectorEventIngressPreview(
+  input: ConnectorEventIngressPreviewInput
+): ConnectorEventIngressPreview {
+  const connector = requiredString(input.connector, 'connector');
+  const channel = requiredString(input.channel, 'channel');
+  const limit = positiveLimit(input.limit);
+  const cursorName = buildConnectorOperatorCursorName({ connector, channel });
+  const advancedThroughSeq = readCursorSeq(input.operatorDb, cursorName);
+  if (limit === 0) {
+    return {
+      cursorName,
+      connector,
+      channel,
+      advancedThroughSeq,
+      events: [],
+    };
+  }
+
+  const rows = input.rawAdapter
+    .prepare(
+      `
+        WITH ordered_events AS (
+          SELECT
+            ROW_NUMBER() OVER (
+              ORDER BY source_timestamp_ms ASC, event_index_id ASC
+            ) AS operator_seq,
+            event_index_id,
+            source_connector,
+            source_id,
+            channel,
+            source_timestamp_ms
+          FROM connector_event_index
+          WHERE source_connector = ?
+            AND channel = ?
+        )
+        SELECT
+          operator_seq,
+          event_index_id,
+          source_connector,
+          source_id,
+          channel,
+          source_timestamp_ms
+        FROM ordered_events
+        WHERE operator_seq > ?
+        ORDER BY operator_seq ASC
+        LIMIT ?
+      `
+    )
+    .all(connector, channel, advancedThroughSeq, limit) as ConnectorEventIngressRow[];
+
+  return {
+    cursorName,
+    connector,
+    channel,
+    advancedThroughSeq,
+    events: rows.map(mapRowToOperatorEvent),
+  };
+}
+
+export function createConnectorEventIngressPreviewProvider(
+  options: ConnectorEventIngressPreviewInput
+): ConnectorEventIngressPreviewProvider {
+  const connector = requiredString(options.connector, 'connector');
+  const channel = requiredString(options.channel, 'channel');
+  return (input) => {
+    const requestedConnector = requiredString(input.connector, 'connector');
+    const requestedChannel = requiredString(input.channel, 'channel');
+    if (requestedConnector !== connector || requestedChannel !== channel) {
+      throw new Error(
+        `Connector ingress preview is locked to the configured connector/channel: ${connector}/${channel}`
+      );
+    }
+    return buildConnectorEventIngressPreview({
+      rawAdapter: options.rawAdapter,
+      operatorDb: options.operatorDb,
+      connector,
+      channel,
+      limit: input.limit,
+    });
+  };
+}

--- a/packages/standalone/tests/operator-vnext/connector-event-ingress.test.ts
+++ b/packages/standalone/tests/operator-vnext/connector-event-ingress.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest';
+
+process.env.MAMA_FORCE_TIER_3 ||= 'true';
+
+import { connectorEventIndexId } from '@jungjaehoon/mama-core/connectors/event-index';
+
+import {
+  buildConnectorEventIngressPreview,
+  buildConnectorOperatorCursorName,
+  createConnectorEventIngressPreviewProvider,
+  resolveConnectorEventIngressConfig,
+} from '../../src/operator-vnext/connector-event-ingress.js';
+import type { SQLiteDatabase } from '../../src/sqlite.js';
+import { countRows, makeOperatorVNextDb } from './fixtures.js';
+
+function insertRawEvent(
+  db: SQLiteDatabase,
+  overrides: {
+    connector?: string;
+    sourceId: string;
+    channel?: string;
+    content?: string;
+    timestampMs: number;
+  }
+) {
+  const connector = overrides.connector ?? 'slack';
+  const channel = overrides.channel ?? 'C-ROLL';
+  const eventIndexId = connectorEventIndexId(connector, overrides.sourceId);
+  db.prepare(
+    `INSERT INTO connector_event_index (
+      event_index_id, source_connector, source_type, source_id, source_locator,
+      channel, author, title, content, event_datetime, event_date, source_timestamp_ms,
+      metadata_json, content_hash, indexed_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    eventIndexId,
+    connector,
+    'message',
+    overrides.sourceId,
+    `${connector}:${channel}:${overrides.sourceId}`,
+    channel,
+    'synthetic-user',
+    null,
+    overrides.content ?? `synthetic public rollout event ${overrides.sourceId}`,
+    overrides.timestampMs,
+    new Date(overrides.timestampMs).toISOString().slice(0, 10),
+    overrides.timestampMs,
+    JSON.stringify({ synthetic: true }),
+    Buffer.alloc(32, 1),
+    '2026-07-02T00:00:00.000Z',
+    '2026-07-02T00:00:00.000Z'
+  );
+  return { event_index_id: eventIndexId };
+}
+
+describe('STORY-VNEXT-PR6-CONNECTOR-INGRESS: connector event dry-run ingress', () => {
+  it('previews one connector/channel as source-linked primary operator events without commits', () => {
+    const db = makeOperatorVNextDb();
+    const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+    insertRawEvent(db, {
+      sourceId: 'msg-other-channel',
+      channel: 'C-OTHER',
+      timestampMs: 1710000000500,
+    });
+    const second = insertRawEvent(db, { sourceId: 'msg-2', timestampMs: 1710000002000 });
+    insertRawEvent(db, {
+      connector: 'discord',
+      sourceId: 'discord-1',
+      channel: 'D-ROLL',
+      timestampMs: 1710000001500,
+    });
+
+    const preview = buildConnectorEventIngressPreview({
+      rawAdapter: db,
+      operatorDb: db,
+      connector: 'slack',
+      channel: 'C-ROLL',
+      limit: 10,
+    });
+
+    expect(preview).toEqual({
+      cursorName: 'connector:slack:channel:C-ROLL',
+      connector: 'slack',
+      channel: 'C-ROLL',
+      advancedThroughSeq: 0,
+      events: [
+        {
+          seq: 1,
+          sourceRef: {
+            kind: 'raw',
+            connector: 'slack',
+            id: first.event_index_id,
+            source_id: 'msg-1',
+            channel_id: 'C-ROLL',
+          },
+          eventIndexId: first.event_index_id,
+          sourceTimestampMs: 1710000001000,
+          sourceId: 'msg-1',
+          channel: 'C-ROLL',
+        },
+        {
+          seq: 2,
+          sourceRef: {
+            kind: 'raw',
+            connector: 'slack',
+            id: second.event_index_id,
+            source_id: 'msg-2',
+            channel_id: 'C-ROLL',
+          },
+          eventIndexId: second.event_index_id,
+          sourceTimestampMs: 1710000002000,
+          sourceId: 'msg-2',
+          channel: 'C-ROLL',
+        },
+      ],
+    });
+    expect(countRows(db, 'vnext_operator_cursors')).toBe(0);
+    expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+    expect(countRows(db, 'operator_no_updates')).toBe(0);
+
+    db.close();
+  });
+
+  it('skips deterministic event seqs already advanced by the matching operator cursor', () => {
+    const db = makeOperatorVNextDb();
+    insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+    const second = insertRawEvent(db, { sourceId: 'msg-2', timestampMs: 1710000002000 });
+    const third = insertRawEvent(db, { sourceId: 'msg-3', timestampMs: 1710000003000 });
+    db.prepare(
+      `INSERT INTO vnext_operator_cursors (
+        cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+      ) VALUES (?, ?, ?, ?)`
+    ).run(buildConnectorOperatorCursorName({ connector: 'slack', channel: 'C-ROLL' }), 1, null, 1);
+
+    const preview = buildConnectorEventIngressPreview({
+      rawAdapter: db,
+      operatorDb: db,
+      connector: 'slack',
+      channel: 'C-ROLL',
+    });
+
+    expect(preview.advancedThroughSeq).toBe(1);
+    expect(preview.events.map((event) => event.seq)).toEqual([2, 3]);
+    expect(preview.events.map((event) => event.eventIndexId)).toEqual([
+      second.event_index_id,
+      third.event_index_id,
+    ]);
+
+    db.close();
+  });
+
+  it('rejects broad connector previews unless a single explicit channel is supplied', () => {
+    const db = makeOperatorVNextDb();
+
+    expect(() =>
+      buildConnectorEventIngressPreview({
+        rawAdapter: db,
+        operatorDb: db,
+        connector: 'slack',
+      })
+    ).toThrow(/channel/i);
+
+    db.close();
+  });
+
+  it('resolves explicit rollout config only when connector and channel are both supplied', () => {
+    expect(resolveConnectorEventIngressConfig({})).toEqual({ enabled: false });
+    expect(
+      resolveConnectorEventIngressConfig({
+        MAMA_VNEXT_INGRESS_CONNECTOR: ' slack ',
+        MAMA_VNEXT_INGRESS_CHANNEL: ' C-ROLL ',
+      })
+    ).toEqual({
+      enabled: true,
+      connector: 'slack',
+      channel: 'C-ROLL',
+    });
+    expect(() =>
+      resolveConnectorEventIngressConfig({
+        MAMA_VNEXT_INGRESS_CONNECTOR: 'slack',
+      })
+    ).toThrow(/channel/i);
+  });
+
+  it('creates a provider locked to the configured connector/channel', () => {
+    const db = makeOperatorVNextDb();
+    const event = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+    const provider = createConnectorEventIngressPreviewProvider({
+      rawAdapter: db,
+      operatorDb: db,
+      connector: 'slack',
+      channel: 'C-ROLL',
+    });
+
+    expect(provider({ connector: 'slack', channel: 'C-ROLL' }).events[0]?.eventIndexId).toBe(
+      event.event_index_id
+    );
+    expect(() => provider({ connector: 'slack', channel: 'C-OTHER' })).toThrow(
+      /configured connector\/channel/i
+    );
+
+    db.close();
+  });
+});

--- a/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
+++ b/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
@@ -1,13 +1,16 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import request from 'supertest';
+import { connectorEventIndexId } from '@jungjaehoon/mama-core/connectors/event-index';
+import { applyMigrationsThrough } from '@jungjaehoon/mama-core/test-utils';
 
 import {
   createVNextBootstrapApiServer,
   createVNextPrimaryOperatorRuntime,
 } from '../../src/cli/commands/start.js';
+import { buildConnectorEventIngressPreview } from '../../src/operator-vnext/connector-event-ingress.js';
 import { ensureVNextOperatorSchema } from '../../src/operator-vnext/schema.js';
 import type { VNextBootstrapRuntimeStatus } from '../../src/runtime-vnext/bootstrap.js';
-import Database from '../../src/sqlite.js';
+import Database, { type SQLiteDatabase } from '../../src/sqlite.js';
 
 const AUTH_TOKEN_ENV = 'MAMA_AUTH_TOKEN';
 
@@ -35,6 +38,35 @@ function makeStatus(): VNextBootstrapRuntimeStatus {
       'manual_status_endpoints',
     ],
   };
+}
+
+function insertRawEvent(db: SQLiteDatabase, sourceId: string): string {
+  const eventIndexId = connectorEventIndexId('slack', sourceId);
+  db.prepare(
+    `INSERT INTO connector_event_index (
+      event_index_id, source_connector, source_type, source_id, source_locator,
+      channel, author, title, content, event_datetime, event_date, source_timestamp_ms,
+      metadata_json, content_hash, indexed_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    eventIndexId,
+    'slack',
+    'message',
+    sourceId,
+    `slack:C-ROLL:${sourceId}`,
+    'C-ROLL',
+    'synthetic-user',
+    null,
+    `synthetic public rollout event ${sourceId}`,
+    1710000001000,
+    '2026-03-09',
+    1710000001000,
+    JSON.stringify({ synthetic: true }),
+    Buffer.alloc(32, 2),
+    '2026-07-02T00:00:00.000Z',
+    '2026-07-02T00:00:00.000Z'
+  );
+  return eventIndexId;
 }
 
 describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
@@ -250,6 +282,75 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
       });
 
       db.close();
+    });
+
+    it('serves authenticated dry-run connector ingress previews without committing', async () => {
+      process.env[AUTH_TOKEN_ENV] = 'vnext-status-token';
+      const db = new Database(':memory:');
+      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 38);
+      const eventIndexId = insertRawEvent(db, 'msg-1');
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressPreviewProvider: (input) =>
+          buildConnectorEventIngressPreview({
+            rawAdapter: db,
+            operatorDb: db,
+            ...input,
+          }),
+      });
+
+      const response = await request(apiServer.app)
+        .get('/api/vnext/ingress/preview?connector=slack&channel=C-ROLL&limit=5')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-status-token');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        ok: true,
+        mode: 'dry_run',
+        preview: {
+          cursorName: 'connector:slack:channel:C-ROLL',
+          connector: 'slack',
+          channel: 'C-ROLL',
+          advancedThroughSeq: 0,
+          events: [
+            {
+              seq: 1,
+              sourceRef: {
+                kind: 'raw',
+                connector: 'slack',
+                id: eventIndexId,
+                source_id: 'msg-1',
+                channel_id: 'C-ROLL',
+              },
+              eventIndexId,
+              sourceTimestampMs: 1710000001000,
+              sourceId: 'msg-1',
+              channel: 'C-ROLL',
+            },
+          ],
+        },
+      });
+      expect(db.prepare('SELECT COUNT(*) AS count FROM vnext_operator_commits').get()).toEqual({
+        count: 0,
+      });
+
+      db.close();
+    });
+
+    it('rejects connector ingress preview when the provider is not configured', async () => {
+      process.env[AUTH_TOKEN_ENV] = 'vnext-status-token';
+      const apiServer = createVNextBootstrapApiServer(makeStatus());
+
+      const response = await request(apiServer.app)
+        .get('/api/vnext/ingress/preview?connector=slack&channel=C-ROLL')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-status-token');
+
+      expect(response.status).toBe(404);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'vnext_ingress_preview_unavailable',
+      });
     });
   });
 });

--- a/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
+++ b/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
@@ -7,7 +7,10 @@ import {
   createVNextBootstrapApiServer,
   createVNextPrimaryOperatorRuntime,
 } from '../../src/cli/commands/start.js';
-import { buildConnectorEventIngressPreview } from '../../src/operator-vnext/connector-event-ingress.js';
+import {
+  buildConnectorEventIngressPreview,
+  createConnectorEventIngressPreviewProvider,
+} from '../../src/operator-vnext/connector-event-ingress.js';
 import { ensureVNextOperatorSchema } from '../../src/operator-vnext/schema.js';
 import type { VNextBootstrapRuntimeStatus } from '../../src/runtime-vnext/bootstrap.js';
 import Database, { type SQLiteDatabase } from '../../src/sqlite.js';
@@ -351,6 +354,32 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
         ok: false,
         code: 'vnext_ingress_preview_unavailable',
       });
+    });
+
+    it('returns 400 for connector ingress preview requests outside the configured channel', async () => {
+      process.env[AUTH_TOKEN_ENV] = 'vnext-status-token';
+      const db = new Database(':memory:');
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressPreviewProvider: createConnectorEventIngressPreviewProvider({
+          rawAdapter: db,
+          operatorDb: db,
+          connector: 'slack',
+          channel: 'C-ROLL',
+        }),
+      });
+
+      const response = await request(apiServer.app)
+        .get('/api/vnext/ingress/preview?connector=slack&channel=C-OTHER')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-status-token');
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'vnext_ingress_preview_invalid_request',
+      });
+
+      db.close();
     });
   });
 });


### PR DESCRIPTION
## Summary
- add an authenticated vNext connector ingress preview endpoint for one configured connector/channel
- read connector_event_index rows as source-linked primary-operator event candidates without commits, cursor advancement, or no-update writes
- document the dry-run rollout env vars and safeguards

## Privacy / internal-information audit
- ./scripts/check-pii.sh passed
- staged diff secret/path scan passed; only public env var names and synthetic test IDs were present
- tests use synthetic connector/channel/source IDs only

## Verification
- codex review --uncommitted: no discrete correctness issues
- MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run tests/operator-vnext/connector-event-ingress.test.ts tests/runtime-vnext/bootstrap-api.test.ts tests/runtime-vnext/bootstrap.test.ts tests/runtime-vnext/legacy-fanout-disabled.test.ts tests/api/report-vnext.test.ts tests/operator-vnext/commit-authority.test.ts tests/operator-vnext/delegation-authority.test.ts
- pnpm --filter @jungjaehoon/mama-os typecheck
- pnpm build
- git diff --cached --check
- pre-commit: gitleaks, doc version sync, standalone typecheck, changed-package build/tests (standalone: 233 files, 3299 tests passed)
