### PR TITLE
test: add vNext architecture invariant coverage

### DIFF
--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -116,6 +116,7 @@ import { EnvelopeEnforcer, EnvelopeViolation } from '../envelope/index.js';
 import type { Envelope, MemoryScope } from '../envelope/index.js';
 import {
   createWikiPublishAdapter,
+  isVNextWikiPublishAdapter,
   type WikiPublishAdapter,
 } from '../wiki-artifacts/wiki-publish-adapter.js';
 import type { WikiPagePublisher, WikiPublishPageInput } from '../wiki-artifacts/types.js';
@@ -2074,7 +2075,7 @@ export class GatewayToolExecutor {
           }
           if (
             this.vNextCommitRuntimeMode === 'vnext' &&
-            this.wikiPublishAdapter?.mode !== 'vnext'
+            !isVNextWikiPublishAdapter(this.wikiPublishAdapter)
           ) {
             throw new AgentError(
               'vNext wiki_publish requires a vNext source-linked wiki artifact adapter',

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -2072,6 +2072,17 @@ export class GatewayToolExecutor {
               false
             );
           }
+          if (
+            this.vNextCommitRuntimeMode === 'vnext' &&
+            this.wikiPublishAdapter?.mode !== 'vnext'
+          ) {
+            throw new AgentError(
+              'vNext wiki_publish requires a vNext source-linked wiki artifact adapter',
+              'TOOL_ERROR',
+              undefined,
+              false
+            );
+          }
           const adapter =
             this.wikiPublishAdapter ??
             createWikiPublishAdapter({

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -61,6 +61,7 @@ import { initCronScheduler, initHeartbeat } from '../runtime/scheduler-init.js';
 import { initConnectors } from '../runtime/connector-init.js';
 import { initApiServer } from '../runtime/api-server-init.js';
 import { registerApiRoutes } from '../runtime/api-routes-init.js';
+import { initVNextWikiPublishAdapter } from '../runtime/wiki-publish-adapter-init.js';
 import { startServer } from '../runtime/server-start.js';
 import { installShutdownHandlers } from '../runtime/shutdown.js';
 import { buildRuntimeEnvelopeBootstrap } from '../runtime/envelope-bootstrap.js';
@@ -680,7 +681,14 @@ function readVNextPrimaryOperatorCursorSeq(db: Database, cursorName: string): nu
   return row?.last_change_seq ?? 0;
 }
 
-export function createVNextPrimaryOperatorRuntime(db: Database): VNextPrimaryOperatorRuntimeHandle {
+export interface VNextPrimaryOperatorRuntimeOptions {
+  wikiPublishAdapter?: VNextPrimaryOperatorRuntimeHandle['wikiPublishAdapter'];
+}
+
+export function createVNextPrimaryOperatorRuntime(
+  db: Database,
+  options: VNextPrimaryOperatorRuntimeOptions = {}
+): VNextPrimaryOperatorRuntimeHandle {
   const runtime = new PrimaryOperatorRuntime({
     db,
     cursorName: VNEXT_PRIMARY_OPERATOR_CURSOR_NAME,
@@ -692,6 +700,7 @@ export function createVNextPrimaryOperatorRuntime(db: Database): VNextPrimaryOpe
 
   return {
     status,
+    wikiPublishAdapter: options.wikiPublishAdapter ?? null,
     processBatch: async (events, decide) => {
       const result = await runtime.processBatch(events, decide);
       status.advancedThroughSeq = result.advancedThroughSeq;
@@ -708,6 +717,15 @@ export function createVNextPrimaryOperatorRuntime(db: Database): VNextPrimaryOpe
       return result;
     },
   };
+}
+
+export function createVNextBootstrapPrimaryOperatorRuntime(
+  db: Database,
+  plan: Pick<ReturnType<typeof buildVNextBootstrapPlan>, 'enabled'>
+): VNextPrimaryOperatorRuntimeHandle {
+  return createVNextPrimaryOperatorRuntime(db, {
+    wikiPublishAdapter: initVNextWikiPublishAdapter(db, { enabled: plan.enabled }),
+  });
 }
 
 export function createVNextBootstrapApiServer(
@@ -1002,7 +1020,8 @@ export async function runAgentLoop(
         return vNextOperatorDb;
       },
       initializeOperatorSchema: ensureVNextOperatorSchema,
-      createPrimaryOperator: createVNextPrimaryOperatorRuntime,
+      createPrimaryOperator: (database) =>
+        createVNextBootstrapPrimaryOperatorRuntime(database, vNext),
       createApiServer: (status) => {
         if (!vNextIngressConfig.enabled) {
           return createVNextBootstrapApiServer(status);

--- a/packages/standalone/src/cli/runtime/agent-loop-init.ts
+++ b/packages/standalone/src/cli/runtime/agent-loop-init.ts
@@ -65,6 +65,7 @@ export function initMainAgentLoop(
     osAgentMode?: boolean;
     envelopeIssuanceMode?: EnvelopeIssuanceMode;
     contextCompileService?: GatewayToolExecutorOptions['contextCompileService'];
+    wikiPublishAdapter?: GatewayToolExecutorOptions['wikiPublishAdapter'];
     vNextRuntimeEnabled?: boolean;
   }
 ): AgentLoopInitResult {
@@ -204,6 +205,7 @@ export function initMainAgentLoop(
       envelopeIssuanceMode: options?.envelopeIssuanceMode ?? 'off',
       metricsStore,
       contextCompileService: options?.contextCompileService,
+      wikiPublishAdapter: options?.wikiPublishAdapter,
       vNextRuntimeEnabled: options?.vNextRuntimeEnabled,
     }
   );

--- a/packages/standalone/src/cli/runtime/wiki-publish-adapter-init.ts
+++ b/packages/standalone/src/cli/runtime/wiki-publish-adapter-init.ts
@@ -1,0 +1,18 @@
+import type { GatewayToolExecutorOptions } from '../../agent/types.js';
+import type { SQLiteDatabase } from '../../sqlite.js';
+import { WikiArtifactStore } from '../../wiki-artifacts/wiki-artifact-store.js';
+import { createWikiPublishAdapter } from '../../wiki-artifacts/wiki-publish-adapter.js';
+
+export function initVNextWikiPublishAdapter(
+  db: SQLiteDatabase,
+  options: { enabled: boolean }
+): GatewayToolExecutorOptions['wikiPublishAdapter'] {
+  if (!options.enabled) {
+    return null;
+  }
+
+  return createWikiPublishAdapter({
+    mode: 'vnext',
+    store: new WikiArtifactStore(db),
+  });
+}

--- a/packages/standalone/src/runtime-vnext/bootstrap.ts
+++ b/packages/standalone/src/runtime-vnext/bootstrap.ts
@@ -3,6 +3,7 @@ import type {
   PrimaryOperatorBatchResult,
   PrimaryOperatorEvent,
 } from '../operator-vnext/primary-operator-runtime.js';
+import type { WikiPublishAdapter } from '../wiki-artifacts/wiki-publish-adapter.js';
 
 export const VNEXT_ALLOWED_STARTUP_STEPS = [
   'config_read',
@@ -50,6 +51,7 @@ export interface VNextPrimaryOperatorReadyStatus {
 
 export interface VNextPrimaryOperatorRuntimeHandle {
   status: VNextPrimaryOperatorReadyStatus;
+  wikiPublishAdapter?: WikiPublishAdapter | null;
   processBatch: (
     events: readonly PrimaryOperatorEvent[],
     decide: (event: PrimaryOperatorEvent) => Promise<unknown> | unknown

--- a/packages/standalone/src/wiki-artifacts/wiki-publish-adapter.ts
+++ b/packages/standalone/src/wiki-artifacts/wiki-publish-adapter.ts
@@ -16,11 +16,12 @@ import type {
   WikiPublishResult,
 } from './types.js';
 
-type WikiPublishMode = 'legacy' | 'vnext';
+export type WikiPublishMode = 'legacy' | 'vnext';
 const MAX_WIKI_PUBLISH_PAGES = 100;
 const MAX_WIKI_PAGE_CONTENT_CHARS = 200_000;
 
 export interface WikiPublishAdapter {
+  mode: WikiPublishMode;
   publish(input: { pages: WikiPublishPageInput[] }): WikiPublishResult;
 }
 
@@ -85,6 +86,7 @@ function normalizeAndDedupePages(
 
 export function createWikiPublishAdapter(options: WikiPublishAdapterOptions): WikiPublishAdapter {
   return {
+    mode: options.mode,
     publish(input: { pages: WikiPublishPageInput[] }): WikiPublishResult {
       const compiledAt = (options.now ?? (() => new Date()))().toISOString();
       if (!Array.isArray(input.pages)) {

--- a/packages/standalone/src/wiki-artifacts/wiki-publish-adapter.ts
+++ b/packages/standalone/src/wiki-artifacts/wiki-publish-adapter.ts
@@ -19,9 +19,10 @@ import type {
 export type WikiPublishMode = 'legacy' | 'vnext';
 const MAX_WIKI_PUBLISH_PAGES = 100;
 const MAX_WIKI_PAGE_CONTENT_CHARS = 200_000;
+const vNextWikiPublishAdapters = new WeakSet<WikiPublishAdapter>();
 
 export interface WikiPublishAdapter {
-  mode: WikiPublishMode;
+  readonly mode: WikiPublishMode;
   publish(input: { pages: WikiPublishPageInput[] }): WikiPublishResult;
 }
 
@@ -85,26 +86,30 @@ function normalizeAndDedupePages(
 }
 
 export function createWikiPublishAdapter(options: WikiPublishAdapterOptions): WikiPublishAdapter {
-  return {
-    mode: options.mode,
+  const mode = options.mode;
+  const publisher = options.publisher ?? null;
+  const store = mode === 'vnext' ? (options.store ?? null) : null;
+  const now = options.now ?? (() => new Date());
+  const nowMs = options.nowMs;
+  const adapter: WikiPublishAdapter = {
+    mode,
     publish(input: { pages: WikiPublishPageInput[] }): WikiPublishResult {
-      const compiledAt = (options.now ?? (() => new Date()))().toISOString();
+      const compiledAt = now().toISOString();
       if (!Array.isArray(input.pages)) {
         throw new Error('wiki_publish pages must be an array');
       }
       if (input.pages.length > MAX_WIKI_PUBLISH_PAGES) {
         throw new Error(`wiki_publish accepts at most ${MAX_WIKI_PUBLISH_PAGES} pages`);
       }
-      const store = options.mode === 'vnext' ? options.store : undefined;
-      if (options.mode === 'vnext' && !store) {
+      if (mode === 'vnext' && !store) {
         throw new Error('Wiki artifact store not configured');
       }
 
-      const pagePairs = normalizeAndDedupePages(input.pages, compiledAt, options.mode);
+      const pagePairs = normalizeAndDedupePages(input.pages, compiledAt, mode);
       const pages = pagePairs.map((pair) => pair.page);
       let artifactsStored = 0;
 
-      if (options.mode === 'vnext') {
+      if (mode === 'vnext') {
         if (!store) {
           throw new Error('Wiki artifact store not configured');
         }
@@ -118,23 +123,33 @@ export function createWikiPublishAdapter(options: WikiPublishAdapterOptions): Wi
             compiledAt: page.compiledAt,
             sourceRefs: rawPage.sourceRefs ?? [],
             sourceIds: page.sourceIds,
-            nowMs: options.nowMs?.(),
+            nowMs: nowMs?.(),
           };
         });
         artifactsStored = store.upsertArtifacts(artifacts).length;
-        if (options.publisher) {
-          options.publisher(pages);
+        if (publisher) {
+          publisher(pages);
         }
-      } else if (options.publisher) {
-        options.publisher(pages);
+      } else if (publisher) {
+        publisher(pages);
       } else {
         throw new Error('Wiki publisher not configured');
       }
 
       return {
-        pagesPublished: options.publisher ? pages.length : 0,
+        pagesPublished: publisher ? pages.length : 0,
         artifactsStored,
       };
     },
   };
+  if (mode === 'vnext') {
+    vNextWikiPublishAdapters.add(adapter);
+  }
+  return Object.freeze(adapter);
+}
+
+export function isVNextWikiPublishAdapter(
+  adapter: WikiPublishAdapter | null | undefined
+): adapter is WikiPublishAdapter {
+  return typeof adapter === 'object' && adapter !== null && vNextWikiPublishAdapters.has(adapter);
 }

--- a/packages/standalone/tests/cli/runtime/agent-loop-init-envelope-options.test.ts
+++ b/packages/standalone/tests/cli/runtime/agent-loop-init-envelope-options.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import Database from '../../../src/sqlite.js';
 import { AgentLoop } from '../../../src/agent/index.js';
 import type { AgentContext, AgentLoopOptions, ContentBlock } from '../../../src/agent/types.js';
 import type { MAMAConfig } from '../../../src/cli/config/types.js';
@@ -10,6 +11,8 @@ import type { MetricsStore } from '../../../src/observability/metrics-store.js';
 import type { SQLiteDatabase } from '../../../src/sqlite.js';
 import { makeSignedEnvelope } from '../../envelope/fixtures.js';
 import { initMainAgentLoop } from '../../../src/cli/runtime/agent-loop-init.js';
+import { initVNextWikiPublishAdapter } from '../../../src/cli/runtime/wiki-publish-adapter-init.js';
+import { isVNextWikiPublishAdapter } from '../../../src/wiki-artifacts/wiki-publish-adapter.js';
 
 function createConfig(): MAMAConfig {
   return {
@@ -141,6 +144,33 @@ describe('Story M1R: initMainAgentLoop envelope options', () => {
       ).mcpExecutor;
 
       expect(executor.vNextCommitRuntimeMode).toBe('vnext');
+    });
+
+    it('passes the vNext wiki publish adapter into the gateway executor', () => {
+      const db = new Database(':memory:');
+      const wikiPublishAdapter = initVNextWikiPublishAdapter(db, { enabled: true });
+      const { agentLoop } = initMainAgentLoop(
+        createConfig(),
+        { getToken: vi.fn() } as unknown as OAuthManager,
+        {} as SQLiteDatabase,
+        null as MetricsStore | null,
+        'claude',
+        { vNextRuntimeEnabled: true, wikiPublishAdapter }
+      );
+
+      try {
+        const executor = (
+          agentLoop as unknown as {
+            mcpExecutor: {
+              wikiPublishAdapter: unknown;
+            };
+          }
+        ).mcpExecutor;
+
+        expect(isVNextWikiPublishAdapter(executor.wikiPublishAdapter)).toBe(true);
+      } finally {
+        db.close();
+      }
     });
   });
 });

--- a/packages/standalone/tests/cli/runtime/wiki-publish-adapter-init.test.ts
+++ b/packages/standalone/tests/cli/runtime/wiki-publish-adapter-init.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import Database from '../../../src/sqlite.js';
+import { initVNextWikiPublishAdapter } from '../../../src/cli/runtime/wiki-publish-adapter-init.js';
+import { isVNextWikiPublishAdapter } from '../../../src/wiki-artifacts/wiki-publish-adapter.js';
+
+describe('Story PR9: Runtime vNext wiki publish adapter wiring', () => {
+  describe('AC #1: startup provides source-linked wiki artifact storage', () => {
+    it('returns no adapter when vNext runtime is disabled', () => {
+      const db = new Database(':memory:');
+
+      try {
+        expect(initVNextWikiPublishAdapter(db, { enabled: false })).toBeNull();
+      } finally {
+        db.close();
+      }
+    });
+
+    it('returns a branded vNext adapter that stores source-linked wiki artifacts', () => {
+      const db = new Database(':memory:');
+      const adapter = initVNextWikiPublishAdapter(db, { enabled: true });
+
+      try {
+        expect(isVNextWikiPublishAdapter(adapter)).toBe(true);
+        const result = adapter?.publish({
+          pages: [
+            {
+              path: 'projects/mama.md',
+              title: 'MAMA',
+              type: 'entity',
+              content: 'source-linked runtime artifact',
+              sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-runtime-wiki' }],
+            },
+          ],
+        });
+
+        expect(result).toEqual({ pagesPublished: 0, artifactsStored: 1 });
+        expect(db.prepare('SELECT path, source_refs_json FROM wiki_artifacts').get()).toEqual({
+          path: 'projects/mama.md',
+          source_refs_json: JSON.stringify(['raw:slack:event-runtime-wiki']),
+        });
+      } finally {
+        db.close();
+      }
+    });
+  });
+});

--- a/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
+++ b/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
@@ -5,6 +5,7 @@ import { applyMigrationsThrough } from '@jungjaehoon/mama-core/test-utils';
 
 import {
   createVNextBootstrapApiServer,
+  createVNextBootstrapPrimaryOperatorRuntime,
   createVNextPrimaryOperatorRuntime,
 } from '../../src/cli/commands/start.js';
 import {
@@ -13,8 +14,13 @@ import {
 } from '../../src/operator-vnext/connector-event-ingress.js';
 import { createConnectorIngressMigrationDryRunProvider } from '../../src/operator-vnext/connector-ingress-migration-dry-run.js';
 import { ensureVNextOperatorSchema } from '../../src/operator-vnext/schema.js';
-import type { VNextBootstrapRuntimeStatus } from '../../src/runtime-vnext/bootstrap.js';
+import {
+  buildVNextBootstrapPlan,
+  startVNextBootstrapRuntime,
+  type VNextBootstrapRuntimeStatus,
+} from '../../src/runtime-vnext/bootstrap.js';
 import Database, { type SQLiteDatabase } from '../../src/sqlite.js';
+import { isVNextWikiPublishAdapter } from '../../src/wiki-artifacts/wiki-publish-adapter.js';
 
 const AUTH_TOKEN_ENV = 'MAMA_AUTH_TOKEN';
 
@@ -230,6 +236,67 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
       });
 
       db.close();
+    });
+
+    it('wires source-linked wiki publishing into the bootstrap primary operator runtime', () => {
+      const db = new Database(':memory:');
+      ensureVNextOperatorSchema(db);
+
+      try {
+        const primaryOperator = createVNextBootstrapPrimaryOperatorRuntime(db, {
+          enabled: true,
+        });
+
+        expect(isVNextWikiPublishAdapter(primaryOperator.wikiPublishAdapter)).toBe(true);
+        const result = primaryOperator.wikiPublishAdapter?.publish({
+          pages: [
+            {
+              path: 'projects/mama.md',
+              title: 'MAMA',
+              type: 'entity',
+              content: 'bootstrap source-linked runtime artifact',
+              sourceRefs: [{ kind: 'raw', connector: 'manual', id: 'event-bootstrap-wiki' }],
+            },
+          ],
+        });
+
+        expect(result).toEqual({ pagesPublished: 0, artifactsStored: 1 });
+        expect(db.prepare('SELECT path, source_refs_json FROM wiki_artifacts').get()).toEqual({
+          path: 'projects/mama.md',
+          source_refs_json: JSON.stringify(['raw:manual:event-bootstrap-wiki']),
+        });
+      } finally {
+        db.close();
+      }
+    });
+
+    it('prepares the source-linked wiki adapter through the bootstrap startup runner', async () => {
+      const db = new Database(':memory:');
+      const plan = buildVNextBootstrapPlan({
+        enabled: true,
+        mode: 'bootstrap',
+        source: 'env',
+      });
+      const apiServer = {
+        start: async () => {},
+        stop: async () => {},
+      };
+
+      try {
+        const handles = await startVNextBootstrapRuntime(plan, {
+          openDatabase: () => db,
+          initializeOperatorSchema: ensureVNextOperatorSchema,
+          createPrimaryOperator: (database) =>
+            createVNextBootstrapPrimaryOperatorRuntime(database, plan),
+          createApiServer: () => apiServer,
+        });
+
+        expect(handles.primaryOperator.wikiPublishAdapter).toBeDefined();
+        expect(isVNextWikiPublishAdapter(handles.primaryOperator.wikiPublishAdapter)).toBe(true);
+        expect(handles.status.primaryOperator).toEqual(handles.primaryOperator.status);
+      } finally {
+        db.close();
+      }
     });
 
     it('marks primary operator runtime degraded after a failed batch', async () => {

--- a/packages/standalone/tests/vnext/architecture-invariants.test.ts
+++ b/packages/standalone/tests/vnext/architecture-invariants.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
-import type { GatewayToolInput, MAMAApiInterface } from '../../src/agent/types.js';
+import type { GatewayToolExecutorOptions, GatewayToolInput } from '../../src/agent/types.js';
 import {
   buildConnectorEventIngressPreview,
   resolveConnectorEventIngressConfig,
@@ -14,9 +14,39 @@ import {
   shouldSkipVNextFanout,
 } from '../../src/runtime-vnext/bootstrap.js';
 import { WikiArtifactStore } from '../../src/wiki-artifacts/wiki-artifact-store.js';
-import { createWikiPublishAdapter } from '../../src/wiki-artifacts/wiki-publish-adapter.js';
+import {
+  createWikiPublishAdapter,
+  type WikiPublishAdapter,
+} from '../../src/wiki-artifacts/wiki-publish-adapter.js';
 import type { SQLiteDatabase } from '../../src/sqlite.js';
 import { countRows, makeOperatorVNextDb } from '../operator-vnext/fixtures.js';
+
+type WikiPublishRejectionCase = {
+  name: string;
+  content: string;
+  configure: (executor: GatewayToolExecutor, legacyPublisher: ReturnType<typeof vi.fn>) => void;
+};
+
+const VNEXT_WIKI_PUBLISH_REJECTION =
+  'vNext wiki_publish requires a vNext source-linked wiki artifact adapter';
+
+const VNEXT_EXECUTION_CONTEXT = {
+  agentId: 'operator:primary',
+  source: 'viewer',
+  channelId: 'default',
+  executionSurface: 'model_tool',
+} as const;
+
+function makeVNextExecutor(
+  options: Omit<GatewayToolExecutorOptions, 'envelopeIssuanceMode' | 'vNextRuntimeEnabled'> = {}
+): GatewayToolExecutor {
+  // This suite verifies vNext wiki routing invariants; direct model-run tracing is covered separately.
+  return new GatewayToolExecutor({
+    ...options,
+    envelopeIssuanceMode: 'off',
+    vNextRuntimeEnabled: true,
+  });
+}
 
 function insertConnectorEvent(db: SQLiteDatabase): void {
   db.prepare(
@@ -45,317 +75,300 @@ function insertConnectorEvent(db: SQLiteDatabase): void {
   );
 }
 
-function makeTraceCapableMockApi(): MAMAApiInterface {
-  const api = {
-    save: vi.fn(),
-    saveCheckpoint: vi.fn(),
-    listDecisions: vi.fn(),
-    suggest: vi.fn(),
-    updateOutcome: vi.fn(),
-    loadCheckpoint: vi.fn(),
-    beginModelRun: vi.fn().mockResolvedValue({ model_run_id: 'model-run-vnext-test' }),
-    commitModelRun: vi.fn().mockResolvedValue({ model_run_id: 'model-run-vnext-test' }),
-    failModelRun: vi.fn().mockResolvedValue({ model_run_id: 'model-run-vnext-test' }),
-    appendToolTrace: vi.fn().mockResolvedValue({}),
-  };
-  return api as unknown as MAMAApiInterface;
-}
-
 describe('STORY-VNEXT-PR0: Architecture invariants', () => {
-  it('keeps vNext startup allowlist-driven and legacy fanout-free', () => {
-    const plan = buildVNextBootstrapPlan({
-      enabled: true,
-      mode: 'bootstrap',
-      source: 'env',
-    });
-
-    expect(plan.allowedStartupSteps).toEqual([
-      'config_read',
-      'db_initialization',
-      'primary_operator_schema',
-      'primary_operator_runtime',
-      'api_server_health',
-      'manual_status_endpoints',
-    ]);
-
-    for (const fanout of [
-      'dashboard_agent_interval',
-      'wiki_agent_interval',
-      'ledger_memory_compose',
-      'obsidian_launch',
-      'mcp_config_rewrite',
-      'agent_config_mutation',
-      'persona_write',
-      'heartbeat_timer',
-      'token_keepalive_timer',
-      'conductor_audit',
-      'message_router_autonomous_process',
-      'connector_polling',
-      'connector_mode',
-    ] as const) {
-      expect(shouldSkipVNextFanout(plan, fanout)).toBe(true);
-    }
-  });
-
-  it('keeps explicit connector ingress previews dry-run only, not legacy polling', () => {
-    const plan = buildVNextBootstrapPlan({
-      enabled: true,
-      mode: 'bootstrap',
-      source: 'env',
-    });
-    const ingressConfig = resolveConnectorEventIngressConfig({
-      MAMA_VNEXT_INGRESS_CONNECTOR: 'slack',
-      MAMA_VNEXT_INGRESS_CHANNEL: 'C-ROLL',
-    });
-    const db = makeOperatorVNextDb();
-    insertConnectorEvent(db);
-
-    try {
-      expect(ingressConfig).toEqual({
+  describe('AC #1: vNext startup is allowlist-driven', () => {
+    it('keeps vNext startup allowlist-driven and legacy fanout-free', () => {
+      const plan = buildVNextBootstrapPlan({
         enabled: true,
-        connector: 'slack',
-        channel: 'C-ROLL',
-      });
-      expect(shouldSkipVNextFanout(plan, 'connector_polling')).toBe(true);
-      expect(shouldSkipVNextFanout(plan, 'connector_mode')).toBe(true);
-
-      const preview = buildConnectorEventIngressPreview({
-        rawAdapter: db,
-        operatorDb: db,
-        connector: 'slack',
-        channel: 'C-ROLL',
-      });
-      expect(preview.events).toHaveLength(1);
-      expect(preview.events[0]?.sourceRef).toMatchObject({
-        kind: 'raw',
-        connector: 'slack',
-        id: 'event-index-1',
-        source_id: 'msg-1',
-        channel_id: 'C-ROLL',
+        mode: 'bootstrap',
+        source: 'env',
       });
 
-      const dryRun = buildConnectorIngressMigrationDryRun({
-        rawAdapter: db,
-        operatorDb: db,
-        connector: 'slack',
-        channel: 'C-ROLL',
+      expect(plan.allowedStartupSteps).toEqual([
+        'config_read',
+        'db_initialization',
+        'primary_operator_schema',
+        'primary_operator_runtime',
+        'api_server_health',
+        'manual_status_endpoints',
+      ]);
+
+      for (const fanout of [
+        'dashboard_agent_interval',
+        'wiki_agent_interval',
+        'ledger_memory_compose',
+        'obsidian_launch',
+        'mcp_config_rewrite',
+        'agent_config_mutation',
+        'persona_write',
+        'heartbeat_timer',
+        'token_keepalive_timer',
+        'conductor_audit',
+        'message_router_autonomous_process',
+        'connector_polling',
+        'connector_mode',
+      ] as const) {
+        expect(shouldSkipVNextFanout(plan, fanout)).toBe(true);
+      }
+    });
+
+    it('keeps explicit connector ingress previews dry-run only, not legacy polling', () => {
+      const plan = buildVNextBootstrapPlan({
+        enabled: true,
+        mode: 'bootstrap',
+        source: 'env',
       });
-      expect(dryRun).toMatchObject({
-        mode: 'dry_run',
-        durableWrites: {
-          commits: 0,
-          cursors: 0,
-          noUpdates: 0,
+      const ingressConfig = resolveConnectorEventIngressConfig({
+        MAMA_VNEXT_INGRESS_CONNECTOR: 'slack',
+        MAMA_VNEXT_INGRESS_CHANNEL: 'C-ROLL',
+      });
+      const db = makeOperatorVNextDb();
+      insertConnectorEvent(db);
+
+      try {
+        expect(ingressConfig).toEqual({
+          enabled: true,
+          connector: 'slack',
+          channel: 'C-ROLL',
+        });
+        expect(shouldSkipVNextFanout(plan, 'connector_polling')).toBe(true);
+        expect(shouldSkipVNextFanout(plan, 'connector_mode')).toBe(true);
+
+        const preview = buildConnectorEventIngressPreview({
+          rawAdapter: db,
+          operatorDb: db,
+          connector: 'slack',
+          channel: 'C-ROLL',
+        });
+        expect(preview.events).toHaveLength(1);
+        expect(preview.events[0]?.sourceRef).toMatchObject({
+          kind: 'raw',
+          connector: 'slack',
+          id: 'event-index-1',
+          source_id: 'msg-1',
+          channel_id: 'C-ROLL',
+        });
+
+        const dryRun = buildConnectorIngressMigrationDryRun({
+          rawAdapter: db,
+          operatorDb: db,
+          connector: 'slack',
+          channel: 'C-ROLL',
+        });
+        expect(dryRun).toMatchObject({
+          mode: 'dry_run',
+          durableWrites: {
+            commits: 0,
+            cursors: 0,
+            noUpdates: 0,
+          },
+        });
+        expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+        expect(countRows(db, 'vnext_operator_cursors')).toBe(0);
+        expect(countRows(db, 'operator_no_updates')).toBe(0);
+      } finally {
+        db.close();
+      }
+    });
+  });
+
+  describe('AC #2: durable vNext writes require source refs', () => {
+    it('requires non-empty source ref metadata before durable vNext wiki and no-update writes', () => {
+      const db = makeOperatorVNextDb();
+      const wikiStore = new WikiArtifactStore(db);
+      wikiStore.ensureSchema();
+      const wikiPublisher = createWikiPublishAdapter({ mode: 'vnext', store: wikiStore });
+
+      try {
+        expect(() =>
+          wikiPublisher.publish({
+            pages: [
+              {
+                path: 'projects/mama.md',
+                title: 'MAMA',
+                type: 'entity',
+                content: 'source-linked wiki page',
+              },
+            ],
+          })
+        ).toThrow(/source refs/i);
+
+        expect(() =>
+          recordNoUpdate(db, {
+            noUpdateId: 'no-update-without-source',
+            scopeKey: 'operator:primary',
+            reason: 'no durable state changed',
+            sourceRefs: [],
+            idempotencyKey: 'connector:manual:seq:1-1',
+            nowMs: 1710000000000,
+          })
+        ).toThrow(/source refs/i);
+
+        expect(db.prepare('SELECT COUNT(*) AS count FROM wiki_artifacts').get()).toEqual({
+          count: 0,
+        });
+        expect(db.prepare('SELECT COUNT(*) AS count FROM operator_no_updates').get()).toEqual({
+          count: 0,
+        });
+      } finally {
+        db.close();
+      }
+    });
+  });
+
+  describe('AC #3: commit authority keeps a single writer', () => {
+    it('keeps workers as proposal producers while dashboard reports remain projections', () => {
+      expect(
+        resolveCommitAuthority({
+          runtimeMode: 'vnext',
+          toolName: 'report_publish',
+          actor: { kind: 'primary_operator', agentId: 'operator:primary' },
+        })
+      ).toMatchObject({
+        allowed: false,
+        code: 'vnext_report_projection_only',
+      });
+
+      expect(
+        resolveCommitAuthority({
+          runtimeMode: 'vnext',
+          toolName: 'wiki_publish',
+          actor: { kind: 'worker', agentId: 'wiki-agent' },
+        })
+      ).toMatchObject({
+        allowed: false,
+        effect: 'proposal_required',
+        code: 'vnext_worker_proposal_required',
+      });
+
+      expect(
+        resolveCommitAuthority({
+          runtimeMode: 'vnext',
+          toolName: 'wiki_publish',
+          actor: { kind: 'primary_operator', agentId: 'operator:primary' },
+        })
+      ).toMatchObject({
+        allowed: true,
+        effect: 'commit',
+      });
+    });
+  });
+
+  describe('AC #4: wiki_publish requires a source-linked vNext adapter', () => {
+    const rejectionCases: WikiPublishRejectionCase[] = [
+      {
+        name: 'without a configured wiki artifact adapter',
+        content: 'legacy fallback should not receive this page',
+        configure: (executor, legacyPublisher) => {
+          executor.setWikiPublisher(legacyPublisher);
         },
-      });
-      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
-      expect(countRows(db, 'vnext_operator_cursors')).toBe(0);
-      expect(countRows(db, 'operator_no_updates')).toBe(0);
-    } finally {
-      db.close();
-    }
-  });
+      },
+      {
+        name: 'with a legacy-mode wiki artifact adapter',
+        content: 'legacy adapter should not receive this page',
+        configure: (executor, legacyPublisher) => {
+          executor.setWikiPublishAdapter(
+            createWikiPublishAdapter({
+              mode: 'legacy',
+              publisher: legacyPublisher,
+            })
+          );
+        },
+      },
+      {
+        name: 'with an unbranded vNext-like wiki artifact adapter',
+        content: 'unbranded adapter should not receive this page',
+        configure: (executor, legacyPublisher) => {
+          const unbrandedAdapter = {
+            mode: 'vnext',
+            publish: vi.fn(() => {
+              legacyPublisher([]);
+              return { pagesPublished: 1, artifactsStored: 0 };
+            }),
+          } as const;
+          // Deliberately bypass compile-time branding to prove the runtime guard rejects forgeries.
+          executor.setWikiPublishAdapter(unbrandedAdapter as unknown as WikiPublishAdapter);
+        },
+      },
+    ];
 
-  it('requires non-empty source ref metadata before durable vNext wiki and no-update writes', () => {
-    const db = makeOperatorVNextDb();
-    const wikiStore = new WikiArtifactStore(db);
-    wikiStore.ensureSchema();
-    const wikiPublisher = createWikiPublishAdapter({ mode: 'vnext', store: wikiStore });
+    it.each(rejectionCases.map((testCase) => [testCase.name, testCase] as const))(
+      'rejects vNext wiki_publish %s',
+      async (_name, { configure, content }) => {
+        const legacyPublisher = vi.fn();
+        const executor = makeVNextExecutor();
+        configure(executor, legacyPublisher);
 
-    try {
-      expect(() =>
-        wikiPublisher.publish({
-          pages: [
+        await expect(
+          executor.execute(
+            'wiki_publish',
             {
-              path: 'projects/mama.md',
-              title: 'MAMA',
-              type: 'entity',
-              content: 'source-linked wiki page',
-            },
-          ],
-        })
-      ).toThrow(/source refs/i);
+              pages: [
+                {
+                  path: 'projects/mama.md',
+                  title: 'MAMA',
+                  type: 'entity',
+                  content,
+                  sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-vnext-rejected' }],
+                },
+              ],
+            } as GatewayToolInput,
+            VNEXT_EXECUTION_CONTEXT
+          )
+        ).rejects.toThrow(VNEXT_WIKI_PUBLISH_REJECTION);
+        expect(legacyPublisher).not.toHaveBeenCalled();
+      }
+    );
 
-      expect(() =>
-        recordNoUpdate(db, {
-          noUpdateId: 'no-update-without-source',
-          scopeKey: 'operator:primary',
-          reason: 'no durable state changed',
-          sourceRefs: [],
-          idempotencyKey: 'connector:manual:seq:1-1',
-          nowMs: 1710000000000,
-        })
-      ).toThrow(/source refs/i);
-
-      expect(db.prepare('SELECT COUNT(*) AS count FROM wiki_artifacts').get()).toEqual({
-        count: 0,
+    it('allows primary operator vNext wiki_publish through a source-linked artifact adapter', async () => {
+      const db = makeOperatorVNextDb();
+      const wikiStore = new WikiArtifactStore(db);
+      const vaultPublisher = vi.fn();
+      const executor = makeVNextExecutor({
+        wikiPublishAdapter: createWikiPublishAdapter({
+          mode: 'vnext',
+          store: wikiStore,
+          publisher: vaultPublisher,
+          now: () => new Date('2026-07-02T00:00:00.000Z'),
+          nowMs: () => 1710000002000,
+        }),
       });
-      expect(db.prepare('SELECT COUNT(*) AS count FROM operator_no_updates').get()).toEqual({
-        count: 0,
-      });
-    } finally {
-      db.close();
-    }
-  });
 
-  it('keeps workers as proposal producers while dashboard reports remain projections', () => {
-    expect(
-      resolveCommitAuthority({
-        runtimeMode: 'vnext',
-        toolName: 'report_publish',
-        actor: { kind: 'primary_operator', agentId: 'operator:primary' },
-      })
-    ).toMatchObject({
-      allowed: false,
-      code: 'vnext_report_projection_only',
-    });
+      try {
+        const result = await executor.execute(
+          'wiki_publish',
+          {
+            pages: [
+              {
+                path: 'projects/mama.md',
+                title: 'MAMA',
+                type: 'entity',
+                content: 'source-linked vNext artifact',
+                sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-vnext-publish' }],
+              },
+            ],
+          } as GatewayToolInput,
+          VNEXT_EXECUTION_CONTEXT
+        );
 
-    expect(
-      resolveCommitAuthority({
-        runtimeMode: 'vnext',
-        toolName: 'wiki_publish',
-        actor: { kind: 'worker', agentId: 'wiki-agent' },
-      })
-    ).toMatchObject({
-      allowed: false,
-      effect: 'proposal_required',
-      code: 'vnext_worker_proposal_required',
-    });
-
-    expect(
-      resolveCommitAuthority({
-        runtimeMode: 'vnext',
-        toolName: 'wiki_publish',
-        actor: { kind: 'primary_operator', agentId: 'operator:primary' },
-      })
-    ).toMatchObject({
-      allowed: true,
-      effect: 'commit',
-    });
-  });
-
-  it('prevents vNext wiki_publish from falling back to the legacy publisher at execution time', async () => {
-    const legacyPublisher = vi.fn();
-    const executor = new GatewayToolExecutor({
-      mamaApi: makeTraceCapableMockApi(),
-      vNextRuntimeEnabled: true,
-    });
-    executor.setWikiPublisher(legacyPublisher);
-
-    await expect(
-      executor.execute(
-        'wiki_publish',
-        {
-          pages: [
-            {
-              path: 'projects/mama.md',
-              title: 'MAMA',
-              type: 'entity',
-              content: 'legacy fallback should not receive this page',
-            },
-          ],
-        } as GatewayToolInput,
-        {
-          agentId: 'operator:primary',
-          source: 'viewer',
-          channelId: 'default',
-          executionSurface: 'direct',
-        }
-      )
-    ).rejects.toThrow('vNext wiki_publish requires a vNext source-linked wiki artifact adapter');
-    expect(legacyPublisher).not.toHaveBeenCalled();
-  });
-
-  it('allows primary operator vNext wiki_publish through a source-linked artifact adapter', async () => {
-    const db = makeOperatorVNextDb();
-    const wikiStore = new WikiArtifactStore(db);
-    const vaultPublisher = vi.fn();
-    const executor = new GatewayToolExecutor({
-      mamaApi: makeTraceCapableMockApi(),
-      vNextRuntimeEnabled: true,
-      wikiPublishAdapter: createWikiPublishAdapter({
-        mode: 'vnext',
-        store: wikiStore,
-        publisher: vaultPublisher,
-        now: () => new Date('2026-07-02T00:00:00.000Z'),
-        nowMs: () => 1710000002000,
-      }),
-    });
-
-    try {
-      const result = await executor.execute(
-        'wiki_publish',
-        {
-          pages: [
-            {
-              path: 'projects/mama.md',
-              title: 'MAMA',
-              type: 'entity',
-              content: 'source-linked vNext artifact',
-              sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-vnext-publish' }],
-            },
-          ],
-        } as GatewayToolInput,
-        {
-          agentId: 'operator:primary',
-          source: 'viewer',
-          channelId: 'default',
-          executionSurface: 'direct',
-        }
-      );
-
-      expect(result).toMatchObject({
-        success: true,
-        message: 'Wiki published: 1 pages',
-        artifactsStored: 1,
-      });
-      expect(wikiStore.getByPath('projects/mama.md')).toMatchObject({
-        path: 'projects/mama.md',
-        sourceRefs: ['raw:slack:event-vnext-publish'],
-      });
-      expect(vaultPublisher).toHaveBeenCalledWith([
-        expect.objectContaining({
+        expect(result).toMatchObject({
+          success: true,
+          message: 'Wiki published: 1 pages',
+          artifactsStored: 1,
+        });
+        expect(wikiStore.getByPath('projects/mama.md')).toMatchObject({
           path: 'projects/mama.md',
           sourceRefs: ['raw:slack:event-vnext-publish'],
-        }),
-      ]);
-    } finally {
-      db.close();
-    }
-  });
-
-  it('rejects structurally compatible legacy wiki adapters in vNext executors', async () => {
-    const legacyPublisher = vi.fn();
-    const executor = new GatewayToolExecutor({
-      mamaApi: makeTraceCapableMockApi(),
-      vNextRuntimeEnabled: true,
-      wikiPublishAdapter: createWikiPublishAdapter({
-        mode: 'legacy',
-        publisher: legacyPublisher,
-      }),
+        });
+        expect(vaultPublisher).toHaveBeenCalledWith([
+          expect.objectContaining({
+            path: 'projects/mama.md',
+            sourceRefs: ['raw:slack:event-vnext-publish'],
+          }),
+        ]);
+      } finally {
+        db.close();
+      }
     });
-
-    await expect(
-      executor.execute(
-        'wiki_publish',
-        {
-          pages: [
-            {
-              path: 'projects/mama.md',
-              title: 'MAMA',
-              type: 'entity',
-              content: 'legacy adapter should not receive this page',
-            },
-          ],
-        } as GatewayToolInput,
-        {
-          agentId: 'operator:primary',
-          source: 'viewer',
-          channelId: 'default',
-          executionSurface: 'direct',
-        }
-      )
-    ).rejects.toThrow('vNext wiki_publish requires a vNext source-linked wiki artifact adapter');
-    expect(legacyPublisher).not.toHaveBeenCalled();
   });
 });

--- a/packages/standalone/tests/vnext/architecture-invariants.test.ts
+++ b/packages/standalone/tests/vnext/architecture-invariants.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
+import type { GatewayToolInput, MAMAApiInterface } from '../../src/agent/types.js';
+import {
+  buildConnectorEventIngressPreview,
+  resolveConnectorEventIngressConfig,
+} from '../../src/operator-vnext/connector-event-ingress.js';
+import { buildConnectorIngressMigrationDryRun } from '../../src/operator-vnext/connector-ingress-migration-dry-run.js';
+import { resolveCommitAuthority } from '../../src/operator-vnext/commit-authority.js';
+import { recordNoUpdate } from '../../src/operator-vnext/no-update-ledger.js';
+import {
+  buildVNextBootstrapPlan,
+  shouldSkipVNextFanout,
+} from '../../src/runtime-vnext/bootstrap.js';
+import { WikiArtifactStore } from '../../src/wiki-artifacts/wiki-artifact-store.js';
+import { createWikiPublishAdapter } from '../../src/wiki-artifacts/wiki-publish-adapter.js';
+import type { SQLiteDatabase } from '../../src/sqlite.js';
+import { countRows, makeOperatorVNextDb } from '../operator-vnext/fixtures.js';
+
+function insertConnectorEvent(db: SQLiteDatabase): void {
+  db.prepare(
+    `INSERT INTO connector_event_index (
+      event_index_id, source_connector, source_type, source_id, source_locator,
+      channel, author, title, content, event_datetime, event_date, source_timestamp_ms,
+      metadata_json, content_hash, indexed_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    'event-index-1',
+    'slack',
+    'message',
+    'msg-1',
+    'slack:C-ROLL:msg-1',
+    'C-ROLL',
+    'synthetic-user',
+    null,
+    'synthetic rollout event',
+    1710000001000,
+    '2024-03-09',
+    1710000001000,
+    JSON.stringify({ synthetic: true }),
+    Buffer.alloc(32, 1),
+    '2026-07-02T00:00:00.000Z',
+    '2026-07-02T00:00:00.000Z'
+  );
+}
+
+function makeTraceCapableMockApi(): MAMAApiInterface {
+  const api = {
+    save: vi.fn(),
+    saveCheckpoint: vi.fn(),
+    listDecisions: vi.fn(),
+    suggest: vi.fn(),
+    updateOutcome: vi.fn(),
+    loadCheckpoint: vi.fn(),
+    beginModelRun: vi.fn().mockResolvedValue({ model_run_id: 'model-run-vnext-test' }),
+    commitModelRun: vi.fn().mockResolvedValue({ model_run_id: 'model-run-vnext-test' }),
+    failModelRun: vi.fn().mockResolvedValue({ model_run_id: 'model-run-vnext-test' }),
+    appendToolTrace: vi.fn().mockResolvedValue({}),
+  };
+  return api as unknown as MAMAApiInterface;
+}
+
+describe('STORY-VNEXT-PR0: Architecture invariants', () => {
+  it('keeps vNext startup allowlist-driven and legacy fanout-free', () => {
+    const plan = buildVNextBootstrapPlan({
+      enabled: true,
+      mode: 'bootstrap',
+      source: 'env',
+    });
+
+    expect(plan.allowedStartupSteps).toEqual([
+      'config_read',
+      'db_initialization',
+      'primary_operator_schema',
+      'primary_operator_runtime',
+      'api_server_health',
+      'manual_status_endpoints',
+    ]);
+
+    for (const fanout of [
+      'dashboard_agent_interval',
+      'wiki_agent_interval',
+      'ledger_memory_compose',
+      'obsidian_launch',
+      'mcp_config_rewrite',
+      'agent_config_mutation',
+      'persona_write',
+      'heartbeat_timer',
+      'token_keepalive_timer',
+      'conductor_audit',
+      'message_router_autonomous_process',
+      'connector_polling',
+      'connector_mode',
+    ] as const) {
+      expect(shouldSkipVNextFanout(plan, fanout)).toBe(true);
+    }
+  });
+
+  it('keeps explicit connector ingress previews dry-run only, not legacy polling', () => {
+    const plan = buildVNextBootstrapPlan({
+      enabled: true,
+      mode: 'bootstrap',
+      source: 'env',
+    });
+    const ingressConfig = resolveConnectorEventIngressConfig({
+      MAMA_VNEXT_INGRESS_CONNECTOR: 'slack',
+      MAMA_VNEXT_INGRESS_CHANNEL: 'C-ROLL',
+    });
+    const db = makeOperatorVNextDb();
+    insertConnectorEvent(db);
+
+    try {
+      expect(ingressConfig).toEqual({
+        enabled: true,
+        connector: 'slack',
+        channel: 'C-ROLL',
+      });
+      expect(shouldSkipVNextFanout(plan, 'connector_polling')).toBe(true);
+      expect(shouldSkipVNextFanout(plan, 'connector_mode')).toBe(true);
+
+      const preview = buildConnectorEventIngressPreview({
+        rawAdapter: db,
+        operatorDb: db,
+        connector: 'slack',
+        channel: 'C-ROLL',
+      });
+      expect(preview.events).toHaveLength(1);
+      expect(preview.events[0]?.sourceRef).toMatchObject({
+        kind: 'raw',
+        connector: 'slack',
+        id: 'event-index-1',
+        source_id: 'msg-1',
+        channel_id: 'C-ROLL',
+      });
+
+      const dryRun = buildConnectorIngressMigrationDryRun({
+        rawAdapter: db,
+        operatorDb: db,
+        connector: 'slack',
+        channel: 'C-ROLL',
+      });
+      expect(dryRun).toMatchObject({
+        mode: 'dry_run',
+        durableWrites: {
+          commits: 0,
+          cursors: 0,
+          noUpdates: 0,
+        },
+      });
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(countRows(db, 'vnext_operator_cursors')).toBe(0);
+      expect(countRows(db, 'operator_no_updates')).toBe(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('requires non-empty source ref metadata before durable vNext wiki and no-update writes', () => {
+    const db = makeOperatorVNextDb();
+    const wikiStore = new WikiArtifactStore(db);
+    wikiStore.ensureSchema();
+    const wikiPublisher = createWikiPublishAdapter({ mode: 'vnext', store: wikiStore });
+
+    try {
+      expect(() =>
+        wikiPublisher.publish({
+          pages: [
+            {
+              path: 'projects/mama.md',
+              title: 'MAMA',
+              type: 'entity',
+              content: 'source-linked wiki page',
+            },
+          ],
+        })
+      ).toThrow(/source refs/i);
+
+      expect(() =>
+        recordNoUpdate(db, {
+          noUpdateId: 'no-update-without-source',
+          scopeKey: 'operator:primary',
+          reason: 'no durable state changed',
+          sourceRefs: [],
+          idempotencyKey: 'connector:manual:seq:1-1',
+          nowMs: 1710000000000,
+        })
+      ).toThrow(/source refs/i);
+
+      expect(db.prepare('SELECT COUNT(*) AS count FROM wiki_artifacts').get()).toEqual({
+        count: 0,
+      });
+      expect(db.prepare('SELECT COUNT(*) AS count FROM operator_no_updates').get()).toEqual({
+        count: 0,
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  it('keeps workers as proposal producers while dashboard reports remain projections', () => {
+    expect(
+      resolveCommitAuthority({
+        runtimeMode: 'vnext',
+        toolName: 'report_publish',
+        actor: { kind: 'primary_operator', agentId: 'operator:primary' },
+      })
+    ).toMatchObject({
+      allowed: false,
+      code: 'vnext_report_projection_only',
+    });
+
+    expect(
+      resolveCommitAuthority({
+        runtimeMode: 'vnext',
+        toolName: 'wiki_publish',
+        actor: { kind: 'worker', agentId: 'wiki-agent' },
+      })
+    ).toMatchObject({
+      allowed: false,
+      effect: 'proposal_required',
+      code: 'vnext_worker_proposal_required',
+    });
+
+    expect(
+      resolveCommitAuthority({
+        runtimeMode: 'vnext',
+        toolName: 'wiki_publish',
+        actor: { kind: 'primary_operator', agentId: 'operator:primary' },
+      })
+    ).toMatchObject({
+      allowed: true,
+      effect: 'commit',
+    });
+  });
+
+  it('prevents vNext wiki_publish from falling back to the legacy publisher at execution time', async () => {
+    const legacyPublisher = vi.fn();
+    const executor = new GatewayToolExecutor({
+      mamaApi: makeTraceCapableMockApi(),
+      vNextRuntimeEnabled: true,
+    });
+    executor.setWikiPublisher(legacyPublisher);
+
+    await expect(
+      executor.execute(
+        'wiki_publish',
+        {
+          pages: [
+            {
+              path: 'projects/mama.md',
+              title: 'MAMA',
+              type: 'entity',
+              content: 'legacy fallback should not receive this page',
+            },
+          ],
+        } as GatewayToolInput,
+        {
+          agentId: 'operator:primary',
+          source: 'viewer',
+          channelId: 'default',
+          executionSurface: 'direct',
+        }
+      )
+    ).rejects.toThrow('vNext wiki_publish requires a vNext source-linked wiki artifact adapter');
+    expect(legacyPublisher).not.toHaveBeenCalled();
+  });
+
+  it('allows primary operator vNext wiki_publish through a source-linked artifact adapter', async () => {
+    const db = makeOperatorVNextDb();
+    const wikiStore = new WikiArtifactStore(db);
+    const vaultPublisher = vi.fn();
+    const executor = new GatewayToolExecutor({
+      mamaApi: makeTraceCapableMockApi(),
+      vNextRuntimeEnabled: true,
+      wikiPublishAdapter: createWikiPublishAdapter({
+        mode: 'vnext',
+        store: wikiStore,
+        publisher: vaultPublisher,
+        now: () => new Date('2026-07-02T00:00:00.000Z'),
+        nowMs: () => 1710000002000,
+      }),
+    });
+
+    try {
+      const result = await executor.execute(
+        'wiki_publish',
+        {
+          pages: [
+            {
+              path: 'projects/mama.md',
+              title: 'MAMA',
+              type: 'entity',
+              content: 'source-linked vNext artifact',
+              sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-vnext-publish' }],
+            },
+          ],
+        } as GatewayToolInput,
+        {
+          agentId: 'operator:primary',
+          source: 'viewer',
+          channelId: 'default',
+          executionSurface: 'direct',
+        }
+      );
+
+      expect(result).toMatchObject({
+        success: true,
+        message: 'Wiki published: 1 pages',
+        artifactsStored: 1,
+      });
+      expect(wikiStore.getByPath('projects/mama.md')).toMatchObject({
+        path: 'projects/mama.md',
+        sourceRefs: ['raw:slack:event-vnext-publish'],
+      });
+      expect(vaultPublisher).toHaveBeenCalledWith([
+        expect.objectContaining({
+          path: 'projects/mama.md',
+          sourceRefs: ['raw:slack:event-vnext-publish'],
+        }),
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('rejects structurally compatible legacy wiki adapters in vNext executors', async () => {
+    const legacyPublisher = vi.fn();
+    const executor = new GatewayToolExecutor({
+      mamaApi: makeTraceCapableMockApi(),
+      vNextRuntimeEnabled: true,
+      wikiPublishAdapter: createWikiPublishAdapter({
+        mode: 'legacy',
+        publisher: legacyPublisher,
+      }),
+    });
+
+    await expect(
+      executor.execute(
+        'wiki_publish',
+        {
+          pages: [
+            {
+              path: 'projects/mama.md',
+              title: 'MAMA',
+              type: 'entity',
+              content: 'legacy adapter should not receive this page',
+            },
+          ],
+        } as GatewayToolInput,
+        {
+          agentId: 'operator:primary',
+          source: 'viewer',
+          channelId: 'default',
+          executionSurface: 'direct',
+        }
+      )
+    ).rejects.toThrow('vNext wiki_publish requires a vNext source-linked wiki artifact adapter');
+    expect(legacyPublisher).not.toHaveBeenCalled();
+  });
+});

--- a/packages/standalone/tests/wiki-artifacts/wiki-publish-adapter.test.ts
+++ b/packages/standalone/tests/wiki-artifacts/wiki-publish-adapter.test.ts
@@ -4,7 +4,10 @@ process.env.MAMA_FORCE_TIER_3 ||= 'true';
 
 import Database from '../../src/sqlite.js';
 import { WikiArtifactStore } from '../../src/wiki-artifacts/wiki-artifact-store.js';
-import { createWikiPublishAdapter } from '../../src/wiki-artifacts/wiki-publish-adapter.js';
+import {
+  createWikiPublishAdapter,
+  isVNextWikiPublishAdapter,
+} from '../../src/wiki-artifacts/wiki-publish-adapter.js';
 
 describe('Story PR4.2: Wiki Publish Adapter', () => {
   describe('AC #1: legacy compatibility, vNext storage, and validation', () => {
@@ -360,6 +363,62 @@ describe('Story PR4.2: Wiki Publish Adapter', () => {
       ]);
 
       db.close();
+    });
+
+    it('keeps legacy adapters out of vNext even if callers try to mutate runtime state', () => {
+      const adapter = createWikiPublishAdapter({
+        mode: 'legacy',
+        publisher: vi.fn(),
+      });
+
+      expect(Reflect.set(adapter, 'mode', 'vnext')).toBe(false);
+      expect(() => {
+        Object.defineProperty(adapter, Symbol('mama.wikiPublishAdapter.mode'), {
+          value: 'vnext',
+        });
+      }).toThrow();
+
+      expect(adapter.mode).toBe('legacy');
+      expect(isVNextWikiPublishAdapter(adapter)).toBe(false);
+    });
+
+    it('does not let later factory options mutation downgrade a branded vNext adapter', () => {
+      const db = new Database(':memory:');
+      const store = new WikiArtifactStore(db);
+      const publisher = vi.fn();
+      const options = {
+        mode: 'vnext' as const,
+        store,
+        publisher,
+      };
+      const adapter = createWikiPublishAdapter(options);
+
+      Reflect.set(options, 'mode', 'legacy');
+      Reflect.set(options, 'store', null);
+      Reflect.set(options, 'publisher', null);
+
+      try {
+        const result = adapter.publish({
+          pages: [
+            {
+              path: 'projects/api.md',
+              title: 'API',
+              type: 'entity',
+              content: 'content',
+              sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-options-mutation' }],
+            },
+          ],
+        });
+
+        expect(result).toEqual({ pagesPublished: 1, artifactsStored: 1 });
+        expect(publisher).toHaveBeenCalledOnce();
+        expect(store.getByPath('projects/api.md')).toMatchObject({
+          sourceRefs: ['raw:slack:event-options-mutation'],
+        });
+        expect(isVNextWikiPublishAdapter(adapter)).toBe(true);
+      } finally {
+        db.close();
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds vNext architecture invariant regression coverage for startup fanout blocking, connector ingress dry-run behavior, source-ref requirements, commit authority, and wiki publish executor boundaries.
- Hardens vNext `wiki_publish` so vNext mode requires a source-linked wiki artifact adapter created by the local factory, not a spoofed/mutated adapter shape.
- Wires bootstrap primary-operator runtime to prepare the source-linked wiki artifact adapter through the real bootstrap runner without opening a new public tool execution API.
- Removes unreachable legacy-loop vNext adapter wiring after the bootstrap early return.

## Test Coverage
New and updated regression coverage lives in:
- `packages/standalone/tests/vnext/architecture-invariants.test.ts`
- `packages/standalone/tests/wiki-artifacts/wiki-publish-adapter.test.ts`
- `packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts`
- `packages/standalone/tests/cli/runtime/wiki-publish-adapter-init.test.ts`
- `packages/standalone/tests/cli/runtime/agent-loop-init-envelope-options.test.ts`

Covered paths:
- vNext startup skips legacy fanout including connector polling/mode.
- Connector ingress preview stays dry-run and performs no durable writes.
- Durable vNext wiki/no-update writes require non-empty source refs.
- Worker/report paths remain proposal/projection-only while primary operator can commit.
- vNext `wiki_publish` rejects absent, legacy, forged, and mutated adapters.
- vNext adapter factory snapshots options so later caller mutation cannot downgrade source-linked storage.
- Bootstrap startup runner prepares the source-linked wiki adapter on the primary operator handle.

## Pre-Landing Review
Independent review gates:
- Gemini comment addressed in `8ae76e49`: removed unsafe `MAMAApiInterface` mock from the architecture invariant tests.
- CodeRabbit comments addressed in `8ae76e49`: removed internal API mock, consolidated rejection cases, and grouped tests under AC sections.
- Codex adversarial review found two real issues: mutable factory options closure and misleading/dead post-bootstrap adapter wiring. Both fixed in `8ae76e49`.
- Final Codex adversarial re-review found one packaging issue: new initializer file was untracked. Fixed by adding the source and test files in `8ae76e49`.
- Review log status: clean after fixes.

## Privacy / Public-Project Audit
- `./scripts/check-pii.sh` passed.
- `git diff --check origin/main HEAD` passed.
- High-risk diff scan found only synthetic test fixtures: fake `getToken`, `MAMA_AUTH_TOKEN` test env name, and `token_keepalive_timer` allowlist text.
- No secrets, real tokens, local user paths, customer/client data, or internal project artifacts are introduced.

## Verification Results
- `MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run tests/wiki-artifacts/wiki-publish-adapter.test.ts tests/runtime-vnext/bootstrap-api.test.ts tests/vnext/architecture-invariants.test.ts tests/cli/runtime/wiki-publish-adapter-init.test.ts tests/cli/runtime/agent-loop-init-envelope-options.test.ts`
  - 5 files passed, 38 tests passed.
- `MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run tests/vnext/architecture-invariants.test.ts tests/cli/runtime/wiki-publish-adapter-init.test.ts tests/cli/runtime/agent-loop-init-envelope-options.test.ts tests/agent/agent-result-memory.test.ts tests/agent/gateway-tool-executor.test.ts tests/wiki-artifacts/wiki-publish-adapter.test.ts tests/wiki-artifacts/wiki-artifact-store.test.ts tests/runtime-vnext/bootstrap-api.test.ts tests/runtime-vnext/bootstrap.test.ts tests/runtime-vnext/legacy-fanout-disabled.test.ts tests/api/report-vnext.test.ts`
  - 11 files passed, 151 tests passed.
- `pnpm --filter @jungjaehoon/mama-os typecheck` passed.
- `pnpm build` passed.
- `MAMA_FORCE_TIER_3=true pnpm test` passed.
  - 7 tasks successful.
  - Standalone: 237 files passed, 3327 passed, 1 skipped.
- Commit hook passed after `8ae76e49`.
  - `lint-staged`, `gitleaks`, doc version sync, typecheck, standalone build, standalone tests.
  - Standalone hook run: 236 files passed, 1 skipped; 3325 passed, 3 skipped.

## Test plan
- [x] Targeted vNext/wiki/executor regression tests pass.
- [x] Related standalone regression suite passes.
- [x] Standalone typecheck passes.
- [x] Build passes.
- [x] Full root test suite passes.
- [x] Commit hook verification passes.
- [x] Privacy/internal-information audit passes.
