### PR TITLE
feat: add vnext ingress migration dry run

### DIFF
--- a/docs/architecture/mama-vnext-primary-operator-rebuild.md
+++ b/docs/architecture/mama-vnext-primary-operator-rebuild.md
@@ -690,6 +690,50 @@ MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run \
   tests/runtime-vnext/legacy-fanout-disabled.test.ts
 ```
 
+### PR 7: Connector Ingress Migration Dry-Run Report
+
+Goal:
+
+- Add an authenticated migration dry-run report on top of the PR 6 connector
+  ingress preview.
+- Report which explicit connector/channel raw events would require primary
+  operator decisions before migration.
+- Keep the report read-only: no commits, cursor movement, no-update rows, or
+  promotion of report/wiki/memory artifacts.
+
+Files:
+
+- Create: `packages/standalone/src/operator-vnext/connector-ingress-migration-dry-run.ts`
+- Modify: `packages/standalone/src/cli/commands/start.ts`
+- Create: `packages/standalone/tests/operator-vnext/connector-ingress-migration-dry-run.test.ts`
+- Modify: `packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts`
+
+Authenticated migration dry-run endpoint:
+
+```text
+GET /api/vnext/ingress/migration-dry-run?connector=slack&channel=C_PUBLIC_SYNTHETIC&limit=25
+```
+
+Rules:
+
+- Migration dry-run is locked to the configured connector/channel.
+- Migration dry-run returns source refs, event seqs, and decision-readiness only.
+- Migration dry-run must not call the primary operator commit path.
+- Migration dry-run must not insert `vnext_operator_commits`,
+  `vnext_operator_cursors`, or `operator_no_updates` rows.
+- Migration dry-run must not promote report/wiki/memory artifacts.
+
+Verify:
+
+```bash
+MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run \
+  tests/operator-vnext/connector-ingress-migration-dry-run.test.ts \
+  tests/operator-vnext/connector-event-ingress.test.ts \
+  tests/runtime-vnext/bootstrap-api.test.ts \
+  tests/runtime-vnext/bootstrap.test.ts \
+  tests/runtime-vnext/legacy-fanout-disabled.test.ts
+```
+
 ## Global Regression Checklist
 
 - legacy mode behavior unchanged
@@ -710,6 +754,7 @@ MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run \
 - crash after cursor write does not duplicate commit
 - two operators racing commit once
 - DB busy retry is bounded
+- migration dry run does not write operator commits, cursors, or no-update rows
 - migration dry run does not promote unverified legacy artifacts
 
 ## Parallelization
@@ -753,7 +798,7 @@ Conflict flags:
 5. Land PR 4 and import one wiki page as unverified, then commit one source-linked artifact.
 6. Land PR 5 and switch Today dashboard to existing projection extension.
 7. Land PR 6 and enable vNext dry-run preview locally for one connector/channel.
-8. Run dry-run migration against the authenticated ingress preview.
+8. Land PR 7 and run the authenticated migration dry-run report for one connector/channel.
 9. Decide whether to remove legacy self-paced agents from default config.
 
 ## Review Notes

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -603,9 +603,11 @@ function queryLimit(value: unknown): number | undefined {
   return limit;
 }
 
-function isVNextIngressPreviewClientError(error: unknown): boolean {
+function isVNextIngressClientError(error: unknown): boolean {
   return (
-    error instanceof Error && error.message.includes('locked to the configured connector/channel')
+    error instanceof Error &&
+    (error.message.includes('locked to the configured connector/channel') ||
+      error.message === 'limit must be a positive integer')
   );
 }
 
@@ -775,7 +777,7 @@ export function createVNextBootstrapApiServer(
         preview: options.ingressPreviewProvider({ connector, channel, limit }),
       });
     } catch (error) {
-      const clientError = isVNextIngressPreviewClientError(error);
+      const clientError = isVNextIngressClientError(error);
       res.status(clientError ? 400 : 500).json({
         ok: false,
         code: clientError
@@ -825,7 +827,7 @@ export function createVNextBootstrapApiServer(
         dry_run: options.ingressMigrationDryRunProvider({ connector, channel, limit }),
       });
     } catch (error) {
-      const clientError = isVNextIngressPreviewClientError(error);
+      const clientError = isVNextIngressClientError(error);
       res.status(clientError ? 400 : 500).json({
         ok: false,
         code: clientError

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -90,6 +90,10 @@ import {
   type ConnectorEventIngressAdapter,
   type ConnectorEventIngressPreview,
 } from '../../operator-vnext/connector-event-ingress.js';
+import {
+  createConnectorIngressMigrationDryRunProvider,
+  type ConnectorIngressMigrationDryRun,
+} from '../../operator-vnext/connector-ingress-migration-dry-run.js';
 import { resolveReactiveProjectRoot } from '../../envelope/reactive-config.js';
 import { deriveMemoryScopes, type MemoryScopeRef } from '../../memory/scope-context.js';
 import { DEFAULT_ROLES, type AgentPersonaConfig, type RoleConfig } from '../config/types.js';
@@ -570,6 +574,9 @@ export interface VNextIngressPreviewRequest {
 
 export interface VNextBootstrapApiServerOptions {
   ingressPreviewProvider?: (input: VNextIngressPreviewRequest) => ConnectorEventIngressPreview;
+  ingressMigrationDryRunProvider?: (
+    input: VNextIngressPreviewRequest
+  ) => ConnectorIngressMigrationDryRun;
 }
 
 function firstQueryString(value: unknown): string | null {
@@ -778,6 +785,56 @@ export function createVNextBootstrapApiServer(
       });
     }
   });
+  app.get('/api/vnext/ingress/migration-dry-run', (req, res) => {
+    if (!options.ingressMigrationDryRunProvider) {
+      res.status(404).json({
+        ok: false,
+        code: 'vnext_ingress_migration_dry_run_unavailable',
+        error: 'vNext connector ingress migration dry-run is not configured.',
+      });
+      return;
+    }
+
+    const connector = firstQueryString(req.query.connector);
+    const channel = firstQueryString(req.query.channel);
+    if (!connector || !channel) {
+      res.status(400).json({
+        ok: false,
+        code: 'vnext_ingress_migration_dry_run_invalid_request',
+        error: 'connector and channel query parameters are required.',
+      });
+      return;
+    }
+
+    let limit: number | undefined;
+    try {
+      limit = queryLimit(req.query.limit);
+    } catch (error) {
+      res.status(400).json({
+        ok: false,
+        code: 'vnext_ingress_migration_dry_run_invalid_request',
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+
+    try {
+      res.json({
+        ok: true,
+        mode: 'dry_run',
+        dry_run: options.ingressMigrationDryRunProvider({ connector, channel, limit }),
+      });
+    } catch (error) {
+      const clientError = isVNextIngressPreviewClientError(error);
+      res.status(clientError ? 400 : 500).json({
+        ok: false,
+        code: clientError
+          ? 'vnext_ingress_migration_dry_run_invalid_request'
+          : 'vnext_ingress_migration_dry_run_failed',
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
   app.get('/api/report', (_req, res) => {
     const projection = buildVNextBootstrapSituationProjection(status);
     res.json({
@@ -955,6 +1012,12 @@ export async function runAgentLoop(
         }
         return createVNextBootstrapApiServer(status, {
           ingressPreviewProvider: createConnectorEventIngressPreviewProvider({
+            rawAdapter: vNextRawAdapter,
+            operatorDb: vNextOperatorDb,
+            connector: vNextIngressConfig.connector,
+            channel: vNextIngressConfig.channel,
+          }),
+          ingressMigrationDryRunProvider: createConnectorIngressMigrationDryRunProvider({
             rawAdapter: vNextRawAdapter,
             operatorDb: vNextOperatorDb,
             connector: vNextIngressConfig.connector,

--- a/packages/standalone/src/operator-vnext/connector-ingress-migration-dry-run.ts
+++ b/packages/standalone/src/operator-vnext/connector-ingress-migration-dry-run.ts
@@ -38,10 +38,23 @@ export type ConnectorIngressMigrationDryRunProvider = (
   input: ConnectorEventIngressScope & { limit?: number }
 ) => ConnectorIngressMigrationDryRun;
 
+function positiveDryRunLimit(value: number | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error('limit must be a positive integer');
+  }
+  return value;
+}
+
 export function buildConnectorIngressMigrationDryRun(
   input: ConnectorEventIngressPreviewInput
 ): ConnectorIngressMigrationDryRun {
-  const preview = buildConnectorEventIngressPreview(input);
+  const preview = buildConnectorEventIngressPreview({
+    ...input,
+    limit: positiveDryRunLimit(input.limit),
+  });
   const candidates = preview.events.map((event): ConnectorIngressMigrationDryRunCandidate => {
     return {
       seq: event.seq,

--- a/packages/standalone/src/operator-vnext/connector-ingress-migration-dry-run.ts
+++ b/packages/standalone/src/operator-vnext/connector-ingress-migration-dry-run.ts
@@ -1,0 +1,95 @@
+import type { SourceRef } from '@jungjaehoon/mama-core/provenance/source-ref';
+
+import {
+  buildConnectorEventIngressPreview,
+  type ConnectorEventIngressPreviewInput,
+  type ConnectorEventIngressScope,
+} from './connector-event-ingress.js';
+import { requiredString } from './validation.js';
+
+export type ConnectorIngressMigrationDryRunStatus = 'idle' | 'ready';
+
+export interface ConnectorIngressMigrationDryRunCandidate {
+  seq: number;
+  eventIndexId: string;
+  sourceRef: SourceRef;
+  readiness: 'requires_decision';
+}
+
+export interface ConnectorIngressMigrationDryRun {
+  mode: 'dry_run';
+  status: ConnectorIngressMigrationDryRunStatus;
+  cursorName: string;
+  connector: string;
+  channel: string;
+  advancedThroughSeq: number;
+  candidateCount: number;
+  highestCandidateSeq: number | null;
+  requiresOperatorDecision: boolean;
+  durableWrites: {
+    commits: 0;
+    cursors: 0;
+    noUpdates: 0;
+  };
+  candidates: ConnectorIngressMigrationDryRunCandidate[];
+}
+
+export type ConnectorIngressMigrationDryRunProvider = (
+  input: ConnectorEventIngressScope & { limit?: number }
+) => ConnectorIngressMigrationDryRun;
+
+export function buildConnectorIngressMigrationDryRun(
+  input: ConnectorEventIngressPreviewInput
+): ConnectorIngressMigrationDryRun {
+  const preview = buildConnectorEventIngressPreview(input);
+  const candidates = preview.events.map((event): ConnectorIngressMigrationDryRunCandidate => {
+    return {
+      seq: event.seq,
+      eventIndexId: event.eventIndexId,
+      sourceRef: event.sourceRef,
+      readiness: 'requires_decision',
+    };
+  });
+  const candidateCount = candidates.length;
+
+  return {
+    mode: 'dry_run',
+    status: candidateCount > 0 ? 'ready' : 'idle',
+    cursorName: preview.cursorName,
+    connector: preview.connector,
+    channel: preview.channel,
+    advancedThroughSeq: preview.advancedThroughSeq,
+    candidateCount,
+    highestCandidateSeq: candidateCount > 0 ? candidates[candidateCount - 1].seq : null,
+    requiresOperatorDecision: candidateCount > 0,
+    durableWrites: {
+      commits: 0,
+      cursors: 0,
+      noUpdates: 0,
+    },
+    candidates,
+  };
+}
+
+export function createConnectorIngressMigrationDryRunProvider(
+  options: ConnectorEventIngressPreviewInput
+): ConnectorIngressMigrationDryRunProvider {
+  const connector = requiredString(options.connector, 'connector');
+  const channel = requiredString(options.channel, 'channel');
+  return (input) => {
+    const requestedConnector = requiredString(input.connector, 'connector');
+    const requestedChannel = requiredString(input.channel, 'channel');
+    if (requestedConnector !== connector || requestedChannel !== channel) {
+      throw new Error(
+        `Connector ingress preview is locked to the configured connector/channel: ${connector}/${channel}`
+      );
+    }
+    return buildConnectorIngressMigrationDryRun({
+      rawAdapter: options.rawAdapter,
+      operatorDb: options.operatorDb,
+      connector,
+      channel,
+      limit: input.limit,
+    });
+  };
+}

--- a/packages/standalone/src/operator-vnext/connector-ingress-migration-dry-run.ts
+++ b/packages/standalone/src/operator-vnext/connector-ingress-migration-dry-run.ts
@@ -81,7 +81,7 @@ export function createConnectorIngressMigrationDryRunProvider(
     const requestedChannel = requiredString(input.channel, 'channel');
     if (requestedConnector !== connector || requestedChannel !== channel) {
       throw new Error(
-        `Connector ingress preview is locked to the configured connector/channel: ${connector}/${channel}`
+        `Connector ingress migration dry-run is locked to the configured connector/channel: ${connector}/${channel}`
       );
     }
     return buildConnectorIngressMigrationDryRun({

--- a/packages/standalone/tests/operator-vnext/connector-ingress-migration-dry-run.test.ts
+++ b/packages/standalone/tests/operator-vnext/connector-ingress-migration-dry-run.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+
+process.env.MAMA_FORCE_TIER_3 ||= 'true';
+
+import { connectorEventIndexId } from '@jungjaehoon/mama-core/connectors/event-index';
+
+import {
+  buildConnectorIngressMigrationDryRun,
+  createConnectorIngressMigrationDryRunProvider,
+} from '../../src/operator-vnext/connector-ingress-migration-dry-run.js';
+import type { SQLiteDatabase } from '../../src/sqlite.js';
+import { countRows, makeOperatorVNextDb } from './fixtures.js';
+
+function insertRawEvent(
+  db: SQLiteDatabase,
+  overrides: {
+    sourceId: string;
+    channel?: string;
+    timestampMs: number;
+  }
+) {
+  const channel = overrides.channel ?? 'C-ROLL';
+  const eventIndexId = connectorEventIndexId('slack', overrides.sourceId);
+  db.prepare(
+    `INSERT INTO connector_event_index (
+      event_index_id, source_connector, source_type, source_id, source_locator,
+      channel, author, title, content, event_datetime, event_date, source_timestamp_ms,
+      metadata_json, content_hash, indexed_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    eventIndexId,
+    'slack',
+    'message',
+    overrides.sourceId,
+    `slack:${channel}:${overrides.sourceId}`,
+    channel,
+    'synthetic-user',
+    null,
+    `synthetic public migration dry-run event ${overrides.sourceId}`,
+    overrides.timestampMs,
+    new Date(overrides.timestampMs).toISOString().slice(0, 10),
+    overrides.timestampMs,
+    JSON.stringify({ synthetic: true }),
+    Buffer.alloc(32, 3),
+    '2026-07-02T00:00:00.000Z',
+    '2026-07-02T00:00:00.000Z'
+  );
+  return eventIndexId;
+}
+
+describe('STORY-VNEXT-PR7-INGRESS-MIGRATION-DRY-RUN: connector ingress migration dry-run', () => {
+  it('reports source-linked migration candidates without durable writes', () => {
+    const db = makeOperatorVNextDb();
+    const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+    const second = insertRawEvent(db, { sourceId: 'msg-2', timestampMs: 1710000002000 });
+
+    const dryRun = buildConnectorIngressMigrationDryRun({
+      rawAdapter: db,
+      operatorDb: db,
+      connector: 'slack',
+      channel: 'C-ROLL',
+      limit: 10,
+    });
+
+    expect(dryRun).toEqual({
+      mode: 'dry_run',
+      status: 'ready',
+      cursorName: 'connector:slack:channel:C-ROLL',
+      connector: 'slack',
+      channel: 'C-ROLL',
+      advancedThroughSeq: 0,
+      candidateCount: 2,
+      highestCandidateSeq: 2,
+      requiresOperatorDecision: true,
+      durableWrites: {
+        commits: 0,
+        cursors: 0,
+        noUpdates: 0,
+      },
+      candidates: [
+        {
+          seq: 1,
+          eventIndexId: first,
+          sourceRef: {
+            kind: 'raw',
+            connector: 'slack',
+            id: first,
+            source_id: 'msg-1',
+            channel_id: 'C-ROLL',
+          },
+          readiness: 'requires_decision',
+        },
+        {
+          seq: 2,
+          eventIndexId: second,
+          sourceRef: {
+            kind: 'raw',
+            connector: 'slack',
+            id: second,
+            source_id: 'msg-2',
+            channel_id: 'C-ROLL',
+          },
+          readiness: 'requires_decision',
+        },
+      ],
+    });
+    expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+    expect(countRows(db, 'vnext_operator_cursors')).toBe(0);
+    expect(countRows(db, 'operator_no_updates')).toBe(0);
+
+    db.close();
+  });
+
+  it('reports idle when no preview candidates exist', () => {
+    const db = makeOperatorVNextDb();
+
+    const dryRun = buildConnectorIngressMigrationDryRun({
+      rawAdapter: db,
+      operatorDb: db,
+      connector: 'slack',
+      channel: 'C-ROLL',
+    });
+
+    expect(dryRun).toMatchObject({
+      mode: 'dry_run',
+      status: 'idle',
+      candidateCount: 0,
+      highestCandidateSeq: null,
+      requiresOperatorDecision: false,
+      candidates: [],
+    });
+
+    db.close();
+  });
+
+  it('creates a provider locked to the configured connector/channel', () => {
+    const db = makeOperatorVNextDb();
+    insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+    const provider = createConnectorIngressMigrationDryRunProvider({
+      rawAdapter: db,
+      operatorDb: db,
+      connector: 'slack',
+      channel: 'C-ROLL',
+    });
+
+    expect(provider({ connector: 'slack', channel: 'C-ROLL' }).status).toBe('ready');
+    expect(() => provider({ connector: 'slack', channel: 'C-OTHER' })).toThrow(
+      /configured connector\/channel/i
+    );
+
+    db.close();
+  });
+});

