### PR TITLE
feat: add vNext manual ingress no-update commit

### DIFF
--- a/packages/mama-core/db/migrations/039-add-connector-event-operator-ingest-seq.sql
+++ b/packages/mama-core/db/migrations/039-add-connector-event-operator-ingest-seq.sql
@@ -1,0 +1,96 @@
+ALTER TABLE connector_event_index
+  ADD COLUMN operator_ingest_seq INTEGER CHECK (
+    operator_ingest_seq IS NULL OR operator_ingest_seq >= 1
+  );
+
+CREATE TABLE IF NOT EXISTS connector_event_index_operator_seq_cursors (
+  source_connector TEXT NOT NULL,
+  channel TEXT NOT NULL DEFAULT '',
+  next_seq INTEGER NOT NULL CHECK (next_seq >= 1),
+  PRIMARY KEY (source_connector, channel)
+);
+
+WITH ranked_events AS (
+  SELECT
+    event_index_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY source_connector, COALESCE(channel, '')
+      ORDER BY rowid ASC
+    ) AS operator_seq
+  FROM connector_event_index
+)
+UPDATE connector_event_index
+SET operator_ingest_seq = (
+  SELECT operator_seq
+  FROM ranked_events
+  WHERE ranked_events.event_index_id = connector_event_index.event_index_id
+)
+WHERE operator_ingest_seq IS NULL;
+
+INSERT OR IGNORE INTO connector_event_index_operator_seq_cursors (
+  source_connector,
+  channel,
+  next_seq
+)
+SELECT
+  source_connector,
+  COALESCE(channel, ''),
+  COALESCE(MAX(operator_ingest_seq), 0) + 1
+FROM connector_event_index
+GROUP BY source_connector, COALESCE(channel, '');
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_connector_event_index_operator_scope_seq
+  ON connector_event_index(source_connector, COALESCE(channel, ''), operator_ingest_seq)
+  WHERE operator_ingest_seq IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_connector_event_index_operator_cursor_order
+  ON connector_event_index(source_connector, channel, operator_ingest_seq);
+
+CREATE TRIGGER IF NOT EXISTS trg_connector_event_index_operator_ingest_seq_ai
+AFTER INSERT ON connector_event_index
+WHEN NEW.operator_ingest_seq IS NULL
+BEGIN
+  INSERT OR IGNORE INTO connector_event_index_operator_seq_cursors (
+    source_connector,
+    channel,
+    next_seq
+  )
+  VALUES (NEW.source_connector, COALESCE(NEW.channel, ''), 1);
+
+  UPDATE connector_event_index
+  SET operator_ingest_seq = (
+    SELECT next_seq
+    FROM connector_event_index_operator_seq_cursors
+    WHERE source_connector = NEW.source_connector
+      AND channel = COALESCE(NEW.channel, '')
+  )
+  WHERE event_index_id = NEW.event_index_id;
+
+  UPDATE connector_event_index_operator_seq_cursors
+  SET next_seq = next_seq + 1
+  WHERE source_connector = NEW.source_connector
+    AND channel = COALESCE(NEW.channel, '');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_connector_event_index_operator_ingest_seq_explicit_ai
+AFTER INSERT ON connector_event_index
+WHEN NEW.operator_ingest_seq IS NOT NULL
+BEGIN
+  INSERT OR IGNORE INTO connector_event_index_operator_seq_cursors (
+    source_connector,
+    channel,
+    next_seq
+  )
+  VALUES (NEW.source_connector, COALESCE(NEW.channel, ''), 1);
+
+  UPDATE connector_event_index_operator_seq_cursors
+  SET next_seq = CASE
+    WHEN next_seq <= NEW.operator_ingest_seq THEN NEW.operator_ingest_seq + 1
+    ELSE next_seq
+  END
+  WHERE source_connector = NEW.source_connector
+    AND channel = COALESCE(NEW.channel, '');
+END;
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES (39, 'Add connector event operator ingest sequence');

--- a/packages/mama-core/tests/cases/migration-chain.test.ts
+++ b/packages/mama-core/tests/cases/migration-chain.test.ts
@@ -476,4 +476,119 @@ describe('Case-First Memory Substrate (migration 030, consolidated Phase 1+2+3)'
 
     db.close();
   });
