### PR TITLE
feat: add vNext atomic changed operator commits

### DIFF
--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -789,23 +789,33 @@ export function createVNextPrimaryOperatorRuntime(
   const status = buildVNextPrimaryOperatorReadyStatus(
     readVNextPrimaryOperatorCursorSeq(db, VNEXT_PRIMARY_OPERATOR_CURSOR_NAME)
   );
+  const sanitizeBatchErrorForStatus = (): string =>
+    'Primary operator batch failed. Check local logs for details.';
+  const applyBatchResult = (result: Awaited<ReturnType<typeof runtime.processBatch>>): void => {
+    status.advancedThroughSeq = result.advancedThroughSeq;
+    status.lastBatchStatus = result.status;
+    if (result.status === 'partial_failure') {
+      status.status = 'degraded';
+      status.failedSeq = result.failedSeq;
+      status.errorMessage = sanitizeBatchErrorForStatus();
+    } else if (result.status === 'committed') {
+      status.status = 'prepared';
+      delete status.failedSeq;
+      delete status.errorMessage;
+    }
+  };
 
   return {
     status,
     wikiPublishAdapter: options.wikiPublishAdapter ?? null,
     processBatch: async (events, decide) => {
       const result = await runtime.processBatch(events, decide);
-      status.advancedThroughSeq = result.advancedThroughSeq;
-      status.lastBatchStatus = result.status;
-      if (result.status === 'partial_failure') {
-        status.status = 'degraded';
-        status.failedSeq = result.failedSeq;
-        status.errorMessage = result.error.message;
-      } else if (result.status === 'committed') {
-        status.status = 'prepared';
-        delete status.failedSeq;
-        delete status.errorMessage;
-      }
+      applyBatchResult(result);
+      return result;
+    },
+    processBatchWithChangedCommit: async (events, decide, commitChanged) => {
+      const result = await runtime.processBatchWithChangedCommit(events, decide, commitChanged);
+      applyBatchResult(result);
       return result;
     },
   };

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -120,6 +120,7 @@ const { DebugLogger } = debugLogger as unknown as {
   };
 };
 const codeActLogger = new DebugLogger('CodeAct');