--- a/packages/standalone/tests/operator-vnext/connector-ingress-migration-dry-run.test.ts
+++ b/packages/standalone/tests/operator-vnext/connector-ingress-migration-dry-run.test.ts
@@ -133,6 +133,24 @@ describe('STORY-VNEXT-PR7-INGRESS-MIGRATION-DRY-RUN: connector ingress migration
     db.close();
   });
 
+  it('rejects non-positive and fractional dry-run limits', () => {
+    const db = makeOperatorVNextDb();
+
+    for (const limit of [0, -1, 0.5]) {
+      expect(() =>
+        buildConnectorIngressMigrationDryRun({
+          rawAdapter: db,
+          operatorDb: db,
+          connector: 'slack',
+          channel: 'C-ROLL',
+          limit,
+        })
+      ).toThrow(/limit must be a positive integer/);
+    }
+
+    db.close();
+  });
+
   it('creates a provider locked to the configured connector/channel', () => {
     const db = makeOperatorVNextDb();
     insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });

--- a/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
+++ b/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
@@ -11,6 +11,7 @@ import {
   buildConnectorEventIngressPreview,
   createConnectorEventIngressPreviewProvider,
 } from '../../src/operator-vnext/connector-event-ingress.js';
+import { createConnectorIngressMigrationDryRunProvider } from '../../src/operator-vnext/connector-ingress-migration-dry-run.js';
 import { ensureVNextOperatorSchema } from '../../src/operator-vnext/schema.js';
 import type { VNextBootstrapRuntimeStatus } from '../../src/runtime-vnext/bootstrap.js';
 import Database, { type SQLiteDatabase } from '../../src/sqlite.js';