+
+  it('records migration 039 connector event operator ingest sequences', () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    applyAll(db);
+
+    expect(columnExists(db, 'connector_event_index', 'operator_ingest_seq')).toBe(true);
+    expect(tableExists(db, 'connector_event_index_operator_seq_cursors')).toBe(true);
+    expect(indexExists(db, 'idx_connector_event_index_operator_scope_seq')).toBe(true);
+    expect(indexExists(db, 'idx_connector_event_index_operator_cursor_order')).toBe(true);
+    expect(triggerExists(db, 'trg_connector_event_index_operator_ingest_seq_ai')).toBe(true);
+
+    const insert = db.prepare(
+      `INSERT INTO connector_event_index (
+        event_index_id, source_connector, source_type, source_id, source_locator,
+        channel, author, title, content, event_datetime, event_date, source_timestamp_ms,
+        metadata_json, content_hash, indexed_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    );
+    insert.run(
+      'evt-c1-1',
+      'slack',
+      'message',
+      'c1-1',
+      'slack:C1:c1-1',
+      'C1',
+      'synthetic-user',
+      null,
+      'synthetic message c1-1',
+      1710000001000,
+      '2024-03-09',
+      1710000001000,
+      '{}',
+      Buffer.alloc(32, 1),
+      '2026-07-03T00:00:00.000Z',
+      '2026-07-03T00:00:00.000Z'
+    );
+    insert.run(
+      'evt-c2-1',
+      'slack',
+      'message',
+      'c2-1',
+      'slack:C2:c2-1',
+      'C2',
+      'synthetic-user',
+      null,
+      'synthetic message c2-1',
+      1710000002000,
+      '2024-03-09',
+      1710000002000,
+      '{}',
+      Buffer.alloc(32, 2),
+      '2026-07-03T00:00:00.000Z',
+      '2026-07-03T00:00:00.000Z'
+    );
+    insert.run(
+      'evt-c1-2',
+      'slack',
+      'message',
+      'c1-2',
+      'slack:C1:c1-2',
+      'C1',
+      'synthetic-user',
+      null,
+      'synthetic message c1-2',
+      1710000003000,
+      '2024-03-09',
+      1710000003000,
+      '{}',
+      Buffer.alloc(32, 3),
+      '2026-07-03T00:00:00.000Z',
+      '2026-07-03T00:00:00.000Z'
+    );
+    db.prepare('DELETE FROM connector_event_index WHERE event_index_id = ?').run('evt-c1-2');
+    insert.run(
+      'evt-c1-3',
+      'slack',
+      'message',
+      'c1-3',
+      'slack:C1:c1-3',
+      'C1',
+      'synthetic-user',
+      null,
+      'synthetic message c1-3',
+      1710000004000,
+      '2024-03-09',
+      1710000004000,
+      '{}',
+      Buffer.alloc(32, 4),
+      '2026-07-03T00:00:00.000Z',
+      '2026-07-03T00:00:00.000Z'
+    );
+
+    expect(
+      db
+        .prepare(
+          `SELECT event_index_id, channel, operator_ingest_seq
+           FROM connector_event_index
+           ORDER BY channel, operator_ingest_seq`
+        )
+        .all()
+    ).toEqual([
+      { event_index_id: 'evt-c1-1', channel: 'C1', operator_ingest_seq: 1 },
+      { event_index_id: 'evt-c1-3', channel: 'C1', operator_ingest_seq: 3 },
+      { event_index_id: 'evt-c2-1', channel: 'C2', operator_ingest_seq: 1 },
+    ]);
+
+    const row = db
+      .prepare('SELECT version, description FROM schema_version WHERE version = 39')
+      .get() as { version: number; description: string } | undefined;
+    expect(row?.version).toBe(39);
+    expect(row?.description).toContain('operator ingest sequence');
+
+    db.close();
+  });
 });

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -34,7 +34,7 @@ import Database from '../../sqlite.js';
 import { existsSync, readFileSync } from 'node:fs';
 import { createServer, type Server as HttpServer } from 'node:http';
 import { minimatch } from 'minimatch';
-import express, { type Express } from 'express';
+import express, { type Express, type NextFunction, type Request, type Response } from 'express';
 import { UICommandQueue } from '../../api/ui-command-handler.js';
 import { initAgentTables, getLatestVersion, createAgentVersion } from '../../db/agent-store.js';
 import { initValidationTables } from '../../validation/store.js';
@@ -65,7 +65,7 @@ import { initVNextWikiPublishAdapter } from '../runtime/wiki-publish-adapter-ini
 import { startServer } from '../runtime/server-start.js';
 import { installShutdownHandlers } from '../runtime/shutdown.js';
 import { buildRuntimeEnvelopeBootstrap } from '../runtime/envelope-bootstrap.js';
-import { requireAuth } from '../../api/auth-middleware.js';
+import { requireAdminAuth, requireAuth } from '../../api/auth-middleware.js';
 import { buildPublicVNextProjectionPayload } from '../../api/report-handler.js';
 import {
   buildVNextBootstrapPlan,
@@ -95,6 +95,12 @@ import {
   createConnectorIngressMigrationDryRunProvider,
   type ConnectorIngressMigrationDryRun,
 } from '../../operator-vnext/connector-ingress-migration-dry-run.js';
+import {
+  createConnectorIngressManualNoUpdateCommitProvider,
+  isConnectorIngressManualCommitRequestError,
+  MAX_MANUAL_NO_UPDATE_EVENT_INDEX_IDS,
+  type ConnectorIngressManualCommitResult,
+} from '../../operator-vnext/connector-ingress-manual-commit.js';
 import { resolveReactiveProjectRoot } from '../../envelope/reactive-config.js';
 import { deriveMemoryScopes, type MemoryScopeRef } from '../../memory/scope-context.js';
 import { DEFAULT_ROLES, type AgentPersonaConfig, type RoleConfig } from '../config/types.js';
@@ -573,11 +579,21 @@ export interface VNextIngressPreviewRequest {
   limit?: number;
 }
 
+export interface VNextIngressManualNoUpdateCommitRequest {
+  connector: string;
+  channel: string;
+  expectedAdvancedThroughSeq: number;
+  eventIndexIds: string[];
+}
+
 export interface VNextBootstrapApiServerOptions {
   ingressPreviewProvider?: (input: VNextIngressPreviewRequest) => ConnectorEventIngressPreview;
   ingressMigrationDryRunProvider?: (
     input: VNextIngressPreviewRequest
   ) => ConnectorIngressMigrationDryRun;
+  ingressManualNoUpdateCommitProvider?: (
+    input: VNextIngressManualNoUpdateCommitRequest
+  ) => Promise<ConnectorIngressManualCommitResult> | ConnectorIngressManualCommitResult;
 }
 
 function firstQueryString(value: unknown): string | null {
@@ -604,12 +620,88 @@ function queryLimit(value: unknown): number | undefined {
   return limit;
 }
 
+function requireRequestBodyRecord(value: unknown): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('request body must be an object');
+  }
+  return value as Record<string, unknown>;
+}
+
+function bodyString(body: Record<string, unknown>, field: string): string {
+  const value = body[field];
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${field} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function bodyNonNegativeInteger(body: Record<string, unknown>, field: string): number {
+  const value = body[field];
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+    throw new Error(`${field} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function bodyStringArray(body: Record<string, unknown>, field: string, maxItems: number): string[] {
+  const value = body[field];
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    !value.every((item) => typeof item === 'string' && item.trim().length > 0)
+  ) {
+    throw new Error(`${field} must be a non-empty string array`);
+  }
+  if (value.length > maxItems) {
+    throw new Error(`${field} must contain at most ${maxItems} items`);
+  }
+  return value.map((item) => item.trim());
+}
+
+function parseManualNoUpdateCommitBody(rawBody: unknown): VNextIngressManualNoUpdateCommitRequest {
+  const body = requireRequestBodyRecord(rawBody);
+  if (
+    Object.prototype.hasOwnProperty.call(body, 'changedRefs') ||
+    Object.prototype.hasOwnProperty.call(body, 'changed_refs')
+  ) {
+    throw new Error('manual no-update commits do not accept changed refs');
+  }
+  return {
+    connector: bodyString(body, 'connector'),
+    channel: bodyString(body, 'channel'),
+    expectedAdvancedThroughSeq: bodyNonNegativeInteger(body, 'expected_advanced_through_seq'),
+    eventIndexIds: bodyStringArray(body, 'event_index_ids', MAX_MANUAL_NO_UPDATE_EVENT_INDEX_IDS),
+  };
+}
+
 function isVNextIngressClientError(error: unknown): boolean {
   return (
     error instanceof Error &&
     (error.message.includes('locked to the configured connector/channel') ||
       error.message === 'limit must be a positive integer')
   );
+}
+
+function isVNextManualCommitClientError(error: unknown): boolean {
+  return isConnectorIngressManualCommitRequestError(error);
+}
+
+function handleVNextManualCommitJsonError(
+  error: unknown,
+  _req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  if (typeof error === 'object' && error !== null && 'status' in error) {
+    const status = (error as { status?: unknown }).status;
+    res.status(typeof status === 'number' && status >= 400 && status < 500 ? status : 400).json({
+      ok: false,
+      code: 'vnext_ingress_manual_commit_invalid_json',
+      error: 'Invalid JSON request body.',
+    });
+    return;
+  }
+  next(error);
 }
 
 function buildVNextStatusPayload(status: VNextBootstrapRuntimeStatus): Record<string, unknown> {
@@ -739,7 +831,7 @@ export function createVNextBootstrapApiServer(
 } {
   const app = express();
   app.disable('x-powered-by');
-  app.use(express.json({ limit: '128kb' }));
+  const jsonBodyParser = express.json({ limit: '128kb' });
 
   app.get('/health', (_req, res) => {
     res.json({
@@ -748,6 +840,53 @@ export function createVNextBootstrapApiServer(
       timestamp: Date.now(),
     });
   });
+  app.post(
+    '/api/vnext/ingress/manual-no-update-commit',
+    requireAdminAuth,
+    jsonBodyParser,
+    async (req, res) => {
+      if (!options.ingressManualNoUpdateCommitProvider) {
+        res.status(404).json({
+          ok: false,
+          code: 'vnext_ingress_manual_commit_unavailable',
+          error: 'vNext manual ingress commit is not configured.',
+        });
+        return;
+      }
+
+      let input: VNextIngressManualNoUpdateCommitRequest;
+      try {
+        input = parseManualNoUpdateCommitBody(req.body);
+      } catch (error) {
+        res.status(400).json({
+          ok: false,
+          code: 'vnext_ingress_manual_commit_invalid_request',
+          error: error instanceof Error ? error.message : 'Invalid manual ingress commit request.',
+        });
+        return;
+      }
+
+      try {
+        const result = await options.ingressManualNoUpdateCommitProvider(input);
+        res.status(result.ok ? 200 : 409).json(result);
+      } catch (error) {
+        const clientError = isVNextManualCommitClientError(error);
+        res.status(clientError ? 400 : 500).json({
+          ok: false,
+          code: clientError
+            ? 'vnext_ingress_manual_commit_invalid_request'
+            : 'vnext_ingress_manual_commit_failed',
+          error: clientError
+            ? error instanceof Error
+              ? error.message
+              : 'Invalid manual ingress commit request.'
+            : 'vNext manual ingress commit failed.',
+        });
+      }
+    }
+  );
+  app.use('/api/vnext/ingress/manual-no-update-commit', handleVNextManualCommitJsonError);
+  app.use(jsonBodyParser);
   app.use('/api', requireAuth);
   app.get('/api/vnext/status', (_req, res) => {
     res.json(buildVNextStatusPayload(status));
@@ -1039,6 +1178,12 @@ export async function runAgentLoop(
             channel: vNextIngressConfig.channel,
           }),
           ingressMigrationDryRunProvider: createConnectorIngressMigrationDryRunProvider({
+            rawAdapter: vNextRawAdapter,
+            operatorDb: vNextOperatorDb,
+            connector: vNextIngressConfig.connector,
+            channel: vNextIngressConfig.channel,
+          }),
+          ingressManualNoUpdateCommitProvider: createConnectorIngressManualNoUpdateCommitProvider({
             rawAdapter: vNextRawAdapter,
             operatorDb: vNextOperatorDb,
             connector: vNextIngressConfig.connector,

--- a/packages/standalone/src/operator-vnext/connector-event-ingress.ts
+++ b/packages/standalone/src/operator-vnext/connector-event-ingress.ts
@@ -65,11 +65,7 @@ const CONNECTOR_ENV = 'MAMA_VNEXT_INGRESS_CONNECTOR';
 const CHANNEL_ENV = 'MAMA_VNEXT_INGRESS_CHANNEL';
 
 export function connectorEventIngressOperatorSeqSql(): string {
-  return `
-    ROW_NUMBER() OVER (
-      ORDER BY rowid ASC
-    )
-  `;
+  return 'operator_ingest_seq';
 }
 
 function positiveLimit(value: number | undefined): number {

--- a/packages/standalone/src/operator-vnext/connector-event-ingress.ts
+++ b/packages/standalone/src/operator-vnext/connector-event-ingress.ts
@@ -64,6 +64,14 @@ const MAX_INGRESS_LIMIT = 100;
 const CONNECTOR_ENV = 'MAMA_VNEXT_INGRESS_CONNECTOR';
 const CHANNEL_ENV = 'MAMA_VNEXT_INGRESS_CHANNEL';
 
+export function connectorEventIngressOperatorSeqSql(): string {
+  return `
+    ROW_NUMBER() OVER (
+      ORDER BY rowid ASC
+    )
+  `;
+}
+
 function positiveLimit(value: number | undefined): number {
   if (value === undefined) {
     return DEFAULT_INGRESS_LIMIT;
@@ -147,9 +155,7 @@ export function buildConnectorEventIngressPreview(
       `
         WITH ordered_events AS (
           SELECT
-            ROW_NUMBER() OVER (
-              ORDER BY rowid ASC
-            ) AS operator_seq,
+            ${connectorEventIngressOperatorSeqSql()} AS operator_seq,
             event_index_id,
             source_connector,
             source_id,

--- a/packages/standalone/src/operator-vnext/connector-event-ingress.ts
+++ b/packages/standalone/src/operator-vnext/connector-event-ingress.ts
@@ -148,7 +148,7 @@ export function buildConnectorEventIngressPreview(
         WITH ordered_events AS (
           SELECT
             ROW_NUMBER() OVER (
-              ORDER BY source_timestamp_ms ASC, event_index_id ASC
+              ORDER BY rowid ASC
             ) AS operator_seq,
             event_index_id,
             source_connector,

--- a/packages/standalone/src/operator-vnext/connector-ingress-manual-commit.ts
+++ b/packages/standalone/src/operator-vnext/connector-ingress-manual-commit.ts
@@ -1,0 +1,305 @@
+import type { SourceRef } from '@jungjaehoon/mama-core/provenance/source-ref';
+
+import type { SQLiteDatabase } from '../sqlite.js';
+import {
+  buildConnectorOperatorCursorName,
+  type ConnectorEventIngressAdapter,
+} from './connector-event-ingress.js';
+import {
+  PrimaryOperatorRuntime,
+  type PrimaryOperatorBatchResult,
+  type PrimaryOperatorEvent,
+} from './primary-operator-runtime.js';
+import { nonNegativeInteger, requiredString } from './validation.js';
+
+interface ConnectorIngressReviewedEventRow {
+  operator_seq: number;
+  event_index_id: string;
+  source_connector: string;
+  source_id: string;
+  channel: string | null;
+}
+
+interface NoUpdateCommitDetailRow {
+  scope_key: string;
+  reason: string;
+}
+
+export interface ConnectorIngressManualCommitInput {
+  rawAdapter: ConnectorEventIngressAdapter;
+  operatorDb: SQLiteDatabase;
+  connector: string;
+  channel: string;
+  expectedAdvancedThroughSeq: number;
+  eventIndexIds: readonly string[];
+  nowMs?: () => number;
+}
+
+export interface ConnectorIngressManualCommitResult {
+  ok: boolean;
+  mode: 'manual_no_update_commit';
+  status: PrimaryOperatorBatchResult['status'];
+  cursorName: string;
+  connector: string;
+  channel: string;
+  requestedCount: number;
+  processed: number;
+  advancedThroughSeq: number;
+  firstSeq: number | null;
+  lastSeq: number | null;
+  commits: Array<{
+    seq: number;
+    status: 'no_update';
+    outcome: 'committed' | 'already_committed' | 'recovered';
+    cursorAdvanced: boolean;
+  }>;
+  failedSeq?: number;
+  error?: string;
+}
+
+export type ConnectorIngressManualNoUpdateCommitProvider = (
+  input: Omit<ConnectorIngressManualCommitInput, 'rawAdapter' | 'operatorDb' | 'nowMs'>
+) => Promise<ConnectorIngressManualCommitResult>;
+
+export class ConnectorIngressManualCommitRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConnectorIngressManualCommitRequestError';
+  }
+}
+
+export const MAX_MANUAL_NO_UPDATE_EVENT_INDEX_IDS = 100;
+
+const NO_UPDATE_REASON = 'manual_ingress_reviewed_no_update';
+
+export function isConnectorIngressManualCommitRequestError(
+  error: unknown
+): error is ConnectorIngressManualCommitRequestError {
+  return error instanceof ConnectorIngressManualCommitRequestError;
+}
+
+function requestError(message: string): ConnectorIngressManualCommitRequestError {
+  return new ConnectorIngressManualCommitRequestError(message);
+}
+
+function readCursorSeq(db: SQLiteDatabase, cursorName: string): number {
+  const row = db
+    .prepare('SELECT last_change_seq FROM vnext_operator_cursors WHERE cursor_name = ?')
+    .get(cursorName) as { last_change_seq: number } | undefined;
+  return row?.last_change_seq ?? 0;
+}
+
+function normalizeEventIndexIds(eventIndexIds: readonly string[]): string[] {
+  if (!Array.isArray(eventIndexIds) || eventIndexIds.length === 0) {
+    throw requestError('eventIndexIds must not be empty');
+  }
+  if (eventIndexIds.length > MAX_MANUAL_NO_UPDATE_EVENT_INDEX_IDS) {
+    throw requestError(
+      `eventIndexIds must contain at most ${MAX_MANUAL_NO_UPDATE_EVENT_INDEX_IDS} items`
+    );
+  }
+  return eventIndexIds.map((eventIndexId) => {
+    try {
+      return requiredString(eventIndexId, 'eventIndexIds[]');
+    } catch {
+      throw requestError('eventIndexIds must be a non-empty string array');
+    }
+  });
+}
+
+function rowToEvent(row: ConnectorIngressReviewedEventRow): PrimaryOperatorEvent {
+  const sourceRef: SourceRef = {
+    kind: 'raw',
+    connector: requiredString(row.source_connector, 'source_connector'),
+    id: requiredString(row.event_index_id, 'event_index_id'),
+    source_id: requiredString(row.source_id, 'source_id'),
+    channel_id: row.channel,
+  };
+  return {
+    seq: nonNegativeInteger(row.operator_seq, 'operator_seq'),
+    sourceRef,
+  };
+}
+
+function readReviewedEvents(input: {
+  rawAdapter: ConnectorEventIngressAdapter;
+  connector: string;
+  channel: string;
+  eventIndexIds: readonly string[];
+}): PrimaryOperatorEvent[] {
+  const ids = normalizeEventIndexIds(input.eventIndexIds);
+  const placeholders = ids.map(() => '?').join(', ');
+  const rows = input.rawAdapter
+    .prepare(
+      `
+        WITH ordered_events AS (
+          SELECT
+            ROW_NUMBER() OVER (
+              ORDER BY rowid ASC
+            ) AS operator_seq,
+            event_index_id,
+            source_connector,
+            source_id,
+            channel
+          FROM connector_event_index
+          WHERE source_connector = ?
+            AND channel = ?
+        )
+        SELECT
+          operator_seq,
+          event_index_id,
+          source_connector,
+          source_id,
+          channel
+        FROM ordered_events
+        WHERE event_index_id IN (${placeholders})
+        ORDER BY operator_seq ASC
+      `
+    )
+    .all(input.connector, input.channel, ...ids) as ConnectorIngressReviewedEventRow[];
+  const orderedIds = rows.map((row) => requiredString(row.event_index_id, 'event_index_id'));
+  if (orderedIds.length !== ids.length || orderedIds.some((id, index) => id !== ids[index])) {
+    throw requestError('Reviewed event ids do not match the current deterministic connector order');
+  }
+  return rows.map(rowToEvent);
+}
+
+function assertReviewedSeqs(
+  events: readonly PrimaryOperatorEvent[],
+  expectedAdvancedThroughSeq: number,
+  currentAdvancedThroughSeq: number
+): void {
+  const expected = nonNegativeInteger(expectedAdvancedThroughSeq, 'expectedAdvancedThroughSeq');
+  const firstSeq = events[0]?.seq ?? null;
+  const lastSeq = events[events.length - 1]?.seq ?? null;
+  if (firstSeq !== expected + 1 || lastSeq !== expected + events.length) {
+    throw requestError('Reviewed event ids do not match the expected contiguous cursor range');
+  }
+  if (currentAdvancedThroughSeq > expected && currentAdvancedThroughSeq < lastSeq) {
+    throw requestError('Reviewed event ids are stale for the current connector cursor');
+  }
+  if (currentAdvancedThroughSeq < expected) {
+    throw requestError('Reviewed cursor is ahead of the current connector cursor');
+  }
+}
+
+function assertManualNoUpdateCommitDetails(
+  db: SQLiteDatabase,
+  cursorName: string,
+  batch: PrimaryOperatorBatchResult
+): void {
+  for (const commit of batch.commits) {
+    if (commit.status !== 'no_update') {
+      throw new Error('Manual no-update commit recovered a non-no-update operator commit');
+    }
+    const row = db
+      .prepare('SELECT scope_key, reason FROM operator_no_updates WHERE idempotency_key = ?')
+      .get(commit.idempotencyKey) as NoUpdateCommitDetailRow | undefined;
+    if (!row || row.scope_key !== cursorName || row.reason !== NO_UPDATE_REASON) {
+      throw new Error('Manual no-update commit recovered mismatched no-update details');
+    }
+  }
+}
+
+export async function commitConnectorIngressNoUpdateBatch(
+  input: ConnectorIngressManualCommitInput
+): Promise<ConnectorIngressManualCommitResult> {
+  const connector = requiredString(input.connector, 'connector');
+  const channel = requiredString(input.channel, 'channel');
+  const cursorName = buildConnectorOperatorCursorName({ connector, channel });
+
+  const runtime = new PrimaryOperatorRuntime({
+    db: input.operatorDb,
+    cursorName,
+    connector,
+    nowMs: input.nowMs,
+  });
+  let events: PrimaryOperatorEvent[] = [];
+  const batch = await runtime.processBatchAfterValidation(
+    () => {
+      events = readReviewedEvents({
+        rawAdapter: input.rawAdapter,
+        connector,
+        channel,
+        eventIndexIds: input.eventIndexIds,
+      });
+      assertReviewedSeqs(
+        events,
+        input.expectedAdvancedThroughSeq,
+        readCursorSeq(input.operatorDb, cursorName)
+      );
+      return events;
+    },
+    () => ({
+      status: 'no_update',
+      reason: NO_UPDATE_REASON,
+      scopeKey: cursorName,
+    })
+  );
+  assertManualNoUpdateCommitDetails(input.operatorDb, cursorName, batch);
+  const firstSeq = events[0]?.seq ?? null;
+  const lastSeq = events[events.length - 1]?.seq ?? null;
+  const commits = batch.commits.map((commit) => ({
+    seq: commit.lastChangeSeq,
+    status: 'no_update' as const,
+    outcome: commit.outcome,
+    cursorAdvanced: commit.cursorAdvanced,
+  }));
+  if (batch.status === 'partial_failure') {
+    return {
+      ok: false,
+      mode: 'manual_no_update_commit',
+      status: batch.status,
+      cursorName,
+      connector,
+      channel,
+      requestedCount: input.eventIndexIds.length,
+      processed: batch.processed,
+      advancedThroughSeq: batch.advancedThroughSeq,
+      firstSeq,
+      lastSeq,
+      commits,
+      failedSeq: batch.failedSeq,
+      error: 'Manual no-update commit partially failed.',
+    };
+  }
+  return {
+    ok: true,
+    mode: 'manual_no_update_commit',
+    status: batch.status,
+    cursorName,
+    connector,
+    channel,
+    requestedCount: input.eventIndexIds.length,
+    processed: batch.processed,
+    advancedThroughSeq: batch.advancedThroughSeq,
+    firstSeq,
+    lastSeq,
+    commits,
+  };
+}
+
+export function createConnectorIngressManualNoUpdateCommitProvider(
+  options: Omit<ConnectorIngressManualCommitInput, 'expectedAdvancedThroughSeq' | 'eventIndexIds'>
+): ConnectorIngressManualNoUpdateCommitProvider {
+  const connector = requiredString(options.connector, 'connector');
+  const channel = requiredString(options.channel, 'channel');
+  return async (input) => {
+    const requestedConnector = requiredString(input.connector, 'connector');
+    const requestedChannel = requiredString(input.channel, 'channel');
+    if (requestedConnector !== connector || requestedChannel !== channel) {
+      throw requestError(
+        `Connector ingress manual commit is locked to the configured connector/channel: ${connector}/${channel}`
+      );
+    }
+    return commitConnectorIngressNoUpdateBatch({
+      rawAdapter: options.rawAdapter,
+      operatorDb: options.operatorDb,
+      connector,
+      channel,
+      expectedAdvancedThroughSeq: input.expectedAdvancedThroughSeq,
+      eventIndexIds: input.eventIndexIds,
+      nowMs: options.nowMs,
+    });
+  };
+}

--- a/packages/standalone/src/operator-vnext/connector-ingress-manual-commit.ts
+++ b/packages/standalone/src/operator-vnext/connector-ingress-manual-commit.ts
@@ -163,7 +163,36 @@ function readReviewedEvents(input: {
   return rows.map(rowToEvent);
 }
 
+function countEventsInSeqRange(input: {
+  rawAdapter: ConnectorEventIngressAdapter;
+  connector: string;
+  channel: string;
+  afterSeq: number;
+  throughSeq: number;
+}): number {
+  const row = input.rawAdapter
+    .prepare(
+      `
+        SELECT COUNT(*) AS count
+        FROM connector_event_index
+        WHERE source_connector = ?
+          AND channel = ?
+          AND ${connectorEventIngressOperatorSeqSql()} > ?
+          AND ${connectorEventIngressOperatorSeqSql()} <= ?
+      `
+    )
+    .get(input.connector, input.channel, input.afterSeq, input.throughSeq) as
+    | { count: number }
+    | undefined;
+  return nonNegativeInteger(row?.count ?? 0, 'reviewed_range_count');
+}
+
 function assertReviewedSeqs(
+  input: {
+    rawAdapter: ConnectorEventIngressAdapter;
+    connector: string;
+    channel: string;
+  },
   events: readonly PrimaryOperatorEvent[],
   expectedAdvancedThroughSeq: number,
   currentAdvancedThroughSeq: number
@@ -171,8 +200,18 @@ function assertReviewedSeqs(
   const expected = nonNegativeInteger(expectedAdvancedThroughSeq, 'expectedAdvancedThroughSeq');
   const firstSeq = events[0]?.seq ?? null;
   const lastSeq = events[events.length - 1]?.seq ?? null;
-  if (firstSeq !== expected + 1 || lastSeq !== expected + events.length) {
-    throw requestError('Reviewed event ids do not match the expected contiguous cursor range');
+  if (firstSeq === null || lastSeq === null || firstSeq <= expected) {
+    throw requestError('Reviewed event ids do not advance the expected connector cursor');
+  }
+  const rangeCount = countEventsInSeqRange({
+    rawAdapter: input.rawAdapter,
+    connector: input.connector,
+    channel: input.channel,
+    afterSeq: expected,
+    throughSeq: lastSeq,
+  });
+  if (rangeCount !== events.length) {
+    throw requestError('Reviewed event ids do not cover the current connector cursor range');
   }
   if (currentAdvancedThroughSeq > expected && currentAdvancedThroughSeq < lastSeq) {
     throw requestError('Reviewed event ids are stale for the current connector cursor');
@@ -212,6 +251,7 @@ export async function commitConnectorIngressNoUpdateBatch(
     cursorName,
     connector,
     nowMs: input.nowMs,
+    allowSeqGaps: true,
   });
   let events: PrimaryOperatorEvent[] = [];
   const batch = await runtime.processBatchAfterValidation(
@@ -223,6 +263,11 @@ export async function commitConnectorIngressNoUpdateBatch(
         eventIndexIds: input.eventIndexIds,
       });
       assertReviewedSeqs(
+        {
+          rawAdapter: input.rawAdapter,
+          connector,
+          channel,
+        },
         events,
         input.expectedAdvancedThroughSeq,
         readCursorSeq(input.operatorDb, cursorName)

--- a/packages/standalone/src/operator-vnext/connector-ingress-manual-commit.ts
+++ b/packages/standalone/src/operator-vnext/connector-ingress-manual-commit.ts
@@ -3,6 +3,7 @@ import type { SourceRef } from '@jungjaehoon/mama-core/provenance/source-ref';
 import type { SQLiteDatabase } from '../sqlite.js';
 import {
   buildConnectorOperatorCursorName,
+  connectorEventIngressOperatorSeqSql,
   type ConnectorEventIngressAdapter,
 } from './connector-event-ingress.js';
 import {
@@ -134,9 +135,7 @@ function readReviewedEvents(input: {
       `
         WITH ordered_events AS (
           SELECT
-            ROW_NUMBER() OVER (
-              ORDER BY rowid ASC
-            ) AS operator_seq,
+            ${connectorEventIngressOperatorSeqSql()} AS operator_seq,
             event_index_id,
             source_connector,
             source_id,

--- a/packages/standalone/src/operator-vnext/operator-commit-result.ts
+++ b/packages/standalone/src/operator-vnext/operator-commit-result.ts
@@ -20,6 +20,7 @@ export interface OperatorCursorCommitInput {
   sourceRefs: readonly SourceRef[];
   noUpdate?: OperatorNoUpdateCommitInput;
   nowMs?: number;
+  allowSeqGaps?: boolean;
 }
 
 export interface OperatorCursorCommitResult {

--- a/packages/standalone/src/operator-vnext/operator-cursor-commit.ts
+++ b/packages/standalone/src/operator-vnext/operator-cursor-commit.ts
@@ -66,6 +66,20 @@ export function buildConnectorIdempotencyKey(
   return `connector:${connector}:seq:${first}-${last}`;
 }
 
+export function buildCursorScopedIdempotencyKey(
+  cursorName: string,
+  firstChangeSeq: number,
+  lastChangeSeq: number
+): string {
+  const cursor = requiredString(cursorName, 'cursorName');
+  const first = nonNegativeInteger(firstChangeSeq, 'firstChangeSeq');
+  const last = nonNegativeInteger(lastChangeSeq, 'lastChangeSeq');
+  if (last < first) {
+    throw new Error('lastChangeSeq must be greater than or equal to firstChangeSeq');
+  }
+  return `cursor:${cursor}:seq:${first}-${last}`;
+}
+
 function ensureCursor(db: SQLiteDatabase, cursorName: string, nowMs: number): void {
   db.prepare(
     `INSERT OR IGNORE INTO vnext_operator_cursors (

--- a/packages/standalone/src/operator-vnext/operator-cursor-commit.ts
+++ b/packages/standalone/src/operator-vnext/operator-cursor-commit.ts
@@ -42,8 +42,10 @@ interface NormalizedNoUpdateCommit {
 export interface ExistingOperatorCursorCommitInput {
   cursorName: string;
   idempotencyKey: string;
+  fallbackIdempotencyKeys?: readonly string[];
   sourceRefs: readonly SourceRef[];
   nowMs?: number;
+  allowSeqGaps?: boolean;
 }
 
 function assertOperatorCommitStatus(status: unknown): asserts status is OperatorCommitStatus {
@@ -128,7 +130,15 @@ function getExistingNoUpdate(db: SQLiteDatabase, idempotencyKey: string): NoUpda
   );
 }
 
-function assertContiguous(cursor: CursorRow, firstChangeSeq: number): void {
+function assertSeqAdvances(cursor: CursorRow, firstChangeSeq: number, allowSeqGaps: boolean): void {
+  if (allowSeqGaps) {
+    if (firstChangeSeq <= cursor.last_change_seq) {
+      throw new Error(
+        `Operator commit must advance cursor ${cursor.cursor_name}: current ${cursor.last_change_seq}, got ${firstChangeSeq}`
+      );
+    }
+    return;
+  }
   const expected = cursor.last_change_seq + 1;
   if (firstChangeSeq !== expected) {
     throw new Error(
@@ -155,7 +165,8 @@ function resultFromStoredCommit(
   db: SQLiteDatabase,
   cursor: CursorRow,
   existing: CommitRow,
-  nowMs: number
+  nowMs: number,
+  allowSeqGaps: boolean
 ): OperatorCursorCommitResult {
   if (existing.status === 'no_update' && !getExistingNoUpdate(db, existing.idempotency_key)) {
     throw new Error('Idempotent no-update replay is missing no-update commit details');
@@ -173,7 +184,7 @@ function resultFromStoredCommit(
     };
   }
 
-  assertContiguous(cursor, existing.first_change_seq);
+  assertSeqAdvances(cursor, existing.first_change_seq, allowSeqGaps);
   updateCursor(db, existing.cursor_name, existing.last_change_seq, existing.idempotency_key, nowMs);
   return {
     outcome: 'recovered',
@@ -199,7 +210,8 @@ function resultFromExistingCommit(
     sourceRefsJson: string;
     noUpdate?: NormalizedNoUpdateCommit;
   },
-  nowMs: number
+  nowMs: number,
+  allowSeqGaps: boolean
 ): OperatorCursorCommitResult {
   if (existing.cursor_name !== cursor.cursor_name) {
     throw new Error(`Idempotency key belongs to a different cursor: ${existing.cursor_name}`);
@@ -228,7 +240,7 @@ function resultFromExistingCommit(
     }
   }
 
-  return resultFromStoredCommit(db, cursor, existing, nowMs);
+  return resultFromStoredCommit(db, cursor, existing, nowMs, allowSeqGaps);
 }
 
 export function recoverExistingOperatorCursorCommit(
@@ -238,21 +250,34 @@ export function recoverExistingOperatorCursorCommit(
   const nowMs = input.nowMs ?? Date.now();
   const cursorName = requiredString(input.cursorName, 'cursorName');
   const idempotencyKey = requiredString(input.idempotencyKey, 'idempotencyKey');
+  const idempotencyKeys = [
+    idempotencyKey,
+    ...(input.fallbackIdempotencyKeys ?? []).map((key) =>
+      requiredString(key, 'fallbackIdempotencyKeys[]')
+    ),
+  ];
   const expectedSourceRefsJson = JSON.stringify(serializeRequiredSourceRefs(input.sourceRefs));
+  const allowSeqGaps = input.allowSeqGaps === true;
 
   const tx = db.transaction(() => {
-    const existing = getExistingCommit(db, idempotencyKey);
-    if (!existing) {
-      return null;
+    for (const [index, key] of idempotencyKeys.entries()) {
+      const existing = getExistingCommit(db, key);
+      if (!existing) {
+        continue;
+      }
+      if (existing.cursor_name !== cursorName) {
+        if (index === 0) {
+          throw new Error(`Idempotency key belongs to a different cursor: ${existing.cursor_name}`);
+        }
+        continue;
+      }
+      if (existing.source_refs_json !== expectedSourceRefsJson) {
+        throw new Error('Idempotent replay source refs do not match the original operator commit');
+      }
+      const cursor = getCursor(db, cursorName);
+      return resultFromStoredCommit(db, cursor, existing, nowMs, allowSeqGaps);
     }
-    if (existing.cursor_name !== cursorName) {
-      throw new Error(`Idempotency key belongs to a different cursor: ${existing.cursor_name}`);
-    }
-    if (existing.source_refs_json !== expectedSourceRefsJson) {
-      throw new Error('Idempotent replay source refs do not match the original operator commit');
-    }
-    const cursor = getCursor(db, cursorName);
-    return resultFromStoredCommit(db, cursor, existing, nowMs);
+    return null;
   });
   return tx();
 }
@@ -266,6 +291,7 @@ export function commitOperatorCursor(
   const idempotencyKey = requiredString(input.idempotencyKey, 'idempotencyKey');
   const firstChangeSeq = nonNegativeInteger(input.firstChangeSeq, 'firstChangeSeq');
   const lastChangeSeq = nonNegativeInteger(input.lastChangeSeq, 'lastChangeSeq');
+  const allowSeqGaps = input.allowSeqGaps === true;
   assertOperatorCommitStatus(input.status);
   if (lastChangeSeq < firstChangeSeq) {
     throw new Error('lastChangeSeq must be greater than or equal to firstChangeSeq');
@@ -318,11 +344,12 @@ export function commitOperatorCursor(
           sourceRefsJson,
           noUpdate,
         },
-        nowMs
+        nowMs,
+        allowSeqGaps
       );
     }
 
-    assertContiguous(cursor, firstChangeSeq);
+    assertSeqAdvances(cursor, firstChangeSeq, allowSeqGaps);
 
     db.prepare(
       `INSERT INTO vnext_operator_commits (

--- a/packages/standalone/src/operator-vnext/primary-operator-runtime.ts
+++ b/packages/standalone/src/operator-vnext/primary-operator-runtime.ts
@@ -2,7 +2,7 @@ import type { SourceRef } from '@jungjaehoon/mama-core/provenance/source-ref';
 
 import type { SQLiteDatabase } from '../sqlite.js';
 import {
-  buildConnectorIdempotencyKey,
+  buildCursorScopedIdempotencyKey,
   commitOperatorCursor,
   recoverExistingOperatorCursorCommit,
 } from './operator-cursor-commit.js';
@@ -156,6 +156,16 @@ export class PrimaryOperatorRuntime {
     return withCursorLock(this.cursorName, () => this.processBatchLocked(events, decide));
   }
 
+  async processBatchAfterValidation(
+    buildEvents: () => Promise<readonly PrimaryOperatorEvent[]> | readonly PrimaryOperatorEvent[],
+    decide: (event: PrimaryOperatorEvent) => Promise<unknown> | unknown
+  ): Promise<PrimaryOperatorBatchResult> {
+    return withCursorLock(this.cursorName, async () => {
+      const events = await buildEvents();
+      return this.processBatchLocked(events, decide);
+    });
+  }
+
   private async processBatchLocked(
     events: readonly PrimaryOperatorEvent[],
     decide: (event: PrimaryOperatorEvent) => Promise<unknown> | unknown
@@ -176,7 +186,7 @@ export class PrimaryOperatorRuntime {
       try {
         const seq = nonNegativeInteger(event.seq, 'event.seq');
         assertRawEventSourceBoundToConnector(event.sourceRef, this.connector);
-        const idempotencyKey = buildConnectorIdempotencyKey(this.connector, seq, seq);
+        const idempotencyKey = buildCursorScopedIdempotencyKey(this.cursorName, seq, seq);
         const sourceRefs = [event.sourceRef];
         const existingCommit = recoverExistingOperatorCursorCommit(this.db, {
           cursorName: this.cursorName,

--- a/packages/standalone/src/operator-vnext/primary-operator-runtime.ts
+++ b/packages/standalone/src/operator-vnext/primary-operator-runtime.ts
@@ -2,6 +2,7 @@ import type { SourceRef } from '@jungjaehoon/mama-core/provenance/source-ref';
 
 import type { SQLiteDatabase } from '../sqlite.js';
 import {
+  buildConnectorIdempotencyKey,
   buildCursorScopedIdempotencyKey,
   commitOperatorCursor,
   recoverExistingOperatorCursorCommit,
@@ -31,6 +32,7 @@ export interface PrimaryOperatorRuntimeOptions {
   cursorName: string;
   connector: string;
   nowMs?: () => number;
+  allowSeqGaps?: boolean;
 }
 
 export type PrimaryOperatorBatchResult =
@@ -135,12 +137,14 @@ export class PrimaryOperatorRuntime {
   private readonly cursorName: string;
   private readonly connector: string;
   private readonly nowMs: () => number;
+  private readonly allowSeqGaps: boolean;
 
   constructor(options: PrimaryOperatorRuntimeOptions) {
     this.db = options.db;
     this.cursorName = options.cursorName.trim();
     this.connector = options.connector.trim();
     this.nowMs = options.nowMs ?? Date.now;
+    this.allowSeqGaps = options.allowSeqGaps === true;
     if (this.cursorName.length === 0) {
       throw new Error('cursorName must not be empty');
     }
@@ -187,21 +191,27 @@ export class PrimaryOperatorRuntime {
         const seq = nonNegativeInteger(event.seq, 'event.seq');
         assertRawEventSourceBoundToConnector(event.sourceRef, this.connector);
         const idempotencyKey = buildCursorScopedIdempotencyKey(this.cursorName, seq, seq);
+        const legacyIdempotencyKey = buildConnectorIdempotencyKey(this.connector, seq, seq);
         const sourceRefs = [event.sourceRef];
         const existingCommit = recoverExistingOperatorCursorCommit(this.db, {
           cursorName: this.cursorName,
           idempotencyKey,
+          fallbackIdempotencyKeys:
+            legacyIdempotencyKey === idempotencyKey ? [] : [legacyIdempotencyKey],
           sourceRefs,
           nowMs: this.nowMs(),
+          allowSeqGaps: this.allowSeqGaps,
         });
         if (existingCommit) {
           commits.push(existingCommit);
           advancedThroughSeq = Math.max(advancedThroughSeq, existingCommit.lastChangeSeq);
           continue;
         }
-        if (seq !== advancedThroughSeq + 1) {
+        if (this.allowSeqGaps ? seq <= advancedThroughSeq : seq !== advancedThroughSeq + 1) {
           throw new Error(
-            `Operator events must be contiguous; expected seq ${advancedThroughSeq + 1}, got ${seq}`
+            this.allowSeqGaps
+              ? `Operator events must advance cursor; current seq ${advancedThroughSeq}, got ${seq}`
+              : `Operator events must be contiguous; expected seq ${advancedThroughSeq + 1}, got ${seq}`
           );
         }
         const decision = parseDecision(await decide(event));
@@ -216,6 +226,7 @@ export class PrimaryOperatorRuntime {
                 changedRefs: decision.changedRefs,
                 sourceRefs,
                 nowMs: this.nowMs(),
+                allowSeqGaps: this.allowSeqGaps,
               })
             : commitOperatorCursor(this.db, {
                 cursorName: this.cursorName,
@@ -229,6 +240,7 @@ export class PrimaryOperatorRuntime {
                   reason: decision.reason,
                 },
                 nowMs: this.nowMs(),
+                allowSeqGaps: this.allowSeqGaps,
               });
         commits.push(commit);
         advancedThroughSeq = Math.max(advancedThroughSeq, commit.lastChangeSeq);

--- a/packages/standalone/tests/operator-vnext/connector-event-ingress.test.ts
+++ b/packages/standalone/tests/operator-vnext/connector-event-ingress.test.ts
@@ -187,6 +187,63 @@ describe('STORY-VNEXT-PR6-CONNECTOR-INGRESS: connector event dry-run ingress', (
     db.close();
   });
 
+  it('does not renumber surviving connector events after earlier indexed rows are deleted', () => {
+    const db = makeOperatorVNextDb();
+    insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+    const deleted = insertRawEvent(db, { sourceId: 'msg-2', timestampMs: 1710000002000 });
+    const surviving = insertRawEvent(db, { sourceId: 'msg-3', timestampMs: 1710000003000 });
+    db.prepare('DELETE FROM connector_event_index WHERE event_index_id = ?').run(
+      deleted.event_index_id
+    );
+    db.prepare(
+      `INSERT INTO vnext_operator_cursors (
+        cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+      ) VALUES (?, ?, ?, ?)`
+    ).run(buildConnectorOperatorCursorName({ connector: 'slack', channel: 'C-ROLL' }), 1, null, 1);
+
+    const preview = buildConnectorEventIngressPreview({
+      rawAdapter: db,
+      operatorDb: db,
+      connector: 'slack',
+      channel: 'C-ROLL',
+    });
+
+    expect(preview.advancedThroughSeq).toBe(1);
+    expect(
+      preview.events.map((event) => ({ seq: event.seq, eventIndexId: event.eventIndexId }))
+    ).toEqual([{ seq: 3, eventIndexId: surviving.event_index_id }]);
+
+    db.close();
+  });
+
+  it('does not reuse deleted connector seqs for later indexed rows', () => {
+    const db = makeOperatorVNextDb();
+    insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+    const deleted = insertRawEvent(db, { sourceId: 'msg-2', timestampMs: 1710000002000 });
+    db.prepare('DELETE FROM connector_event_index WHERE event_index_id = ?').run(
+      deleted.event_index_id
+    );
+    const later = insertRawEvent(db, { sourceId: 'msg-3', timestampMs: 1710000003000 });
+    db.prepare(
+      `INSERT INTO vnext_operator_cursors (
+        cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+      ) VALUES (?, ?, ?, ?)`
+    ).run(buildConnectorOperatorCursorName({ connector: 'slack', channel: 'C-ROLL' }), 1, null, 1);
+
+    const preview = buildConnectorEventIngressPreview({
+      rawAdapter: db,
+      operatorDb: db,
+      connector: 'slack',
+      channel: 'C-ROLL',
+    });
+
+    expect(preview.advancedThroughSeq).toBe(1);
+    expect(preview.events.map((event) => event.seq)).toEqual([3]);
+    expect(preview.events.map((event) => event.eventIndexId)).toEqual([later.event_index_id]);
+
+    db.close();
+  });
+
   it('rejects broad connector previews unless a single explicit channel is supplied', () => {
     const db = makeOperatorVNextDb();
 

--- a/packages/standalone/tests/operator-vnext/connector-event-ingress.test.ts
+++ b/packages/standalone/tests/operator-vnext/connector-event-ingress.test.ts
@@ -149,6 +149,44 @@ describe('STORY-VNEXT-PR6-CONNECTOR-INGRESS: connector event dry-run ingress', (
     db.close();
   });
 
+  it('keeps late backfilled connector events behind the current cursor instead of renumbering them away', () => {
+    const db = makeOperatorVNextDb();
+    insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+    db.prepare(
+      `INSERT INTO vnext_operator_cursors (
+        cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+      ) VALUES (?, ?, ?, ?)`
+    ).run(buildConnectorOperatorCursorName({ connector: 'slack', channel: 'C-ROLL' }), 1, null, 1);
+    const lateBackfill = insertRawEvent(db, {
+      sourceId: 'msg-late-backfill',
+      timestampMs: 1710000000000,
+    });
+
+    const preview = buildConnectorEventIngressPreview({
+      rawAdapter: db,
+      operatorDb: db,
+      connector: 'slack',
+      channel: 'C-ROLL',
+    });
+
+    expect(preview.advancedThroughSeq).toBe(1);
+    expect(
+      preview.events.map((event) => ({
+        seq: event.seq,
+        eventIndexId: event.eventIndexId,
+        sourceTimestampMs: event.sourceTimestampMs,
+      }))
+    ).toEqual([
+      {
+        seq: 2,
+        eventIndexId: lateBackfill.event_index_id,
+        sourceTimestampMs: 1710000000000,
+      },
+    ]);
+
+    db.close();
+  });
+
   it('rejects broad connector previews unless a single explicit channel is supplied', () => {
     const db = makeOperatorVNextDb();
 

--- a/packages/standalone/tests/operator-vnext/connector-ingress-manual-commit.test.ts
+++ b/packages/standalone/tests/operator-vnext/connector-ingress-manual-commit.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, it } from 'vitest';
+
+process.env.MAMA_FORCE_TIER_3 ||= 'true';
+
+import { connectorEventIndexId } from '@jungjaehoon/mama-core/connectors/event-index';
+
+import {
+  commitConnectorIngressNoUpdateBatch,
+  createConnectorIngressManualNoUpdateCommitProvider,
+  type ConnectorIngressManualCommitInput,
+} from '../../src/operator-vnext/connector-ingress-manual-commit.js';
+import type { SQLiteDatabase } from '../../src/sqlite.js';
+import { countRows, makeOperatorVNextDb } from './fixtures.js';
+
+function insertRawEvent(
+  db: SQLiteDatabase,
+  overrides: {
+    connector?: string;
+    sourceId: string;
+    channel?: string;
+    timestampMs: number;
+  }
+): string {
+  const connector = overrides.connector ?? 'slack';
+  const channel = overrides.channel ?? 'C_PUBLIC_SYNTHETIC';
+  const eventIndexId = connectorEventIndexId(connector, overrides.sourceId);
+  db.prepare(
+    `INSERT INTO connector_event_index (
+      event_index_id, source_connector, source_type, source_id, source_locator,
+      channel, author, title, content, event_datetime, event_date, source_timestamp_ms,
+      metadata_json, content_hash, indexed_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    eventIndexId,
+    connector,
+    'message',
+    overrides.sourceId,
+    `${connector}:${channel}:${overrides.sourceId}`,
+    channel,
+    'synthetic-user',
+    null,
+    `synthetic public rollout event ${overrides.sourceId}`,
+    overrides.timestampMs,
+    new Date(overrides.timestampMs).toISOString().slice(0, 10),
+    overrides.timestampMs,
+    JSON.stringify({ synthetic: true }),
+    Buffer.alloc(32, 3),
+    '2026-07-03T00:00:00.000Z',
+    '2026-07-03T00:00:00.000Z'
+  );
+  return eventIndexId;
+}
+
+function makeInput(
+  db: SQLiteDatabase,
+  eventIndexIds: string[],
+  overrides: Partial<ConnectorIngressManualCommitInput> = {}
+): ConnectorIngressManualCommitInput {
+  return {
+    rawAdapter: db,
+    operatorDb: db,
+    connector: 'slack',
+    channel: 'C_PUBLIC_SYNTHETIC',
+    expectedAdvancedThroughSeq: 0,
+    eventIndexIds,
+    nowMs: () => 1710000000000,
+    ...overrides,
+  };
+}
+
+function cursorRow(db: SQLiteDatabase) {
+  return db
+    .prepare(
+      `SELECT cursor_name, last_change_seq, last_idempotency_key
+       FROM vnext_operator_cursors
+       WHERE cursor_name = ?`
+    )
+    .get('connector:slack:channel:C_PUBLIC_SYNTHETIC');
+}
+
+describe('STORY-VNEXT-PR10-MANUAL-INGRESS: connector ingress manual no-update commit', () => {
+  describe('AC: reviewed no-update batches advance only the connector/channel cursor', () => {
+    it('commits reviewed connector events as no-updates without exposing raw connector content', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const second = insertRawEvent(db, { sourceId: 'msg-2', timestampMs: 1710000002000 });
+
+      const result = await commitConnectorIngressNoUpdateBatch(makeInput(db, [first, second]));
+
+      expect(result).toEqual({
+        ok: true,
+        mode: 'manual_no_update_commit',
+        status: 'committed',
+        cursorName: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        connector: 'slack',
+        channel: 'C_PUBLIC_SYNTHETIC',
+        requestedCount: 2,
+        processed: 2,
+        advancedThroughSeq: 2,
+        firstSeq: 1,
+        lastSeq: 2,
+        commits: [
+          { seq: 1, status: 'no_update', outcome: 'committed', cursorAdvanced: true },
+          { seq: 2, status: 'no_update', outcome: 'committed', cursorAdvanced: true },
+        ],
+      });
+      expect(JSON.stringify(result)).not.toContain('synthetic public rollout event');
+      expect(JSON.stringify(result)).not.toContain('synthetic-user');
+      expect(JSON.stringify(result)).not.toContain('metadata_json');
+      expect(cursorRow(db)).toEqual({
+        cursor_name: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        last_change_seq: 2,
+        last_idempotency_key: 'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:2-2',
+      });
+      expect(countRows(db, 'vnext_operator_commits')).toBe(2);
+      expect(countRows(db, 'operator_no_updates')).toBe(2);
+      expect(db.prepare('SELECT DISTINCT status FROM vnext_operator_commits').all()).toEqual([
+        { status: 'no_update' },
+      ]);
+
+      db.close();
+    });
+
+    it('replays duplicate reviewed batches idempotently without inserting duplicate rows', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const second = insertRawEvent(db, { sourceId: 'msg-2', timestampMs: 1710000002000 });
+      const input = makeInput(db, [first, second]);
+
+      await commitConnectorIngressNoUpdateBatch(input);
+      const replay = await commitConnectorIngressNoUpdateBatch(input);
+
+      expect(replay).toMatchObject({
+        ok: true,
+        status: 'committed',
+        requestedCount: 2,
+        processed: 2,
+        advancedThroughSeq: 2,
+        commits: [
+          { seq: 1, outcome: 'already_committed', cursorAdvanced: false },
+          { seq: 2, outcome: 'already_committed', cursorAdvanced: false },
+        ],
+      });
+      expect(countRows(db, 'vnext_operator_commits')).toBe(2);
+      expect(countRows(db, 'operator_no_updates')).toBe(2);
+
+      db.close();
+    });
+
+    it('rejects concurrent stale reviewed batches after revalidating under the cursor lock', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const second = insertRawEvent(db, { sourceId: 'msg-2', timestampMs: 1710000002000 });
+
+      const firstCommit = commitConnectorIngressNoUpdateBatch(makeInput(db, [first]));
+      const staleBatch = commitConnectorIngressNoUpdateBatch(makeInput(db, [first, second]));
+
+      await expect(firstCommit).resolves.toMatchObject({
+        status: 'committed',
+        processed: 1,
+        advancedThroughSeq: 1,
+      });
+      await expect(staleBatch).rejects.toThrow(/stale/i);
+      expect(cursorRow(db)).toEqual({
+        cursor_name: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        last_change_seq: 1,
+        last_idempotency_key: 'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:1-1',
+      });
+      expect(countRows(db, 'vnext_operator_commits')).toBe(1);
+      expect(countRows(db, 'operator_no_updates')).toBe(1);
+
+      db.close();
+    });
+
+    it('does not report a stale changed commit as a manual no-update replay', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      db.prepare(
+        `INSERT INTO vnext_operator_cursors (
+          cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+        ) VALUES (?, ?, ?, ?)`
+      ).run(
+        'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        1,
+        'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:1-1',
+        1710000000000
+      );
+      db.prepare(
+        `INSERT INTO vnext_operator_commits (
+          commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+          status, changed_refs_json, source_refs_json, created_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        'commit:changed-existing',
+        'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:1-1',
+        1,
+        1,
+        'changed',
+        JSON.stringify(['os_task:synthetic-task']),
+        JSON.stringify([`raw:slack:${first}`]),
+        1710000000000
+      );
+
+      await expect(commitConnectorIngressNoUpdateBatch(makeInput(db, [first]))).rejects.toThrow(
+        /non-no-update/i
+      );
+      expect(countRows(db, 'operator_no_updates')).toBe(0);
+
+      db.close();
+    });
+  });
+
+  describe('AC: stale or unsafe commit requests fail closed', () => {
+    it('rejects reordered reviewed batches without durable writes', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const second = insertRawEvent(db, { sourceId: 'msg-2', timestampMs: 1710000002000 });
+      const lateBackfill = insertRawEvent(db, { sourceId: 'msg-0', timestampMs: 1710000000000 });
+
+      await expect(
+        commitConnectorIngressNoUpdateBatch(makeInput(db, [first, lateBackfill, second]))
+      ).rejects.toThrow(/reviewed event ids do not match/i);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(countRows(db, 'operator_no_updates')).toBe(0);
+      expect(countRows(db, 'vnext_operator_cursors')).toBe(0);
+
+      db.close();
+    });
+
+    it('uses cursor-scoped idempotency keys so connector seqs cannot collide across channels', async () => {
+      const db = makeOperatorVNextDb();
+      const publicEvent = insertRawEvent(db, {
+        sourceId: 'msg-public-1',
+        channel: 'C_PUBLIC_SYNTHETIC',
+        timestampMs: 1710000001000,
+      });
+      const otherEvent = insertRawEvent(db, {
+        sourceId: 'msg-other-1',
+        channel: 'C_OTHER_SYNTHETIC',
+        timestampMs: 1710000001000,
+      });
+
+      await commitConnectorIngressNoUpdateBatch(makeInput(db, [publicEvent]));
+      await commitConnectorIngressNoUpdateBatch(
+        makeInput(db, [otherEvent], { channel: 'C_OTHER_SYNTHETIC' })
+      );
+
+      const keys = db
+        .prepare('SELECT idempotency_key FROM vnext_operator_commits ORDER BY idempotency_key')
+        .all() as Array<{ idempotency_key: string }>;
+      expect(keys).toEqual([
+        { idempotency_key: 'cursor:connector:slack:channel:C_OTHER_SYNTHETIC:seq:1-1' },
+        { idempotency_key: 'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:1-1' },
+      ]);
+
+      db.close();
+    });
+
+    it('keeps a committed prefix when a later reviewed event cannot be committed', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const second = insertRawEvent(db, { sourceId: 'msg-2', timestampMs: 1710000002000 });
+      db.prepare(
+        `INSERT INTO vnext_operator_cursors (
+          cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+        ) VALUES (?, ?, ?, ?)`
+      ).run('connector:slack:channel:C_PUBLIC_SYNTHETIC', 0, null, 1710000000000);
+      db.prepare(
+        `INSERT INTO vnext_operator_commits (
+          commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+          status, changed_refs_json, source_refs_json, created_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        'commit:preexisting-conflict',
+        'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:2-2',
+        2,
+        2,
+        'no_update',
+        JSON.stringify([]),
+        JSON.stringify(['raw:slack:conflicting-synthetic-event']),
+        1710000000000
+      );
+
+      const result = await commitConnectorIngressNoUpdateBatch(makeInput(db, [first, second]));
+
+      expect(result).toMatchObject({
+        ok: false,
+        status: 'partial_failure',
+        requestedCount: 2,
+        processed: 1,
+        advancedThroughSeq: 1,
+        failedSeq: 2,
+        error: 'Manual no-update commit partially failed.',
+        commits: [{ seq: 1, status: 'no_update', outcome: 'committed', cursorAdvanced: true }],
+      });
+      expect(cursorRow(db)).toEqual({
+        cursor_name: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        last_change_seq: 1,
+        last_idempotency_key: 'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:1-1',
+      });
+      expect(
+        db
+          .prepare(
+            `SELECT idempotency_key, status
+             FROM vnext_operator_commits
+             WHERE cursor_name = ?
+             ORDER BY first_change_seq`
+          )
+          .all('connector:slack:channel:C_PUBLIC_SYNTHETIC')
+      ).toEqual([
+        {
+          idempotency_key: 'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:1-1',
+          status: 'no_update',
+        },
+        {
+          idempotency_key: 'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:2-2',
+          status: 'no_update',
+        },
+      ]);
+      expect(countRows(db, 'operator_no_updates')).toBe(1);
+
+      db.close();
+    });
+
+    it('creates a provider locked to one configured connector/channel', async () => {
+      const db = makeOperatorVNextDb();
+      const eventIndexId = insertRawEvent(db, {
+        sourceId: 'msg-public-1',
+        channel: 'C_PUBLIC_SYNTHETIC',
+        timestampMs: 1710000001000,
+      });
+      const provider = createConnectorIngressManualNoUpdateCommitProvider({
+        rawAdapter: db,
+        operatorDb: db,
+        connector: 'slack',
+        channel: 'C_PUBLIC_SYNTHETIC',
+        nowMs: () => 1710000000000,
+      });
+
+      await expect(
+        provider({
+          connector: 'slack',
+          channel: 'C_OTHER_SYNTHETIC',
+          expectedAdvancedThroughSeq: 0,
+          eventIndexIds: [eventIndexId],
+        })
+      ).rejects.toThrow(/configured connector\/channel/i);
+      const committed = await provider({
+        connector: 'slack',
+        channel: 'C_PUBLIC_SYNTHETIC',
+        expectedAdvancedThroughSeq: 0,
+        eventIndexIds: [eventIndexId],
+      });
+      expect(committed.status).toBe('committed');
+
+      db.close();
+    });
+  });
+});

--- a/packages/standalone/tests/operator-vnext/connector-ingress-manual-commit.test.ts
+++ b/packages/standalone/tests/operator-vnext/connector-ingress-manual-commit.test.ts
@@ -147,6 +147,39 @@ describe('STORY-VNEXT-PR10-MANUAL-INGRESS: connector ingress manual no-update co
       db.close();
     });
 
+    it('commits the next surviving indexed event without requiring rowid-contiguous seqs', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const deleted = insertRawEvent(db, { sourceId: 'msg-2', timestampMs: 1710000002000 });
+      const surviving = insertRawEvent(db, { sourceId: 'msg-3', timestampMs: 1710000003000 });
+
+      await commitConnectorIngressNoUpdateBatch(makeInput(db, [first]));
+      db.prepare('DELETE FROM connector_event_index WHERE event_index_id = ?').run(deleted);
+
+      const result = await commitConnectorIngressNoUpdateBatch(
+        makeInput(db, [surviving], { expectedAdvancedThroughSeq: 1 })
+      );
+
+      expect(result).toMatchObject({
+        ok: true,
+        status: 'committed',
+        processed: 1,
+        advancedThroughSeq: 3,
+        firstSeq: 3,
+        lastSeq: 3,
+        commits: [{ seq: 3, outcome: 'committed', cursorAdvanced: true }],
+      });
+      expect(cursorRow(db)).toEqual({
+        cursor_name: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        last_change_seq: 3,
+        last_idempotency_key: 'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:3-3',
+      });
+      expect(countRows(db, 'vnext_operator_commits')).toBe(2);
+      expect(countRows(db, 'operator_no_updates')).toBe(2);
+
+      db.close();
+    });
+
     it('rejects concurrent stale reviewed batches after revalidating under the cursor lock', async () => {
       const db = makeOperatorVNextDb();
       const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
@@ -221,6 +254,22 @@ describe('STORY-VNEXT-PR10-MANUAL-INGRESS: connector ingress manual no-update co
       await expect(
         commitConnectorIngressNoUpdateBatch(makeInput(db, [first, lateBackfill, second]))
       ).rejects.toThrow(/reviewed event ids do not match/i);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(countRows(db, 'operator_no_updates')).toBe(0);
+      expect(countRows(db, 'vnext_operator_cursors')).toBe(0);
+
+      db.close();
+    });
+
+    it('rejects reviewed batches that skip a surviving connector event in the cursor range', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      insertRawEvent(db, { sourceId: 'msg-2', timestampMs: 1710000002000 });
+      const third = insertRawEvent(db, { sourceId: 'msg-3', timestampMs: 1710000003000 });
+
+      await expect(
+        commitConnectorIngressNoUpdateBatch(makeInput(db, [first, third]))
+      ).rejects.toThrow(/cover the current connector cursor range/i);
       expect(countRows(db, 'vnext_operator_commits')).toBe(0);
       expect(countRows(db, 'operator_no_updates')).toBe(0);
       expect(countRows(db, 'vnext_operator_cursors')).toBe(0);

--- a/packages/standalone/tests/operator-vnext/fixtures.ts
+++ b/packages/standalone/tests/operator-vnext/fixtures.ts
@@ -6,7 +6,7 @@ export function makeOperatorVNextDb(): SQLiteDatabase {
   const db = new Database(':memory:');
   db.pragma('foreign_keys = ON');
   // The standalone SQLite wrapper exposes the migration helper's required better-sqlite3 surface.
-  applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 38);
+  applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 39);
   return db;
 }
 

--- a/packages/standalone/tests/operator-vnext/primary-operator-runtime.test.ts
+++ b/packages/standalone/tests/operator-vnext/primary-operator-runtime.test.ts
@@ -329,7 +329,7 @@ describe('STORY-VNEXT-PR2-PRIMARY-OPERATOR: primary operator commit shell', () =
       ).run(
         'commit-orphaned',
         'connector:slack',
-        'connector:slack:seq:1-1',
+        'cursor:connector:slack:seq:1-1',
         1,
         1,
         'changed',
@@ -379,7 +379,7 @@ describe('STORY-VNEXT-PR2-PRIMARY-OPERATOR: primary operator commit shell', () =
       ).run(
         'commit-orphaned',
         'connector:slack',
-        'connector:slack:seq:1-1',
+        'cursor:connector:slack:seq:1-1',
         1,
         1,
         'changed',

--- a/packages/standalone/tests/operator-vnext/primary-operator-runtime.test.ts
+++ b/packages/standalone/tests/operator-vnext/primary-operator-runtime.test.ts
@@ -364,6 +364,59 @@ describe('STORY-VNEXT-PR2-PRIMARY-OPERATOR: primary operator commit shell', () =
       db.close();
     });
 
+    it('recovers legacy connector-scoped idempotency keys before invoking the decider', async () => {
+      const db = makeOperatorVNextDb();
+      db.prepare(
+        `INSERT INTO vnext_operator_cursors (
+          cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+        ) VALUES (?, ?, ?, ?)`
+      ).run('connector:slack', 0, null, 1710000000000);
+      db.prepare(
+        `INSERT INTO vnext_operator_commits (
+          commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+          status, changed_refs_json, source_refs_json, created_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        'commit-legacy-key',
+        'connector:slack',
+        'connector:slack:seq:1-1',
+        1,
+        1,
+        'changed',
+        '["os_task:task-1"]',
+        '["raw:slack:event-1"]',
+        1710000000000
+      );
+      const runtime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000001,
+      });
+      const decide = vi.fn(() => {
+        throw new Error('decider must not run');
+      });
+
+      const result = await runtime.processBatch(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } }],
+        decide
+      );
+
+      expect(result).toMatchObject({
+        status: 'committed',
+        processed: 1,
+        advancedThroughSeq: 1,
+      });
+      expect(result.commits[0]).toMatchObject({
+        outcome: 'recovered',
+        idempotencyKey: 'connector:slack:seq:1-1',
+      });
+      expect(decide).not.toHaveBeenCalled();
+      expect(lastCursorSeq(db)).toBe(1);
+
+      db.close();
+    });
+
     it('rejects recovered commits with mismatched raw source provenance before invoking the decider', async () => {
       const db = makeOperatorVNextDb();
       db.prepare(

--- a/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
+++ b/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
@@ -12,6 +12,10 @@ import {
   buildConnectorEventIngressPreview,
   createConnectorEventIngressPreviewProvider,
 } from '../../src/operator-vnext/connector-event-ingress.js';
+import {
+  commitConnectorIngressNoUpdateBatch,
+  createConnectorIngressManualNoUpdateCommitProvider,
+} from '../../src/operator-vnext/connector-ingress-manual-commit.js';
 import { createConnectorIngressMigrationDryRunProvider } from '../../src/operator-vnext/connector-ingress-migration-dry-run.js';
 import { ensureVNextOperatorSchema } from '../../src/operator-vnext/schema.js';
 import {
@@ -23,6 +27,8 @@ import Database, { type SQLiteDatabase } from '../../src/sqlite.js';
 import { isVNextWikiPublishAdapter } from '../../src/wiki-artifacts/wiki-publish-adapter.js';
 
 const AUTH_TOKEN_ENV = 'MAMA_AUTH_TOKEN';
+const ADMIN_TOKEN_ENV = 'MAMA_ADMIN_TOKEN';
+const LOCAL_PATH_PREFIX = ['', 'Users', ''].join('/');
 
 function makeStatus(): VNextBootstrapRuntimeStatus {
   return {
@@ -50,7 +56,13 @@ function makeStatus(): VNextBootstrapRuntimeStatus {
   };
 }
 
-function insertRawEvent(db: SQLiteDatabase, sourceId: string): string {
+function insertRawEvent(
+  db: SQLiteDatabase,
+  sourceId: string,
+  options: { channel?: string; timestampMs?: number } = {}
+): string {
+  const channel = options.channel ?? 'C-ROLL';
+  const timestampMs = options.timestampMs ?? 1710000001000;
   const eventIndexId = connectorEventIndexId('slack', sourceId);
   db.prepare(
     `INSERT INTO connector_event_index (
@@ -63,14 +75,14 @@ function insertRawEvent(db: SQLiteDatabase, sourceId: string): string {
     'slack',
     'message',
     sourceId,
-    `slack:C-ROLL:${sourceId}`,
-    'C-ROLL',
+    `slack:${channel}:${sourceId}`,
+    channel,
     'synthetic-user',
     null,
     `synthetic public rollout event ${sourceId}`,
-    1710000001000,
+    timestampMs,
     '2026-03-09',
-    1710000001000,
+    timestampMs,
     JSON.stringify({ synthetic: true }),
     Buffer.alloc(32, 2),
     '2026-07-02T00:00:00.000Z',
@@ -81,12 +93,18 @@ function insertRawEvent(db: SQLiteDatabase, sourceId: string): string {
 
 describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
   const originalAuthToken = process.env[AUTH_TOKEN_ENV];
+  const originalAdminToken = process.env[ADMIN_TOKEN_ENV];
 
   afterEach(() => {
     if (originalAuthToken === undefined) {
       delete process.env[AUTH_TOKEN_ENV];
     } else {
       process.env[AUTH_TOKEN_ENV] = originalAuthToken;
+    }
+    if (originalAdminToken === undefined) {
+      delete process.env[ADMIN_TOKEN_ENV];
+    } else {
+      process.env[ADMIN_TOKEN_ENV] = originalAdminToken;
     }
   });
 
@@ -544,6 +562,397 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
       }
 
       db.close();
+    });
+
+    it('requires admin auth for manual no-update ingress commits', async () => {
+      process.env[AUTH_TOKEN_ENV] = 'vnext-status-token';
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      const db = new Database(':memory:');
+      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 38);
+      const eventIndexId = insertRawEvent(db, 'msg-1', { channel: 'C_PUBLIC_SYNTHETIC' });
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualNoUpdateCommitProvider: (input) =>
+          commitConnectorIngressNoUpdateBatch({
+            rawAdapter: db,
+            operatorDb: db,
+            ...input,
+            nowMs: () => 1710000000000,
+          }),
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-no-update-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-status-token')
+        .send({
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_index_ids: [eventIndexId],
+        });
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        error: true,
+        code: 'UNAUTHORIZED',
+      });
+      expect(db.prepare('SELECT COUNT(*) AS count FROM vnext_operator_commits').get()).toEqual({
+        count: 0,
+      });
+
+      db.close();
+    });
+
+    it('fails closed when admin auth is not configured for manual no-update ingress commits', async () => {
+      delete process.env[ADMIN_TOKEN_ENV];
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualNoUpdateCommitProvider: () => {
+          throw new Error('provider must not run without admin auth');
+        },
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-no-update-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .send({
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_index_ids: ['synthetic-event-index-id'],
+        });
+
+      expect(response.status).toBe(503);
+      expect(response.body).toMatchObject({
+        error: true,
+        code: 'admin_token_required',
+      });
+    });
+
+    it('requires admin auth before parsing malformed manual commit JSON bodies', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualNoUpdateCommitProvider: () => {
+          throw new Error('provider must not run for unauthorized malformed JSON');
+        },
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-no-update-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('content-type', 'application/json')
+        .send('{');
+
+      expect(response.status).toBe(401);
+      expect(response.type).toBe('application/json');
+      expect(JSON.stringify(response.body)).not.toContain(LOCAL_PATH_PREFIX);
+    });
+
+    it('sanitizes malformed manual commit JSON after admin auth succeeds', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualNoUpdateCommitProvider: () => {
+          throw new Error('provider must not run for malformed JSON');
+        },
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-no-update-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .set('content-type', 'application/json')
+        .send('{');
+
+      expect(response.status).toBe(400);
+      expect(response.type).toBe('application/json');
+      expect(response.body).toEqual({
+        ok: false,
+        code: 'vnext_ingress_manual_commit_invalid_json',
+        error: 'Invalid JSON request body.',
+      });
+      expect(JSON.stringify(response.body)).not.toContain(LOCAL_PATH_PREFIX);
+    });
+
+    it('serves admin-only manual no-update ingress commits with an allowlisted payload', async () => {
+      process.env[AUTH_TOKEN_ENV] = 'vnext-status-token';
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      const db = new Database(':memory:');
+      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 38);
+      const eventIndexId = insertRawEvent(db, 'msg-1', { channel: 'C_PUBLIC_SYNTHETIC' });
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualNoUpdateCommitProvider: (input) =>
+          commitConnectorIngressNoUpdateBatch({
+            rawAdapter: db,
+            operatorDb: db,
+            ...input,
+            nowMs: () => 1710000000000,
+          }),
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-no-update-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send({
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_index_ids: [eventIndexId],
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        ok: true,
+        mode: 'manual_no_update_commit',
+        status: 'committed',
+        cursorName: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        connector: 'slack',
+        channel: 'C_PUBLIC_SYNTHETIC',
+        requestedCount: 1,
+        processed: 1,
+        advancedThroughSeq: 1,
+        firstSeq: 1,
+        lastSeq: 1,
+        commits: [{ seq: 1, status: 'no_update', outcome: 'committed', cursorAdvanced: true }],
+      });
+      expect(JSON.stringify(response.body)).not.toContain('synthetic public rollout event');
+      expect(JSON.stringify(response.body)).not.toContain('synthetic-user');
+      expect(JSON.stringify(response.body)).not.toContain('author');
+      expect(JSON.stringify(response.body)).not.toContain('title');
+      expect(JSON.stringify(response.body)).not.toContain('metadata_json');
+      expect(JSON.stringify(response.body)).not.toContain('source_locator');
+      expect(JSON.stringify(response.body)).not.toContain('artifact_locator');
+      expect(JSON.stringify(response.body)).not.toContain('source_cursor');
+      expect(JSON.stringify(response.body)).not.toContain(LOCAL_PATH_PREFIX);
+      expect(db.prepare('SELECT DISTINCT status FROM vnext_operator_commits').all()).toEqual([
+        { status: 'no_update' },
+      ]);
+
+      db.close();
+    });
+
+    it('rejects manual no-update ingress commit requests that try to supply changed refs', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      const db = new Database(':memory:');
+      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 38);
+      const eventIndexId = insertRawEvent(db, 'msg-1', { channel: 'C_PUBLIC_SYNTHETIC' });
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualNoUpdateCommitProvider: (input) =>
+          commitConnectorIngressNoUpdateBatch({
+            rawAdapter: db,
+            operatorDb: db,
+            ...input,
+            nowMs: () => 1710000000000,
+          }),
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-no-update-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send({
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_index_ids: [eventIndexId],
+          changedRefs: [{ kind: 'os_task', id: 'task-should-not-be-accepted' }],
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'vnext_ingress_manual_commit_invalid_request',
+      });
+      expect(db.prepare('SELECT COUNT(*) AS count FROM vnext_operator_commits').get()).toEqual({
+        count: 0,
+      });
+
+      db.close();
+    });
+
+    it('rejects manual no-update ingress commits for the wrong configured channel', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      const db = new Database(':memory:');
+      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 38);
+      const eventIndexId = insertRawEvent(db, 'msg-1', { channel: 'C_PUBLIC_SYNTHETIC' });
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualNoUpdateCommitProvider: createConnectorIngressManualNoUpdateCommitProvider({
+          rawAdapter: db,
+          operatorDb: db,
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          nowMs: () => 1710000000000,
+        }),
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-no-update-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send({
+          connector: 'slack',
+          channel: 'C_OTHER_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_index_ids: [eventIndexId],
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'vnext_ingress_manual_commit_invalid_request',
+      });
+      expect(db.prepare('SELECT COUNT(*) AS count FROM vnext_operator_commits').get()).toEqual({
+        count: 0,
+      });
+
+      db.close();
+    });
+
+    it('rejects unbounded manual no-update ingress commit batches before provider execution', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualNoUpdateCommitProvider: () => {
+          throw new Error('provider must not run for unbounded batches');
+        },
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-no-update-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send({
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_index_ids: Array.from({ length: 101 }, (_, index) => `synthetic-event-${index}`),
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'vnext_ingress_manual_commit_invalid_request',
+        error: 'event_index_ids must contain at most 100 items',
+      });
+    });
+
+    it('sanitizes unexpected manual no-update ingress commit failures', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualNoUpdateCommitProvider: () => {
+          throw new Error('cursor backend failed with synthetic-error-marker');
+        },
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-no-update-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send({
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_index_ids: ['synthetic-event-index-id'],
+        });
+
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({
+        ok: false,
+        code: 'vnext_ingress_manual_commit_failed',
+        error: 'vNext manual ingress commit failed.',
+      });
+      expect(JSON.stringify(response.body)).not.toContain('cursor backend');
+      expect(JSON.stringify(response.body)).not.toContain('synthetic-error-marker');
+    });
+
+    it('returns conflict with a safe payload when a manual no-update commit partially fails', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      const db = new Database(':memory:');
+      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 38);
+      const first = insertRawEvent(db, 'msg-1', {
+        channel: 'C_PUBLIC_SYNTHETIC',
+        timestampMs: 1710000001000,
+      });
+      const second = insertRawEvent(db, 'msg-2', {
+        channel: 'C_PUBLIC_SYNTHETIC',
+        timestampMs: 1710000002000,
+      });
+      db.prepare(
+        `INSERT INTO vnext_operator_cursors (
+          cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+        ) VALUES (?, ?, ?, ?)`
+      ).run('connector:slack:channel:C_PUBLIC_SYNTHETIC', 0, null, 1710000000000);
+      db.prepare(
+        `INSERT INTO vnext_operator_commits (
+          commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+          status, changed_refs_json, source_refs_json, created_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        'commit:preexisting-conflict',
+        'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:2-2',
+        2,
+        2,
+        'no_update',
+        JSON.stringify([]),
+        JSON.stringify(['raw:slack:conflicting-synthetic-event']),
+        1710000000000
+      );
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualNoUpdateCommitProvider: (input) =>
+          commitConnectorIngressNoUpdateBatch({
+            rawAdapter: db,
+            operatorDb: db,
+            ...input,
+            nowMs: () => 1710000000000,
+          }),
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-no-update-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send({
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_index_ids: [first, second],
+        });
+
+      expect(response.status).toBe(409);
+      expect(response.body).toMatchObject({
+        ok: false,
+        mode: 'manual_no_update_commit',
+        status: 'partial_failure',
+        processed: 1,
+        advancedThroughSeq: 1,
+        failedSeq: 2,
+        error: 'Manual no-update commit partially failed.',
+      });
+      expect(JSON.stringify(response.body)).not.toContain('source refs');
+      expect(JSON.stringify(response.body)).not.toContain(LOCAL_PATH_PREFIX);
+
+      db.close();
+    });
+
+    it('rejects manual no-update ingress commits when the provider is not configured', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      const apiServer = createVNextBootstrapApiServer(makeStatus());
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-no-update-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send({
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_index_ids: ['event_missing_provider'],
+        });
+
+      expect(response.status).toBe(404);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'vnext_ingress_manual_commit_unavailable',
+      });
     });
   });
 });

--- a/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
+++ b/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
@@ -81,7 +81,7 @@ function insertRawEvent(
     null,
     `synthetic public rollout event ${sourceId}`,
     timestampMs,
-    '2026-03-09',
+    new Date(timestampMs).toISOString().slice(0, 10),
     timestampMs,
     JSON.stringify({ synthetic: true }),
     Buffer.alloc(32, 2),
@@ -376,7 +376,7 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
     it('serves authenticated dry-run connector ingress previews without committing', async () => {
       process.env[AUTH_TOKEN_ENV] = 'vnext-status-token';
       const db = new Database(':memory:');
-      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 38);
+      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 39);
       const eventIndexId = insertRawEvent(db, 'msg-1');
       const apiServer = createVNextBootstrapApiServer(makeStatus(), {
         ingressPreviewProvider: (input) =>
@@ -471,7 +471,7 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
     it('serves authenticated connector ingress migration dry-run reports without committing', async () => {
       process.env[AUTH_TOKEN_ENV] = 'vnext-status-token';
       const db = new Database(':memory:');
-      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 38);
+      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 39);
       const eventIndexId = insertRawEvent(db, 'msg-1');
       const apiServer = createVNextBootstrapApiServer(makeStatus(), {
         ingressMigrationDryRunProvider: createConnectorIngressMigrationDryRunProvider({
@@ -568,7 +568,7 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
       process.env[AUTH_TOKEN_ENV] = 'vnext-status-token';
       process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
       const db = new Database(':memory:');
-      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 38);
+      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 39);
       const eventIndexId = insertRawEvent(db, 'msg-1', { channel: 'C_PUBLIC_SYNTHETIC' });
       const apiServer = createVNextBootstrapApiServer(makeStatus(), {
         ingressManualNoUpdateCommitProvider: (input) =>
@@ -676,7 +676,7 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
       process.env[AUTH_TOKEN_ENV] = 'vnext-status-token';
       process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
       const db = new Database(':memory:');
-      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 38);
+      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 39);
       const eventIndexId = insertRawEvent(db, 'msg-1', { channel: 'C_PUBLIC_SYNTHETIC' });
       const apiServer = createVNextBootstrapApiServer(makeStatus(), {
         ingressManualNoUpdateCommitProvider: (input) =>
@@ -733,7 +733,7 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
     it('rejects manual no-update ingress commit requests that try to supply changed refs', async () => {
       process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
       const db = new Database(':memory:');
-      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 38);
+      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 39);
       const eventIndexId = insertRawEvent(db, 'msg-1', { channel: 'C_PUBLIC_SYNTHETIC' });
       const apiServer = createVNextBootstrapApiServer(makeStatus(), {
         ingressManualNoUpdateCommitProvider: (input) =>
@@ -772,7 +772,7 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
     it('rejects manual no-update ingress commits for the wrong configured channel', async () => {
       process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
       const db = new Database(':memory:');
-      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 38);
+      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 39);
       const eventIndexId = insertRawEvent(db, 'msg-1', { channel: 'C_PUBLIC_SYNTHETIC' });
       const apiServer = createVNextBootstrapApiServer(makeStatus(), {
         ingressManualNoUpdateCommitProvider: createConnectorIngressManualNoUpdateCommitProvider({
@@ -866,7 +866,7 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
     it('returns conflict with a safe payload when a manual no-update commit partially fails', async () => {
       process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
       const db = new Database(':memory:');
-      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 38);
+      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 39);
       const first = insertRawEvent(db, 'msg-1', {
         channel: 'C_PUBLIC_SYNTHETIC',
         timestampMs: 1710000001000,

--- a/packages/standalone/tests/runtime-vnext/legacy-fanout-disabled.test.ts
+++ b/packages/standalone/tests/runtime-vnext/legacy-fanout-disabled.test.ts
@@ -3,11 +3,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import request from 'supertest';
 
 import { AgentLoop } from '../../src/agent/index.js';
 import { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
 import { createApiServer } from '../../src/api/index.js';
 import { OAuthManager } from '../../src/auth/index.js';
+import { createVNextBootstrapApiServer } from '../../src/cli/commands/start.js';
 import { MessageRouter } from '../../src/gateways/index.js';
 import { SessionStore } from '../../src/gateways/session-store.js';
 import { AgentEventBus } from '../../src/multi-agent/agent-event-bus.js';
@@ -17,7 +19,12 @@ import type { MAMAConfig } from '../../src/cli/config/types.js';
 import { registerApiRoutes } from '../../src/cli/runtime/api-routes-init.js';
 import { initConnectors } from '../../src/cli/runtime/connector-init.js';
 import { initCronScheduler, initHeartbeat } from '../../src/cli/runtime/scheduler-init.js';
-import { buildVNextBootstrapPlan } from '../../src/runtime-vnext/bootstrap.js';
+import {
+  buildVNextBootstrapPlan,
+  type VNextBootstrapRuntimeStatus,
+} from '../../src/runtime-vnext/bootstrap.js';
+
+const ADMIN_TOKEN_ENV = 'MAMA_ADMIN_TOKEN';
 
 function makeConfig(overrides: Partial<MAMAConfig> = {}): MAMAConfig {
   return {
@@ -103,6 +110,25 @@ function makeVNextPlan() {
   });
 }
 
+function makeVNextStatus(): VNextBootstrapRuntimeStatus {
+  return {
+    enabled: true,
+    mode: 'bootstrap',
+    source: 'env',
+    startedAtMs: 1710000000000,
+    primaryOperator: {
+      kind: 'primary_operator',
+      status: 'prepared',
+      mode: 'manual_batch',
+      ingress: 'not_wired',
+      cursorName: 'operator:primary',
+      connector: 'manual',
+      advancedThroughSeq: 0,
+    },
+    executedStartupSteps: ['manual_status_endpoints'],
+  };
+}
+
 function makeOAuthManager(home: string): OAuthManager {
   return new OAuthManager({
     credentialsPath: join(home, '.claude', '.credentials.json'),
@@ -145,11 +171,13 @@ function makeAdapter() {
 describe('STORY-VNEXT-PR1-FANOUT-OFF: vNext disables legacy fanout', () => {
   let tempHome: string;
   let originalHome: string | undefined;
+  let originalAdminToken: string | undefined;
   let databases: SQLiteDatabase[];
 
   beforeEach(() => {
     tempHome = mkdtempSync(join(tmpdir(), 'mama-vnext-home-'));
     originalHome = process.env.HOME;
+    originalAdminToken = process.env[ADMIN_TOKEN_ENV];
     process.env.HOME = tempHome;
     databases = [];
   });
@@ -162,6 +190,11 @@ describe('STORY-VNEXT-PR1-FANOUT-OFF: vNext disables legacy fanout', () => {
       delete process.env.HOME;
     } else {
       process.env.HOME = originalHome;
+    }
+    if (originalAdminToken === undefined) {
+      delete process.env[ADMIN_TOKEN_ENV];
+    } else {
+      process.env[ADMIN_TOKEN_ENV] = originalAdminToken;
     }
     rmSync(tempHome, { recursive: true, force: true });
     vi.restoreAllMocks();
@@ -205,6 +238,57 @@ describe('STORY-VNEXT-PR1-FANOUT-OFF: vNext disables legacy fanout', () => {
         enabledConnectorNames: [],
         connectorSchedulerStop: undefined,
       });
+    });
+
+    it('does not start legacy fanout when the manual no-update commit endpoint is called', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      const messageRouterSpy = vi.spyOn(MessageRouter.prototype, 'process');
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+      const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+      const apiServer = createVNextBootstrapApiServer(makeVNextStatus(), {
+        ingressManualNoUpdateCommitProvider: async (input) => ({
+          ok: true,
+          mode: 'manual_no_update_commit',
+          status: 'committed',
+          cursorName: `connector:${input.connector}:channel:${input.channel}`,
+          connector: input.connector,
+          channel: input.channel,
+          requestedCount: input.eventIndexIds.length,
+          processed: input.eventIndexIds.length,
+          advancedThroughSeq: input.expectedAdvancedThroughSeq + input.eventIndexIds.length,
+          firstSeq: input.expectedAdvancedThroughSeq + 1,
+          lastSeq: input.expectedAdvancedThroughSeq + input.eventIndexIds.length,
+          commits: input.eventIndexIds.map((_, index) => ({
+            seq: input.expectedAdvancedThroughSeq + index + 1,
+            status: 'no_update',
+            outcome: 'committed',
+            cursorAdvanced: true,
+          })),
+        }),
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-no-update-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send({
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_index_ids: ['synthetic-event-index-id'],
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: true,
+        mode: 'manual_no_update_commit',
+        processed: 1,
+      });
+      expect(messageRouterSpy).not.toHaveBeenCalled();
+      expect(setTimeoutSpy).not.toHaveBeenCalledWith(expect.any(Function), 10_000);
+      expect(setTimeoutSpy).not.toHaveBeenCalledWith(expect.any(Function), 15_000);
+      expect(setTimeoutSpy).not.toHaveBeenCalledWith(expect.any(Function), 5 * 60 * 1000);
+      expect(setIntervalSpy).not.toHaveBeenCalled();
     });
 
     it('keeps cron loading active in legacy mode', () => {


### PR DESCRIPTION
## Summary

- Adds the admin-only manual no-update ingress commit endpoint for reviewed vNext connector events.
- Uses cursor-scoped idempotency for channel-safe commits while preserving recovery of legacy connector-scoped keys.
- Adds migration 039 with persisted connector/channel operator_ingest_seq so connector ingress cursors do not depend on row_number or rowid renumbering.
- Validates reviewed manual batches under the cursor lock and prevents skipping surviving connector rows.

## Review And Privacy Gate

- Gemini Code Assist reported no review comments on the initial PR review.
- CodeRabbit CLI review after fixes returned 0 issues.
- The GitHub CodeRabbit app hit a rate limit on the latest push; a PR comment records the CLI review result and the fixed review threads.
- Privacy/internal-info scan found no real secrets, local paths, or private project data. Token-like strings in the diff are synthetic test auth literals.

## Verification

- MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-core exec vitest run tests/cases/migration-chain.test.ts tests/connectors/connector-event-index-schema.test.ts
- MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run tests/operator-vnext/connector-event-ingress.test.ts tests/operator-vnext/connector-ingress-manual-commit.test.ts tests/operator-vnext/primary-operator-runtime.test.ts tests/runtime-vnext/bootstrap-api.test.ts
- pnpm typecheck
- pnpm build
- git diff --check
- ./scripts/check-pii.sh
- MAMA_FORCE_TIER_3=true pnpm test: 238 files, 3353 passed, 1 skipped
- pre-commit hook on fa3a9268: gitleaks, doc version sync, typecheck, changed package tests