### PR TITLE
feat: make legacy self-paced agents opt-in

### DIFF
--- a/docs/architecture/mama-vnext-primary-operator-rebuild.md
+++ b/docs/architecture/mama-vnext-primary-operator-rebuild.md
@@ -734,6 +734,52 @@ MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run \
   tests/runtime-vnext/legacy-fanout-disabled.test.ts
 ```
 
+### PR 8: Default Config Drops Legacy Self-Paced Agents
+
+Decision:
+
+- Remove legacy self-paced `dashboard-agent` and `wiki-agent` from new default
+  `multi_agent.agents`.
+- Stop automatically backfilling those agents into existing configs.
+- Preserve user-defined `dashboard-agent` and `wiki-agent` entries and keep their
+  legacy permission migrations active.
+- Update agent guidance so dashboard/wiki delegation is opt-in and only happens
+  when the agent exists in config.
+
+Files:
+
+- Modify: `packages/standalone/src/cli/config/config-manager.ts`
+- Modify: `packages/standalone/src/cli/commands/start.ts`
+- Modify: `packages/standalone/src/cli/runtime/api-routes-init.ts`
+- Modify: `packages/standalone/tests/cli/config-manager.test.ts`
+- Modify: `packages/standalone/tests/agent/gateway-tool-executor.test.ts`
+- Modify: `packages/standalone/tests/runtime-vnext/legacy-fanout-disabled.test.ts`
+- Modify: `packages/standalone/src/agent/os-agent-capabilities.md`
+- Modify: `packages/standalone/src/multi-agent/conductor-persona.ts`
+
+Rules:
+
+- New default config includes the primary operator-facing agents only:
+  `os-agent`, `conductor`, and `memory`.
+- Loading an older config must not create missing `dashboard-agent` or
+  `wiki-agent` entries, even when `wiki.enabled` is true.
+- Runtime startup must not persist missing `dashboard-agent` or `wiki-agent`
+  entries back into config.
+- Legacy dashboard/wiki timers, publishers, persona writes, MCP rewrites, and
+  Obsidian wiring only start when the corresponding agent is explicitly
+  configured and not disabled.
+- Loading an older config that already has those agents must keep them and still
+  migrate old Code-Act gateway permission allowlists.
+
+Verify:
+
+```bash
+MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run \
+  tests/cli/config-manager.test.ts \
+  tests/agent/gateway-tool-executor.test.ts \
+  tests/runtime-vnext/legacy-fanout-disabled.test.ts
+```
+
 ## Global Regression Checklist
 
 - legacy mode behavior unchanged
@@ -799,7 +845,7 @@ Conflict flags:
 6. Land PR 5 and switch Today dashboard to existing projection extension.
 7. Land PR 6 and enable vNext dry-run preview locally for one connector/channel.
 8. Land PR 7 and run the authenticated migration dry-run report for one connector/channel.
-9. Decide whether to remove legacy self-paced agents from default config.
+9. Land PR 8 and verify legacy self-paced agents are opt-in, not default config.
 
 ## Review Notes
 

--- a/packages/standalone/src/agent/os-agent-capabilities.md
+++ b/packages/standalone/src/agent/os-agent-capabilities.md
@@ -244,19 +244,19 @@ Do NOT use Bash, Read, Write, or any other tool to do work that a sub-agent can 
 
 ### Sub-Agent Roster
 
-Check which agents are configured in `~/.mama/config.yaml` under `multi_agent.agents`.
+Check which agents are configured and enabled in `~/.mama/config.yaml` under `multi_agent.agents`.
 Dashboard and wiki workers are legacy opt-in agents, not default agents.
 
-| agentId         | Role                          | Delegate when configured...          |
-| --------------- | ----------------------------- | ------------------------------------ |
-| dashboard-agent | Dashboard briefing generation | "update briefing", "dashboard"       |
-| wiki-agent      | Wiki page compilation         | "wiki", "update wiki", documentation |
+| agentId         | Role                          | Delegate when configured and enabled... |
+| --------------- | ----------------------------- | --------------------------------------- |
+| dashboard-agent | Dashboard briefing generation | "update briefing", "dashboard"          |
+| wiki-agent      | Wiki page compilation         | "wiki", "update wiki", documentation    |
 
-Other agents (developer, reviewer, etc.) depend on runtime config. Only delegate to agents that exist in config.
+Other agents (developer, reviewer, etc.) depend on runtime config. Only delegate to agents that exist in config and are enabled.
 
 ### Delegation Rules (NON-NEGOTIABLE)
 
-1. **ALWAYS delegate to configured agents** — If the request matches a configured sub-agent role above, call `delegate()`. Do NOT attempt the work yourself using Bash/Read/Write.
+1. **ALWAYS delegate to configured and enabled agents** — If the request matches a configured and enabled sub-agent role above, call `delegate()`. Do NOT attempt the work yourself using Bash/Read/Write.
 2. **Verify results** — When you receive delegation results, summarize and relay to the user.
 3. **Handle failures** — If delegation returns an error, report it clearly. The executor already retries with backoff — do not retry at prompt level.
 4. **Parallel delegation** — Independent tasks can run concurrently with `background: true`.
@@ -271,11 +271,11 @@ Other agents (developer, reviewer, etc.) depend on runtime config. Only delegate
 
 ### What you MUST delegate (NEVER do yourself)
 
-- Dashboard briefing with `dashboard-agent` configured → `delegate("dashboard-agent", ...)`
-- Wiki updates with `wiki-agent` configured → `delegate("wiki-agent", ...)`
-- Code tasks with `developer` configured → `delegate("developer", ...)`
-- Code review with `reviewer` configured → `delegate("reviewer", ...)`
-- Architecture analysis with `architect` configured → `delegate("architect", ...)`
+- Dashboard briefing with `dashboard-agent` configured and enabled → `delegate("dashboard-agent", ...)`
+- Wiki updates with `wiki-agent` configured and enabled → `delegate("wiki-agent", ...)`
+- Code tasks with `developer` configured and enabled → `delegate("developer", ...)`
+- Code review with `reviewer` configured and enabled → `delegate("reviewer", ...)`
+- Architecture analysis with `architect` configured and enabled → `delegate("architect", ...)`
 
 ## Isolation Rules
 

--- a/packages/standalone/src/agent/os-agent-capabilities.md
+++ b/packages/standalone/src/agent/os-agent-capabilities.md
@@ -244,9 +244,10 @@ Do NOT use Bash, Read, Write, or any other tool to do work that a sub-agent can 
 
 ### Sub-Agent Roster
 
-Check which agents are configured in `~/.mama/config.yaml` under `multi_agent.agents`. Common agents:
+Check which agents are configured in `~/.mama/config.yaml` under `multi_agent.agents`.
+Dashboard and wiki workers are legacy opt-in agents, not default agents.
 
-| agentId         | Role                          | YOU MUST delegate when...            |
+| agentId         | Role                          | Delegate when configured...          |
 | --------------- | ----------------------------- | ------------------------------------ |
 | dashboard-agent | Dashboard briefing generation | "update briefing", "dashboard"       |
 | wiki-agent      | Wiki page compilation         | "wiki", "update wiki", documentation |
@@ -255,7 +256,7 @@ Other agents (developer, reviewer, etc.) depend on runtime config. Only delegate
 
 ### Delegation Rules (NON-NEGOTIABLE)
 
-1. **ALWAYS delegate** — If the request matches any sub-agent role above, call `delegate()`. Do NOT attempt the work yourself using Bash/Read/Write.
+1. **ALWAYS delegate to configured agents** — If the request matches a configured sub-agent role above, call `delegate()`. Do NOT attempt the work yourself using Bash/Read/Write.
 2. **Verify results** — When you receive delegation results, summarize and relay to the user.
 3. **Handle failures** — If delegation returns an error, report it clearly. The executor already retries with backoff — do not retry at prompt level.
 4. **Parallel delegation** — Independent tasks can run concurrently with `background: true`.
@@ -270,11 +271,11 @@ Other agents (developer, reviewer, etc.) depend on runtime config. Only delegate
 
 ### What you MUST delegate (NEVER do yourself)
 
-- Dashboard briefing → `delegate("dashboard-agent", ...)`
-- Wiki updates → `delegate("wiki-agent", ...)`
-- Code tasks → `delegate("developer", ...)`
-- Code review → `delegate("reviewer", ...)`
-- Architecture analysis → `delegate("architect", ...)`
+- Dashboard briefing with `dashboard-agent` configured → `delegate("dashboard-agent", ...)`
+- Wiki updates with `wiki-agent` configured → `delegate("wiki-agent", ...)`
+- Code tasks with `developer` configured → `delegate("developer", ...)`
+- Code review with `reviewer` configured → `delegate("reviewer", ...)`
+- Architecture analysis with `architect` configured → `delegate("architect", ...)`
 
 ## Isolation Rules
 

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -1367,7 +1367,8 @@ export async function runAgentLoop(
     !shouldSkipVNextFanout(vNext, 'agent_config_mutation') &&
     !shouldSkipVNextFanout(vNext, 'persona_write')
   ) {
-    // Ensure OS system agents exist in config (memory agent may be missing in older configs)
+    // Ensure current primary system agents exist in config. Legacy self-paced
+    // dashboard/wiki agents are opt-in and must not be backfilled here.
     if (!config.multi_agent) {
       config.multi_agent = getDefaultMultiAgentConfig();
     }
@@ -1386,15 +1387,6 @@ export async function runAgentLoop(
         model: string;
         can_delegate?: boolean;
         enabled?: boolean;
-        useCodeAct?: boolean;
-        tool_permissions?: {
-          allowed?: string[];
-          blocked?: string[];
-        };
-        gateway_tool_permissions?: {
-          allowed?: string[];
-          blocked?: string[];
-        };
       }
     > = {
       'os-agent': {
@@ -1419,58 +1411,7 @@ export async function runAgentLoop(
         can_delegate: false,
         enabled: true,
       },
-      'dashboard-agent': {
-        name: 'Dashboard Agent',
-        display_name: '📊 Dashboard',
-        trigger_prefix: '!dashboard',
-        persona_file: '~/.mama/personas/dashboard.md',
-        tier: 2,
-        backend: runtimeBackend,
-        model: config.agent.model,
-        can_delegate: false,
-        enabled: true,
-        useCodeAct: true,
-        tool_permissions: {
-          allowed: ['Read', 'Grep', 'Glob', 'code_act'],
-          blocked: ['Bash', 'Write', 'Edit', 'Agent', 'WebSearch', 'WebFetch'],
-        },
-        gateway_tool_permissions: {
-          allowed: ['mama_search', 'context_compile', 'agent_notices', 'report_publish'],
-          blocked: [],
-        },
-      },
     };
-    const wikiConfig = config.wiki as { enabled?: boolean } | undefined;
-    if (wikiConfig?.enabled) {
-      osAgents['wiki-agent'] = {
-        name: 'Wiki Agent',
-        display_name: '📚 Wiki',
-        trigger_prefix: '!wiki',
-        persona_file: '~/.mama/personas/wiki.md',
-        tier: 2,
-        backend: runtimeBackend,
-        model: config.agent.model,
-        can_delegate: false,
-        enabled: true,
-        useCodeAct: true,
-        tool_permissions: {
-          allowed: ['Read', 'Grep', 'Glob', 'code_act'],
-          blocked: ['Bash', 'Write', 'Edit', 'Agent', 'WebSearch', 'WebFetch'],
-        },
-        gateway_tool_permissions: {
-          allowed: [
-            'mama_search',
-            'context_compile',
-            'agent_notices',
-            'case_list',
-            'case_assemble',
-            'obsidian',
-            'wiki_publish',
-          ],
-          blocked: [],
-        },
-      };
-    }
     let osAgentsAdded = false;
     for (const [id, cfg] of Object.entries(osAgents)) {
       if (!config.multi_agent.agents[id]) {

--- a/packages/standalone/src/cli/config/config-manager.ts
+++ b/packages/standalone/src/cli/config/config-manager.ts
@@ -382,8 +382,7 @@ export async function createDefaultConfig(overwrite = false): Promise<string> {
  * SECURITY: Type guards ensure safe defaults for optional fields
  */
 function mergeWithDefaults(config: Partial<MAMAConfig>): MAMAConfig {
-  const wikiEnabled = (config as { wiki?: { enabled?: boolean } }).wiki?.enabled === true;
-  const multiAgent = normalizeLegacyMultiAgentConfig(config.multi_agent, { wikiEnabled });
+  const multiAgent = normalizeLegacyMultiAgentConfig(config.multi_agent);
 
   return {
     // Preserve all user-defined fields (scheduling, custom sections, etc.)
@@ -436,8 +435,7 @@ function mergeWithDefaults(config: Partial<MAMAConfig>): MAMAConfig {
  * delegate work, so we gently upgrade missing permission metadata.
  */
 function normalizeLegacyMultiAgentConfig(
-  multiAgentConfig?: MultiAgentConfig,
-  options: { wikiEnabled?: boolean } = {}
+  multiAgentConfig?: MultiAgentConfig
 ): MultiAgentConfig | undefined {
   if (!multiAgentConfig?.agents) {
     return multiAgentConfig;
@@ -475,13 +473,6 @@ function normalizeLegacyMultiAgentConfig(
   let addedBuiltinAgent = false;
   let changedBuiltinAgent = false;
   for (const [agentId, defaultAgent] of Object.entries(defaultAgents)) {
-    // wiki-agent's runtime provisioning (persona, vault wiring) only runs when
-    // config.wiki.enabled is true. Skip the static backfill here unless the
-    // flag is on so we don't advertise an agent the runtime treats as
-    // optional. A user-defined wiki-agent entry is preserved as-is.
-    if (agentId === 'wiki-agent' && !options.wikiEnabled && !mergedAgents[agentId]) {
-      continue;
-    }
     if (!mergedAgents[agentId]) {
       mergedAgents[agentId] = defaultAgent;
       addedBuiltinAgent = true;
@@ -495,6 +486,21 @@ function normalizeLegacyMultiAgentConfig(
         changedBuiltinAgent = true;
         mergedAgents[agentId] = normalizedAgent;
       }
+    }
+  }
+  for (const [agentId, defaultAgent] of Object.entries(getLegacySelfPacedAgentDefaults())) {
+    const existingAgent = mergedAgents[agentId];
+    if (!existingAgent) {
+      continue;
+    }
+    const normalizedAgent = normalizeBuiltinCodeActAgentPermissions(
+      agentId,
+      existingAgent,
+      defaultAgent
+    );
+    if (normalizedAgent !== existingAgent) {
+      changedBuiltinAgent = true;
+      mergedAgents[agentId] = normalizedAgent;
     }
   }
   if (addedBuiltinAgent || changedBuiltinAgent) {
@@ -701,50 +707,6 @@ export function getDefaultMultiAgentConfig(): MultiAgentConfig {
         can_delegate: false,
         enabled: true,
       },
-      'dashboard-agent': {
-        name: 'Dashboard Agent',
-        display_name: '📊 Dashboard',
-        trigger_prefix: '!dashboard',
-        persona_file: '~/.mama/personas/dashboard.md',
-        tier: 2,
-        can_delegate: false,
-        enabled: true,
-        useCodeAct: true,
-        tool_permissions: {
-          allowed: ['Read', 'Grep', 'Glob', 'code_act'],
-          blocked: ['Bash', 'Write', 'Edit', 'Agent', 'WebSearch', 'WebFetch'],
-        },
-        gateway_tool_permissions: {
-          allowed: ['mama_search', 'context_compile', 'agent_notices', 'report_publish'],
-          blocked: [],
-        },
-      },
-      'wiki-agent': {
-        name: 'Wiki Agent',
-        display_name: '📚 Wiki',
-        trigger_prefix: '!wiki',
-        persona_file: '~/.mama/personas/wiki.md',
-        tier: 2,
-        can_delegate: false,
-        enabled: true,
-        useCodeAct: true,
-        tool_permissions: {
-          allowed: ['Read', 'Grep', 'Glob', 'code_act'],
-          blocked: ['Bash', 'Write', 'Edit', 'Agent', 'WebSearch', 'WebFetch'],
-        },
-        gateway_tool_permissions: {
-          allowed: [
-            'mama_search',
-            'context_compile',
-            'agent_notices',
-            'case_list',
-            'case_assemble',
-            'obsidian',
-            'wiki_publish',
-          ],
-          blocked: [],
-        },
-      },
     },
     loop_prevention: {
       max_chain_length: 5,
@@ -756,6 +718,55 @@ export function getDefaultMultiAgentConfig(): MultiAgentConfig {
     },
     council: {
       enabled: true,
+    },
+  };
+}
+
+function getLegacySelfPacedAgentDefaults(): Record<string, Omit<AgentPersonaConfig, 'id'>> {
+  return {
+    'dashboard-agent': {
+      name: 'Dashboard Agent',
+      display_name: '📊 Dashboard',
+      trigger_prefix: '!dashboard',
+      persona_file: '~/.mama/personas/dashboard.md',
+      tier: 2,
+      can_delegate: false,
+      enabled: true,
+      useCodeAct: true,
+      tool_permissions: {
+        allowed: ['Read', 'Grep', 'Glob', 'code_act'],
+        blocked: ['Bash', 'Write', 'Edit', 'Agent', 'WebSearch', 'WebFetch'],
+      },
+      gateway_tool_permissions: {
+        allowed: ['mama_search', 'context_compile', 'agent_notices', 'report_publish'],
+        blocked: [],
+      },
+    },
+    'wiki-agent': {
+      name: 'Wiki Agent',
+      display_name: '📚 Wiki',
+      trigger_prefix: '!wiki',
+      persona_file: '~/.mama/personas/wiki.md',
+      tier: 2,
+      can_delegate: false,
+      enabled: true,
+      useCodeAct: true,
+      tool_permissions: {
+        allowed: ['Read', 'Grep', 'Glob', 'code_act'],
+        blocked: ['Bash', 'Write', 'Edit', 'Agent', 'WebSearch', 'WebFetch'],
+      },
+      gateway_tool_permissions: {
+        allowed: [
+          'mama_search',
+          'context_compile',
+          'agent_notices',
+          'case_list',
+          'case_assemble',
+          'obsidian',
+          'wiki_publish',
+        ],
+        blocked: [],
+      },
     },
   };
 }

--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -258,6 +258,11 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
   // Wire EventBus to tool executor for agent_notices tool
   toolExecutor.setAgentEventBus(eventBus);
 
+  const hasEnabledAgentConfig = (agentId: string): boolean => {
+    const agentConfig = config.multi_agent?.agents?.[agentId];
+    return Boolean(agentConfig && agentConfig.enabled !== false);
+  };
+
   // ── Report Slots + legacy dashboard/wiki fanout ───────────────────────
   if (
     !shouldSkipVNextFanout(vNext, 'dashboard_agent_interval') &&
@@ -266,61 +271,68 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
     !shouldSkipVNextFanout(vNext, 'mcp_config_rewrite') &&
     !shouldSkipVNextFanout(vNext, 'obsidian_launch')
   ) {
-    const { broadcastReportUpdate } = await import('../../api/report-handler.js');
+    const dashboardAgentConfigured = hasEnabledAgentConfig('dashboard-agent');
+    const wikiAgentConfigured = hasEnabledAgentConfig('wiki-agent');
 
     // Manual refresh endpoint (kept for compatibility)
     apiServer.app.post('/api/report/refresh', requireAuth, (_req, res) => {
       res.json({ ok: true, message: 'Viewer now renders data directly from Intelligence API' });
     });
 
-    // Wire report_publish tool to OS agent — only briefing slot
-    toolExecutor.setReportPublisher((slots) => {
-      for (const [slotId, html] of Object.entries(slots)) {
-        if (slotId !== 'briefing') continue; // only accept briefing slot
-        apiServer.reportStore.update(slotId, html, 0);
-      }
-      broadcastReportUpdate(apiServer.reportSseClients, {
-        slots: apiServer.reportStore.getAllSorted(),
-      });
-      routesLogger.debug(`[Report] Agent published briefing slot`);
-      eventBus.emit({
-        type: 'agent:action',
-        agent: 'dashboard-agent',
-        action: 'publish',
-        target: 'briefing',
-      });
-    });
-
     // ── Conductor Persona (section injection — non-destructive) ────────
     const { ensureConductorPersona } = await import('../../multi-agent/conductor-persona.js');
     ensureConductorPersona();
 
-    // ── Dashboard Agent ─────────────────────────────────────────────────
-    const { ensureDashboardPersona } = await import('../../multi-agent/dashboard-agent-persona.js');
-    ensureDashboardPersona();
-    routesLogger.debug('[Dashboard Agent] Persona ensured at ~/.mama/personas/dashboard.md');
-
-    // Merge code-act MCP server into mama-mcp-config.json
-    // Makes code_act available to all CLI processes (AgentProcessManager agents)
-    const codeActServerPath = path.join(__dirname, '../../mcp/code-act-server.js');
-    try {
-      const mamaMcpConfigPath = path.join(homedir(), '.mama', 'mama-mcp-config.json');
-      const existing = existsSync(mamaMcpConfigPath)
-        ? JSON.parse(readFileSync(mamaMcpConfigPath, 'utf-8'))
-        : { mcpServers: {} };
-      existing.mcpServers['code-act'] = {
-        command: 'node',
-        args: [codeActServerPath],
-        env: { MAMA_SERVER_PORT: String(API_PORT) },
-      };
-      writeFileSync(mamaMcpConfigPath, JSON.stringify(existing, null, 2), 'utf-8');
-      routesLogger.debug('[api-routes-init] code-act MCP merged into mama-mcp-config.json');
-    } catch (err) {
-      routesLogger.warn('[api-routes-init] Failed to merge code-act into MCP config:', err);
+    if (dashboardAgentConfigured || wikiAgentConfigured) {
+      // Merge code-act MCP server into mama-mcp-config.json.
+      // Makes code_act available to configured legacy self-paced agents.
+      const codeActServerPath = path.join(__dirname, '../../mcp/code-act-server.js');
+      try {
+        const mamaMcpConfigPath = path.join(homedir(), '.mama', 'mama-mcp-config.json');
+        const existing = existsSync(mamaMcpConfigPath)
+          ? JSON.parse(readFileSync(mamaMcpConfigPath, 'utf-8'))
+          : { mcpServers: {} };
+        existing.mcpServers['code-act'] = {
+          command: 'node',
+          args: [codeActServerPath],
+          env: { MAMA_SERVER_PORT: String(API_PORT) },
+        };
+        writeFileSync(mamaMcpConfigPath, JSON.stringify(existing, null, 2), 'utf-8');
+        routesLogger.debug('[api-routes-init] code-act MCP merged into mama-mcp-config.json');
+      } catch (err) {
+        routesLogger.warn('[api-routes-init] Failed to merge code-act into MCP config:', err);
+      }
     }
 
-    // Dashboard cron: 30-min interval via AgentProcessManager
-    const dashboardPrompt = `You are triggered on a schedule. Before writing anything, determine if an update is needed:
+    if (dashboardAgentConfigured) {
+      const { broadcastReportUpdate } = await import('../../api/report-handler.js');
+
+      // Wire report_publish tool to Dashboard Agent — only briefing slot
+      toolExecutor.setReportPublisher((slots) => {
+        for (const [slotId, html] of Object.entries(slots)) {
+          if (slotId !== 'briefing') continue; // only accept briefing slot
+          apiServer.reportStore.update(slotId, html, 0);
+        }
+        broadcastReportUpdate(apiServer.reportSseClients, {
+          slots: apiServer.reportStore.getAllSorted(),
+        });
+        routesLogger.debug(`[Report] Agent published briefing slot`);
+        eventBus.emit({
+          type: 'agent:action',
+          agent: 'dashboard-agent',
+          action: 'publish',
+          target: 'briefing',
+        });
+      });
+
+      // ── Dashboard Agent ───────────────────────────────────────────────
+      const { ensureDashboardPersona } =
+        await import('../../multi-agent/dashboard-agent-persona.js');
+      ensureDashboardPersona();
+      routesLogger.debug('[Dashboard Agent] Persona ensured at ~/.mama/personas/dashboard.md');
+
+      // Dashboard cron: 30-min interval via AgentProcessManager
+      const dashboardPrompt = `You are triggered on a schedule. Before writing anything, determine if an update is needed:
 
 1. Use agent_notices({limit: 50}) to find the most recent dashboard-agent publish/task_complete notice. Treat that as the last briefing boundary.
 2. Use context_compile first to find recent substantive decisions (limit 20, max_tool_calls 2, strictness "balanced").
@@ -333,41 +345,44 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
 
 This saves resources. Only publish when there is genuinely new information to report.`;
 
-    const runDashboardAgent = async () => {
-      const pm = toolExecutor.getAgentProcessManager();
-      if (!pm) {
-        routesLogger.warn('[Dashboard Agent] AgentProcessManager not available yet');
-        return;
-      }
-      try {
-        routesLogger.debug('[Dashboard Agent] Checking for updates...');
-        const { noUpdate } = await executeValidatedRun('dashboard-agent', dashboardPrompt);
-        if (noUpdate) {
-          routesLogger.debug('[Dashboard Agent] No changes detected, skipped');
-        } else {
-          routesLogger.debug('[Dashboard Agent] Briefing published');
+      const runDashboardAgent = async () => {
+        const pm = toolExecutor.getAgentProcessManager();
+        if (!pm) {
+          routesLogger.warn('[Dashboard Agent] AgentProcessManager not available yet');
+          return;
         }
-      } catch (err) {
-        routesLogger.error('[Dashboard Agent] Error:', err instanceof Error ? err.message : err);
-      }
-    };
+        try {
+          routesLogger.debug('[Dashboard Agent] Checking for updates...');
+          const { noUpdate } = await executeValidatedRun('dashboard-agent', dashboardPrompt);
+          if (noUpdate) {
+            routesLogger.debug('[Dashboard Agent] No changes detected, skipped');
+          } else {
+            routesLogger.debug('[Dashboard Agent] Briefing published');
+          }
+        } catch (err) {
+          routesLogger.error('[Dashboard Agent] Error:', err instanceof Error ? err.message : err);
+        }
+      };
 
-    // First run after 10s (let connectors poll first), then every 30 min
-    setTimeout(runDashboardAgent, 10_000);
-    setInterval(runDashboardAgent, 30 * 60 * 1000);
+      // First run after 10s (let connectors poll first), then every 30 min
+      setTimeout(runDashboardAgent, 10_000);
+      setInterval(runDashboardAgent, 30 * 60 * 1000);
 
-    // Manual trigger
-    apiServer.app.post('/api/report/agent-refresh', requireAuth, async (_req, res) => {
-      runDashboardAgent().catch(() => {});
-      res.json({ ok: true, message: 'Dashboard agent triggered' });
-    });
+      // Manual trigger
+      apiServer.app.post('/api/report/agent-refresh', requireAuth, async (_req, res) => {
+        runDashboardAgent().catch(() => {});
+        res.json({ ok: true, message: 'Dashboard agent triggered' });
+      });
+    } else {
+      routesLogger.debug('[Dashboard Agent] Skipped; dashboard-agent is not configured');
+    }
 
     // ── Wiki Agent ──────────────────────────────────────────────────────
     const wikiConfig = config.wiki as
       | { enabled?: boolean; vaultPath?: string; wikiDir?: string }
       | undefined;
 
-    if (wikiConfig?.enabled && wikiConfig.vaultPath) {
+    if (wikiAgentConfigured && wikiConfig?.enabled && wikiConfig.vaultPath) {
       const { ensureWikiPersona } = await import('../../multi-agent/wiki-agent-persona.js');
       const { ObsidianWriter } = await import('../../wiki/obsidian-writer.js');
 

--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -289,9 +289,30 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
       const codeActServerPath = path.join(__dirname, '../../mcp/code-act-server.js');
       try {
         const mamaMcpConfigPath = path.join(homedir(), '.mama', 'mama-mcp-config.json');
-        const existing = existsSync(mamaMcpConfigPath)
-          ? JSON.parse(readFileSync(mamaMcpConfigPath, 'utf-8'))
-          : { mcpServers: {} };
+        let existing: {
+          mcpServers?: Record<string, unknown>;
+          [key: string]: unknown;
+        } = { mcpServers: {} };
+        if (existsSync(mamaMcpConfigPath)) {
+          try {
+            const parsedConfig = JSON.parse(readFileSync(mamaMcpConfigPath, 'utf-8')) as unknown;
+            if (parsedConfig && typeof parsedConfig === 'object' && !Array.isArray(parsedConfig)) {
+              existing = parsedConfig as typeof existing;
+            }
+          } catch (parseErr) {
+            routesLogger.warn(
+              '[api-routes-init] Invalid MCP config JSON; recreating code-act entry:',
+              parseErr
+            );
+          }
+        }
+        if (
+          !existing.mcpServers ||
+          typeof existing.mcpServers !== 'object' ||
+          Array.isArray(existing.mcpServers)
+        ) {
+          existing.mcpServers = {};
+        }
         existing.mcpServers['code-act'] = {
           command: 'node',
           args: [codeActServerPath],

--- a/packages/standalone/src/multi-agent/conductor-persona.ts
+++ b/packages/standalone/src/multi-agent/conductor-persona.ts
@@ -92,8 +92,8 @@ If they're on the agent list, summarize which agents need attention.
 
 **Active UI guidance:**
 - Use \`viewer_navigate("agents")\` to show the agent list
-- Use \`viewer_navigate("agents", {id: "wiki-agent"})\` to show agent detail
-- Use \`viewer_notify({type: "warning", message: "wiki-agent regressed: latency 70s > 60s threshold"})\` for alerts
+- Use \`viewer_navigate("agents", {id: agentId})\` to show an enabled agent detail
+- Use \`viewer_notify({type: "warning", message: "[agentId] regressed: latency 70s > 60s threshold"})\` for alerts
 - After running \`agent_test\`, navigate to validation tab: \`viewer_navigate("agents", {id: agentId})\` and tell user to check the Validation tab
 
 **Validation checks during audit:**

--- a/packages/standalone/tests/agent/gateway-tool-executor.test.ts
+++ b/packages/standalone/tests/agent/gateway-tool-executor.test.ts
@@ -567,10 +567,33 @@ describe('STORY-V019 - GatewayToolExecutor', () => {
         executor.setRestartMultiAgentAgent(restartMultiAgentAgent);
 
         const multiAgentConfig = getDefaultMultiAgentConfig();
+        multiAgentConfig.agents['wiki-agent'] = {
+          name: 'Wiki Agent',
+          display_name: 'Wiki',
+          trigger_prefix: '!wiki',
+          persona_file: '~/.mama/personas/wiki.md',
+          tier: 2,
+          useCodeAct: true,
+          tool_permissions: {
+            allowed: ['Read', 'Grep', 'Glob', 'code_act'],
+            blocked: ['Bash', 'Write', 'Edit', 'Agent', 'WebSearch', 'WebFetch'],
+          },
+          gateway_tool_permissions: {
+            allowed: [
+              'mama_search',
+              'context_compile',
+              'agent_notices',
+              'case_list',
+              'case_assemble',
+              'obsidian',
+              'wiki_publish',
+            ],
+            blocked: [],
+          },
+        };
         await saveConfig({ ...DEFAULT_CONFIG, multi_agent: multiAgentConfig });
 
-        const wikiAgentConfig = multiAgentConfig.agents['wiki-agent'];
-        expect(wikiAgentConfig).toBeDefined();
+        const wikiAgentConfig = multiAgentConfig.agents['wiki-agent']!;
         createAgentVersion(db, {
           agent_id: 'wiki-agent',
           snapshot: wikiAgentConfig as Record<string, unknown>,

--- a/packages/standalone/tests/cli/config-manager.test.ts
+++ b/packages/standalone/tests/cli/config-manager.test.ts
@@ -153,8 +153,8 @@ describe('ConfigManager', () => {
       expect(loaded.multi_agent?.agents?.developer?.tool_permissions?.blocked).toEqual([]);
     });
 
-    it('should merge missing built-in agents into existing multi-agent configs on load', async () => {
-      // AC: Existing configs keep custom agents while receiving newly introduced built-ins.
+    it('should merge current built-in agents into existing multi-agent configs on load', async () => {
+      // AC: Existing configs keep custom agents while receiving current built-ins.
       const mamaDir = join(testDir, '.mama');
       await mkdir(mamaDir, { recursive: true });
       const configPath = join(mamaDir, 'config.yaml');
@@ -185,13 +185,15 @@ describe('ConfigManager', () => {
       const loaded = await loadConfig();
 
       expect(loaded.multi_agent?.agents?.custom?.tool_permissions?.allowed).toEqual(['Read']);
-      expect(loaded.multi_agent?.agents?.['dashboard-agent']).toBeDefined();
-      expect(loaded.multi_agent?.agents?.['wiki-agent']).toBeDefined();
+      expect(loaded.multi_agent?.agents?.['os-agent']).toBeDefined();
+      expect(loaded.multi_agent?.agents?.conductor).toBeDefined();
+      expect(loaded.multi_agent?.agents?.memory).toBeDefined();
+      expect(loaded.multi_agent?.agents).not.toHaveProperty('dashboard-agent');
+      expect(loaded.multi_agent?.agents).not.toHaveProperty('wiki-agent');
     });
 
-    it('should skip wiki-agent backfill when config.wiki.enabled is not set', async () => {
-      // AC: wiki-agent runtime provisioning is gated on config.wiki.enabled, so
-      // the static backfill must not advertise it when wiki is disabled.
+    it('should not backfill legacy self-paced agents when wiki is enabled', async () => {
+      // AC: vNext removes legacy self-paced dashboard/wiki agents from default backfill.
       const mamaDir = join(testDir, '.mama');
       await mkdir(mamaDir, { recursive: true });
       const configPath = join(mamaDir, 'config.yaml');
@@ -201,6 +203,7 @@ describe('ConfigManager', () => {
         agent: { model: 'custom-model' },
         database: { path: '~/.test/db.sqlite' },
         logging: { level: 'info', file: '~/.test/logs/test.log' },
+        wiki: { enabled: true },
         multi_agent: {
           enabled: true,
           agents: {
@@ -219,7 +222,8 @@ describe('ConfigManager', () => {
 
       const loaded = await loadConfig();
 
-      expect(loaded.multi_agent?.agents?.['dashboard-agent']).toBeDefined();
+      expect(loaded.multi_agent?.agents?.custom).toBeDefined();
+      expect(loaded.multi_agent?.agents).not.toHaveProperty('dashboard-agent');
       expect(loaded.multi_agent?.agents?.['wiki-agent']).toBeUndefined();
     });
 
@@ -382,55 +386,26 @@ describe('ConfigManager', () => {
   });
 
   describe('getDefaultMultiAgentConfig()', () => {
-    it('should include os-agent in the default system agent set', () => {
-      // AC: System agents expose CLI read tools separately from Code-Act gateway tools.
+    it('should include only current primary agents in the default system agent set', () => {
+      // AC: Legacy self-paced dashboard/wiki agents are opt-in, not default config.
       const multiAgentConfig = getDefaultMultiAgentConfig();
 
       expect(multiAgentConfig.agents['os-agent']).toBeDefined();
       expect(multiAgentConfig.agents['os-agent']?.enabled).toBe(true);
-      expect(multiAgentConfig.agents['dashboard-agent']).toMatchObject({
-        tier: 2,
+      expect(multiAgentConfig.agents.conductor).toMatchObject({
+        tier: 1,
+        can_delegate: true,
+      });
+      expect(multiAgentConfig.agents.memory).toMatchObject({
+        tier: 3,
         can_delegate: false,
         enabled: true,
-        persona_file: '~/.mama/personas/dashboard.md',
       });
-      expect(
-        multiAgentConfig.agents['dashboard-agent']?.gateway_tool_permissions?.allowed
-      ).toContain('report_publish');
-      expect(
-        multiAgentConfig.agents['dashboard-agent']?.gateway_tool_permissions?.allowed
-      ).toContain('context_compile');
-      expect(multiAgentConfig.agents['dashboard-agent']?.tool_permissions?.allowed).toContain(
-        'Read'
-      );
-      expect(multiAgentConfig.agents['dashboard-agent']?.tool_permissions?.allowed).toContain(
-        'code_act'
-      );
-      expect(multiAgentConfig.agents['dashboard-agent']?.tool_permissions?.blocked).not.toContain(
-        'Read'
-      );
-      expect(multiAgentConfig.agents['wiki-agent']).toMatchObject({
-        tier: 2,
-        can_delegate: false,
-        enabled: true,
-        persona_file: '~/.mama/personas/wiki.md',
-      });
-      expect(multiAgentConfig.agents['wiki-agent']?.gateway_tool_permissions?.allowed).toContain(
-        'wiki_publish'
-      );
-      expect(multiAgentConfig.agents['wiki-agent']?.gateway_tool_permissions?.allowed).toContain(
-        'agent_notices'
-      );
-      expect(multiAgentConfig.agents['wiki-agent']?.gateway_tool_permissions?.allowed).toContain(
-        'context_compile'
-      );
-      expect(multiAgentConfig.agents['wiki-agent']?.tool_permissions?.allowed).toContain('Read');
-      expect(multiAgentConfig.agents['wiki-agent']?.tool_permissions?.blocked).not.toContain(
-        'Read'
-      );
+      expect(multiAgentConfig.agents).not.toHaveProperty('dashboard-agent');
+      expect(multiAgentConfig.agents).not.toHaveProperty('wiki-agent');
     });
 
-    it('should exclude legacy swarm agents from the default agent set', () => {
+    it('should exclude legacy swarm and self-paced agents from the default agent set', () => {
       const multiAgentConfig = getDefaultMultiAgentConfig();
 
       expect(multiAgentConfig.agents.conductor).toBeDefined();
@@ -438,6 +413,8 @@ describe('ConfigManager', () => {
       expect(multiAgentConfig.agents).not.toHaveProperty('reviewer');
       expect(multiAgentConfig.agents).not.toHaveProperty('architect');
       expect(multiAgentConfig.agents).not.toHaveProperty('pm');
+      expect(multiAgentConfig.agents).not.toHaveProperty('dashboard-agent');
+      expect(multiAgentConfig.agents).not.toHaveProperty('wiki-agent');
     });
   });
 

--- a/packages/standalone/tests/runtime-vnext/legacy-fanout-disabled.test.ts
+++ b/packages/standalone/tests/runtime-vnext/legacy-fanout-disabled.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -408,6 +408,63 @@ describe('STORY-VNEXT-PR1-FANOUT-OFF: vNext disables legacy fanout', () => {
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 10_000);
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5 * 60 * 1000);
       expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 30 * 60 * 1000);
+    });
+
+    it('recreates code-act MCP config when legacy self-paced agent config finds invalid JSON', async () => {
+      const mamaDir = join(tempHome, '.mama');
+      const mamaMcpConfigPath = join(mamaDir, 'mama-mcp-config.json');
+      mkdirSync(mamaDir, { recursive: true });
+      writeFileSync(mamaMcpConfigPath, '{ invalid json', 'utf-8');
+
+      const apiServer = createApiServer({
+        scheduler: initCronScheduler(makeConfig()).scheduler,
+        port: 0,
+      });
+      const eventBus = new AgentEventBus();
+      const toolExecutor = new GatewayToolExecutor();
+      const db = new Database(':memory:');
+      databases.push(db);
+      const messageRouter = makeMessageRouter(db, tempHome);
+      const agentLoop = makeAgentLoop(tempHome);
+      vi.spyOn(globalThis, 'setTimeout').mockImplementation(
+        () => ({ unref: vi.fn() }) as unknown as ReturnType<typeof setTimeout>
+      );
+      vi.spyOn(globalThis, 'setInterval').mockImplementation(
+        () => ({ unref: vi.fn() }) as unknown as ReturnType<typeof setInterval>
+      );
+
+      await registerApiRoutes({
+        config: makeConfig({
+          wiki: { enabled: false },
+          multi_agent: makeMultiAgentConfig({
+            'dashboard-agent': makeDashboardAgentConfig(),
+          }),
+        }),
+        apiServer,
+        eventBus,
+        oauthManager: makeOAuthManager(tempHome),
+        mamaApi: {},
+        messageRouter,
+        agentLoop,
+        toolExecutor,
+        discordGateway: null,
+        slackGateway: null,
+        graphHandler: async () => false,
+        getAdapter: makeAdapter,
+      });
+
+      const mcpConfig = JSON.parse(readFileSync(mamaMcpConfigPath, 'utf-8')) as {
+        mcpServers?: Record<
+          string,
+          { command?: string; args?: string[]; env?: Record<string, string> }
+        >;
+      };
+
+      expect(mcpConfig.mcpServers?.['code-act']).toMatchObject({
+        command: 'node',
+        env: { MAMA_SERVER_PORT: '3847' },
+      });
+      expect(mcpConfig.mcpServers?.['code-act']?.args?.[0]).toContain('code-act-server.js');
     });
 
     it('keeps wiki fanout active in legacy mode when wiki-agent is configured', async () => {

--- a/packages/standalone/tests/runtime-vnext/legacy-fanout-disabled.test.ts
+++ b/packages/standalone/tests/runtime-vnext/legacy-fanout-disabled.test.ts
@@ -47,6 +47,54 @@ function makeConfig(overrides: Partial<MAMAConfig> = {}): MAMAConfig {
   } as unknown as MAMAConfig;
 }
 
+function makeMultiAgentConfig(
+  agents: NonNullable<MAMAConfig['multi_agent']>['agents']
+): NonNullable<MAMAConfig['multi_agent']> {
+  return {
+    enabled: false,
+    free_chat: true,
+    default_agent: 'conductor',
+    agents,
+    loop_prevention: {
+      max_chain_length: 5,
+      global_cooldown_ms: 1000,
+      chain_window_ms: 60000,
+    },
+    workflow: { enabled: true },
+    council: { enabled: true },
+  };
+}
+
+function makeDashboardAgentConfig(): NonNullable<MAMAConfig['multi_agent']>['agents'][string] {
+  return {
+    name: 'Dashboard Agent',
+    display_name: 'Dashboard',
+    trigger_prefix: '!dashboard',
+    persona_file: '~/.mama/personas/dashboard.md',
+    tier: 2,
+    backend: 'claude',
+    model: 'claude-sonnet-4-6',
+    can_delegate: false,
+    enabled: true,
+    useCodeAct: true,
+  };
+}
+
+function makeWikiAgentConfig(): NonNullable<MAMAConfig['multi_agent']>['agents'][string] {
+  return {
+    name: 'Wiki Agent',
+    display_name: 'Wiki',
+    trigger_prefix: '!wiki',
+    persona_file: '~/.mama/personas/wiki.md',
+    tier: 2,
+    backend: 'claude',
+    model: 'claude-sonnet-4-6',
+    can_delegate: false,
+    enabled: true,
+    useCodeAct: true,
+  };
+}
+
 function makeVNextPlan() {
   return buildVNextBootstrapPlan({
     enabled: true,
@@ -117,6 +165,7 @@ describe('STORY-VNEXT-PR1-FANOUT-OFF: vNext disables legacy fanout', () => {
     }
     rmSync(tempHome, { recursive: true, force: true });
     vi.restoreAllMocks();
+    vi.doUnmock('child_process');
   });
 
   describe('AC: startup schedulers are inert in vNext bootstrap mode', () => {
@@ -215,7 +264,106 @@ describe('STORY-VNEXT-PR1-FANOUT-OFF: vNext disables legacy fanout', () => {
       expect(setIntervalSpy).not.toHaveBeenCalled();
     });
 
-    it('keeps dashboard and conductor fanout active in legacy mode', async () => {
+    it('does not start legacy self-paced agents in legacy mode unless configured', async () => {
+      const apiServer = createApiServer({
+        scheduler: initCronScheduler(makeConfig()).scheduler,
+        port: 0,
+      });
+      const eventBus = new AgentEventBus();
+      const toolExecutor = new GatewayToolExecutor();
+      const setReportPublisherSpy = vi.spyOn(toolExecutor, 'setReportPublisher');
+      const setObsidianVaultPathSpy = vi.spyOn(toolExecutor, 'setObsidianVaultPath');
+      const setWikiPublisherSpy = vi.spyOn(toolExecutor, 'setWikiPublisher');
+      const db = new Database(':memory:');
+      databases.push(db);
+      const messageRouter = makeMessageRouter(db, tempHome);
+      const agentLoop = makeAgentLoop(tempHome);
+      const setTimeoutSpy = vi
+        .spyOn(globalThis, 'setTimeout')
+        .mockImplementation(() => ({ unref: vi.fn() }) as unknown as ReturnType<typeof setTimeout>);
+      const setIntervalSpy = vi
+        .spyOn(globalThis, 'setInterval')
+        .mockImplementation(
+          () => ({ unref: vi.fn() }) as unknown as ReturnType<typeof setInterval>
+        );
+
+      await registerApiRoutes({
+        config: makeConfig(),
+        apiServer,
+        eventBus,
+        oauthManager: makeOAuthManager(tempHome),
+        mamaApi: {},
+        messageRouter,
+        agentLoop,
+        toolExecutor,
+        discordGateway: null,
+        slackGateway: null,
+        graphHandler: async () => false,
+        getAdapter: makeAdapter,
+      });
+
+      expect(setReportPublisherSpy).not.toHaveBeenCalled();
+      expect(setObsidianVaultPathSpy).not.toHaveBeenCalled();
+      expect(setWikiPublisherSpy).not.toHaveBeenCalled();
+      expect(setTimeoutSpy).not.toHaveBeenCalledWith(expect.any(Function), 10_000);
+      expect(setTimeoutSpy).not.toHaveBeenCalledWith(expect.any(Function), 15_000);
+      expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 30 * 60 * 1000);
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5 * 60 * 1000);
+    });
+
+    it('does not start explicitly disabled legacy self-paced agents in legacy mode', async () => {
+      const apiServer = createApiServer({
+        scheduler: initCronScheduler(makeConfig()).scheduler,
+        port: 0,
+      });
+      const eventBus = new AgentEventBus();
+      const toolExecutor = new GatewayToolExecutor();
+      const setReportPublisherSpy = vi.spyOn(toolExecutor, 'setReportPublisher');
+      const setObsidianVaultPathSpy = vi.spyOn(toolExecutor, 'setObsidianVaultPath');
+      const setWikiPublisherSpy = vi.spyOn(toolExecutor, 'setWikiPublisher');
+      const db = new Database(':memory:');
+      databases.push(db);
+      const messageRouter = makeMessageRouter(db, tempHome);
+      const agentLoop = makeAgentLoop(tempHome);
+      const setTimeoutSpy = vi
+        .spyOn(globalThis, 'setTimeout')
+        .mockImplementation(() => ({ unref: vi.fn() }) as unknown as ReturnType<typeof setTimeout>);
+      const setIntervalSpy = vi
+        .spyOn(globalThis, 'setInterval')
+        .mockImplementation(
+          () => ({ unref: vi.fn() }) as unknown as ReturnType<typeof setInterval>
+        );
+
+      await registerApiRoutes({
+        config: makeConfig({
+          multi_agent: makeMultiAgentConfig({
+            'dashboard-agent': { ...makeDashboardAgentConfig(), enabled: false },
+            'wiki-agent': { ...makeWikiAgentConfig(), enabled: false },
+          }),
+        }),
+        apiServer,
+        eventBus,
+        oauthManager: makeOAuthManager(tempHome),
+        mamaApi: {},
+        messageRouter,
+        agentLoop,
+        toolExecutor,
+        discordGateway: null,
+        slackGateway: null,
+        graphHandler: async () => false,
+        getAdapter: makeAdapter,
+      });
+
+      expect(setReportPublisherSpy).not.toHaveBeenCalled();
+      expect(setObsidianVaultPathSpy).not.toHaveBeenCalled();
+      expect(setWikiPublisherSpy).not.toHaveBeenCalled();
+      expect(setTimeoutSpy).not.toHaveBeenCalledWith(expect.any(Function), 10_000);
+      expect(setTimeoutSpy).not.toHaveBeenCalledWith(expect.any(Function), 15_000);
+      expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 30 * 60 * 1000);
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5 * 60 * 1000);
+    });
+
+    it('keeps dashboard and conductor fanout active in legacy mode when configured', async () => {
       const apiServer = createApiServer({
         scheduler: initCronScheduler(makeConfig()).scheduler,
         port: 0,
@@ -237,7 +385,12 @@ describe('STORY-VNEXT-PR1-FANOUT-OFF: vNext disables legacy fanout', () => {
         );
 
       await registerApiRoutes({
-        config: makeConfig({ wiki: { enabled: false } }),
+        config: makeConfig({
+          wiki: { enabled: false },
+          multi_agent: makeMultiAgentConfig({
+            'dashboard-agent': makeDashboardAgentConfig(),
+          }),
+        }),
         apiServer,
         eventBus,
         oauthManager: makeOAuthManager(tempHome),
@@ -255,6 +408,62 @@ describe('STORY-VNEXT-PR1-FANOUT-OFF: vNext disables legacy fanout', () => {
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 10_000);
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5 * 60 * 1000);
       expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 30 * 60 * 1000);
+    });
+
+    it('keeps wiki fanout active in legacy mode when wiki-agent is configured', async () => {
+      vi.doMock('child_process', () => ({ execSync: vi.fn() }));
+
+      const wikiVault = join(tempHome, 'vault');
+      const wikiDir = 'knowledge';
+      const apiServer = createApiServer({
+        scheduler: initCronScheduler(makeConfig()).scheduler,
+        port: 0,
+      });
+      const eventBus = new AgentEventBus();
+      const toolExecutor = new GatewayToolExecutor();
+      const setReportPublisherSpy = vi.spyOn(toolExecutor, 'setReportPublisher');
+      const setObsidianVaultPathSpy = vi.spyOn(toolExecutor, 'setObsidianVaultPath');
+      const setWikiPublisherSpy = vi.spyOn(toolExecutor, 'setWikiPublisher');
+      const db = new Database(':memory:');
+      databases.push(db);
+      const messageRouter = makeMessageRouter(db, tempHome);
+      const agentLoop = makeAgentLoop(tempHome);
+      const setTimeoutSpy = vi
+        .spyOn(globalThis, 'setTimeout')
+        .mockImplementation(() => ({ unref: vi.fn() }) as unknown as ReturnType<typeof setTimeout>);
+      const setIntervalSpy = vi
+        .spyOn(globalThis, 'setInterval')
+        .mockImplementation(
+          () => ({ unref: vi.fn() }) as unknown as ReturnType<typeof setInterval>
+        );
+
+      await registerApiRoutes({
+        config: makeConfig({
+          wiki: { enabled: true, vaultPath: wikiVault, wikiDir },
+          multi_agent: makeMultiAgentConfig({
+            'wiki-agent': makeWikiAgentConfig(),
+          }),
+        }),
+        apiServer,
+        eventBus,
+        oauthManager: makeOAuthManager(tempHome),
+        mamaApi: {},
+        messageRouter,
+        agentLoop,
+        toolExecutor,
+        discordGateway: null,
+        slackGateway: null,
+        graphHandler: async () => false,
+        getAdapter: makeAdapter,
+      });
+
+      expect(setReportPublisherSpy).not.toHaveBeenCalled();
+      expect(setObsidianVaultPathSpy).toHaveBeenCalledWith(join(wikiVault, wikiDir));
+      expect(setWikiPublisherSpy).toHaveBeenCalledOnce();
+      expect(setTimeoutSpy).not.toHaveBeenCalledWith(expect.any(Function), 10_000);
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 15_000);
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5 * 60 * 1000);
+      expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 30 * 60 * 1000);
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR makes the legacy self-paced `dashboard-agent` and `wiki-agent` opt-in instead of default agents.

- Removes `dashboard-agent` and `wiki-agent` from new default `multi_agent.agents`.
- Stops config load and startup from backfilling missing legacy self-paced agents, including when `wiki.enabled` is true.
- Preserves existing user-defined dashboard/wiki agent entries and still migrates their legacy Code-Act gateway permissions.
- Gates runtime dashboard/wiki publishers, timers, persona writes, Code-Act MCP rewrites, and Obsidian wiring on explicit enabled agent config.
- Recovers the Code-Act MCP merge when an existing `~/.mama/mama-mcp-config.json` file is invalid or non-object JSON.
- Updates OS/conductor delegation guidance so dashboard/wiki and old swarm-style agents are only delegated to when configured and enabled.
- Records PR8 rollout rules in the vNext rebuild architecture doc.

## Test Coverage

Runtime-vNext coverage now checks:

- missing dashboard/wiki agents do not start self-paced fanout
- explicitly disabled dashboard/wiki agents do not start self-paced fanout
- explicit `dashboard-agent` starts dashboard fanout
- explicit `wiki-agent` starts wiki/Obsidian wiring
- invalid existing MCP config JSON is recreated when a configured legacy self-paced agent needs Code-Act
- default config and config-load migration keep legacy self-paced agents opt-in

## Pre-Landing Review

- Code review subagent: clear, no blocking findings after fixes.
- Follow-up review after test-gap closure: clear.
- Gemini Code Assist review comment: fixed in `c10e86cf`.
- CodeRabbit review comment: fixed in `c29310cb`.
- CodeRabbit fixture-extraction nitpick: reviewed and intentionally deferred because the config-manager cases use pre-migration legacy shapes while runtime/gateway tests use current explicit-agent shapes.

## Privacy / Internal Info Audit

- `./scripts/check-pii.sh`: pass.
- High-risk diff scan: no actionable leaks. Only benign public package scope matches such as `@jungjaehoon/mama-os`.
- Privacy subagent: clear, no secrets, credentials, private local paths, or inappropriate internal project data in the diff.

## Verification Results

- `git diff --check`: pass.
- `MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run tests/cli/config-manager.test.ts tests/agent/gateway-tool-executor.test.ts tests/runtime-vnext/legacy-fanout-disabled.test.ts`: 3 files passed, 101 tests passed.
- `pnpm --filter @jungjaehoon/mama-os typecheck`: pass.
- `pnpm build`: pass.
- Pre-commit hook after final review fix: lint-staged, secret scan, doc version sync, typecheck, build, and standalone tests passed. Standalone test summary: 234 files passed, 1 skipped; 3310 tests passed, 3 skipped.
- Latest PR CI after `c29310cb`: `changes`, `setup`, `lint`, `test-standalone`, and CodeRabbit passed; scoped jobs for untouched packages skipped.

## Eval Results

No dedicated eval suite was run for these config/runtime/default-agent changes.