@@ -377,6 +378,73 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
       expect(response.body).toMatchObject({
         ok: false,
         code: 'vnext_ingress_preview_invalid_request',
+      });
+
+      db.close();
+    });
+
+    it('serves authenticated connector ingress migration dry-run reports without committing', async () => {
+      process.env[AUTH_TOKEN_ENV] = 'vnext-status-token';
+      const db = new Database(':memory:');
+      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 38);
+      const eventIndexId = insertRawEvent(db, 'msg-1');
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressMigrationDryRunProvider: createConnectorIngressMigrationDryRunProvider({
+          rawAdapter: db,
+          operatorDb: db,
+          connector: 'slack',
+          channel: 'C-ROLL',
+        }),
+      });
+
+      const response = await request(apiServer.app)
+        .get('/api/vnext/ingress/migration-dry-run?connector=slack&channel=C-ROLL&limit=5')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-status-token');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        ok: true,
+        mode: 'dry_run',
+        dry_run: {
+          mode: 'dry_run',
+          status: 'ready',
+          cursorName: 'connector:slack:channel:C-ROLL',
+          connector: 'slack',
+          channel: 'C-ROLL',
+          advancedThroughSeq: 0,
+          candidateCount: 1,
+          highestCandidateSeq: 1,
+          requiresOperatorDecision: true,
+          durableWrites: {
+            commits: 0,
+            cursors: 0,
+            noUpdates: 0,
+          },
+          candidates: [
+            {
+              seq: 1,
+              eventIndexId,
+              sourceRef: {
+                kind: 'raw',
+                connector: 'slack',
+                id: eventIndexId,
+                source_id: 'msg-1',
+                channel_id: 'C-ROLL',
+              },
+              readiness: 'requires_decision',
+            },
+          ],
+        },
+      });
+      expect(db.prepare('SELECT COUNT(*) AS count FROM vnext_operator_commits').get()).toEqual({
+        count: 0,
+      });
+      expect(db.prepare('SELECT COUNT(*) AS count FROM vnext_operator_cursors').get()).toEqual({
+        count: 0,
+      });
+      expect(db.prepare('SELECT COUNT(*) AS count FROM operator_no_updates').get()).toEqual({
+        count: 0,
       });
 
       db.close();