+const vNextOperatorLogger = new DebugLogger('VNextPrimaryOperator');
 type RuntimeBackend = 'claude' | 'codex' | 'codex-mcp';
 const TRUTHY_ENV_VALUES = new Set(['1', 'true', 'yes', 'on']);
 const CODE_ACT_MUTATION_TOOLS = new Set([
@@ -795,6 +796,10 @@ export function createVNextPrimaryOperatorRuntime(
     status.advancedThroughSeq = result.advancedThroughSeq;
     status.lastBatchStatus = result.status;
     if (result.status === 'partial_failure') {
+      vNextOperatorLogger.warn('Primary operator batch failed', {
+        failedSeq: result.failedSeq,
+        error: result.error.message,
+      });
       status.status = 'degraded';
       status.failedSeq = result.failedSeq;
       status.errorMessage = sanitizeBatchErrorForStatus();

--- a/packages/standalone/src/operator-vnext/operator-commit-result.ts
+++ b/packages/standalone/src/operator-vnext/operator-commit-result.ts
@@ -23,6 +23,19 @@ export interface OperatorCursorCommitInput {
   allowSeqGaps?: boolean;
 }
 
+export interface OperatorChangedCursorCommitInput {
+  commitId?: string;
+  cursorName: string;
+  firstChangeSeq: number;
+  lastChangeSeq: number;
+  idempotencyKey: string;
+  fallbackIdempotencyKeys?: readonly string[];
+  sourceRefs: readonly SourceRef[];
+  writeChangedLedger: () => readonly SourceRef[];
+  nowMs?: number;
+  allowSeqGaps?: boolean;
+}
+
 export interface OperatorCursorCommitResult {
   outcome: OperatorCommitOutcome;
   commitId: string;

--- a/packages/standalone/src/operator-vnext/operator-commit-result.ts
+++ b/packages/standalone/src/operator-vnext/operator-commit-result.ts
@@ -31,7 +31,7 @@ export interface OperatorChangedCursorCommitInput {
   idempotencyKey: string;
   fallbackIdempotencyKeys?: readonly string[];
   sourceRefs: readonly SourceRef[];
-  writeChangedLedger: () => readonly SourceRef[];
+  writeChangedLedger: (input: { idempotencyKey: string }) => readonly SourceRef[];
   nowMs?: number;
   allowSeqGaps?: boolean;
 }

--- a/packages/standalone/src/operator-vnext/operator-cursor-commit.ts
+++ b/packages/standalone/src/operator-vnext/operator-cursor-commit.ts
@@ -3,6 +3,7 @@ import type { SourceRef } from '@jungjaehoon/mama-core/provenance/source-ref';
 import type { SQLiteDatabase } from '../sqlite.js';
 import { recordNoUpdate, serializeRequiredSourceRefs } from './no-update-ledger.js';
 import type {
+  OperatorChangedCursorCommitInput,
   OperatorCommitStatus,
   OperatorCursorCommitInput,
   OperatorCursorCommitResult,
@@ -39,10 +40,13 @@ interface NormalizedNoUpdateCommit {
   reason: string;
 }
 
+let changedReplaySavepointSeq = 0;
+
 export interface ExistingOperatorCursorCommitInput {
   cursorName: string;
   idempotencyKey: string;
   fallbackIdempotencyKeys?: readonly string[];
+  statusFilter?: readonly OperatorCommitStatus[];
   sourceRefs: readonly SourceRef[];
   nowMs?: number;
   allowSeqGaps?: boolean;
@@ -243,6 +247,89 @@ function resultFromExistingCommit(
   return resultFromStoredCommit(db, cursor, existing, nowMs, allowSeqGaps);
 }
 
+function resultFromExistingChangedWriteCommit(
+  db: SQLiteDatabase,
+  cursor: CursorRow,
+  existing: CommitRow,
+  expected: {
+    firstChangeSeq: number;
+    lastChangeSeq: number;
+    changedRefsJson: string;
+    sourceRefsJson: string;
+  },
+  nowMs: number,
+  allowSeqGaps: boolean
+): OperatorCursorCommitResult {
+  if (existing.changed_refs_json !== expected.changedRefsJson) {
+    throw new Error('Idempotency key replay changed refs do not match the durable changed writer');
+  }
+
+  return resultFromStoredCommit(db, cursor, existing, nowMs, allowSeqGaps);
+}
+
+function assertExistingChangedWriteCommitMetadata(
+  cursor: CursorRow,
+  existing: CommitRow,
+  expected: {
+    firstChangeSeq: number;
+    lastChangeSeq: number;
+    sourceRefsJson: string;
+  }
+): void {
+  if (existing.cursor_name !== cursor.cursor_name) {
+    throw new Error(`Idempotency key belongs to a different cursor: ${existing.cursor_name}`);
+  }
+  if (
+    existing.status !== 'changed' ||
+    existing.first_change_seq !== expected.firstChangeSeq ||
+    existing.last_change_seq !== expected.lastChangeSeq ||
+    existing.source_refs_json !== expected.sourceRefsJson
+  ) {
+    throw new Error('Idempotency key replay does not match the original changed operator commit');
+  }
+}
+
+function nextChangedReplaySavepointName(): string {
+  changedReplaySavepointSeq = (changedReplaySavepointSeq + 1) % Number.MAX_SAFE_INTEGER;
+  return `vnext_changed_replay_${changedReplaySavepointSeq}`;
+}
+
+function rollbackAndReleaseSavepoint(db: SQLiteDatabase, savepointName: string): void {
+  try {
+    db.exec(`ROLLBACK TO SAVEPOINT ${savepointName}`);
+  } finally {
+    db.exec(`RELEASE SAVEPOINT ${savepointName}`);
+  }
+}
+
+function readChangedRefsWithoutPersistingReplayWrites(
+  db: SQLiteDatabase,
+  writeChangedLedger: () => readonly SourceRef[]
+): string[] {
+  const savepointName = nextChangedReplaySavepointName();
+  db.exec(`SAVEPOINT ${savepointName}`);
+  try {
+    const changedRefs = serializeRequiredSourceRefs(writeChangedLedger());
+    rollbackAndReleaseSavepoint(db, savepointName);
+    return changedRefs;
+  } catch (error) {
+    rollbackAndReleaseSavepoint(db, savepointName);
+    throw error;
+  }
+}
+
+function readChangedRefsForExistingChangedCommit(
+  db: SQLiteDatabase,
+  cursor: CursorRow,
+  existing: CommitRow,
+  writeChangedLedger: () => readonly SourceRef[]
+): string[] {
+  if (cursor.last_change_seq < existing.last_change_seq) {
+    return serializeRequiredSourceRefs(writeChangedLedger());
+  }
+  return readChangedRefsWithoutPersistingReplayWrites(db, writeChangedLedger);
+}
+
 export function recoverExistingOperatorCursorCommit(
   db: SQLiteDatabase,
   input: ExistingOperatorCursorCommitInput
@@ -258,6 +345,8 @@ export function recoverExistingOperatorCursorCommit(
   ];
   const expectedSourceRefsJson = JSON.stringify(serializeRequiredSourceRefs(input.sourceRefs));
   const allowSeqGaps = input.allowSeqGaps === true;
+  const statusFilter =
+    input.statusFilter === undefined ? null : new Set<OperatorCommitStatus>(input.statusFilter);
 
   const tx = db.transaction(() => {
     for (const [index, key] of idempotencyKeys.entries()) {
@@ -271,6 +360,9 @@ export function recoverExistingOperatorCursorCommit(
         }
         continue;
       }
+      if (statusFilter && !statusFilter.has(existing.status)) {
+        continue;
+      }
       if (existing.source_refs_json !== expectedSourceRefsJson) {
         throw new Error('Idempotent replay source refs do not match the original operator commit');
       }
@@ -278,6 +370,173 @@ export function recoverExistingOperatorCursorCommit(
       return resultFromStoredCommit(db, cursor, existing, nowMs, allowSeqGaps);
     }
     return null;
+  });
+  return tx();
+}
+
+export function recoverExistingOperatorCursorChangedWrite(
+  db: SQLiteDatabase,
+  input: OperatorChangedCursorCommitInput
+): OperatorCursorCommitResult | null {
+  const nowMs = input.nowMs ?? Date.now();
+  const cursorName = requiredString(input.cursorName, 'cursorName');
+  const idempotencyKey = requiredString(input.idempotencyKey, 'idempotencyKey');
+  const idempotencyKeys = [
+    idempotencyKey,
+    ...(input.fallbackIdempotencyKeys ?? []).map((key) =>
+      requiredString(key, 'fallbackIdempotencyKeys[]')
+    ),
+  ];
+  const firstChangeSeq = nonNegativeInteger(input.firstChangeSeq, 'firstChangeSeq');
+  const lastChangeSeq = nonNegativeInteger(input.lastChangeSeq, 'lastChangeSeq');
+  const allowSeqGaps = input.allowSeqGaps === true;
+  if (lastChangeSeq < firstChangeSeq) {
+    throw new Error('lastChangeSeq must be greater than or equal to firstChangeSeq');
+  }
+
+  const sourceRefs = serializeRequiredSourceRefs(input.sourceRefs);
+  const sourceRefsJson = JSON.stringify(sourceRefs);
+
+  const tx = db.transaction(() => {
+    for (const [index, key] of idempotencyKeys.entries()) {
+      const existing = getExistingCommit(db, key);
+      if (!existing) {
+        continue;
+      }
+      if (existing.cursor_name !== cursorName) {
+        if (index === 0) {
+          throw new Error(`Idempotency key belongs to a different cursor: ${existing.cursor_name}`);
+        }
+        continue;
+      }
+      const cursor = getCursor(db, cursorName);
+      assertExistingChangedWriteCommitMetadata(cursor, existing, {
+        firstChangeSeq,
+        lastChangeSeq,
+        sourceRefsJson,
+      });
+      const changedRefs = readChangedRefsForExistingChangedCommit(
+        db,
+        cursor,
+        existing,
+        input.writeChangedLedger
+      );
+      return resultFromExistingChangedWriteCommit(
+        db,
+        cursor,
+        existing,
+        {
+          firstChangeSeq,
+          lastChangeSeq,
+          changedRefsJson: JSON.stringify(changedRefs),
+          sourceRefsJson,
+        },
+        nowMs,
+        allowSeqGaps
+      );
+    }
+    return null;
+  });
+  return tx();
+}
+
+export function commitOperatorCursorWithChangedWrite(
+  db: SQLiteDatabase,
+  input: OperatorChangedCursorCommitInput
+): OperatorCursorCommitResult {
+  const nowMs = input.nowMs ?? Date.now();
+  const cursorName = requiredString(input.cursorName, 'cursorName');
+  const idempotencyKey = requiredString(input.idempotencyKey, 'idempotencyKey');
+  const idempotencyKeys = [
+    idempotencyKey,
+    ...(input.fallbackIdempotencyKeys ?? []).map((key) =>
+      requiredString(key, 'fallbackIdempotencyKeys[]')
+    ),
+  ];
+  const firstChangeSeq = nonNegativeInteger(input.firstChangeSeq, 'firstChangeSeq');
+  const lastChangeSeq = nonNegativeInteger(input.lastChangeSeq, 'lastChangeSeq');
+  const allowSeqGaps = input.allowSeqGaps === true;
+  if (lastChangeSeq < firstChangeSeq) {
+    throw new Error('lastChangeSeq must be greater than or equal to firstChangeSeq');
+  }
+
+  const sourceRefs = serializeRequiredSourceRefs(input.sourceRefs);
+  const sourceRefsJson = JSON.stringify(sourceRefs);
+  const commitId = requiredString(input.commitId ?? `commit:${idempotencyKey}`, 'commitId');
+
+  const tx = db.transaction(() => {
+    ensureCursor(db, cursorName, nowMs);
+    const cursor = getCursor(db, cursorName);
+    for (const [index, key] of idempotencyKeys.entries()) {
+      const existing = getExistingCommit(db, key);
+      if (!existing) {
+        continue;
+      }
+      if (existing.cursor_name !== cursorName) {
+        if (index === 0) {
+          throw new Error(`Idempotency key belongs to a different cursor: ${existing.cursor_name}`);
+        }
+        continue;
+      }
+      assertExistingChangedWriteCommitMetadata(cursor, existing, {
+        firstChangeSeq,
+        lastChangeSeq,
+        sourceRefsJson,
+      });
+      const changedRefs = readChangedRefsForExistingChangedCommit(
+        db,
+        cursor,
+        existing,
+        input.writeChangedLedger
+      );
+      return resultFromExistingChangedWriteCommit(
+        db,
+        cursor,
+        existing,
+        {
+          firstChangeSeq,
+          lastChangeSeq,
+          changedRefsJson: JSON.stringify(changedRefs),
+          sourceRefsJson,
+        },
+        nowMs,
+        allowSeqGaps
+      );
+    }
+
+    assertSeqAdvances(cursor, firstChangeSeq, allowSeqGaps);
+    const changedRefs = serializeRequiredSourceRefs(input.writeChangedLedger());
+    const changedRefsJson = JSON.stringify(changedRefs);
+
+    db.prepare(
+      `INSERT INTO vnext_operator_commits (
+        commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+        status, changed_refs_json, source_refs_json, created_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      commitId,
+      cursorName,
+      idempotencyKey,
+      firstChangeSeq,
+      lastChangeSeq,
+      'changed',
+      changedRefsJson,
+      sourceRefsJson,
+      nowMs
+    );
+
+    updateCursor(db, cursorName, lastChangeSeq, idempotencyKey, nowMs);
+
+    return {
+      outcome: 'committed',
+      commitId,
+      cursorName,
+      firstChangeSeq,
+      lastChangeSeq,
+      idempotencyKey,
+      status: 'changed',
+      cursorAdvanced: true,
+    } satisfies OperatorCursorCommitResult;
   });
   return tx();
 }

--- a/packages/standalone/src/operator-vnext/operator-cursor-commit.ts
+++ b/packages/standalone/src/operator-vnext/operator-cursor-commit.ts
@@ -297,24 +297,59 @@ function nextChangedReplaySavepointName(): string {
 function rollbackAndReleaseSavepoint(db: SQLiteDatabase, savepointName: string): void {
   try {
     db.exec(`ROLLBACK TO SAVEPOINT ${savepointName}`);
-  } finally {
-    db.exec(`RELEASE SAVEPOINT ${savepointName}`);
+  } catch (error) {
+    try {
+      db.exec(`RELEASE SAVEPOINT ${savepointName}`);
+    } catch {
+      // Preserve the rollback failure; release can fail after a broken savepoint state.
+    }
+    throw error;
   }
+  db.exec(`RELEASE SAVEPOINT ${savepointName}`);
+}
+
+function rollbackAndReleaseSavepointAfterError(
+  db: SQLiteDatabase,
+  savepointName: string,
+  originalError: unknown
+): never {
+  try {
+    rollbackAndReleaseSavepoint(db, savepointName);
+  } catch {
+    // Preserve the original durable writer error; rollback/release are cleanup.
+  }
+  throw originalError;
+}
+
+function validateChangedWriteInput(input: OperatorChangedCursorCommitInput): {
+  sourceRefsJson: string;
+  writeChangedLedger: OperatorChangedCursorCommitInput['writeChangedLedger'];
+} {
+  if (!input.sourceRefs || input.sourceRefs.length === 0) {
+    throw new Error('sourceRefs must not be empty');
+  }
+  if (typeof input.writeChangedLedger !== 'function') {
+    throw new Error('writeChangedLedger must be a function');
+  }
+  return {
+    sourceRefsJson: JSON.stringify(serializeRequiredSourceRefs(input.sourceRefs)),
+    writeChangedLedger: input.writeChangedLedger,
+  };
 }
 
 function readChangedRefsWithoutPersistingReplayWrites(
   db: SQLiteDatabase,
-  writeChangedLedger: () => readonly SourceRef[]
+  idempotencyKey: string,
+  writeChangedLedger: OperatorChangedCursorCommitInput['writeChangedLedger']
 ): string[] {
   const savepointName = nextChangedReplaySavepointName();
   db.exec(`SAVEPOINT ${savepointName}`);
   try {
-    const changedRefs = serializeRequiredSourceRefs(writeChangedLedger());
+    const changedRefs = serializeRequiredSourceRefs(writeChangedLedger({ idempotencyKey }));
     rollbackAndReleaseSavepoint(db, savepointName);
     return changedRefs;
   } catch (error) {
-    rollbackAndReleaseSavepoint(db, savepointName);
-    throw error;
+    rollbackAndReleaseSavepointAfterError(db, savepointName, error);
   }
 }
 
@@ -322,12 +357,18 @@ function readChangedRefsForExistingChangedCommit(
   db: SQLiteDatabase,
   cursor: CursorRow,
   existing: CommitRow,
-  writeChangedLedger: () => readonly SourceRef[]
+  writeChangedLedger: OperatorChangedCursorCommitInput['writeChangedLedger']
 ): string[] {
   if (cursor.last_change_seq < existing.last_change_seq) {
-    return serializeRequiredSourceRefs(writeChangedLedger());
+    return serializeRequiredSourceRefs(
+      writeChangedLedger({ idempotencyKey: existing.idempotency_key })
+    );
   }
-  return readChangedRefsWithoutPersistingReplayWrites(db, writeChangedLedger);
+  return readChangedRefsWithoutPersistingReplayWrites(
+    db,
+    existing.idempotency_key,
+    writeChangedLedger
+  );
 }
 
 export function recoverExistingOperatorCursorCommit(
@@ -394,8 +435,7 @@ export function recoverExistingOperatorCursorChangedWrite(
     throw new Error('lastChangeSeq must be greater than or equal to firstChangeSeq');
   }
 
-  const sourceRefs = serializeRequiredSourceRefs(input.sourceRefs);
-  const sourceRefsJson = JSON.stringify(sourceRefs);
+  const { sourceRefsJson, writeChangedLedger } = validateChangedWriteInput(input);
 
   const tx = db.transaction(() => {
     for (const [index, key] of idempotencyKeys.entries()) {
@@ -419,7 +459,7 @@ export function recoverExistingOperatorCursorChangedWrite(
         db,
         cursor,
         existing,
-        input.writeChangedLedger
+        writeChangedLedger
       );
       return resultFromExistingChangedWriteCommit(
         db,
@@ -460,8 +500,7 @@ export function commitOperatorCursorWithChangedWrite(
     throw new Error('lastChangeSeq must be greater than or equal to firstChangeSeq');
   }
 
-  const sourceRefs = serializeRequiredSourceRefs(input.sourceRefs);
-  const sourceRefsJson = JSON.stringify(sourceRefs);
+  const { sourceRefsJson, writeChangedLedger } = validateChangedWriteInput(input);
   const commitId = requiredString(input.commitId ?? `commit:${idempotencyKey}`, 'commitId');
 
   const tx = db.transaction(() => {
@@ -487,7 +526,7 @@ export function commitOperatorCursorWithChangedWrite(
         db,
         cursor,
         existing,
-        input.writeChangedLedger
+        writeChangedLedger
       );
       return resultFromExistingChangedWriteCommit(
         db,
@@ -505,7 +544,7 @@ export function commitOperatorCursorWithChangedWrite(
     }
 
     assertSeqAdvances(cursor, firstChangeSeq, allowSeqGaps);
-    const changedRefs = serializeRequiredSourceRefs(input.writeChangedLedger());
+    const changedRefs = serializeRequiredSourceRefs(writeChangedLedger({ idempotencyKey }));
     const changedRefsJson = JSON.stringify(changedRefs);
 
     db.prepare(

--- a/packages/standalone/src/operator-vnext/operator-cursor-commit.ts
+++ b/packages/standalone/src/operator-vnext/operator-cursor-commit.ts
@@ -40,6 +40,30 @@ interface NormalizedNoUpdateCommit {
   reason: string;
 }
 
+interface NormalizedChangedWriteCommitInput {
+  nowMs: number;
+  cursorName: string;
+  idempotencyKey: string;
+  idempotencyKeys: string[];
+  firstChangeSeq: number;
+  lastChangeSeq: number;
+  allowSeqGaps: boolean;
+  sourceRefsJson: string;
+  writeChangedLedger: OperatorChangedCursorCommitInput['writeChangedLedger'];
+}
+
+interface ExistingChangedWriteCommitLookup {
+  cursorName: string;
+  idempotencyKeys: readonly string[];
+  firstChangeSeq: number;
+  lastChangeSeq: number;
+  sourceRefsJson: string;
+  writeChangedLedger: OperatorChangedCursorCommitInput['writeChangedLedger'];
+  nowMs: number;
+  allowSeqGaps: boolean;
+  cursor?: CursorRow;
+}
+
 let changedReplaySavepointSeq = 0;
 
 export interface ExistingOperatorCursorCommitInput {
@@ -337,6 +361,39 @@ function validateChangedWriteInput(input: OperatorChangedCursorCommitInput): {
   };
 }
 
+function normalizeChangedWriteCommitInput(
+  input: OperatorChangedCursorCommitInput
+): NormalizedChangedWriteCommitInput {
+  const nowMs = input.nowMs ?? Date.now();
+  const cursorName = requiredString(input.cursorName, 'cursorName');
+  const idempotencyKey = requiredString(input.idempotencyKey, 'idempotencyKey');
+  const idempotencyKeys = [
+    idempotencyKey,
+    ...(input.fallbackIdempotencyKeys ?? []).map((key) =>
+      requiredString(key, 'fallbackIdempotencyKeys[]')
+    ),
+  ];
+  const firstChangeSeq = nonNegativeInteger(input.firstChangeSeq, 'firstChangeSeq');
+  const lastChangeSeq = nonNegativeInteger(input.lastChangeSeq, 'lastChangeSeq');
+  const allowSeqGaps = input.allowSeqGaps === true;
+  if (lastChangeSeq < firstChangeSeq) {
+    throw new Error('lastChangeSeq must be greater than or equal to firstChangeSeq');
+  }
+
+  const { sourceRefsJson, writeChangedLedger } = validateChangedWriteInput(input);
+  return {
+    nowMs,
+    cursorName,
+    idempotencyKey,
+    idempotencyKeys,
+    firstChangeSeq,
+    lastChangeSeq,
+    allowSeqGaps,
+    sourceRefsJson,
+    writeChangedLedger,
+  };
+}
+
 function readChangedRefsWithoutPersistingReplayWrites(
   db: SQLiteDatabase,
   idempotencyKey: string,
@@ -369,6 +426,50 @@ function readChangedRefsForExistingChangedCommit(
     existing.idempotency_key,
     writeChangedLedger
   );
+}
+
+function findExistingChangedWriteCommit(
+  db: SQLiteDatabase,
+  input: ExistingChangedWriteCommitLookup
+): OperatorCursorCommitResult | null {
+  for (const [index, key] of input.idempotencyKeys.entries()) {
+    const existing = getExistingCommit(db, key);
+    if (!existing) {
+      continue;
+    }
+    if (existing.cursor_name !== input.cursorName) {
+      if (index === 0) {
+        throw new Error(`Idempotency key belongs to a different cursor: ${existing.cursor_name}`);
+      }
+      continue;
+    }
+    const cursor = input.cursor ?? getCursor(db, input.cursorName);
+    assertExistingChangedWriteCommitMetadata(cursor, existing, {
+      firstChangeSeq: input.firstChangeSeq,
+      lastChangeSeq: input.lastChangeSeq,
+      sourceRefsJson: input.sourceRefsJson,
+    });
+    const changedRefs = readChangedRefsForExistingChangedCommit(
+      db,
+      cursor,
+      existing,
+      input.writeChangedLedger
+    );
+    return resultFromExistingChangedWriteCommit(
+      db,
+      cursor,
+      existing,
+      {
+        firstChangeSeq: input.firstChangeSeq,
+        lastChangeSeq: input.lastChangeSeq,
+        changedRefsJson: JSON.stringify(changedRefs),
+        sourceRefsJson: input.sourceRefsJson,
+      },
+      input.nowMs,
+      input.allowSeqGaps
+    );
+  }
+  return null;
 }
 
 export function recoverExistingOperatorCursorCommit(
@@ -419,63 +520,10 @@ export function recoverExistingOperatorCursorChangedWrite(
   db: SQLiteDatabase,
   input: OperatorChangedCursorCommitInput
 ): OperatorCursorCommitResult | null {
-  const nowMs = input.nowMs ?? Date.now();
-  const cursorName = requiredString(input.cursorName, 'cursorName');
-  const idempotencyKey = requiredString(input.idempotencyKey, 'idempotencyKey');
-  const idempotencyKeys = [
-    idempotencyKey,
-    ...(input.fallbackIdempotencyKeys ?? []).map((key) =>
-      requiredString(key, 'fallbackIdempotencyKeys[]')
-    ),
-  ];
-  const firstChangeSeq = nonNegativeInteger(input.firstChangeSeq, 'firstChangeSeq');
-  const lastChangeSeq = nonNegativeInteger(input.lastChangeSeq, 'lastChangeSeq');
-  const allowSeqGaps = input.allowSeqGaps === true;
-  if (lastChangeSeq < firstChangeSeq) {
-    throw new Error('lastChangeSeq must be greater than or equal to firstChangeSeq');
-  }
-
-  const { sourceRefsJson, writeChangedLedger } = validateChangedWriteInput(input);
+  const normalized = normalizeChangedWriteCommitInput(input);
 
   const tx = db.transaction(() => {
-    for (const [index, key] of idempotencyKeys.entries()) {
-      const existing = getExistingCommit(db, key);
-      if (!existing) {
-        continue;
-      }
-      if (existing.cursor_name !== cursorName) {
-        if (index === 0) {
-          throw new Error(`Idempotency key belongs to a different cursor: ${existing.cursor_name}`);
-        }
-        continue;
-      }
-      const cursor = getCursor(db, cursorName);
-      assertExistingChangedWriteCommitMetadata(cursor, existing, {
-        firstChangeSeq,
-        lastChangeSeq,
-        sourceRefsJson,
-      });
-      const changedRefs = readChangedRefsForExistingChangedCommit(
-        db,
-        cursor,
-        existing,
-        writeChangedLedger
-      );
-      return resultFromExistingChangedWriteCommit(
-        db,
-        cursor,
-        existing,
-        {
-          firstChangeSeq,
-          lastChangeSeq,
-          changedRefsJson: JSON.stringify(changedRefs),
-          sourceRefsJson,
-        },
-        nowMs,
-        allowSeqGaps
-      );
-    }
-    return null;
+    return findExistingChangedWriteCommit(db, normalized);
   });
   return tx();
 }
@@ -484,67 +532,27 @@ export function commitOperatorCursorWithChangedWrite(
   db: SQLiteDatabase,
   input: OperatorChangedCursorCommitInput
 ): OperatorCursorCommitResult {
-  const nowMs = input.nowMs ?? Date.now();
-  const cursorName = requiredString(input.cursorName, 'cursorName');
-  const idempotencyKey = requiredString(input.idempotencyKey, 'idempotencyKey');
-  const idempotencyKeys = [
-    idempotencyKey,
-    ...(input.fallbackIdempotencyKeys ?? []).map((key) =>
-      requiredString(key, 'fallbackIdempotencyKeys[]')
-    ),
-  ];
-  const firstChangeSeq = nonNegativeInteger(input.firstChangeSeq, 'firstChangeSeq');
-  const lastChangeSeq = nonNegativeInteger(input.lastChangeSeq, 'lastChangeSeq');
-  const allowSeqGaps = input.allowSeqGaps === true;
-  if (lastChangeSeq < firstChangeSeq) {
-    throw new Error('lastChangeSeq must be greater than or equal to firstChangeSeq');
-  }
-
-  const { sourceRefsJson, writeChangedLedger } = validateChangedWriteInput(input);
-  const commitId = requiredString(input.commitId ?? `commit:${idempotencyKey}`, 'commitId');
+  const normalized = normalizeChangedWriteCommitInput(input);
+  const commitId = requiredString(
+    input.commitId ?? `commit:${normalized.idempotencyKey}`,
+    'commitId'
+  );
 
   const tx = db.transaction(() => {
-    ensureCursor(db, cursorName, nowMs);
-    const cursor = getCursor(db, cursorName);
-    for (const [index, key] of idempotencyKeys.entries()) {
-      const existing = getExistingCommit(db, key);
-      if (!existing) {
-        continue;
-      }
-      if (existing.cursor_name !== cursorName) {
-        if (index === 0) {
-          throw new Error(`Idempotency key belongs to a different cursor: ${existing.cursor_name}`);
-        }
-        continue;
-      }
-      assertExistingChangedWriteCommitMetadata(cursor, existing, {
-        firstChangeSeq,
-        lastChangeSeq,
-        sourceRefsJson,
-      });
-      const changedRefs = readChangedRefsForExistingChangedCommit(
-        db,
-        cursor,
-        existing,
-        writeChangedLedger
-      );
-      return resultFromExistingChangedWriteCommit(
-        db,
-        cursor,
-        existing,
-        {
-          firstChangeSeq,
-          lastChangeSeq,
-          changedRefsJson: JSON.stringify(changedRefs),
-          sourceRefsJson,
-        },
-        nowMs,
-        allowSeqGaps
-      );
+    ensureCursor(db, normalized.cursorName, normalized.nowMs);
+    const cursor = getCursor(db, normalized.cursorName);
+    const existing = findExistingChangedWriteCommit(db, {
+      ...normalized,
+      cursor,
+    });
+    if (existing) {
+      return existing;
     }
 
-    assertSeqAdvances(cursor, firstChangeSeq, allowSeqGaps);
-    const changedRefs = serializeRequiredSourceRefs(writeChangedLedger({ idempotencyKey }));
+    assertSeqAdvances(cursor, normalized.firstChangeSeq, normalized.allowSeqGaps);
+    const changedRefs = serializeRequiredSourceRefs(
+      normalized.writeChangedLedger({ idempotencyKey: normalized.idempotencyKey })
+    );
     const changedRefsJson = JSON.stringify(changedRefs);
 
     db.prepare(
@@ -554,25 +562,31 @@ export function commitOperatorCursorWithChangedWrite(
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       commitId,
-      cursorName,
-      idempotencyKey,
-      firstChangeSeq,
-      lastChangeSeq,
+      normalized.cursorName,
+      normalized.idempotencyKey,
+      normalized.firstChangeSeq,
+      normalized.lastChangeSeq,
       'changed',
       changedRefsJson,
-      sourceRefsJson,
-      nowMs
+      normalized.sourceRefsJson,
+      normalized.nowMs
     );
 
-    updateCursor(db, cursorName, lastChangeSeq, idempotencyKey, nowMs);
+    updateCursor(
+      db,
+      normalized.cursorName,
+      normalized.lastChangeSeq,
+      normalized.idempotencyKey,
+      normalized.nowMs
+    );
 
     return {
       outcome: 'committed',
       commitId,
-      cursorName,
-      firstChangeSeq,
-      lastChangeSeq,
-      idempotencyKey,
+      cursorName: normalized.cursorName,
+      firstChangeSeq: normalized.firstChangeSeq,
+      lastChangeSeq: normalized.lastChangeSeq,
+      idempotencyKey: normalized.idempotencyKey,
       status: 'changed',
       cursorAdvanced: true,
     } satisfies OperatorCursorCommitResult;

--- a/packages/standalone/src/operator-vnext/primary-operator-runtime.ts
+++ b/packages/standalone/src/operator-vnext/primary-operator-runtime.ts
@@ -293,12 +293,12 @@ export class PrimaryOperatorRuntime {
             sourceRefs,
             nowMs: commitNowMs,
             allowSeqGaps: this.allowSeqGaps,
-            writeChangedLedger: () =>
+            writeChangedLedger: ({ idempotencyKey: matchedIdempotencyKey }) =>
               commitChanged({
                 event,
                 decision: { status: 'changed' },
                 sourceRefs,
-                idempotencyKey,
+                idempotencyKey: matchedIdempotencyKey,
                 nowMs: commitNowMs,
               }),
           });
@@ -415,12 +415,12 @@ export class PrimaryOperatorRuntime {
         sourceRefs: input.sourceRefs,
         nowMs: input.nowMs,
         allowSeqGaps: this.allowSeqGaps,
-        writeChangedLedger: () =>
+        writeChangedLedger: ({ idempotencyKey }) =>
           commitChanged({
             event: input.event,
             decision: { status: 'changed' },
             sourceRefs: input.sourceRefs,
-            idempotencyKey: input.idempotencyKey,
+            idempotencyKey,
             nowMs: input.nowMs,
           }),
       });

--- a/packages/standalone/src/operator-vnext/primary-operator-runtime.ts
+++ b/packages/standalone/src/operator-vnext/primary-operator-runtime.ts
@@ -46,6 +46,16 @@ type ParsedPrimaryOperatorDecision =
       scopeKey?: string;
     };
 
+interface ParsedPrimaryOperatorCommitContext {
+  event: PrimaryOperatorEvent;
+  sourceRefs: readonly SourceRef[];
+  idempotencyKey: string;
+  fallbackIdempotencyKeys: readonly string[];
+  seq: number;
+  nowMs: number;
+  commitChanged?: PrimaryOperatorChangedCommitter;
+}
+
 export interface PrimaryOperatorChangedCommitInput {
   event: PrimaryOperatorEvent;
   decision: PrimaryOperatorTrustedChangedCommitDecision;
@@ -311,32 +321,15 @@ export class PrimaryOperatorRuntime {
           const decision = parseDecision(await decide(event), {
             requireChangedRefs: false,
           });
-          const commit =
-            decision.status === 'changed'
-              ? this.commitChangedDecision({
-                  event,
-                  decision,
-                  sourceRefs,
-                  idempotencyKey,
-                  fallbackIdempotencyKeys,
-                  seq,
-                  nowMs: commitNowMs,
-                  commitChanged,
-                })
-              : commitOperatorCursor(this.db, {
-                  cursorName: this.cursorName,
-                  firstChangeSeq: seq,
-                  lastChangeSeq: seq,
-                  idempotencyKey,
-                  status: 'no_update',
-                  sourceRefs,
-                  noUpdate: {
-                    scopeKey: this.resolveNoUpdateScope(decision.scopeKey),
-                    reason: decision.reason,
-                  },
-                  nowMs: commitNowMs,
-                  allowSeqGaps: this.allowSeqGaps,
-                });
+          const commit = this.commitParsedDecision(decision, {
+            event,
+            sourceRefs,
+            idempotencyKey,
+            fallbackIdempotencyKeys,
+            seq,
+            nowMs: commitNowMs,
+            commitChanged,
+          });
           commits.push(commit);
           advancedThroughSeq = Math.max(advancedThroughSeq, commit.lastChangeSeq);
           continue;
@@ -346,32 +339,15 @@ export class PrimaryOperatorRuntime {
         const decision = parseDecision(await decide(event), {
           requireChangedRefs: true,
         });
-        const commit =
-          decision.status === 'changed'
-            ? this.commitChangedDecision({
-                event,
-                decision,
-                sourceRefs,
-                idempotencyKey,
-                fallbackIdempotencyKeys,
-                seq,
-                nowMs: commitNowMs,
-                commitChanged,
-              })
-            : commitOperatorCursor(this.db, {
-                cursorName: this.cursorName,
-                firstChangeSeq: seq,
-                lastChangeSeq: seq,
-                idempotencyKey,
-                status: 'no_update',
-                sourceRefs,
-                noUpdate: {
-                  scopeKey: this.resolveNoUpdateScope(decision.scopeKey),
-                  reason: decision.reason,
-                },
-                nowMs: commitNowMs,
-                allowSeqGaps: this.allowSeqGaps,
-              });
+        const commit = this.commitParsedDecision(decision, {
+          event,
+          sourceRefs,
+          idempotencyKey,
+          fallbackIdempotencyKeys,
+          seq,
+          nowMs: commitNowMs,
+          commitChanged,
+        });
         commits.push(commit);
         advancedThroughSeq = Math.max(advancedThroughSeq, commit.lastChangeSeq);
       } catch (error) {
@@ -392,6 +368,32 @@ export class PrimaryOperatorRuntime {
       advancedThroughSeq,
       commits,
     };
+  }
+
+  private commitParsedDecision(
+    decision: ParsedPrimaryOperatorDecision,
+    context: ParsedPrimaryOperatorCommitContext
+  ): OperatorCursorCommitResult {
+    if (decision.status === 'changed') {
+      return this.commitChangedDecision({
+        ...context,
+        decision,
+      });
+    }
+    return commitOperatorCursor(this.db, {
+      cursorName: this.cursorName,
+      firstChangeSeq: context.seq,
+      lastChangeSeq: context.seq,
+      idempotencyKey: context.idempotencyKey,
+      status: 'no_update',
+      sourceRefs: context.sourceRefs,
+      noUpdate: {
+        scopeKey: this.resolveNoUpdateScope(decision.scopeKey),
+        reason: decision.reason,
+      },
+      nowMs: context.nowMs,
+      allowSeqGaps: this.allowSeqGaps,
+    });
   }
 
   private commitChangedDecision(input: {

--- a/packages/standalone/src/operator-vnext/primary-operator-runtime.ts
+++ b/packages/standalone/src/operator-vnext/primary-operator-runtime.ts
@@ -5,6 +5,8 @@ import {
   buildConnectorIdempotencyKey,
   buildCursorScopedIdempotencyKey,
   commitOperatorCursor,
+  commitOperatorCursorWithChangedWrite,
+  recoverExistingOperatorCursorChangedWrite,
   recoverExistingOperatorCursorCommit,
 } from './operator-cursor-commit.js';
 import type { OperatorCursorCommitResult } from './operator-commit-result.js';
@@ -26,6 +28,35 @@ export type PrimaryOperatorDecision =
       reason: string;
       scopeKey?: string;
     };
+
+export type PrimaryOperatorChangedCommitDecision = {
+  status: 'changed';
+  changedRefs?: readonly SourceRef[];
+};
+
+export type PrimaryOperatorTrustedChangedCommitDecision = {
+  status: 'changed';
+};
+
+type ParsedPrimaryOperatorDecision =
+  | PrimaryOperatorChangedCommitDecision
+  | {
+      status: 'no_update';
+      reason: string;
+      scopeKey?: string;
+    };
+
+export interface PrimaryOperatorChangedCommitInput {
+  event: PrimaryOperatorEvent;
+  decision: PrimaryOperatorTrustedChangedCommitDecision;
+  sourceRefs: readonly SourceRef[];
+  idempotencyKey: string;
+  nowMs: number;
+}
+
+export type PrimaryOperatorChangedCommitter = (
+  input: PrimaryOperatorChangedCommitInput
+) => readonly SourceRef[];
 
 export interface PrimaryOperatorRuntimeOptions {
   db: SQLiteDatabase;
@@ -87,13 +118,24 @@ function asError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
 
-function parseDecision(value: unknown): PrimaryOperatorDecision {
+function parseDecision(
+  value: unknown,
+  options: { requireChangedRefs: boolean }
+): ParsedPrimaryOperatorDecision {
   if (!isRecord(value)) {
     throw new Error('Primary operator decision must be an object');
   }
   if (value.status === 'changed') {
+    if (value.changedRefs === undefined) {
+      if (options.requireChangedRefs) {
+        throw new Error('Changed primary operator decisions require changedRefs');
+      }
+      return {
+        status: 'changed',
+      };
+    }
     if (!Array.isArray(value.changedRefs)) {
-      throw new Error('Changed primary operator decisions require changedRefs');
+      throw new Error('Changed primary operator decision changedRefs must be an array');
     }
     return {
       status: 'changed',
@@ -132,6 +174,26 @@ function readCursorSeq(db: SQLiteDatabase, cursorName: string): number {
   return row?.last_change_seq ?? 0;
 }
 
+function assertEventAdvancesCursor(
+  seq: number,
+  advancedThroughSeq: number,
+  allowSeqGaps: boolean
+): void {
+  if (allowSeqGaps) {
+    if (seq <= advancedThroughSeq) {
+      throw new Error(
+        `Operator events must advance cursor; current seq ${advancedThroughSeq}, got ${seq}`
+      );
+    }
+    return;
+  }
+  if (seq !== advancedThroughSeq + 1) {
+    throw new Error(
+      `Operator events must be contiguous; expected seq ${advancedThroughSeq + 1}, got ${seq}`
+    );
+  }
+}
+
 export class PrimaryOperatorRuntime {
   private readonly db: SQLiteDatabase;
   private readonly cursorName: string;
@@ -160,6 +222,16 @@ export class PrimaryOperatorRuntime {
     return withCursorLock(this.cursorName, () => this.processBatchLocked(events, decide));
   }
 
+  async processBatchWithChangedCommit(
+    events: readonly PrimaryOperatorEvent[],
+    decide: (event: PrimaryOperatorEvent) => Promise<unknown> | unknown,
+    commitChanged: PrimaryOperatorChangedCommitter
+  ): Promise<PrimaryOperatorBatchResult> {
+    return withCursorLock(this.cursorName, () =>
+      this.processBatchLocked(events, decide, commitChanged)
+    );
+  }
+
   async processBatchAfterValidation(
     buildEvents: () => Promise<readonly PrimaryOperatorEvent[]> | readonly PrimaryOperatorEvent[],
     decide: (event: PrimaryOperatorEvent) => Promise<unknown> | unknown
@@ -172,7 +244,8 @@ export class PrimaryOperatorRuntime {
 
   private async processBatchLocked(
     events: readonly PrimaryOperatorEvent[],
-    decide: (event: PrimaryOperatorEvent) => Promise<unknown> | unknown
+    decide: (event: PrimaryOperatorEvent) => Promise<unknown> | unknown,
+    commitChanged?: PrimaryOperatorChangedCommitter
   ): Promise<PrimaryOperatorBatchResult> {
     if (events.length === 0) {
       return {
@@ -193,11 +266,13 @@ export class PrimaryOperatorRuntime {
         const idempotencyKey = buildCursorScopedIdempotencyKey(this.cursorName, seq, seq);
         const legacyIdempotencyKey = buildConnectorIdempotencyKey(this.connector, seq, seq);
         const sourceRefs = [event.sourceRef];
+        const fallbackIdempotencyKeys =
+          legacyIdempotencyKey === idempotencyKey ? [] : [legacyIdempotencyKey];
         const existingCommit = recoverExistingOperatorCursorCommit(this.db, {
           cursorName: this.cursorName,
           idempotencyKey,
-          fallbackIdempotencyKeys:
-            legacyIdempotencyKey === idempotencyKey ? [] : [legacyIdempotencyKey],
+          fallbackIdempotencyKeys,
+          statusFilter: commitChanged === undefined ? undefined : ['no_update'],
           sourceRefs,
           nowMs: this.nowMs(),
           allowSeqGaps: this.allowSeqGaps,
@@ -207,26 +282,81 @@ export class PrimaryOperatorRuntime {
           advancedThroughSeq = Math.max(advancedThroughSeq, existingCommit.lastChangeSeq);
           continue;
         }
-        if (this.allowSeqGaps ? seq <= advancedThroughSeq : seq !== advancedThroughSeq + 1) {
-          throw new Error(
-            this.allowSeqGaps
-              ? `Operator events must advance cursor; current seq ${advancedThroughSeq}, got ${seq}`
-              : `Operator events must be contiguous; expected seq ${advancedThroughSeq + 1}, got ${seq}`
-          );
+        if (commitChanged) {
+          const commitNowMs = this.nowMs();
+          const existingChangedCommit = recoverExistingOperatorCursorChangedWrite(this.db, {
+            cursorName: this.cursorName,
+            firstChangeSeq: seq,
+            lastChangeSeq: seq,
+            idempotencyKey,
+            fallbackIdempotencyKeys,
+            sourceRefs,
+            nowMs: commitNowMs,
+            allowSeqGaps: this.allowSeqGaps,
+            writeChangedLedger: () =>
+              commitChanged({
+                event,
+                decision: { status: 'changed' },
+                sourceRefs,
+                idempotencyKey,
+                nowMs: commitNowMs,
+              }),
+          });
+          if (existingChangedCommit) {
+            commits.push(existingChangedCommit);
+            advancedThroughSeq = Math.max(advancedThroughSeq, existingChangedCommit.lastChangeSeq);
+            continue;
+          }
+          assertEventAdvancesCursor(seq, advancedThroughSeq, this.allowSeqGaps);
+          const decision = parseDecision(await decide(event), {
+            requireChangedRefs: false,
+          });
+          const commit =
+            decision.status === 'changed'
+              ? this.commitChangedDecision({
+                  event,
+                  decision,
+                  sourceRefs,
+                  idempotencyKey,
+                  fallbackIdempotencyKeys,
+                  seq,
+                  nowMs: commitNowMs,
+                  commitChanged,
+                })
+              : commitOperatorCursor(this.db, {
+                  cursorName: this.cursorName,
+                  firstChangeSeq: seq,
+                  lastChangeSeq: seq,
+                  idempotencyKey,
+                  status: 'no_update',
+                  sourceRefs,
+                  noUpdate: {
+                    scopeKey: this.resolveNoUpdateScope(decision.scopeKey),
+                    reason: decision.reason,
+                  },
+                  nowMs: commitNowMs,
+                  allowSeqGaps: this.allowSeqGaps,
+                });
+          commits.push(commit);
+          advancedThroughSeq = Math.max(advancedThroughSeq, commit.lastChangeSeq);
+          continue;
         }
-        const decision = parseDecision(await decide(event));
+        assertEventAdvancesCursor(seq, advancedThroughSeq, this.allowSeqGaps);
+        const commitNowMs = this.nowMs();
+        const decision = parseDecision(await decide(event), {
+          requireChangedRefs: true,
+        });
         const commit =
           decision.status === 'changed'
-            ? commitOperatorCursor(this.db, {
-                cursorName: this.cursorName,
-                firstChangeSeq: seq,
-                lastChangeSeq: seq,
-                idempotencyKey,
-                status: 'changed',
-                changedRefs: decision.changedRefs,
+            ? this.commitChangedDecision({
+                event,
+                decision,
                 sourceRefs,
-                nowMs: this.nowMs(),
-                allowSeqGaps: this.allowSeqGaps,
+                idempotencyKey,
+                fallbackIdempotencyKeys,
+                seq,
+                nowMs: commitNowMs,
+                commitChanged,
               })
             : commitOperatorCursor(this.db, {
                 cursorName: this.cursorName,
@@ -239,7 +369,7 @@ export class PrimaryOperatorRuntime {
                   scopeKey: this.resolveNoUpdateScope(decision.scopeKey),
                   reason: decision.reason,
                 },
-                nowMs: this.nowMs(),
+                nowMs: commitNowMs,
                 allowSeqGaps: this.allowSeqGaps,
               });
         commits.push(commit);
@@ -262,6 +392,53 @@ export class PrimaryOperatorRuntime {
       advancedThroughSeq,
       commits,
     };
+  }
+
+  private commitChangedDecision(input: {
+    event: PrimaryOperatorEvent;
+    decision: PrimaryOperatorChangedCommitDecision;
+    sourceRefs: readonly SourceRef[];
+    idempotencyKey: string;
+    fallbackIdempotencyKeys: readonly string[];
+    seq: number;
+    nowMs: number;
+    commitChanged?: PrimaryOperatorChangedCommitter;
+  }): OperatorCursorCommitResult {
+    const commitChanged = input.commitChanged;
+    if (commitChanged) {
+      return commitOperatorCursorWithChangedWrite(this.db, {
+        cursorName: this.cursorName,
+        firstChangeSeq: input.seq,
+        lastChangeSeq: input.seq,
+        idempotencyKey: input.idempotencyKey,
+        fallbackIdempotencyKeys: input.fallbackIdempotencyKeys,
+        sourceRefs: input.sourceRefs,
+        nowMs: input.nowMs,
+        allowSeqGaps: this.allowSeqGaps,
+        writeChangedLedger: () =>
+          commitChanged({
+            event: input.event,
+            decision: { status: 'changed' },
+            sourceRefs: input.sourceRefs,
+            idempotencyKey: input.idempotencyKey,
+            nowMs: input.nowMs,
+          }),
+      });
+    }
+    if (!input.decision.changedRefs) {
+      throw new Error('Changed primary operator decisions require changedRefs');
+    }
+    return commitOperatorCursor(this.db, {
+      cursorName: this.cursorName,
+      firstChangeSeq: input.seq,
+      lastChangeSeq: input.seq,
+      idempotencyKey: input.idempotencyKey,
+      status: 'changed',
+      changedRefs: input.decision.changedRefs,
+      sourceRefs: input.sourceRefs,
+      nowMs: input.nowMs,
+      allowSeqGaps: this.allowSeqGaps,
+    });
   }
 
   private resolveNoUpdateScope(candidateScopeKey: string | undefined): string {

--- a/packages/standalone/src/runtime-vnext/bootstrap.ts
+++ b/packages/standalone/src/runtime-vnext/bootstrap.ts
@@ -1,5 +1,6 @@
 import type { VNextRuntimeFlags } from './feature-flags.js';
 import type {
+  PrimaryOperatorChangedCommitter,
   PrimaryOperatorBatchResult,
   PrimaryOperatorEvent,
 } from '../operator-vnext/primary-operator-runtime.js';
@@ -55,6 +56,11 @@ export interface VNextPrimaryOperatorRuntimeHandle {
   processBatch: (
     events: readonly PrimaryOperatorEvent[],
     decide: (event: PrimaryOperatorEvent) => Promise<unknown> | unknown
+  ) => Promise<PrimaryOperatorBatchResult>;
+  processBatchWithChangedCommit: (
+    events: readonly PrimaryOperatorEvent[],
+    decide: (event: PrimaryOperatorEvent) => Promise<unknown> | unknown,
+    commitChanged: PrimaryOperatorChangedCommitter
   ) => Promise<PrimaryOperatorBatchResult>;
 }
 

--- a/packages/standalone/src/wiki-artifacts/wiki-artifact-store.ts
+++ b/packages/standalone/src/wiki-artifacts/wiki-artifact-store.ts
@@ -83,8 +83,20 @@ export class WikiArtifactStore {
 
   constructor(private readonly db: SQLiteDatabase) {}
 
+  private hasSchema(): boolean {
+    return (
+      this.db
+        .prepare(
+          `SELECT name
+           FROM sqlite_master
+           WHERE type = 'table' AND name = 'wiki_artifacts'`
+        )
+        .get() !== undefined
+    );
+  }
+
   ensureSchema(): void {
-    if (this.schemaEnsured) {
+    if (this.schemaEnsured && this.hasSchema()) {
       return;
     }
     applyWikiArtifactsMigration(this.db);

--- a/packages/standalone/src/wiki-artifacts/wiki-artifact-store.ts
+++ b/packages/standalone/src/wiki-artifacts/wiki-artifact-store.ts
@@ -80,19 +80,17 @@ function rowToRecord(row: WikiArtifactRow): WikiArtifactRecord {
 
 export class WikiArtifactStore {
   private schemaEnsured = false;
+  private hasSchemaStatement: ReturnType<SQLiteDatabase['prepare']> | undefined;
 
   constructor(private readonly db: SQLiteDatabase) {}
 
   private hasSchema(): boolean {
-    return (
-      this.db
-        .prepare(
-          `SELECT name
-           FROM sqlite_master
-           WHERE type = 'table' AND name = 'wiki_artifacts'`
-        )
-        .get() !== undefined
+    this.hasSchemaStatement ??= this.db.prepare(
+      `SELECT name
+       FROM sqlite_master
+       WHERE type = 'table' AND name = 'wiki_artifacts'`
     );
+    return this.hasSchemaStatement.get() !== undefined;
   }
 
   ensureSchema(): void {

--- a/packages/standalone/tests/operator-vnext/operator-cursor-commit.test.ts
+++ b/packages/standalone/tests/operator-vnext/operator-cursor-commit.test.ts
@@ -134,6 +134,38 @@ describe('STORY-VNEXT-PR2-CURSOR-COMMIT: atomic cursor commits', () => {
       db.close();
     });
 
+    it('rejects trusted changed commits with clear input validation errors', () => {
+      const db = makeOperatorVNextDb();
+      const missingWriterInput = {
+        commitId: 'commit-missing-writer',
+        cursorName: 'connector:slack',
+        firstChangeSeq: 1,
+        lastChangeSeq: 1,
+        idempotencyKey: buildConnectorIdempotencyKey('slack', 1, 1),
+        sourceRefs: [{ kind: 'raw' as const, connector: 'slack', id: 'event-1' }],
+        nowMs: 1710000000000,
+      } as unknown as Parameters<typeof commitOperatorCursorWithChangedWrite>[1];
+
+      expect(() =>
+        commitOperatorCursorWithChangedWrite(db, {
+          commitId: 'commit-empty-source-refs',
+          cursorName: 'connector:slack',
+          firstChangeSeq: 1,
+          lastChangeSeq: 1,
+          idempotencyKey: buildConnectorIdempotencyKey('slack', 1, 1),
+          sourceRefs: [],
+          nowMs: 1710000000000,
+          writeChangedLedger: () => [{ kind: 'wiki_page', id: 'docs/synthetic.md' }],
+        })
+      ).toThrow(/sourceRefs must not be empty/);
+      expect(() => commitOperatorCursorWithChangedWrite(db, missingWriterInput)).toThrow(
+        /writeChangedLedger must be a function/
+      );
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+
+      db.close();
+    });
+
     it('commits no-update rows and advances the cursor atomically', () => {
       const db = makeOperatorVNextDb();
 
@@ -454,6 +486,87 @@ describe('STORY-VNEXT-PR2-CURSOR-COMMIT: atomic cursor commits', () => {
         content: 'original artifact',
         updated_at_ms: 1710000000000,
       });
+
+      db.close();
+    });
+
+    it('preserves the durable writer error when replay cleanup fails', () => {
+      const db = makeOperatorVNextDb();
+      const originalExec = db.exec.bind(db);
+
+      commitOperatorCursorWithChangedWrite(db, {
+        commitId: 'commit-replay-cleanup-error',
+        cursorName: 'connector:slack',
+        firstChangeSeq: 1,
+        lastChangeSeq: 1,
+        idempotencyKey: buildConnectorIdempotencyKey('slack', 1, 1),
+        sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+        nowMs: 1710000000000,
+        writeChangedLedger: () => [{ kind: 'wiki_page', id: 'docs/synthetic.md' }],
+      });
+
+      db.exec = (sql: string) => {
+        if (sql.startsWith('ROLLBACK TO SAVEPOINT')) {
+          throw new Error('rollback cleanup failed');
+        }
+        originalExec(sql);
+      };
+
+      expect(() =>
+        commitOperatorCursorWithChangedWrite(db, {
+          commitId: 'commit-replay-cleanup-error',
+          cursorName: 'connector:slack',
+          firstChangeSeq: 1,
+          lastChangeSeq: 1,
+          idempotencyKey: buildConnectorIdempotencyKey('slack', 1, 1),
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          nowMs: 1710000000001,
+          writeChangedLedger: () => {
+            throw new Error('ledger write failed');
+          },
+        })
+      ).toThrow(/ledger write failed/);
+
+      db.close();
+    });
+
+    it('preserves rollback errors when replay release cleanup also fails', () => {
+      const db = makeOperatorVNextDb();
+      const originalExec = db.exec.bind(db);
+
+      commitOperatorCursorWithChangedWrite(db, {
+        commitId: 'commit-replay-release-error',
+        cursorName: 'connector:slack',
+        firstChangeSeq: 1,
+        lastChangeSeq: 1,
+        idempotencyKey: buildConnectorIdempotencyKey('slack', 1, 1),
+        sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+        nowMs: 1710000000000,
+        writeChangedLedger: () => [{ kind: 'wiki_page', id: 'docs/synthetic.md' }],
+      });
+
+      db.exec = (sql: string) => {
+        if (sql.startsWith('ROLLBACK TO SAVEPOINT')) {
+          throw new Error('rollback cleanup failed');
+        }
+        if (sql.startsWith('RELEASE SAVEPOINT')) {
+          throw new Error('release cleanup failed');
+        }
+        originalExec(sql);
+      };
+
+      expect(() =>
+        commitOperatorCursorWithChangedWrite(db, {
+          commitId: 'commit-replay-release-error',
+          cursorName: 'connector:slack',
+          firstChangeSeq: 1,
+          lastChangeSeq: 1,
+          idempotencyKey: buildConnectorIdempotencyKey('slack', 1, 1),
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          nowMs: 1710000000001,
+          writeChangedLedger: () => [{ kind: 'wiki_page', id: 'docs/synthetic.md' }],
+        })
+      ).toThrow(/rollback cleanup failed/);
 
       db.close();
     });

--- a/packages/standalone/tests/operator-vnext/operator-cursor-commit.test.ts
+++ b/packages/standalone/tests/operator-vnext/operator-cursor-commit.test.ts
@@ -5,7 +5,9 @@ process.env.MAMA_FORCE_TIER_3 ||= 'true';
 import {
   buildConnectorIdempotencyKey,
   commitOperatorCursor,
+  commitOperatorCursorWithChangedWrite,
 } from '../../src/operator-vnext/operator-cursor-commit.js';
+import { WikiArtifactStore } from '../../src/wiki-artifacts/wiki-artifact-store.js';
 import { countRows, makeOperatorVNextDb } from './fixtures.js';
 
 describe('STORY-VNEXT-PR2-CURSOR-COMMIT: atomic cursor commits', () => {
@@ -42,6 +44,92 @@ describe('STORY-VNEXT-PR2-CURSOR-COMMIT: atomic cursor commits', () => {
         changed_refs_json: '["os_task:task-1"]',
         source_refs_json: '["raw:slack:event-1"]',
       });
+
+      db.close();
+    });
+
+    it('runs durable changed writers inside the cursor commit transaction', () => {
+      const db = makeOperatorVNextDb();
+      const store = new WikiArtifactStore(db);
+
+      const result = commitOperatorCursorWithChangedWrite(db, {
+        commitId: 'commit-wiki-artifact',
+        cursorName: 'connector:slack',
+        firstChangeSeq: 1,
+        lastChangeSeq: 1,
+        idempotencyKey: buildConnectorIdempotencyKey('slack', 1, 1),
+        sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+        nowMs: 1710000000000,
+        writeChangedLedger: () => {
+          const artifact = store.upsertArtifact({
+            path: 'docs/synthetic.md',
+            title: 'Synthetic',
+            type: 'entity',
+            content: 'synthetic artifact',
+            confidence: 'high',
+            sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+            nowMs: 1710000000000,
+          });
+          return [{ kind: 'wiki_page', id: artifact.path }];
+        },
+      });
+
+      expect(result.outcome).toBe('committed');
+      expect(countRows(db, 'wiki_artifacts')).toBe(1);
+      expect(db.prepare('SELECT path, source_refs_json FROM wiki_artifacts').get()).toEqual({
+        path: 'docs/synthetic.md',
+        source_refs_json: '["raw:slack:event-1"]',
+      });
+      expect(
+        db.prepare('SELECT status, changed_refs_json FROM vnext_operator_commits').get()
+      ).toEqual({
+        status: 'changed',
+        changed_refs_json: '["wiki_page:docs/synthetic.md"]',
+      });
+      expect(
+        db
+          .prepare('SELECT last_change_seq FROM vnext_operator_cursors WHERE cursor_name = ?')
+          .get('connector:slack')
+      ).toEqual({ last_change_seq: 1 });
+
+      db.close();
+    });
+
+    it('rolls back durable changed writer side effects when returned refs are invalid', () => {
+      const db = makeOperatorVNextDb();
+      const store = new WikiArtifactStore(db);
+
+      expect(() =>
+        commitOperatorCursorWithChangedWrite(db, {
+          commitId: 'commit-empty-wiki-ref',
+          cursorName: 'connector:slack',
+          firstChangeSeq: 1,
+          lastChangeSeq: 1,
+          idempotencyKey: buildConnectorIdempotencyKey('slack', 1, 1),
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          nowMs: 1710000000000,
+          writeChangedLedger: () => {
+            store.upsertArtifact({
+              path: 'docs/rollback.md',
+              title: 'Rollback',
+              type: 'entity',
+              content: 'rollback artifact',
+              confidence: 'high',
+              sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+              nowMs: 1710000000000,
+            });
+            return [];
+          },
+        })
+      ).toThrow(/Source refs must not be empty/i);
+
+      expect(
+        db
+          .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+          .get('wiki_artifacts')
+      ).toBeUndefined();
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(countRows(db, 'vnext_operator_cursors')).toBe(0);
 
       db.close();
     });
@@ -289,6 +377,276 @@ describe('STORY-VNEXT-PR2-CURSOR-COMMIT: atomic cursor commits', () => {
       expect(commitOperatorCursor(db, input).outcome).toBe('committed');
       expect(commitOperatorCursor(db, input).outcome).toBe('already_committed');
       expect(countRows(db, 'vnext_operator_commits')).toBe(1);
+
+      db.close();
+    });
+
+    it('reruns durable changed writers to verify idempotent replay refs', () => {
+      const db = makeOperatorVNextDb();
+      let writes = 0;
+      const input = {
+        commitId: 'commit-writer-once',
+        cursorName: 'connector:slack',
+        firstChangeSeq: 1,
+        lastChangeSeq: 1,
+        idempotencyKey: buildConnectorIdempotencyKey('slack', 1, 1),
+        sourceRefs: [{ kind: 'raw' as const, connector: 'slack', id: 'event-1' }],
+        nowMs: 1710000000000,
+        writeChangedLedger: () => {
+          writes += 1;
+          return [{ kind: 'wiki_page' as const, id: 'docs/synthetic.md' }];
+        },
+      };
+
+      expect(commitOperatorCursorWithChangedWrite(db, input).outcome).toBe('committed');
+      expect(commitOperatorCursorWithChangedWrite(db, input).outcome).toBe('already_committed');
+      expect(writes).toBe(2);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(1);
+
+      db.close();
+    });
+
+    it('rolls back durable writer side effects during changed replay verification', () => {
+      const db = makeOperatorVNextDb();
+      const store = new WikiArtifactStore(db);
+      const input = {
+        commitId: 'commit-replay-savepoint',
+        cursorName: 'connector:slack',
+        firstChangeSeq: 1,
+        lastChangeSeq: 1,
+        idempotencyKey: buildConnectorIdempotencyKey('slack', 1, 1),
+        sourceRefs: [{ kind: 'raw' as const, connector: 'slack', id: 'event-1' }],
+        nowMs: 1710000000000,
+        writeChangedLedger: () => {
+          const artifact = store.upsertArtifact({
+            path: 'docs/synthetic.md',
+            title: 'Synthetic',
+            type: 'entity',
+            content: 'original artifact',
+            confidence: 'high',
+            sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+            nowMs: 1710000000000,
+          });
+          return [{ kind: 'wiki_page' as const, id: artifact.path }];
+        },
+      };
+
+      expect(commitOperatorCursorWithChangedWrite(db, input).outcome).toBe('committed');
+      expect(
+        commitOperatorCursorWithChangedWrite(db, {
+          ...input,
+          writeChangedLedger: () => {
+            const artifact = store.upsertArtifact({
+              path: 'docs/synthetic.md',
+              title: 'Synthetic Replay',
+              type: 'entity',
+              content: 'replayed artifact',
+              confidence: 'high',
+              sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+              nowMs: 1710000000001,
+            });
+            return [{ kind: 'wiki_page' as const, id: artifact.path }];
+          },
+        }).outcome
+      ).toBe('already_committed');
+      expect(db.prepare('SELECT title, content, updated_at_ms FROM wiki_artifacts').get()).toEqual({
+        title: 'Synthetic',
+        content: 'original artifact',
+        updated_at_ms: 1710000000000,
+      });
+
+      db.close();
+    });
+
+    it('persists durable writer side effects while recovering a changed cursor', () => {
+      const db = makeOperatorVNextDb();
+      const store = new WikiArtifactStore(db);
+
+      db.prepare(
+        `INSERT INTO vnext_operator_cursors (
+          cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+        ) VALUES (?, ?, ?, ?)`
+      ).run('connector:slack', 0, null, 1710000000000);
+      db.prepare(
+        `INSERT INTO vnext_operator_commits (
+          commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+          status, changed_refs_json, source_refs_json, created_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        'commit-existing',
+        'connector:slack',
+        'connector:slack:seq:1-1',
+        1,
+        1,
+        'changed',
+        '["wiki_page:docs/synthetic.md"]',
+        '["raw:slack:event-1"]',
+        1710000000000
+      );
+
+      const result = commitOperatorCursorWithChangedWrite(db, {
+        cursorName: 'connector:slack',
+        firstChangeSeq: 1,
+        lastChangeSeq: 1,
+        idempotencyKey: 'connector:slack:seq:1-1',
+        sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+        nowMs: 1710000000001,
+        writeChangedLedger: () => {
+          const artifact = store.upsertArtifact({
+            path: 'docs/synthetic.md',
+            title: 'Synthetic Recovery',
+            type: 'entity',
+            content: 'recovered artifact',
+            confidence: 'high',
+            sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+            nowMs: 1710000000001,
+          });
+          return [{ kind: 'wiki_page' as const, id: artifact.path }];
+        },
+      });
+
+      expect(result.outcome).toBe('recovered');
+      expect(db.prepare('SELECT path, content FROM wiki_artifacts').get()).toEqual({
+        path: 'docs/synthetic.md',
+        content: 'recovered artifact',
+      });
+      expect(
+        db
+          .prepare('SELECT last_change_seq FROM vnext_operator_cursors WHERE cursor_name = ?')
+          .get('connector:slack')
+      ).toEqual({ last_change_seq: 1 });
+
+      db.close();
+    });
+
+    it('keeps wiki artifact schema cache valid after replay verification rolls back first schema creation', () => {
+      const db = makeOperatorVNextDb();
+      const store = new WikiArtifactStore(db);
+
+      db.prepare(
+        `INSERT INTO vnext_operator_cursors (
+          cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+        ) VALUES (?, ?, ?, ?)`
+      ).run('connector:slack', 1, 'connector:slack:seq:1-1', 1710000000000);
+      db.prepare(
+        `INSERT INTO vnext_operator_commits (
+          commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+          status, changed_refs_json, source_refs_json, created_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        'commit-existing',
+        'connector:slack',
+        'connector:slack:seq:1-1',
+        1,
+        1,
+        'changed',
+        '["wiki_page:docs/synthetic.md"]',
+        '["raw:slack:event-1"]',
+        1710000000000
+      );
+
+      expect(
+        commitOperatorCursorWithChangedWrite(db, {
+          cursorName: 'connector:slack',
+          firstChangeSeq: 1,
+          lastChangeSeq: 1,
+          idempotencyKey: 'connector:slack:seq:1-1',
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+          nowMs: 1710000000001,
+          writeChangedLedger: () => {
+            const artifact = store.upsertArtifact({
+              path: 'docs/synthetic.md',
+              title: 'Synthetic Replay',
+              type: 'entity',
+              content: 'replayed artifact',
+              confidence: 'high',
+              sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-1' }],
+              nowMs: 1710000000001,
+            });
+            return [{ kind: 'wiki_page' as const, id: artifact.path }];
+          },
+        }).outcome
+      ).toBe('already_committed');
+      expect(
+        db
+          .prepare(
+            `SELECT name
+             FROM sqlite_master
+             WHERE type = 'table' AND name = 'wiki_artifacts'`
+          )
+          .get()
+      ).toBeUndefined();
+
+      expect(
+        commitOperatorCursorWithChangedWrite(db, {
+          commitId: 'commit-next',
+          cursorName: 'connector:slack',
+          firstChangeSeq: 2,
+          lastChangeSeq: 2,
+          idempotencyKey: 'connector:slack:seq:2-2',
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
+          nowMs: 1710000000002,
+          writeChangedLedger: () => {
+            const artifact = store.upsertArtifact({
+              path: 'docs/synthetic-2.md',
+              title: 'Synthetic Next',
+              type: 'entity',
+              content: 'next artifact',
+              confidence: 'high',
+              sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
+              nowMs: 1710000000002,
+            });
+            return [{ kind: 'wiki_page' as const, id: artifact.path }];
+          },
+        }).outcome
+      ).toBe('committed');
+      expect(db.prepare('SELECT path FROM wiki_artifacts').get()).toEqual({
+        path: 'docs/synthetic-2.md',
+      });
+
+      db.close();
+    });
+
+    it('does not run durable changed writers when replay metadata mismatches', () => {
+      const db = makeOperatorVNextDb();
+      db.prepare(
+        `INSERT INTO vnext_operator_cursors (
+          cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+        ) VALUES (?, ?, ?, ?)`
+      ).run('connector:slack', 1, 'cursor:connector:slack:seq:1-1', 1710000000000);
+      db.prepare(
+        `INSERT INTO vnext_operator_commits (
+          commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+          status, changed_refs_json, source_refs_json, created_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        'commit-writer-mismatch',
+        'connector:slack',
+        'cursor:connector:slack:seq:1-1',
+        1,
+        1,
+        'changed',
+        '["wiki_page:docs/synthetic.md"]',
+        '["raw:slack:event-1"]',
+        1710000000000
+      );
+      let writes = 0;
+
+      expect(() =>
+        commitOperatorCursorWithChangedWrite(db, {
+          cursorName: 'connector:slack',
+          firstChangeSeq: 1,
+          lastChangeSeq: 1,
+          idempotencyKey: 'cursor:connector:slack:seq:1-1',
+          sourceRefs: [{ kind: 'raw', connector: 'slack', id: 'event-2' }],
+          nowMs: 1710000000001,
+          writeChangedLedger: () => {
+            writes += 1;
+            return [{ kind: 'wiki_page', id: 'docs/synthetic.md' }];
+          },
+        })
+      ).toThrow(/original changed operator commit/i);
+      expect(writes).toBe(0);
 
       db.close();
     });

--- a/packages/standalone/tests/operator-vnext/primary-operator-runtime.test.ts
+++ b/packages/standalone/tests/operator-vnext/primary-operator-runtime.test.ts
@@ -119,6 +119,314 @@ describe('STORY-VNEXT-PR2-PRIMARY-OPERATOR: primary operator commit shell', () =
       db.close();
     });
 
+    it('uses changed refs returned by the durable committer instead of model-supplied refs', async () => {
+      const db = makeOperatorVNextDb();
+      db.exec(
+        `CREATE TABLE canonical_changed_artifacts (
+          artifact_id TEXT PRIMARY KEY,
+          source_refs_json TEXT NOT NULL,
+          idempotency_key TEXT NOT NULL
+        )`
+      );
+      const runtime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000000,
+      });
+
+      const result = await runtime.processBatchWithChangedCommit(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } }],
+        async () => ({
+          status: 'changed',
+          changedRefs: [{ kind: 'os_task', id: 'model-supplied-ref' }],
+        }),
+        ({ decision, idempotencyKey, sourceRefs }) => {
+          expect('changedRefs' in decision).toBe(false);
+          db.prepare(
+            `INSERT INTO canonical_changed_artifacts (
+              artifact_id, source_refs_json, idempotency_key
+            ) VALUES (?, ?, ?)`
+          ).run('artifact-1', JSON.stringify(sourceRefs), idempotencyKey);
+          return [{ kind: 'wiki_page', id: 'docs/synthetic.md' }];
+        }
+      );
+
+      expect(result).toMatchObject({
+        status: 'committed',
+        processed: 1,
+        advancedThroughSeq: 1,
+      });
+      expect(
+        db.prepare('SELECT status, changed_refs_json FROM vnext_operator_commits').get()
+      ).toEqual({
+        status: 'changed',
+        changed_refs_json: '["wiki_page:docs/synthetic.md"]',
+      });
+      expect(db.prepare('SELECT * FROM canonical_changed_artifacts').get()).toEqual({
+        artifact_id: 'artifact-1',
+        source_refs_json: JSON.stringify([{ kind: 'raw', connector: 'slack', id: 'event-1' }]),
+        idempotency_key: 'cursor:connector:slack:seq:1-1',
+      });
+
+      db.close();
+    });
+
+    it('rolls back changed ledger writes and cursor advancement when the committer fails', async () => {
+      const db = makeOperatorVNextDb();
+      db.exec(
+        `CREATE TABLE canonical_changed_artifacts (
+          artifact_id TEXT PRIMARY KEY,
+          source_refs_json TEXT NOT NULL
+        )`
+      );
+      const runtime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000000,
+      });
+
+      const result = await runtime.processBatchWithChangedCommit(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } }],
+        async () => ({ status: 'changed' }),
+        ({ sourceRefs }) => {
+          db.prepare(
+            `INSERT INTO canonical_changed_artifacts (
+              artifact_id, source_refs_json
+            ) VALUES (?, ?)`
+          ).run('artifact-rollback', JSON.stringify(sourceRefs));
+          throw new Error('canonical write failed');
+        }
+      );
+
+      expect(result).toMatchObject({
+        status: 'partial_failure',
+        processed: 0,
+        advancedThroughSeq: 0,
+        failedSeq: 1,
+      });
+      expect(result.error.message).toMatch(/canonical write failed/i);
+      expect(lastCursorSeq(db)).toBe(0);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(countRows(db, 'canonical_changed_artifacts')).toBe(0);
+
+      db.close();
+    });
+
+    it('rejects replayed changed commits whose refs were not produced by the durable committer', async () => {
+      const db = makeOperatorVNextDb();
+      db.exec(
+        `CREATE TABLE canonical_changed_artifacts (
+          artifact_id TEXT PRIMARY KEY,
+          source_refs_json TEXT NOT NULL
+        )`
+      );
+      db.prepare(
+        `INSERT INTO vnext_operator_cursors (
+          cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+        ) VALUES (?, ?, ?, ?)`
+      ).run('connector:slack', 1, 'cursor:connector:slack:seq:1-1', 1710000000000);
+      db.prepare(
+        `INSERT INTO vnext_operator_commits (
+          commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+          status, changed_refs_json, source_refs_json, created_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        'commit-legacy-model-ref',
+        'connector:slack',
+        'cursor:connector:slack:seq:1-1',
+        1,
+        1,
+        'changed',
+        '["os_task:model-supplied-ref"]',
+        '["raw:slack:event-1"]',
+        1710000000000
+      );
+      const runtime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000001,
+      });
+      const decide = vi.fn(() => ({ status: 'changed' }));
+
+      const result = await runtime.processBatchWithChangedCommit(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } }],
+        decide,
+        ({ sourceRefs }) => {
+          db.prepare(
+            `INSERT INTO canonical_changed_artifacts (
+              artifact_id, source_refs_json
+            ) VALUES (?, ?)`
+          ).run('artifact-replay-mismatch', JSON.stringify(sourceRefs));
+          return [{ kind: 'wiki_page', id: 'docs/synthetic.md' }];
+        }
+      );
+
+      expect(result).toMatchObject({
+        status: 'partial_failure',
+        processed: 0,
+        advancedThroughSeq: 1,
+        failedSeq: 1,
+      });
+      expect(result.error.message).toMatch(/changed refs/i);
+      expect(decide).not.toHaveBeenCalled();
+      expect(countRows(db, 'canonical_changed_artifacts')).toBe(0);
+      expect(db.prepare('SELECT changed_refs_json FROM vnext_operator_commits').get()).toEqual({
+        changed_refs_json: '["os_task:model-supplied-ref"]',
+      });
+
+      db.close();
+    });
+
+    it('recovers no-update replays in trusted changed mode without invoking decider or writer', async () => {
+      const db = makeOperatorVNextDb();
+      const runtime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000000,
+      });
+      const first = await runtime.processBatch(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } }],
+        async () => ({
+          status: 'no_update',
+          reason: 'event did not change canonical state',
+          scopeKey: 'connector:slack',
+        })
+      );
+      expect(first.status).toBe('committed');
+      const decide = vi.fn(() => {
+        throw new Error('decider must not run');
+      });
+      const commitChanged = vi.fn(() => {
+        throw new Error('changed writer must not run');
+      });
+
+      const replay = await runtime.processBatchWithChangedCommit(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } }],
+        decide,
+        commitChanged
+      );
+
+      expect(replay).toMatchObject({
+        status: 'committed',
+        processed: 1,
+        advancedThroughSeq: 1,
+      });
+      expect(replay.commits[0]).toMatchObject({
+        outcome: 'already_committed',
+        status: 'no_update',
+      });
+      expect(decide).not.toHaveBeenCalled();
+      expect(commitChanged).not.toHaveBeenCalled();
+
+      db.close();
+    });
+
+    it('recovers legacy no-update commits in trusted changed mode before invoking decider', async () => {
+      const db = makeOperatorVNextDb();
+      db.prepare(
+        `INSERT INTO vnext_operator_cursors (
+          cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+        ) VALUES (?, ?, ?, ?)`
+      ).run('connector:slack', 0, null, 1710000000000);
+      db.prepare(
+        `INSERT INTO vnext_operator_commits (
+          commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+          status, changed_refs_json, source_refs_json, created_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        'commit-legacy-no-update',
+        'connector:slack',
+        'connector:slack:seq:1-1',
+        1,
+        1,
+        'no_update',
+        '[]',
+        '["raw:slack:event-1"]',
+        1710000000000
+      );
+      db.prepare(
+        `INSERT INTO operator_no_updates (
+          no_update_id, scope_key, reason, source_refs_json, idempotency_key, created_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?)`
+      ).run(
+        'no-update-legacy',
+        'connector:slack',
+        'event did not change canonical state',
+        '["raw:slack:event-1"]',
+        'connector:slack:seq:1-1',
+        1710000000000
+      );
+      const runtime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000001,
+      });
+      const decide = vi.fn(() => {
+        throw new Error('decider must not run');
+      });
+      const commitChanged = vi.fn(() => {
+        throw new Error('changed writer must not run');
+      });
+
+      const result = await runtime.processBatchWithChangedCommit(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } }],
+        decide,
+        commitChanged
+      );
+
+      expect(result).toMatchObject({
+        status: 'committed',
+        processed: 1,
+        advancedThroughSeq: 1,
+      });
+      expect(result.commits[0]).toMatchObject({
+        outcome: 'recovered',
+        idempotencyKey: 'connector:slack:seq:1-1',
+        status: 'no_update',
+      });
+      expect(decide).not.toHaveBeenCalled();
+      expect(commitChanged).not.toHaveBeenCalled();
+      expect(lastCursorSeq(db)).toBe(1);
+
+      db.close();
+    });
+
+    it('rejects non-contiguous trusted changed events before invoking decider or writer', async () => {
+      const db = makeOperatorVNextDb();
+      const runtime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000000,
+      });
+      const decide = vi.fn(() => ({ status: 'changed' }));
+      const commitChanged = vi.fn(() => [{ kind: 'wiki_page' as const, id: 'docs/synthetic.md' }]);
+
+      const result = await runtime.processBatchWithChangedCommit(
+        [{ seq: 2, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-2' } }],
+        decide,
+        commitChanged
+      );
+
+      expect(result).toMatchObject({
+        status: 'partial_failure',
+        processed: 0,
+        advancedThroughSeq: 0,
+        failedSeq: 2,
+      });
+      expect(result.error.message).toMatch(/contiguous/i);
+      expect(decide).not.toHaveBeenCalled();
+      expect(commitChanged).not.toHaveBeenCalled();
+      expect(lastCursorSeq(db)).toBe(0);
+
+      db.close();
+    });
+
     it('ignores model-supplied supplemental source refs', async () => {
       const db = makeOperatorVNextDb();
       const runtime = new PrimaryOperatorRuntime({

--- a/packages/standalone/tests/operator-vnext/primary-operator-runtime.test.ts
+++ b/packages/standalone/tests/operator-vnext/primary-operator-runtime.test.ts
@@ -396,6 +396,70 @@ describe('STORY-VNEXT-PR2-PRIMARY-OPERATOR: primary operator commit shell', () =
       db.close();
     });
 
+    it('passes the matched legacy idempotency key to changed writers during trusted replay', async () => {
+      const db = makeOperatorVNextDb();
+      const legacyIdempotencyKey = 'connector:slack:seq:1-1';
+      db.prepare(
+        `INSERT INTO vnext_operator_cursors (
+          cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+        ) VALUES (?, ?, ?, ?)`
+      ).run('connector:slack', 1, legacyIdempotencyKey, 1710000000000);
+      db.prepare(
+        `INSERT INTO vnext_operator_commits (
+          commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+          status, changed_refs_json, source_refs_json, created_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        'commit-legacy-changed',
+        'connector:slack',
+        legacyIdempotencyKey,
+        1,
+        1,
+        'changed',
+        '["wiki_page:docs/legacy.md"]',
+        '["raw:slack:event-1"]',
+        1710000000000
+      );
+      const runtime = new PrimaryOperatorRuntime({
+        db,
+        cursorName: 'connector:slack',
+        connector: 'slack',
+        nowMs: () => 1710000000001,
+      });
+      const decide = vi.fn(() => {
+        throw new Error('decider must not run');
+      });
+      const commitChanged = vi.fn(({ idempotencyKey }) => [
+        {
+          kind: 'wiki_page' as const,
+          id: idempotencyKey === legacyIdempotencyKey ? 'docs/legacy.md' : 'docs/cursor-scoped.md',
+        },
+      ]);
+
+      const result = await runtime.processBatchWithChangedCommit(
+        [{ seq: 1, sourceRef: { kind: 'raw', connector: 'slack', id: 'event-1' } }],
+        decide,
+        commitChanged
+      );
+
+      expect(result).toMatchObject({
+        status: 'committed',
+        processed: 1,
+        advancedThroughSeq: 1,
+      });
+      expect(result.commits[0]).toMatchObject({
+        outcome: 'already_committed',
+        idempotencyKey: legacyIdempotencyKey,
+        status: 'changed',
+      });
+      expect(commitChanged).toHaveBeenCalledWith(
+        expect.objectContaining({ idempotencyKey: legacyIdempotencyKey })
+      );
+      expect(decide).not.toHaveBeenCalled();
+
+      db.close();
+    });
+
     it('rejects non-contiguous trusted changed events before invoking decider or writer', async () => {
       const db = makeOperatorVNextDb();
       const runtime = new PrimaryOperatorRuntime({

--- a/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
+++ b/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
@@ -343,7 +343,9 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
         status: 'degraded',
         lastBatchStatus: 'partial_failure',
         failedSeq: 1,
+        errorMessage: 'Primary operator batch failed. Check local logs for details.',
       });
+      expect(primaryOperator.status.errorMessage).not.toContain('slack');
 
       const idleResult = await primaryOperator.processBatch([], () => ({
         status: 'no_update',
@@ -368,7 +370,9 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
         status: 'degraded',
         last_batch_status: 'idle',
         failed_seq: 1,
+        error_message: 'Primary operator batch failed. Check local logs for details.',
       });
+      expect(statusResponse.body.primary_operator_runtime.error_message).not.toContain('slack');
 
       db.close();
     });

--- a/packages/standalone/tests/runtime-vnext/bootstrap.test.ts
+++ b/packages/standalone/tests/runtime-vnext/bootstrap.test.ts
@@ -152,6 +152,12 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP: vNext bootstrap contract', () => {
           advancedThroughSeq: 7,
           commits: [],
         }),
+        processBatchWithChangedCommit: async () => ({
+          status: 'idle' as const,
+          processed: 0,
+          advancedThroughSeq: 7,
+          commits: [],
+        }),
       };
       const apiServer = {
         start: async () => {
@@ -269,6 +275,12 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP: vNext bootstrap contract', () => {
               advancedThroughSeq: 0,
             },
             processBatch: async () => ({
+              status: 'idle',
+              processed: 0,
+              advancedThroughSeq: 0,
+              commits: [],
+            }),
+            processBatchWithChangedCommit: async () => ({
               status: 'idle',
               processed: 0,
               advancedThroughSeq: 0,


### PR DESCRIPTION
## Summary
- Add a trusted changed-commit path for the vNext primary operator (`processBatchWithChangedCommit` and `commitOperatorCursorWithChangedWrite`).
- Store `changed_refs_json` from the durable writer return value instead of model/API-supplied `changedRefs`.
- Preserve no-update and legacy no-update replay without invoking the decider or writer.
- Verify existing changed replays while rolling back already-committed replay writer side effects.
- Persist durable writer effects when recovering from an existing changed commit before advancing the cursor.
- Validate event sequence locally before calling the decider in the trusted path.
- Sanitize primary operator status errors exposed through status/report APIs.
- Harden wiki artifact lazy schema caching after savepoint rollback.

## Tests
- `MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run tests/operator-vnext/primary-operator-runtime.test.ts tests/operator-vnext/operator-cursor-commit.test.ts tests/runtime-vnext/bootstrap-api.test.ts tests/runtime-vnext/bootstrap.test.ts`
- `pnpm --filter @jungjaehoon/mama-os exec prettier --check packages/standalone/src/operator-vnext/operator-commit-result.ts packages/standalone/src/operator-vnext/operator-cursor-commit.ts packages/standalone/src/operator-vnext/primary-operator-runtime.ts packages/standalone/src/runtime-vnext/bootstrap.ts packages/standalone/src/cli/commands/start.ts packages/standalone/src/wiki-artifacts/wiki-artifact-store.ts packages/standalone/tests/operator-vnext/primary-operator-runtime.test.ts packages/standalone/tests/operator-vnext/operator-cursor-commit.test.ts packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts packages/standalone/tests/runtime-vnext/bootstrap.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint`
- `git diff --check`
- `./scripts/check-pii.sh`
- `MAMA_FORCE_TIER_3=true pnpm test`
- Codex review: clear after fixes.

## Privacy / Public-Project Audit
- Checked changed source/tests for local absolute paths, user/project-private identifiers, tokens, passwords, API keys, and secret-like material.
- Only synthetic fixture identifiers remain, such as `event-1`, `task-1`, `docs/synthetic.md`, and `connector:slack`.
- `./scripts/check-pii.sh` passed.

## Notes
- Full root `MAMA_FORCE_TIER_3=true pnpm test` passed: 7 tasks successful; standalone 238 files; 3366 passed, 1 skipped.
- Full `pnpm format:check` was not used as a gate here because it currently reports unrelated pre-existing formatting drift; targeted Prettier for all changed files passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for processing batches with “changed write” commits, enabling more reliable handling of durable changes and replay behavior.

* **Bug Fixes**
  * Improved status handling for partial failures and now shows a generic, sanitized error message.
  * Added better recovery for existing commits and safer rollback behavior when a write cannot be completed.
  * Schema setup now checks the database more reliably before reapplying migrations.

* **Tests**
  * Expanded coverage for changed-write processing, recovery, rollback, and runtime error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->