--- a/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
+++ b/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
@@ -449,5 +449,34 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
 
       db.close();
     });
+
+    it('returns 400 for non-positive or fractional migration dry-run limits', async () => {
+      process.env[AUTH_TOKEN_ENV] = 'vnext-status-token';
+      const db = new Database(':memory:');
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressMigrationDryRunProvider: createConnectorIngressMigrationDryRunProvider({
+          rawAdapter: db,
+          operatorDb: db,
+          connector: 'slack',
+          channel: 'C-ROLL',
+        }),
+      });
+
+      for (const limit of ['0', '-1', '0.5']) {
+        const response = await request(apiServer.app)
+          .get(`/api/vnext/ingress/migration-dry-run?connector=slack&channel=C-ROLL&limit=${limit}`)
+          .set('cf-connecting-ip', '203.0.113.10')
+          .set('authorization', 'Bearer vnext-status-token');
+
+        expect(response.status).toBe(400);
+        expect(response.body).toMatchObject({
+          ok: false,
+          code: 'vnext_ingress_migration_dry_run_invalid_request',
+          error: 'limit must be a positive integer',
+        });
+      }
+
+      db.close();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add an authenticated vNext connector ingress migration dry-run report endpoint
- derive read-only migration candidates from the PR6 connector ingress preview
- document PR7 rollout scope and keep commits/cursors/no-update rows at zero in tests

## Privacy/Internal Info Gate
- `git diff --cached --check`: passed before commit
- `./scripts/check-pii.sh`: passed before commit
- high-risk staged diff scan for secrets, local paths, webhook URLs, and real-looking connector IDs: no matches
- examples and fixtures use synthetic connector/channel/message/user values only

## Verification
- `MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run tests/operator-vnext/connector-ingress-migration-dry-run.test.ts tests/runtime-vnext/bootstrap-api.test.ts`
- `pnpm --filter @jungjaehoon/mama-os typecheck`
- `MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run tests/operator-vnext/connector-ingress-migration-dry-run.test.ts tests/operator-vnext/connector-event-ingress.test.ts tests/runtime-vnext/bootstrap-api.test.ts tests/runtime-vnext/bootstrap.test.ts tests/runtime-vnext/legacy-fanout-disabled.test.ts`
- `pnpm build`
- pre-commit: lint-staged, gitleaks, version sync, standalone typecheck/build/test (`234 passed, 1 skipped`; `3304 passed, 3 skipped`)

## Local Review
- `codex review --uncommitted`: no discrete correctness issues found; reviewer reran targeted tests, standalone typecheck, and standalone build
