### PR TITLE
feat: add vNext manual wiki ingress commits

### DIFF
--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -101,6 +101,16 @@ import {
   MAX_MANUAL_NO_UPDATE_EVENT_INDEX_IDS,
   type ConnectorIngressManualCommitResult,
 } from '../../operator-vnext/connector-ingress-manual-commit.js';
+import {
+  createConnectorIngressManualWikiCommitProvider,
+  MAX_MANUAL_WIKI_COMMIT_TOTAL_PAGES,
+  type ConnectorIngressManualWikiCommitResult,
+} from '../../operator-vnext/connector-ingress-manual-wiki-commit.js';
+import {
+  MAX_WIKI_PAGE_CONTENT_CHARS,
+  MAX_WIKI_PUBLISH_PAGES,
+} from '../../wiki-artifacts/wiki-publish-adapter.js';
+import type { WikiPublishPageInput } from '../../wiki-artifacts/types.js';
 import { resolveReactiveProjectRoot } from '../../envelope/reactive-config.js';
 import { deriveMemoryScopes, type MemoryScopeRef } from '../../memory/scope-context.js';
 import { DEFAULT_ROLES, type AgentPersonaConfig, type RoleConfig } from '../config/types.js';
@@ -123,6 +133,13 @@ const codeActLogger = new DebugLogger('CodeAct');
 const vNextOperatorLogger = new DebugLogger('VNextPrimaryOperator');
 type RuntimeBackend = 'claude' | 'codex' | 'codex-mcp';
 const TRUTHY_ENV_VALUES = new Set(['1', 'true', 'yes', 'on']);
+const JSON_ESCAPE_BYTES_PER_UTF16_UNIT = 6;
+const MANUAL_WIKI_COMMIT_JSON_ENVELOPE_BYTES = 1024 * 1024;
+const MANUAL_WIKI_COMMIT_JSON_LIMIT_BYTES =
+  MAX_MANUAL_WIKI_COMMIT_TOTAL_PAGES *
+    MAX_WIKI_PAGE_CONTENT_CHARS *
+    JSON_ESCAPE_BYTES_PER_UTF16_UNIT +
+  MANUAL_WIKI_COMMIT_JSON_ENVELOPE_BYTES;
 const CODE_ACT_MUTATION_TOOLS = new Set([
   'mama_save',
   'context_compile',
@@ -587,6 +604,16 @@ export interface VNextIngressManualNoUpdateCommitRequest {
   eventIndexIds: string[];
 }
 
+export interface VNextIngressManualWikiCommitRequest {
+  connector: string;
+  channel: string;
+  expectedAdvancedThroughSeq: number;
+  eventPages: Array<{
+    eventIndexId: string;
+    pages: WikiPublishPageInput[];
+  }>;
+}
+
 export interface VNextBootstrapApiServerOptions {
   ingressPreviewProvider?: (input: VNextIngressPreviewRequest) => ConnectorEventIngressPreview;
   ingressMigrationDryRunProvider?: (
@@ -595,6 +622,9 @@ export interface VNextBootstrapApiServerOptions {
   ingressManualNoUpdateCommitProvider?: (
     input: VNextIngressManualNoUpdateCommitRequest
   ) => Promise<ConnectorIngressManualCommitResult> | ConnectorIngressManualCommitResult;
+  ingressManualWikiCommitProvider?: (
+    input: VNextIngressManualWikiCommitRequest
+  ) => Promise<ConnectorIngressManualWikiCommitResult> | ConnectorIngressManualWikiCommitResult;
 }
 
 function firstQueryString(value: unknown): string | null {
@@ -659,6 +689,74 @@ function bodyStringArray(body: Record<string, unknown>, field: string, maxItems:
   return value.map((item) => item.trim());
 }
 
+function bodyWikiPages(value: unknown): WikiPublishPageInput[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error('event_pages[].pages must be a non-empty array');
+  }
+  if (value.length > MAX_WIKI_PUBLISH_PAGES) {
+    throw new Error(`event_pages[].pages must contain at most ${MAX_WIKI_PUBLISH_PAGES} pages`);
+  }
+  return value.map((item) => {
+    const page = requireRequestBodyRecord(item);
+    if (
+      Object.prototype.hasOwnProperty.call(page, 'sourceRefs') ||
+      Object.prototype.hasOwnProperty.call(page, 'source_refs') ||
+      Object.prototype.hasOwnProperty.call(page, 'sourceIds') ||
+      Object.prototype.hasOwnProperty.call(page, 'source_ids')
+    ) {
+      throw new Error('manual wiki commits derive source refs from reviewed events');
+    }
+    const parsed: WikiPublishPageInput = {
+      path: bodyString(page, 'path'),
+      title: bodyString(page, 'title'),
+      content: bodyString(page, 'content'),
+    };
+    const type = page.type;
+    if (type !== undefined) {
+      if (typeof type !== 'string' || type.trim().length === 0) {
+        throw new Error('type must be a non-empty string');
+      }
+      parsed.type = type.trim();
+    }
+    const confidence = page.confidence;
+    if (confidence !== undefined) {
+      if (typeof confidence !== 'string' || confidence.trim().length === 0) {
+        throw new Error('confidence must be a non-empty string');
+      }
+      parsed.confidence = confidence.trim();
+    }
+    return parsed;
+  });
+}
+
+function bodyManualWikiEventPages(
+  body: Record<string, unknown>
+): VNextIngressManualWikiCommitRequest['eventPages'] {
+  const value = body.event_pages;
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error('event_pages must be a non-empty array');
+  }
+  if (value.length > MAX_MANUAL_NO_UPDATE_EVENT_INDEX_IDS) {
+    throw new Error(
+      `event_pages must contain at most ${MAX_MANUAL_NO_UPDATE_EVENT_INDEX_IDS} items`
+    );
+  }
+  const parsed = value.map((item) => {
+    const eventPage = requireRequestBodyRecord(item);
+    return {
+      eventIndexId: bodyString(eventPage, 'event_index_id'),
+      pages: bodyWikiPages(eventPage.pages),
+    };
+  });
+  const totalPages = parsed.reduce((total, eventPage) => total + eventPage.pages.length, 0);
+  if (totalPages > MAX_MANUAL_WIKI_COMMIT_TOTAL_PAGES) {
+    throw new Error(
+      `event_pages must contain at most ${MAX_MANUAL_WIKI_COMMIT_TOTAL_PAGES} total pages`
+    );
+  }
+  return parsed;
+}
+
 function parseManualNoUpdateCommitBody(rawBody: unknown): VNextIngressManualNoUpdateCommitRequest {
   const body = requireRequestBodyRecord(rawBody);
   if (
@@ -672,6 +770,22 @@ function parseManualNoUpdateCommitBody(rawBody: unknown): VNextIngressManualNoUp
     channel: bodyString(body, 'channel'),
     expectedAdvancedThroughSeq: bodyNonNegativeInteger(body, 'expected_advanced_through_seq'),
     eventIndexIds: bodyStringArray(body, 'event_index_ids', MAX_MANUAL_NO_UPDATE_EVENT_INDEX_IDS),
+  };
+}
+
+function parseManualWikiCommitBody(rawBody: unknown): VNextIngressManualWikiCommitRequest {
+  const body = requireRequestBodyRecord(rawBody);
+  if (
+    Object.prototype.hasOwnProperty.call(body, 'changedRefs') ||
+    Object.prototype.hasOwnProperty.call(body, 'changed_refs')
+  ) {
+    throw new Error('manual wiki commits do not accept changed refs');
+  }
+  return {
+    connector: bodyString(body, 'connector'),
+    channel: bodyString(body, 'channel'),
+    expectedAdvancedThroughSeq: bodyNonNegativeInteger(body, 'expected_advanced_through_seq'),
+    eventPages: bodyManualWikiEventPages(body),
   };
 }
 
@@ -847,6 +961,9 @@ export function createVNextBootstrapApiServer(
   const app = express();
   app.disable('x-powered-by');
   const jsonBodyParser = express.json({ limit: '128kb' });
+  const manualWikiCommitJsonBodyParser = express.json({
+    limit: MANUAL_WIKI_COMMIT_JSON_LIMIT_BYTES,
+  });
 
   app.get('/health', (_req, res) => {
     res.json({
@@ -901,6 +1018,52 @@ export function createVNextBootstrapApiServer(
     }
   );
   app.use('/api/vnext/ingress/manual-no-update-commit', handleVNextManualCommitJsonError);
+  app.post(
+    '/api/vnext/ingress/manual-wiki-commit',
+    requireAdminAuth,
+    manualWikiCommitJsonBodyParser,
+    async (req, res) => {
+      if (!options.ingressManualWikiCommitProvider) {
+        res.status(404).json({
+          ok: false,
+          code: 'vnext_ingress_manual_wiki_commit_unavailable',
+          error: 'vNext manual wiki ingress commit is not configured.',
+        });
+        return;
+      }
+
+      let input: VNextIngressManualWikiCommitRequest;
+      try {
+        input = parseManualWikiCommitBody(req.body);
+      } catch (error) {
+        res.status(400).json({
+          ok: false,
+          code: 'vnext_ingress_manual_wiki_commit_invalid_request',
+          error: error instanceof Error ? error.message : 'Invalid manual wiki commit request.',
+        });
+        return;
+      }
+
+      try {
+        const result = await options.ingressManualWikiCommitProvider(input);
+        res.status(result.ok ? 200 : 409).json(result);
+      } catch (error) {
+        const clientError = isVNextManualCommitClientError(error);
+        res.status(clientError ? 400 : 500).json({
+          ok: false,
+          code: clientError
+            ? 'vnext_ingress_manual_wiki_commit_invalid_request'
+            : 'vnext_ingress_manual_wiki_commit_failed',
+          error: clientError
+            ? error instanceof Error
+              ? error.message
+              : 'Invalid manual wiki commit request.'
+            : 'vNext manual wiki ingress commit failed.',
+        });
+      }
+    }
+  );
+  app.use('/api/vnext/ingress/manual-wiki-commit', handleVNextManualCommitJsonError);
   app.use(jsonBodyParser);
   app.use('/api', requireAuth);
   app.get('/api/vnext/status', (_req, res) => {
@@ -1201,6 +1364,13 @@ export async function runAgentLoop(
           ingressManualNoUpdateCommitProvider: createConnectorIngressManualNoUpdateCommitProvider({
             rawAdapter: vNextRawAdapter,
             operatorDb: vNextOperatorDb,
+            connector: vNextIngressConfig.connector,
+            channel: vNextIngressConfig.channel,
+          }),
+          ingressManualWikiCommitProvider: createConnectorIngressManualWikiCommitProvider({
+            rawAdapter: vNextRawAdapter,
+            operatorDb: vNextOperatorDb,
+            wikiPublishAdapter: initVNextWikiPublishAdapter(vNextOperatorDb, { enabled: true })!,
             connector: vNextIngressConfig.connector,
             channel: vNextIngressConfig.channel,
           }),

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -702,9 +702,13 @@ function bodyWikiPages(value: unknown): WikiPublishPageInput[] {
       Object.prototype.hasOwnProperty.call(page, 'sourceRefs') ||
       Object.prototype.hasOwnProperty.call(page, 'source_refs') ||
       Object.prototype.hasOwnProperty.call(page, 'sourceIds') ||
-      Object.prototype.hasOwnProperty.call(page, 'source_ids')
+      Object.prototype.hasOwnProperty.call(page, 'source_ids') ||
+      Object.prototype.hasOwnProperty.call(page, 'changedRefs') ||
+      Object.prototype.hasOwnProperty.call(page, 'changed_refs')
     ) {
-      throw new Error('manual wiki commits derive source refs from reviewed events');
+      throw new Error(
+        'manual wiki commits derive source refs from reviewed events and changed refs from wiki page paths'
+      );
     }
     const parsed: WikiPublishPageInput = {
       path: bodyString(page, 'path'),

--- a/packages/standalone/src/operator-vnext/connector-ingress-manual-commit.ts
+++ b/packages/standalone/src/operator-vnext/connector-ingress-manual-commit.ts
@@ -1,25 +1,21 @@
-import type { SourceRef } from '@jungjaehoon/mama-core/provenance/source-ref';
-
 import type { SQLiteDatabase } from '../sqlite.js';
 import {
   buildConnectorOperatorCursorName,
-  connectorEventIngressOperatorSeqSql,
   type ConnectorEventIngressAdapter,
 } from './connector-event-ingress.js';
+import {
+  assertReviewedConnectorIngressSeqs,
+  MAX_REVIEWED_CONNECTOR_INGRESS_EVENTS,
+  normalizeReviewedEventIndexIds,
+  readConnectorOperatorCursorSeq,
+  readReviewedConnectorIngressEvents,
+} from './connector-ingress-reviewed-events.js';
 import {
   PrimaryOperatorRuntime,
   type PrimaryOperatorBatchResult,
   type PrimaryOperatorEvent,
 } from './primary-operator-runtime.js';
-import { nonNegativeInteger, requiredString } from './validation.js';
-
-interface ConnectorIngressReviewedEventRow {
-  operator_seq: number;
-  event_index_id: string;
-  source_connector: string;
-  source_id: string;
-  channel: string | null;
-}
+import { requiredString } from './validation.js';
 
 interface NoUpdateCommitDetailRow {
   scope_key: string;
@@ -69,7 +65,7 @@ export class ConnectorIngressManualCommitRequestError extends Error {
   }
 }
 
-export const MAX_MANUAL_NO_UPDATE_EVENT_INDEX_IDS = 100;
+export const MAX_MANUAL_NO_UPDATE_EVENT_INDEX_IDS = MAX_REVIEWED_CONNECTOR_INGRESS_EVENTS;
 
 const NO_UPDATE_REASON = 'manual_ingress_reviewed_no_update';
 
@@ -83,43 +79,12 @@ function requestError(message: string): ConnectorIngressManualCommitRequestError
   return new ConnectorIngressManualCommitRequestError(message);
 }
 
-function readCursorSeq(db: SQLiteDatabase, cursorName: string): number {
-  const row = db
-    .prepare('SELECT last_change_seq FROM vnext_operator_cursors WHERE cursor_name = ?')
-    .get(cursorName) as { last_change_seq: number } | undefined;
-  return row?.last_change_seq ?? 0;
-}
-
 function normalizeEventIndexIds(eventIndexIds: readonly string[]): string[] {
-  if (!Array.isArray(eventIndexIds) || eventIndexIds.length === 0) {
-    throw requestError('eventIndexIds must not be empty');
-  }
-  if (eventIndexIds.length > MAX_MANUAL_NO_UPDATE_EVENT_INDEX_IDS) {
-    throw requestError(
-      `eventIndexIds must contain at most ${MAX_MANUAL_NO_UPDATE_EVENT_INDEX_IDS} items`
-    );
-  }
-  return eventIndexIds.map((eventIndexId) => {
-    try {
-      return requiredString(eventIndexId, 'eventIndexIds[]');
-    } catch {
-      throw requestError('eventIndexIds must be a non-empty string array');
-    }
+  return normalizeReviewedEventIndexIds(eventIndexIds, {
+    fieldName: 'eventIndexIds',
+    maxItems: MAX_MANUAL_NO_UPDATE_EVENT_INDEX_IDS,
+    requestError,
   });
-}
-
-function rowToEvent(row: ConnectorIngressReviewedEventRow): PrimaryOperatorEvent {
-  const sourceRef: SourceRef = {
-    kind: 'raw',
-    connector: requiredString(row.source_connector, 'source_connector'),
-    id: requiredString(row.event_index_id, 'event_index_id'),
-    source_id: requiredString(row.source_id, 'source_id'),
-    channel_id: row.channel,
-  };
-  return {
-    seq: nonNegativeInteger(row.operator_seq, 'operator_seq'),
-    sourceRef,
-  };
 }
 
 function readReviewedEvents(input: {
@@ -129,96 +94,13 @@ function readReviewedEvents(input: {
   eventIndexIds: readonly string[];
 }): PrimaryOperatorEvent[] {
   const ids = normalizeEventIndexIds(input.eventIndexIds);
-  const placeholders = ids.map(() => '?').join(', ');
-  const rows = input.rawAdapter
-    .prepare(
-      `
-        WITH ordered_events AS (
-          SELECT
-            ${connectorEventIngressOperatorSeqSql()} AS operator_seq,
-            event_index_id,
-            source_connector,
-            source_id,
-            channel
-          FROM connector_event_index
-          WHERE source_connector = ?
-            AND channel = ?
-        )
-        SELECT
-          operator_seq,
-          event_index_id,
-          source_connector,
-          source_id,
-          channel
-        FROM ordered_events
-        WHERE event_index_id IN (${placeholders})
-        ORDER BY operator_seq ASC
-      `
-    )
-    .all(input.connector, input.channel, ...ids) as ConnectorIngressReviewedEventRow[];
-  const orderedIds = rows.map((row) => requiredString(row.event_index_id, 'event_index_id'));
-  if (orderedIds.length !== ids.length || orderedIds.some((id, index) => id !== ids[index])) {
-    throw requestError('Reviewed event ids do not match the current deterministic connector order');
-  }
-  return rows.map(rowToEvent);
-}
-
-function countEventsInSeqRange(input: {
-  rawAdapter: ConnectorEventIngressAdapter;
-  connector: string;
-  channel: string;
-  afterSeq: number;
-  throughSeq: number;
-}): number {
-  const row = input.rawAdapter
-    .prepare(
-      `
-        SELECT COUNT(*) AS count
-        FROM connector_event_index
-        WHERE source_connector = ?
-          AND channel = ?
-          AND ${connectorEventIngressOperatorSeqSql()} > ?
-          AND ${connectorEventIngressOperatorSeqSql()} <= ?
-      `
-    )
-    .get(input.connector, input.channel, input.afterSeq, input.throughSeq) as
-    | { count: number }
-    | undefined;
-  return nonNegativeInteger(row?.count ?? 0, 'reviewed_range_count');
-}
-
-function assertReviewedSeqs(
-  input: {
-    rawAdapter: ConnectorEventIngressAdapter;
-    connector: string;
-    channel: string;
-  },
-  events: readonly PrimaryOperatorEvent[],
-  expectedAdvancedThroughSeq: number,
-  currentAdvancedThroughSeq: number
-): void {
-  const expected = nonNegativeInteger(expectedAdvancedThroughSeq, 'expectedAdvancedThroughSeq');
-  const firstSeq = events[0]?.seq ?? null;
-  const lastSeq = events[events.length - 1]?.seq ?? null;
-  if (firstSeq === null || lastSeq === null || firstSeq <= expected) {
-    throw requestError('Reviewed event ids do not advance the expected connector cursor');
-  }
-  const rangeCount = countEventsInSeqRange({
+  return readReviewedConnectorIngressEvents({
     rawAdapter: input.rawAdapter,
     connector: input.connector,
     channel: input.channel,
-    afterSeq: expected,
-    throughSeq: lastSeq,
+    eventIndexIds: ids,
+    requestError,
   });
-  if (rangeCount !== events.length) {
-    throw requestError('Reviewed event ids do not cover the current connector cursor range');
-  }
-  if (currentAdvancedThroughSeq > expected && currentAdvancedThroughSeq < lastSeq) {
-    throw requestError('Reviewed event ids are stale for the current connector cursor');
-  }
-  if (currentAdvancedThroughSeq < expected) {
-    throw requestError('Reviewed cursor is ahead of the current connector cursor');
-  }
 }
 
 function assertManualNoUpdateCommitDetails(
@@ -262,7 +144,7 @@ export async function commitConnectorIngressNoUpdateBatch(
         channel,
         eventIndexIds: input.eventIndexIds,
       });
-      assertReviewedSeqs(
+      assertReviewedConnectorIngressSeqs(
         {
           rawAdapter: input.rawAdapter,
           connector,
@@ -270,7 +152,8 @@ export async function commitConnectorIngressNoUpdateBatch(
         },
         events,
         input.expectedAdvancedThroughSeq,
-        readCursorSeq(input.operatorDb, cursorName)
+        readConnectorOperatorCursorSeq(input.operatorDb, cursorName),
+        requestError
       );
       return events;
     },

--- a/packages/standalone/src/operator-vnext/connector-ingress-manual-wiki-commit.ts
+++ b/packages/standalone/src/operator-vnext/connector-ingress-manual-wiki-commit.ts
@@ -98,6 +98,10 @@ function rejectWikiPageError(error: unknown): never {
 }
 
 function normalizeManualWikiPage(page: WikiPublishPageInput): WikiPublishPageInput {
+  if (page === null || typeof page !== 'object') {
+    throw requestError('Each wiki page must be a non-null object');
+  }
+  // Runtime API payloads can still include forbidden caller-supplied keys beyond the TS shape.
   const rawPage = page as unknown as Record<string, unknown>;
   if (
     Object.prototype.hasOwnProperty.call(rawPage, 'sourceRefs') ||
@@ -217,23 +221,27 @@ function assertNoExistingNonChangedCommits(input: {
   connector: string;
   events: readonly PrimaryOperatorEvent[];
 }): void {
-  const lookupExistingCommit = input.operatorDb.prepare(
-    `SELECT status
-     FROM vnext_operator_commits
-     WHERE cursor_name = ?
-       AND idempotency_key IN (?, ?)`
-  );
+  if (input.events.length === 0) {
+    return;
+  }
+  const idempotencyKeys: string[] = [];
   for (const event of input.events) {
-    const cursorScopedKey = buildCursorScopedIdempotencyKey(input.cursorName, event.seq, event.seq);
-    const legacyKey = buildConnectorIdempotencyKey(input.connector, event.seq, event.seq);
-    const rows = lookupExistingCommit.all(
-      input.cursorName,
-      cursorScopedKey,
-      legacyKey
-    ) as ExistingOperatorCommitStatusRow[];
-    if (rows.some((row) => row.status !== 'changed')) {
-      throw requestError('Manual wiki commit cannot replace a non-changed operator commit');
-    }
+    idempotencyKeys.push(
+      buildCursorScopedIdempotencyKey(input.cursorName, event.seq, event.seq),
+      buildConnectorIdempotencyKey(input.connector, event.seq, event.seq)
+    );
+  }
+  const placeholders = idempotencyKeys.map(() => '?').join(', ');
+  const rows = input.operatorDb
+    .prepare(
+      `SELECT status
+       FROM vnext_operator_commits
+       WHERE cursor_name = ?
+         AND idempotency_key IN (${placeholders})`
+    )
+    .all(input.cursorName, ...idempotencyKeys) as ExistingOperatorCommitStatusRow[];
+  if (rows.some((row) => row.status !== 'changed')) {
+    throw requestError('Manual wiki commit cannot replace a non-changed operator commit');
   }
 }
 

--- a/packages/standalone/src/operator-vnext/connector-ingress-manual-wiki-commit.ts
+++ b/packages/standalone/src/operator-vnext/connector-ingress-manual-wiki-commit.ts
@@ -107,9 +107,13 @@ function normalizeManualWikiPage(page: WikiPublishPageInput): WikiPublishPageInp
     Object.prototype.hasOwnProperty.call(rawPage, 'sourceRefs') ||
     Object.prototype.hasOwnProperty.call(rawPage, 'source_refs') ||
     Object.prototype.hasOwnProperty.call(rawPage, 'sourceIds') ||
-    Object.prototype.hasOwnProperty.call(rawPage, 'source_ids')
+    Object.prototype.hasOwnProperty.call(rawPage, 'source_ids') ||
+    Object.prototype.hasOwnProperty.call(rawPage, 'changedRefs') ||
+    Object.prototype.hasOwnProperty.call(rawPage, 'changed_refs')
   ) {
-    throw requestError('Wiki source refs are derived from reviewed events');
+    throw requestError(
+      'Wiki source refs are derived from reviewed events and changed refs are derived from wiki page paths'
+    );
   }
   try {
     const content = requiredWikiString(page.content, 'content', 'manual wiki commit page');

--- a/packages/standalone/src/operator-vnext/connector-ingress-manual-wiki-commit.ts
+++ b/packages/standalone/src/operator-vnext/connector-ingress-manual-wiki-commit.ts
@@ -1,0 +1,377 @@
+import type { SourceRef } from '@jungjaehoon/mama-core/provenance/source-ref';
+
+import type { SQLiteDatabase } from '../sqlite.js';
+import {
+  isVNextWikiPublishAdapter,
+  MAX_WIKI_PAGE_CONTENT_CHARS,
+  MAX_WIKI_PUBLISH_PAGES,
+  type WikiPublishAdapter,
+} from '../wiki-artifacts/wiki-publish-adapter.js';
+import type { WikiPublishPageInput } from '../wiki-artifacts/types.js';
+import {
+  normalizeWikiConfidence,
+  normalizeWikiPagePath,
+  normalizeWikiPageType,
+  requiredWikiString,
+} from '../wiki-artifacts/normalization.js';
+import {
+  buildConnectorOperatorCursorName,
+  type ConnectorEventIngressAdapter,
+} from './connector-event-ingress.js';
+import {
+  assertReviewedConnectorIngressSeqs,
+  MAX_REVIEWED_CONNECTOR_INGRESS_EVENTS,
+  readConnectorOperatorCursorSeq,
+  readReviewedConnectorIngressEvents,
+} from './connector-ingress-reviewed-events.js';
+import { ConnectorIngressManualCommitRequestError } from './connector-ingress-manual-commit.js';
+import {
+  PrimaryOperatorRuntime,
+  type PrimaryOperatorBatchResult,
+  type PrimaryOperatorEvent,
+} from './primary-operator-runtime.js';
+import {
+  buildConnectorIdempotencyKey,
+  buildCursorScopedIdempotencyKey,
+} from './operator-cursor-commit.js';
+import { requiredString } from './validation.js';
+
+interface ExistingOperatorCommitStatusRow {
+  status: string;
+}
+
+export interface ConnectorIngressManualWikiEventPages {
+  eventIndexId: string;
+  pages: readonly WikiPublishPageInput[];
+}
+
+export interface ConnectorIngressManualWikiCommitInput {
+  rawAdapter: ConnectorEventIngressAdapter;
+  operatorDb: SQLiteDatabase;
+  wikiPublishAdapter: WikiPublishAdapter;
+  connector: string;
+  channel: string;
+  expectedAdvancedThroughSeq: number;
+  eventPages: readonly ConnectorIngressManualWikiEventPages[];
+  nowMs?: () => number;
+}
+
+export interface ConnectorIngressManualWikiCommitResult {
+  ok: boolean;
+  mode: 'manual_wiki_commit';
+  status: PrimaryOperatorBatchResult['status'];
+  cursorName: string;
+  connector: string;
+  channel: string;
+  requestedCount: number;
+  processed: number;
+  advancedThroughSeq: number;
+  firstSeq: number | null;
+  lastSeq: number | null;
+  pagesStored: number;
+  commits: Array<{
+    seq: number;
+    status: 'changed';
+    outcome: 'committed' | 'already_committed' | 'recovered';
+    cursorAdvanced: boolean;
+  }>;
+  failedSeq?: number;
+  error?: string;
+}
+
+export type ConnectorIngressManualWikiCommitProvider = (
+  input: Omit<
+    ConnectorIngressManualWikiCommitInput,
+    'rawAdapter' | 'operatorDb' | 'wikiPublishAdapter' | 'nowMs'
+  >
+) => Promise<ConnectorIngressManualWikiCommitResult>;
+
+const PARTIAL_FAILURE_MESSAGE = 'Manual wiki commit partially failed.';
+export const MAX_MANUAL_WIKI_COMMIT_TOTAL_PAGES = MAX_WIKI_PUBLISH_PAGES;
+
+function requestError(message: string): ConnectorIngressManualCommitRequestError {
+  return new ConnectorIngressManualCommitRequestError(message);
+}
+
+function rejectWikiPageError(error: unknown): never {
+  throw requestError(error instanceof Error ? error.message : 'Invalid manual wiki page');
+}
+
+function normalizeManualWikiPage(page: WikiPublishPageInput): WikiPublishPageInput {
+  const rawPage = page as unknown as Record<string, unknown>;
+  if (
+    Object.prototype.hasOwnProperty.call(rawPage, 'sourceRefs') ||
+    Object.prototype.hasOwnProperty.call(rawPage, 'source_refs') ||
+    Object.prototype.hasOwnProperty.call(rawPage, 'sourceIds') ||
+    Object.prototype.hasOwnProperty.call(rawPage, 'source_ids')
+  ) {
+    throw requestError('Wiki source refs are derived from reviewed events');
+  }
+  try {
+    const content = requiredWikiString(page.content, 'content', 'manual wiki commit page');
+    if (content.length > MAX_WIKI_PAGE_CONTENT_CHARS) {
+      throw new Error(
+        `manual wiki commit page content must not exceed ${MAX_WIKI_PAGE_CONTENT_CHARS} characters`
+      );
+    }
+    return {
+      path: normalizeWikiPagePath(page.path, 'manual wiki commit page path'),
+      title: requiredWikiString(page.title, 'title', 'manual wiki commit page'),
+      type: normalizeWikiPageType(page.type, 'manual wiki commit page'),
+      content,
+      confidence: normalizeWikiConfidence(page.confidence, 'manual wiki commit page'),
+    };
+  } catch (error) {
+    rejectWikiPageError(error);
+  }
+}
+
+function normalizeEventPages(eventPages: readonly ConnectorIngressManualWikiEventPages[]): {
+  eventIndexIds: string[];
+  pagesByEventIndexId: Map<string, readonly WikiPublishPageInput[]>;
+} {
+  if (!Array.isArray(eventPages) || eventPages.length === 0) {
+    throw requestError('event_pages must not be empty');
+  }
+  if (eventPages.length > MAX_REVIEWED_CONNECTOR_INGRESS_EVENTS) {
+    throw requestError(
+      `event_pages must contain at most ${MAX_REVIEWED_CONNECTOR_INGRESS_EVENTS} items`
+    );
+  }
+  const eventIndexIds: string[] = [];
+  const pagesByEventIndexId = new Map<string, readonly WikiPublishPageInput[]>();
+  const eventIndexIdByPagePath = new Map<string, string>();
+  let totalPages = 0;
+  for (const eventPage of eventPages) {
+    const eventIndexId = requiredString(eventPage.eventIndexId, 'event_pages[].event_index_id');
+    if (pagesByEventIndexId.has(eventIndexId)) {
+      throw requestError('event_pages must not contain duplicate event_index_id values');
+    }
+    if (!Array.isArray(eventPage.pages) || eventPage.pages.length === 0) {
+      throw requestError('event_pages[].pages must not be empty');
+    }
+    if (eventPage.pages.length > MAX_WIKI_PUBLISH_PAGES) {
+      throw requestError(
+        `event_pages[].pages must contain at most ${MAX_WIKI_PUBLISH_PAGES} pages`
+      );
+    }
+    totalPages += eventPage.pages.length;
+    if (totalPages > MAX_MANUAL_WIKI_COMMIT_TOTAL_PAGES) {
+      throw requestError(
+        `event_pages must contain at most ${MAX_MANUAL_WIKI_COMMIT_TOTAL_PAGES} total pages`
+      );
+    }
+    const pages = eventPage.pages.map((page: WikiPublishPageInput) =>
+      normalizeManualWikiPage(page)
+    );
+    for (const page of pages) {
+      const existingEventIndexId = eventIndexIdByPagePath.get(page.path);
+      if (existingEventIndexId && existingEventIndexId !== eventIndexId) {
+        throw requestError(`duplicate wiki page path across events: ${page.path}`);
+      }
+      eventIndexIdByPagePath.set(page.path, eventIndexId);
+    }
+    eventIndexIds.push(eventIndexId);
+    pagesByEventIndexId.set(eventIndexId, pages);
+  }
+  return { eventIndexIds, pagesByEventIndexId };
+}
+
+function readReviewedEvents(input: {
+  rawAdapter: ConnectorEventIngressAdapter;
+  connector: string;
+  channel: string;
+  eventIndexIds: readonly string[];
+}): PrimaryOperatorEvent[] {
+  return readReviewedConnectorIngressEvents({
+    rawAdapter: input.rawAdapter,
+    connector: input.connector,
+    channel: input.channel,
+    eventIndexIds: input.eventIndexIds,
+    requestError,
+  });
+}
+
+function buildChangedRefs(pages: readonly WikiPublishPageInput[]): SourceRef[] {
+  const paths = new Set<string>();
+  for (const page of pages) {
+    paths.add(normalizeWikiPagePath(page.path, 'wiki manual commit page path'));
+  }
+  return [...paths].map((path) => ({ kind: 'wiki_page', id: path }) satisfies SourceRef);
+}
+
+function pagesForEvent(
+  pagesByEventIndexId: Map<string, readonly WikiPublishPageInput[]>,
+  event: PrimaryOperatorEvent
+): readonly WikiPublishPageInput[] {
+  const pages = pagesByEventIndexId.get(event.sourceRef.id);
+  if (!pages || pages.length === 0) {
+    throw requestError('Reviewed event is missing wiki pages');
+  }
+  return pages;
+}
+
+function assertNoExistingNonChangedCommits(input: {
+  operatorDb: SQLiteDatabase;
+  cursorName: string;
+  connector: string;
+  events: readonly PrimaryOperatorEvent[];
+}): void {
+  const lookupExistingCommit = input.operatorDb.prepare(
+    `SELECT status
+     FROM vnext_operator_commits
+     WHERE cursor_name = ?
+       AND idempotency_key IN (?, ?)`
+  );
+  for (const event of input.events) {
+    const cursorScopedKey = buildCursorScopedIdempotencyKey(input.cursorName, event.seq, event.seq);
+    const legacyKey = buildConnectorIdempotencyKey(input.connector, event.seq, event.seq);
+    const rows = lookupExistingCommit.all(
+      input.cursorName,
+      cursorScopedKey,
+      legacyKey
+    ) as ExistingOperatorCommitStatusRow[];
+    if (rows.some((row) => row.status !== 'changed')) {
+      throw requestError('Manual wiki commit cannot replace a non-changed operator commit');
+    }
+  }
+}
+
+export async function commitConnectorIngressWikiBatch(
+  input: ConnectorIngressManualWikiCommitInput
+): Promise<ConnectorIngressManualWikiCommitResult> {
+  const connector = requiredString(input.connector, 'connector');
+  const channel = requiredString(input.channel, 'channel');
+  const cursorName = buildConnectorOperatorCursorName({ connector, channel });
+  if (!isVNextWikiPublishAdapter(input.wikiPublishAdapter)) {
+    throw requestError('Manual wiki commit requires a vNext wiki publish adapter');
+  }
+  const { eventIndexIds, pagesByEventIndexId } = normalizeEventPages(input.eventPages);
+
+  const runtime = new PrimaryOperatorRuntime({
+    db: input.operatorDb,
+    cursorName,
+    connector,
+    nowMs: input.nowMs,
+    allowSeqGaps: true,
+  });
+  let events: PrimaryOperatorEvent[] = [];
+  const batch = await runtime.processBatchWithChangedCommitAfterValidation(
+    () => {
+      events = readReviewedEvents({
+        rawAdapter: input.rawAdapter,
+        connector,
+        channel,
+        eventIndexIds,
+      });
+      assertReviewedConnectorIngressSeqs(
+        {
+          rawAdapter: input.rawAdapter,
+          connector,
+          channel,
+        },
+        events,
+        input.expectedAdvancedThroughSeq,
+        readConnectorOperatorCursorSeq(input.operatorDb, cursorName),
+        requestError
+      );
+      assertNoExistingNonChangedCommits({
+        operatorDb: input.operatorDb,
+        cursorName,
+        connector,
+        events,
+      });
+      return events;
+    },
+    () => ({ status: 'changed' }),
+    ({ event, sourceRefs }) => {
+      const pages = pagesForEvent(pagesByEventIndexId, event);
+      const changedRefs = buildChangedRefs(pages);
+      const publishResult = input.wikiPublishAdapter.publish({
+        pages: pages.map((page) => ({
+          ...page,
+          sourceRefs: [...sourceRefs],
+        })),
+      });
+      if (publishResult.artifactsStored !== changedRefs.length) {
+        throw new Error('Manual wiki commit did not store every changed wiki artifact');
+      }
+      return changedRefs;
+    }
+  );
+  const firstSeq = events[0]?.seq ?? null;
+  const lastSeq = events[events.length - 1]?.seq ?? null;
+  const commits = batch.commits.map((commit) => ({
+    seq: commit.lastChangeSeq,
+    status: 'changed' as const,
+    outcome: commit.outcome,
+    cursorAdvanced: commit.cursorAdvanced,
+  }));
+  const pagesStored = batch.commits.reduce((total, commit) => {
+    if (commit.status !== 'changed' || commit.outcome === 'already_committed') {
+      return total;
+    }
+    const event = events.find((candidate) => candidate.seq === commit.lastChangeSeq);
+    return total + (event ? buildChangedRefs(pagesForEvent(pagesByEventIndexId, event)).length : 0);
+  }, 0);
+  if (batch.status === 'partial_failure') {
+    return {
+      ok: false,
+      mode: 'manual_wiki_commit',
+      status: batch.status,
+      cursorName,
+      connector,
+      channel,
+      requestedCount: input.eventPages.length,
+      processed: batch.processed,
+      advancedThroughSeq: batch.advancedThroughSeq,
+      firstSeq,
+      lastSeq,
+      pagesStored,
+      commits,
+      failedSeq: batch.failedSeq,
+      error: PARTIAL_FAILURE_MESSAGE,
+    };
+  }
+  return {
+    ok: true,
+    mode: 'manual_wiki_commit',
+    status: batch.status,
+    cursorName,
+    connector,
+    channel,
+    requestedCount: input.eventPages.length,
+    processed: batch.processed,
+    advancedThroughSeq: batch.advancedThroughSeq,
+    firstSeq,
+    lastSeq,
+    pagesStored,
+    commits,
+  };
+}
+
+export function createConnectorIngressManualWikiCommitProvider(
+  options: Omit<ConnectorIngressManualWikiCommitInput, 'expectedAdvancedThroughSeq' | 'eventPages'>
+): ConnectorIngressManualWikiCommitProvider {
+  const connector = requiredString(options.connector, 'connector');
+  const channel = requiredString(options.channel, 'channel');
+  return async (input) => {
+    const requestedConnector = requiredString(input.connector, 'connector');
+    const requestedChannel = requiredString(input.channel, 'channel');
+    if (requestedConnector !== connector || requestedChannel !== channel) {
+      throw requestError(
+        `Connector ingress manual wiki commit is locked to the configured connector/channel: ${connector}/${channel}`
+      );
+    }
+    return commitConnectorIngressWikiBatch({
+      rawAdapter: options.rawAdapter,
+      operatorDb: options.operatorDb,
+      wikiPublishAdapter: options.wikiPublishAdapter,
+      connector,
+      channel,
+      expectedAdvancedThroughSeq: input.expectedAdvancedThroughSeq,
+      eventPages: input.eventPages,
+      nowMs: options.nowMs,
+    });
+  };
+}

--- a/packages/standalone/src/operator-vnext/connector-ingress-reviewed-events.ts
+++ b/packages/standalone/src/operator-vnext/connector-ingress-reviewed-events.ts
@@ -51,12 +51,19 @@ export function normalizeReviewedEventIndexIds(
   if (eventIndexIds.length > maxItems) {
     throwRequestError(requestError, `${options.fieldName} must contain at most ${maxItems} items`);
   }
+  const seen = new Set<string>();
   return eventIndexIds.map((eventIndexId) => {
+    let normalized: string;
     try {
-      return requiredString(eventIndexId, `${options.fieldName}[]`);
+      normalized = requiredString(eventIndexId, `${options.fieldName}[]`);
     } catch {
       throwRequestError(requestError, `${options.fieldName} must be a non-empty string array`);
     }
+    if (seen.has(normalized)) {
+      throwRequestError(requestError, `${options.fieldName} must not contain duplicate values`);
+    }
+    seen.add(normalized);
+    return normalized;
   });
 }
 

--- a/packages/standalone/src/operator-vnext/connector-ingress-reviewed-events.ts
+++ b/packages/standalone/src/operator-vnext/connector-ingress-reviewed-events.ts
@@ -1,0 +1,195 @@
+import type { SourceRef } from '@jungjaehoon/mama-core/provenance/source-ref';
+
+import type { SQLiteDatabase } from '../sqlite.js';
+import {
+  connectorEventIngressOperatorSeqSql,
+  type ConnectorEventIngressAdapter,
+} from './connector-event-ingress.js';
+import type { PrimaryOperatorEvent } from './primary-operator-runtime.js';
+import { nonNegativeInteger, requiredString } from './validation.js';
+
+interface ConnectorIngressReviewedEventRow {
+  operator_seq: number;
+  event_index_id: string;
+  source_connector: string;
+  source_id: string;
+  channel: string | null;
+}
+
+export const MAX_REVIEWED_CONNECTOR_INGRESS_EVENTS = 100;
+
+export type ConnectorIngressRequestErrorFactory = (message: string) => Error;
+
+function defaultRequestError(message: string): Error {
+  return new Error(message);
+}
+
+function throwRequestError(factory: ConnectorIngressRequestErrorFactory, message: string): never {
+  throw factory(message);
+}
+
+export function readConnectorOperatorCursorSeq(db: SQLiteDatabase, cursorName: string): number {
+  const row = db
+    .prepare('SELECT last_change_seq FROM vnext_operator_cursors WHERE cursor_name = ?')
+    .get(cursorName) as { last_change_seq: number } | undefined;
+  return row?.last_change_seq ?? 0;
+}
+
+export function normalizeReviewedEventIndexIds(
+  eventIndexIds: readonly string[],
+  options: {
+    fieldName: string;
+    maxItems?: number;
+    requestError?: ConnectorIngressRequestErrorFactory;
+  }
+): string[] {
+  const requestError = options.requestError ?? defaultRequestError;
+  const maxItems = options.maxItems ?? MAX_REVIEWED_CONNECTOR_INGRESS_EVENTS;
+  if (!Array.isArray(eventIndexIds) || eventIndexIds.length === 0) {
+    throwRequestError(requestError, `${options.fieldName} must not be empty`);
+  }
+  if (eventIndexIds.length > maxItems) {
+    throwRequestError(requestError, `${options.fieldName} must contain at most ${maxItems} items`);
+  }
+  return eventIndexIds.map((eventIndexId) => {
+    try {
+      return requiredString(eventIndexId, `${options.fieldName}[]`);
+    } catch {
+      throwRequestError(requestError, `${options.fieldName} must be a non-empty string array`);
+    }
+  });
+}
+
+function rowToEvent(row: ConnectorIngressReviewedEventRow): PrimaryOperatorEvent {
+  const sourceRef: SourceRef = {
+    kind: 'raw',
+    connector: requiredString(row.source_connector, 'source_connector'),
+    id: requiredString(row.event_index_id, 'event_index_id'),
+    source_id: requiredString(row.source_id, 'source_id'),
+    channel_id: row.channel,
+  };
+  return {
+    seq: nonNegativeInteger(row.operator_seq, 'operator_seq'),
+    sourceRef,
+  };
+}
+
+export function readReviewedConnectorIngressEvents(input: {
+  rawAdapter: ConnectorEventIngressAdapter;
+  connector: string;
+  channel: string;
+  eventIndexIds: readonly string[];
+  requestError?: ConnectorIngressRequestErrorFactory;
+}): PrimaryOperatorEvent[] {
+  const requestError = input.requestError ?? defaultRequestError;
+  const placeholders = input.eventIndexIds.map(() => '?').join(', ');
+  const rows = input.rawAdapter
+    .prepare(
+      `
+        WITH ordered_events AS (
+          SELECT
+            ${connectorEventIngressOperatorSeqSql()} AS operator_seq,
+            event_index_id,
+            source_connector,
+            source_id,
+            channel
+          FROM connector_event_index
+          WHERE source_connector = ?
+            AND channel = ?
+        )
+        SELECT
+          operator_seq,
+          event_index_id,
+          source_connector,
+          source_id,
+          channel
+        FROM ordered_events
+        WHERE event_index_id IN (${placeholders})
+        ORDER BY operator_seq ASC
+      `
+    )
+    .all(
+      input.connector,
+      input.channel,
+      ...input.eventIndexIds
+    ) as ConnectorIngressReviewedEventRow[];
+  const orderedIds = rows.map((row) => requiredString(row.event_index_id, 'event_index_id'));
+  if (
+    orderedIds.length !== input.eventIndexIds.length ||
+    orderedIds.some((id, index) => id !== input.eventIndexIds[index])
+  ) {
+    throwRequestError(
+      requestError,
+      'Reviewed event ids do not match the current deterministic connector order'
+    );
+  }
+  return rows.map(rowToEvent);
+}
+
+function countEventsInSeqRange(input: {
+  rawAdapter: ConnectorEventIngressAdapter;
+  connector: string;
+  channel: string;
+  afterSeq: number;
+  throughSeq: number;
+}): number {
+  const row = input.rawAdapter
+    .prepare(
+      `
+        SELECT COUNT(*) AS count
+        FROM connector_event_index
+        WHERE source_connector = ?
+          AND channel = ?
+          AND ${connectorEventIngressOperatorSeqSql()} > ?
+          AND ${connectorEventIngressOperatorSeqSql()} <= ?
+      `
+    )
+    .get(input.connector, input.channel, input.afterSeq, input.throughSeq) as
+    | { count: number }
+    | undefined;
+  return nonNegativeInteger(row?.count ?? 0, 'reviewed_range_count');
+}
+
+export function assertReviewedConnectorIngressSeqs(
+  input: {
+    rawAdapter: ConnectorEventIngressAdapter;
+    connector: string;
+    channel: string;
+  },
+  events: readonly PrimaryOperatorEvent[],
+  expectedAdvancedThroughSeq: number,
+  currentAdvancedThroughSeq: number,
+  requestError: ConnectorIngressRequestErrorFactory = defaultRequestError
+): void {
+  const expected = nonNegativeInteger(expectedAdvancedThroughSeq, 'expectedAdvancedThroughSeq');
+  const firstSeq = events[0]?.seq ?? null;
+  const lastSeq = events[events.length - 1]?.seq ?? null;
+  if (firstSeq === null || lastSeq === null || firstSeq <= expected) {
+    throwRequestError(
+      requestError,
+      'Reviewed event ids do not advance the expected connector cursor'
+    );
+  }
+  const rangeCount = countEventsInSeqRange({
+    rawAdapter: input.rawAdapter,
+    connector: input.connector,
+    channel: input.channel,
+    afterSeq: expected,
+    throughSeq: lastSeq,
+  });
+  if (rangeCount !== events.length) {
+    throwRequestError(
+      requestError,
+      'Reviewed event ids do not cover the current connector cursor range'
+    );
+  }
+  if (currentAdvancedThroughSeq > expected && currentAdvancedThroughSeq < lastSeq) {
+    throwRequestError(
+      requestError,
+      'Reviewed event ids are stale for the current connector cursor'
+    );
+  }
+  if (currentAdvancedThroughSeq < expected) {
+    throwRequestError(requestError, 'Reviewed cursor is ahead of the current connector cursor');
+  }
+}

--- a/packages/standalone/src/operator-vnext/primary-operator-runtime.ts
+++ b/packages/standalone/src/operator-vnext/primary-operator-runtime.ts
@@ -242,6 +242,17 @@ export class PrimaryOperatorRuntime {
     );
   }
 
+  async processBatchWithChangedCommitAfterValidation(
+    buildEvents: () => Promise<readonly PrimaryOperatorEvent[]> | readonly PrimaryOperatorEvent[],
+    decide: (event: PrimaryOperatorEvent) => Promise<unknown> | unknown,
+    commitChanged: PrimaryOperatorChangedCommitter
+  ): Promise<PrimaryOperatorBatchResult> {
+    return withCursorLock(this.cursorName, async () => {
+      const events = await buildEvents();
+      return this.processBatchLocked(events, decide, commitChanged);
+    });
+  }
+
   async processBatchAfterValidation(
     buildEvents: () => Promise<readonly PrimaryOperatorEvent[]> | readonly PrimaryOperatorEvent[],
     decide: (event: PrimaryOperatorEvent) => Promise<unknown> | unknown

--- a/packages/standalone/src/wiki-artifacts/wiki-publish-adapter.ts
+++ b/packages/standalone/src/wiki-artifacts/wiki-publish-adapter.ts
@@ -17,8 +17,8 @@ import type {
 } from './types.js';
 
 export type WikiPublishMode = 'legacy' | 'vnext';
-const MAX_WIKI_PUBLISH_PAGES = 100;
-const MAX_WIKI_PAGE_CONTENT_CHARS = 200_000;
+export const MAX_WIKI_PUBLISH_PAGES = 100;
+export const MAX_WIKI_PAGE_CONTENT_CHARS = 200_000;
 const vNextWikiPublishAdapters = new WeakSet<WikiPublishAdapter>();
 
 export interface WikiPublishAdapter {

--- a/packages/standalone/tests/operator-vnext/connector-ingress-manual-commit.test.ts
+++ b/packages/standalone/tests/operator-vnext/connector-ingress-manual-commit.test.ts
@@ -277,6 +277,20 @@ describe('STORY-VNEXT-PR10-MANUAL-INGRESS: connector ingress manual no-update co
       db.close();
     });
 
+    it('rejects duplicate reviewed event ids with a clear error before durable writes', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+
+      await expect(
+        commitConnectorIngressNoUpdateBatch(makeInput(db, [first, first]))
+      ).rejects.toThrow(/duplicate values/i);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(countRows(db, 'operator_no_updates')).toBe(0);
+      expect(countRows(db, 'vnext_operator_cursors')).toBe(0);
+
+      db.close();
+    });
+
     it('uses cursor-scoped idempotency keys so connector seqs cannot collide across channels', async () => {
       const db = makeOperatorVNextDb();
       const publicEvent = insertRawEvent(db, {

--- a/packages/standalone/tests/operator-vnext/connector-ingress-manual-wiki-commit.test.ts
+++ b/packages/standalone/tests/operator-vnext/connector-ingress-manual-wiki-commit.test.ts
@@ -1,0 +1,570 @@
+import { describe, expect, it } from 'vitest';
+
+process.env.MAMA_FORCE_TIER_3 ||= 'true';
+
+import { connectorEventIndexId } from '@jungjaehoon/mama-core/connectors/event-index';
+
+import { commitConnectorIngressNoUpdateBatch } from '../../src/operator-vnext/connector-ingress-manual-commit.js';
+import { commitConnectorIngressWikiBatch } from '../../src/operator-vnext/connector-ingress-manual-wiki-commit.js';
+import type { SQLiteDatabase } from '../../src/sqlite.js';
+import { WikiArtifactStore } from '../../src/wiki-artifacts/wiki-artifact-store.js';
+import { createWikiPublishAdapter } from '../../src/wiki-artifacts/wiki-publish-adapter.js';
+import { countRows, makeOperatorVNextDb } from './fixtures.js';
+
+function insertRawEvent(
+  db: SQLiteDatabase,
+  overrides: {
+    connector?: string;
+    sourceId: string;
+    channel?: string;
+    timestampMs: number;
+  }
+): string {
+  const connector = overrides.connector ?? 'slack';
+  const channel = overrides.channel ?? 'C_PUBLIC_SYNTHETIC';
+  const eventIndexId = connectorEventIndexId(connector, overrides.sourceId);
+  db.prepare(
+    `INSERT INTO connector_event_index (
+      event_index_id, source_connector, source_type, source_id, source_locator,
+      channel, author, title, content, event_datetime, event_date, source_timestamp_ms,
+      metadata_json, content_hash, indexed_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    eventIndexId,
+    connector,
+    'message',
+    overrides.sourceId,
+    `${connector}:${channel}:${overrides.sourceId}`,
+    channel,
+    'synthetic-user',
+    null,
+    `synthetic public rollout event ${overrides.sourceId}`,
+    overrides.timestampMs,
+    new Date(overrides.timestampMs).toISOString().slice(0, 10),
+    overrides.timestampMs,
+    JSON.stringify({ synthetic: true }),
+    Buffer.alloc(32, 4),
+    '2026-07-03T00:00:00.000Z',
+    '2026-07-03T00:00:00.000Z'
+  );
+  return eventIndexId;
+}
+
+function cursorRow(db: SQLiteDatabase) {
+  return db
+    .prepare(
+      `SELECT cursor_name, last_change_seq, last_idempotency_key
+       FROM vnext_operator_cursors
+       WHERE cursor_name = ?`
+    )
+    .get('connector:slack:channel:C_PUBLIC_SYNTHETIC');
+}
+
+function makeWikiPages(count: number, prefix: string) {
+  return Array.from({ length: count }, (_, index) => ({
+    path: `projects/${prefix}-${index}.md`,
+    title: `${prefix} ${index}`,
+    type: 'entity',
+    content: 'operator-authored wiki summary',
+  }));
+}
+
+describe('STORY-VNEXT-PR12-MANUAL-WIKI: connector ingress manual wiki commit', () => {
+  describe('AC: reviewed events commit source-linked wiki artifacts atomically', () => {
+    it('commits reviewed event pages as changed operator commits without exposing raw content', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const second = insertRawEvent(db, { sourceId: 'msg-2', timestampMs: 1710000002000 });
+      const store = new WikiArtifactStore(db);
+      const wikiPublishAdapter = createWikiPublishAdapter({
+        mode: 'vnext',
+        store,
+        now: () => new Date('2026-07-03T00:00:00.000Z'),
+        nowMs: () => 1710000000000,
+      });
+
+      const result = await commitConnectorIngressWikiBatch({
+        rawAdapter: db,
+        operatorDb: db,
+        wikiPublishAdapter,
+        connector: 'slack',
+        channel: 'C_PUBLIC_SYNTHETIC',
+        expectedAdvancedThroughSeq: 0,
+        eventPages: [
+          {
+            eventIndexId: first,
+            pages: [
+              {
+                path: 'projects/rollout-one.md',
+                title: 'Rollout One',
+                type: 'entity',
+                content: 'operator-authored wiki summary one',
+              },
+            ],
+          },
+          {
+            eventIndexId: second,
+            pages: [
+              {
+                path: 'projects/rollout-two.md',
+                title: 'Rollout Two',
+                type: 'entity',
+                content: 'operator-authored wiki summary two',
+              },
+            ],
+          },
+        ],
+        nowMs: () => 1710000000000,
+      });
+
+      expect(result).toEqual({
+        ok: true,
+        mode: 'manual_wiki_commit',
+        status: 'committed',
+        cursorName: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        connector: 'slack',
+        channel: 'C_PUBLIC_SYNTHETIC',
+        requestedCount: 2,
+        processed: 2,
+        advancedThroughSeq: 2,
+        firstSeq: 1,
+        lastSeq: 2,
+        pagesStored: 2,
+        commits: [
+          { seq: 1, status: 'changed', outcome: 'committed', cursorAdvanced: true },
+          { seq: 2, status: 'changed', outcome: 'committed', cursorAdvanced: true },
+        ],
+      });
+      expect(JSON.stringify(result)).not.toContain('synthetic public rollout event');
+      expect(JSON.stringify(result)).not.toContain('synthetic-user');
+      expect(JSON.stringify(result)).not.toContain('metadata_json');
+      expect(cursorRow(db)).toEqual({
+        cursor_name: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        last_change_seq: 2,
+        last_idempotency_key: 'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:2-2',
+      });
+      expect(countRows(db, 'vnext_operator_commits')).toBe(2);
+      expect(countRows(db, 'wiki_artifacts')).toBe(2);
+      expect(db.prepare('SELECT DISTINCT status FROM vnext_operator_commits').all()).toEqual([
+        { status: 'changed' },
+      ]);
+      expect(store.getByPath('projects/rollout-one.md')?.sourceRefs).toEqual([
+        `raw:slack:${first}`,
+      ]);
+      expect(store.getByPath('projects/rollout-two.md')?.sourceRefs).toEqual([
+        `raw:slack:${second}`,
+      ]);
+      expect(
+        db
+          .prepare(
+            `SELECT changed_refs_json, source_refs_json
+             FROM vnext_operator_commits
+             ORDER BY first_change_seq ASC`
+          )
+          .all()
+      ).toEqual([
+        {
+          changed_refs_json: JSON.stringify(['wiki_page:projects/rollout-one.md']),
+          source_refs_json: JSON.stringify([`raw:slack:${first}`]),
+        },
+        {
+          changed_refs_json: JSON.stringify(['wiki_page:projects/rollout-two.md']),
+          source_refs_json: JSON.stringify([`raw:slack:${second}`]),
+        },
+      ]);
+
+      db.close();
+    });
+
+    it('rejects request-supplied wiki source refs before durable writes', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const store = new WikiArtifactStore(db);
+      store.ensureSchema();
+      const wikiPublishAdapter = createWikiPublishAdapter({ mode: 'vnext', store });
+
+      await expect(
+        commitConnectorIngressWikiBatch({
+          rawAdapter: db,
+          operatorDb: db,
+          wikiPublishAdapter,
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expectedAdvancedThroughSeq: 0,
+          eventPages: [
+            {
+              eventIndexId: first,
+              pages: [
+                {
+                  path: 'projects/unsafe.md',
+                  title: 'Unsafe',
+                  type: 'entity',
+                  content: 'operator-authored wiki summary',
+                  sourceRefs: [{ kind: 'wiki_page', id: 'caller-supplied-ref' }],
+                },
+              ],
+            },
+          ],
+        })
+      ).rejects.toThrow(/source refs are derived from reviewed events/i);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(countRows(db, 'wiki_artifacts')).toBe(0);
+
+      db.close();
+    });
+
+    it('rejects invalid wiki pages before any durable commit writes', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const second = insertRawEvent(db, { sourceId: 'msg-2', timestampMs: 1710000002000 });
+      const store = new WikiArtifactStore(db);
+      store.ensureSchema();
+      const wikiPublishAdapter = createWikiPublishAdapter({ mode: 'vnext', store });
+
+      await expect(
+        commitConnectorIngressWikiBatch({
+          rawAdapter: db,
+          operatorDb: db,
+          wikiPublishAdapter,
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expectedAdvancedThroughSeq: 0,
+          eventPages: [
+            {
+              eventIndexId: first,
+              pages: [
+                {
+                  path: 'projects/valid.md',
+                  title: 'Valid',
+                  type: 'entity',
+                  content: 'operator-authored wiki summary',
+                },
+              ],
+            },
+            {
+              eventIndexId: second,
+              pages: [
+                {
+                  path: 'projects/invalid.md',
+                  title: 'Invalid',
+                  type: 'unsupported-type',
+                  content: 'operator-authored wiki summary',
+                },
+              ],
+            },
+          ],
+          nowMs: () => 1710000000000,
+        })
+      ).rejects.toThrow(/type is not supported/i);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(countRows(db, 'wiki_artifacts')).toBe(0);
+      expect(cursorRow(db)).toBeUndefined();
+
+      db.close();
+    });
+
+    it('rejects duplicate wiki paths across events before any durable commit writes', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const second = insertRawEvent(db, { sourceId: 'msg-2', timestampMs: 1710000002000 });
+      const store = new WikiArtifactStore(db);
+      store.ensureSchema();
+      const wikiPublishAdapter = createWikiPublishAdapter({ mode: 'vnext', store });
+
+      await expect(
+        commitConnectorIngressWikiBatch({
+          rawAdapter: db,
+          operatorDb: db,
+          wikiPublishAdapter,
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expectedAdvancedThroughSeq: 0,
+          eventPages: [
+            {
+              eventIndexId: first,
+              pages: [
+                {
+                  path: 'projects/shared.md',
+                  title: 'Shared One',
+                  type: 'entity',
+                  content: 'operator-authored wiki summary one',
+                },
+              ],
+            },
+            {
+              eventIndexId: second,
+              pages: [
+                {
+                  path: './projects/shared.md',
+                  title: 'Shared Two',
+                  type: 'entity',
+                  content: 'operator-authored wiki summary two',
+                },
+              ],
+            },
+          ],
+          nowMs: () => 1710000000000,
+        })
+      ).rejects.toThrow(/duplicate wiki page path/i);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(countRows(db, 'wiki_artifacts')).toBe(0);
+      expect(cursorRow(db)).toBeUndefined();
+
+      db.close();
+    });
+
+    it('rejects page batches above the publish limit before any durable commit writes', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const second = insertRawEvent(db, { sourceId: 'msg-2', timestampMs: 1710000002000 });
+      const store = new WikiArtifactStore(db);
+      store.ensureSchema();
+      const wikiPublishAdapter = createWikiPublishAdapter({ mode: 'vnext', store });
+      const tooManyPages = makeWikiPages(101, 'oversized');
+
+      await expect(
+        commitConnectorIngressWikiBatch({
+          rawAdapter: db,
+          operatorDb: db,
+          wikiPublishAdapter,
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expectedAdvancedThroughSeq: 0,
+          eventPages: [
+            {
+              eventIndexId: first,
+              pages: [
+                {
+                  path: 'projects/valid.md',
+                  title: 'Valid',
+                  type: 'entity',
+                  content: 'operator-authored wiki summary',
+                },
+              ],
+            },
+            {
+              eventIndexId: second,
+              pages: tooManyPages,
+            },
+          ],
+          nowMs: () => 1710000000000,
+        })
+      ).rejects.toThrow(/at most 100 pages/i);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(countRows(db, 'wiki_artifacts')).toBe(0);
+      expect(cursorRow(db)).toBeUndefined();
+
+      db.close();
+    });
+
+    it('rejects aggregate page counts above the request limit before durable writes', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const second = insertRawEvent(db, { sourceId: 'msg-2', timestampMs: 1710000002000 });
+      const store = new WikiArtifactStore(db);
+      store.ensureSchema();
+      const wikiPublishAdapter = createWikiPublishAdapter({ mode: 'vnext', store });
+
+      await expect(
+        commitConnectorIngressWikiBatch({
+          rawAdapter: db,
+          operatorDb: db,
+          wikiPublishAdapter,
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expectedAdvancedThroughSeq: 0,
+          eventPages: [
+            {
+              eventIndexId: first,
+              pages: makeWikiPages(60, 'first'),
+            },
+            {
+              eventIndexId: second,
+              pages: makeWikiPages(41, 'second'),
+            },
+          ],
+          nowMs: () => 1710000000000,
+        })
+      ).rejects.toThrow(/at most 100 total pages/i);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(countRows(db, 'wiki_artifacts')).toBe(0);
+      expect(cursorRow(db)).toBeUndefined();
+
+      db.close();
+    });
+
+    it('rejects non-vNext wiki adapters before advancing the operator cursor', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      let publishedPages = 0;
+      const wikiPublishAdapter = createWikiPublishAdapter({
+        mode: 'legacy',
+        publisher: (pages) => {
+          publishedPages += pages.length;
+        },
+      });
+
+      await expect(
+        commitConnectorIngressWikiBatch({
+          rawAdapter: db,
+          operatorDb: db,
+          wikiPublishAdapter,
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expectedAdvancedThroughSeq: 0,
+          eventPages: [
+            {
+              eventIndexId: first,
+              pages: [
+                {
+                  path: 'projects/legacy-adapter.md',
+                  title: 'Legacy Adapter',
+                  type: 'entity',
+                  content: 'operator-authored wiki summary',
+                },
+              ],
+            },
+          ],
+          nowMs: () => 1710000000000,
+        })
+      ).rejects.toThrow(/vNext wiki publish adapter/i);
+      expect(publishedPages).toBe(0);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(cursorRow(db)).toBeUndefined();
+
+      db.close();
+    });
+
+    it('validates reviewed events after waiting for an in-flight cursor commit', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const second = insertRawEvent(db, { sourceId: 'msg-2', timestampMs: 1710000002000 });
+      const store = new WikiArtifactStore(db);
+      let nestedCommit: Promise<unknown> | null = null;
+      let nestedStarted = false;
+      const wikiPublishAdapter = createWikiPublishAdapter({
+        mode: 'vnext',
+        store,
+        now: () => new Date('2026-07-03T00:00:00.000Z'),
+        nowMs: () => 1710000000000,
+        publisher: () => {
+          if (!nestedStarted) {
+            nestedStarted = true;
+            nestedCommit = commitConnectorIngressWikiBatch({
+              rawAdapter: db,
+              operatorDb: db,
+              wikiPublishAdapter,
+              connector: 'slack',
+              channel: 'C_PUBLIC_SYNTHETIC',
+              expectedAdvancedThroughSeq: 1,
+              eventPages: [
+                {
+                  eventIndexId: second,
+                  pages: [
+                    {
+                      path: 'projects/rollout-two.md',
+                      title: 'Rollout Two',
+                      type: 'entity',
+                      content: 'operator-authored wiki summary two',
+                    },
+                  ],
+                },
+              ],
+              nowMs: () => 1710000000000,
+            });
+            nestedCommit.catch(() => undefined);
+          }
+        },
+      });
+
+      const firstResult = await commitConnectorIngressWikiBatch({
+        rawAdapter: db,
+        operatorDb: db,
+        wikiPublishAdapter,
+        connector: 'slack',
+        channel: 'C_PUBLIC_SYNTHETIC',
+        expectedAdvancedThroughSeq: 0,
+        eventPages: [
+          {
+            eventIndexId: first,
+            pages: [
+              {
+                path: 'projects/rollout-one.md',
+                title: 'Rollout One',
+                type: 'entity',
+                content: 'operator-authored wiki summary one',
+              },
+            ],
+          },
+        ],
+        nowMs: () => 1710000000000,
+      });
+
+      expect(firstResult).toMatchObject({
+        ok: true,
+        processed: 1,
+        advancedThroughSeq: 1,
+      });
+      await expect(nestedCommit).resolves.toMatchObject({
+        ok: true,
+        processed: 1,
+        advancedThroughSeq: 2,
+      });
+      expect(cursorRow(db)).toMatchObject({
+        last_change_seq: 2,
+        last_idempotency_key: 'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:2-2',
+      });
+      expect(store.getByPath('projects/rollout-two.md')?.sourceRefs).toEqual([
+        `raw:slack:${second}`,
+      ]);
+
+      db.close();
+    });
+
+    it('rejects events already committed as no-update before writing wiki artifacts', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      await commitConnectorIngressNoUpdateBatch({
+        rawAdapter: db,
+        operatorDb: db,
+        connector: 'slack',
+        channel: 'C_PUBLIC_SYNTHETIC',
+        expectedAdvancedThroughSeq: 0,
+        eventIndexIds: [first],
+        nowMs: () => 1710000000000,
+      });
+      const store = new WikiArtifactStore(db);
+      store.ensureSchema();
+      const wikiPublishAdapter = createWikiPublishAdapter({ mode: 'vnext', store });
+
+      await expect(
+        commitConnectorIngressWikiBatch({
+          rawAdapter: db,
+          operatorDb: db,
+          wikiPublishAdapter,
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expectedAdvancedThroughSeq: 0,
+          eventPages: [
+            {
+              eventIndexId: first,
+              pages: [
+                {
+                  path: 'projects/should-not-write.md',
+                  title: 'Should Not Write',
+                  type: 'entity',
+                  content: 'operator-authored wiki summary',
+                },
+              ],
+            },
+          ],
+          nowMs: () => 1710000000000,
+        })
+      ).rejects.toThrow(/non-changed operator commit/i);
+      expect(countRows(db, 'wiki_artifacts')).toBe(0);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(1);
+
+      db.close();
+    });
+  });
+});

--- a/packages/standalone/tests/operator-vnext/connector-ingress-manual-wiki-commit.test.ts
+++ b/packages/standalone/tests/operator-vnext/connector-ingress-manual-wiki-commit.test.ts
@@ -9,6 +9,7 @@ import { commitConnectorIngressWikiBatch } from '../../src/operator-vnext/connec
 import type { SQLiteDatabase } from '../../src/sqlite.js';
 import { WikiArtifactStore } from '../../src/wiki-artifacts/wiki-artifact-store.js';
 import { createWikiPublishAdapter } from '../../src/wiki-artifacts/wiki-publish-adapter.js';
+import type { WikiPublishPageInput } from '../../src/wiki-artifacts/types.js';
 import { countRows, makeOperatorVNextDb } from './fixtures.js';
 
 function insertRawEvent(
@@ -206,7 +207,43 @@ describe('STORY-VNEXT-PR12-MANUAL-WIKI: connector ingress manual wiki commit', (
             },
           ],
         })
-      ).rejects.toThrow(/source refs are derived from reviewed events/i);
+      ).rejects.toThrow(/source refs.*reviewed events.*changed refs.*wiki page paths/i);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(countRows(db, 'wiki_artifacts')).toBe(0);
+
+      db.close();
+    });
+
+    it('rejects request-supplied wiki changed refs before durable writes', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const store = new WikiArtifactStore(db);
+      store.ensureSchema();
+      const wikiPublishAdapter = createWikiPublishAdapter({ mode: 'vnext', store });
+      const pageWithCallerChangedRefs: WikiPublishPageInput & { changedRefs: string[] } = {
+        path: 'projects/unsafe.md',
+        title: 'Unsafe',
+        type: 'entity',
+        content: 'operator-authored wiki summary',
+        changedRefs: ['wiki_page:projects/caller-supplied.md'],
+      };
+
+      await expect(
+        commitConnectorIngressWikiBatch({
+          rawAdapter: db,
+          operatorDb: db,
+          wikiPublishAdapter,
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expectedAdvancedThroughSeq: 0,
+          eventPages: [
+            {
+              eventIndexId: first,
+              pages: [pageWithCallerChangedRefs],
+            },
+          ],
+        })
+      ).rejects.toThrow(/source refs.*reviewed events.*changed refs.*wiki page paths/i);
       expect(countRows(db, 'vnext_operator_commits')).toBe(0);
       expect(countRows(db, 'wiki_artifacts')).toBe(0);
 

--- a/packages/standalone/tests/operator-vnext/connector-ingress-manual-wiki-commit.test.ts
+++ b/packages/standalone/tests/operator-vnext/connector-ingress-manual-wiki-commit.test.ts
@@ -263,6 +263,37 @@ describe('STORY-VNEXT-PR12-MANUAL-WIKI: connector ingress manual wiki commit', (
       db.close();
     });
 
+    it('rejects null wiki pages before any durable commit writes', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const store = new WikiArtifactStore(db);
+      store.ensureSchema();
+      const wikiPublishAdapter = createWikiPublishAdapter({ mode: 'vnext', store });
+
+      await expect(
+        commitConnectorIngressWikiBatch({
+          rawAdapter: db,
+          operatorDb: db,
+          wikiPublishAdapter,
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expectedAdvancedThroughSeq: 0,
+          eventPages: [
+            {
+              eventIndexId: first,
+              pages: [null as never],
+            },
+          ],
+          nowMs: () => 1710000000000,
+        })
+      ).rejects.toThrow(/non-null object/i);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(countRows(db, 'wiki_artifacts')).toBe(0);
+      expect(cursorRow(db)).toBeUndefined();
+
+      db.close();
+    });
+
     it('rejects duplicate wiki paths across events before any durable commit writes', async () => {
       const db = makeOperatorVNextDb();
       const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });

--- a/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
+++ b/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
@@ -16,6 +16,7 @@ import {
   commitConnectorIngressNoUpdateBatch,
   createConnectorIngressManualNoUpdateCommitProvider,
 } from '../../src/operator-vnext/connector-ingress-manual-commit.js';
+import { commitConnectorIngressWikiBatch } from '../../src/operator-vnext/connector-ingress-manual-wiki-commit.js';
 import { createConnectorIngressMigrationDryRunProvider } from '../../src/operator-vnext/connector-ingress-migration-dry-run.js';
 import { ensureVNextOperatorSchema } from '../../src/operator-vnext/schema.js';
 import {
@@ -24,7 +25,12 @@ import {
   type VNextBootstrapRuntimeStatus,
 } from '../../src/runtime-vnext/bootstrap.js';
 import Database, { type SQLiteDatabase } from '../../src/sqlite.js';
-import { isVNextWikiPublishAdapter } from '../../src/wiki-artifacts/wiki-publish-adapter.js';
+import { WikiArtifactStore } from '../../src/wiki-artifacts/wiki-artifact-store.js';
+import {
+  createWikiPublishAdapter,
+  isVNextWikiPublishAdapter,
+  MAX_WIKI_PAGE_CONTENT_CHARS,
+} from '../../src/wiki-artifacts/wiki-publish-adapter.js';
 
 const AUTH_TOKEN_ENV = 'MAMA_AUTH_TOKEN';
 const ADMIN_TOKEN_ENV = 'MAMA_ADMIN_TOKEN';
@@ -89,6 +95,15 @@ function insertRawEvent(
     '2026-07-02T00:00:00.000Z'
   );
   return eventIndexId;
+}
+
+function makeManualWikiPages(count: number, prefix: string) {
+  return Array.from({ length: count }, (_, index) => ({
+    path: `projects/${prefix}-${index}.md`,
+    title: `${prefix} ${index}`,
+    type: 'entity',
+    content: 'operator-authored wiki summary',
+  }));
 }
 
 describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
@@ -732,6 +747,320 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
       ]);
 
       db.close();
+    });
+
+    it('serves admin-only manual wiki ingress commits with an allowlisted payload', async () => {
+      process.env[AUTH_TOKEN_ENV] = 'vnext-status-token';
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      const db = new Database(':memory:');
+      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 39);
+      const eventIndexId = insertRawEvent(db, 'msg-1', { channel: 'C_PUBLIC_SYNTHETIC' });
+      const store = new WikiArtifactStore(db);
+      const wikiPublishAdapter = createWikiPublishAdapter({
+        mode: 'vnext',
+        store,
+        now: () => new Date('2026-07-03T00:00:00.000Z'),
+        nowMs: () => 1710000000000,
+      });
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualWikiCommitProvider: (input) =>
+          commitConnectorIngressWikiBatch({
+            rawAdapter: db,
+            operatorDb: db,
+            wikiPublishAdapter,
+            ...input,
+            nowMs: () => 1710000000000,
+          }),
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-wiki-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send({
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_pages: [
+            {
+              event_index_id: eventIndexId,
+              pages: [
+                {
+                  path: 'projects/manual-wiki.md',
+                  title: 'Manual Wiki',
+                  type: 'entity',
+                  content: 'operator-authored wiki summary',
+                },
+              ],
+            },
+          ],
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        ok: true,
+        mode: 'manual_wiki_commit',
+        status: 'committed',
+        cursorName: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        connector: 'slack',
+        channel: 'C_PUBLIC_SYNTHETIC',
+        requestedCount: 1,
+        processed: 1,
+        advancedThroughSeq: 1,
+        firstSeq: 1,
+        lastSeq: 1,
+        pagesStored: 1,
+        commits: [{ seq: 1, status: 'changed', outcome: 'committed', cursorAdvanced: true }],
+      });
+      expect(JSON.stringify(response.body)).not.toContain('synthetic public rollout event');
+      expect(JSON.stringify(response.body)).not.toContain('synthetic-user');
+      expect(JSON.stringify(response.body)).not.toContain('metadata_json');
+      expect(JSON.stringify(response.body)).not.toContain(LOCAL_PATH_PREFIX);
+      expect(store.getByPath('projects/manual-wiki.md')?.sourceRefs).toEqual([
+        `raw:slack:${eventIndexId}`,
+      ]);
+
+      db.close();
+    });
+
+    it('accepts manual wiki content below the core wiki content limit through the API', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      const validLargeContent = 'x'.repeat(MAX_WIKI_PAGE_CONTENT_CHARS - 1);
+      let providerCalls = 0;
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualWikiCommitProvider: (input) => {
+          providerCalls += 1;
+          expect(input.eventPages[0]?.pages[0]?.content).toHaveLength(validLargeContent.length);
+          return {
+            ok: true,
+            mode: 'manual_wiki_commit',
+            status: 'committed',
+            cursorName: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+            connector: 'slack',
+            channel: 'C_PUBLIC_SYNTHETIC',
+            requestedCount: 1,
+            processed: 1,
+            advancedThroughSeq: 1,
+            firstSeq: 1,
+            lastSeq: 1,
+            pagesStored: 1,
+            commits: [{ seq: 1, status: 'changed', outcome: 'committed', cursorAdvanced: true }],
+          };
+        },
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-wiki-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send({
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_pages: [
+            {
+              event_index_id: 'synthetic-event-index-id',
+              pages: [
+                {
+                  path: 'projects/manual-wiki.md',
+                  title: 'Manual Wiki',
+                  type: 'entity',
+                  content: validLargeContent,
+                },
+              ],
+            },
+          ],
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: true,
+        mode: 'manual_wiki_commit',
+        pagesStored: 1,
+      });
+      expect(providerCalls).toBe(1);
+    });
+
+    it('accepts valid manual wiki payloads whose JSON encoding expands content bytes', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      const validEscapedContent = '"'.repeat(MAX_WIKI_PAGE_CONTENT_CHARS);
+      let providerCalls = 0;
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualWikiCommitProvider: (input) => {
+          providerCalls += 1;
+          expect(input.eventPages).toHaveLength(100);
+          expect(input.eventPages[0]?.pages[0]?.content).toHaveLength(MAX_WIKI_PAGE_CONTENT_CHARS);
+          return {
+            ok: true,
+            mode: 'manual_wiki_commit',
+            status: 'committed',
+            cursorName: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+            connector: 'slack',
+            channel: 'C_PUBLIC_SYNTHETIC',
+            requestedCount: 100,
+            processed: 100,
+            advancedThroughSeq: 100,
+            firstSeq: 1,
+            lastSeq: 100,
+            pagesStored: 100,
+            commits: [],
+          };
+        },
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-wiki-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send({
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_pages: Array.from({ length: 100 }, (_, index) => ({
+            event_index_id: `synthetic-event-index-id-${index}`,
+            pages: [
+              {
+                path: `projects/manual-wiki-${index}.md`,
+                title: `Manual Wiki ${index}`,
+                type: 'entity',
+                content: validEscapedContent,
+              },
+            ],
+          })),
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: true,
+        mode: 'manual_wiki_commit',
+        pagesStored: 100,
+      });
+      expect(providerCalls).toBe(1);
+    });
+
+    it('rejects manual wiki API requests above the aggregate page limit before provider execution', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      let providerCalls = 0;
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualWikiCommitProvider: () => {
+          providerCalls += 1;
+          throw new Error('provider must not run when aggregate pages exceed the request limit');
+        },
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-wiki-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send({
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_pages: [
+            {
+              event_index_id: 'synthetic-event-index-id-1',
+              pages: makeManualWikiPages(60, 'first'),
+            },
+            {
+              event_index_id: 'synthetic-event-index-id-2',
+              pages: makeManualWikiPages(41, 'second'),
+            },
+          ],
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'vnext_ingress_manual_wiki_commit_invalid_request',
+      });
+      expect(response.body.error).toMatch(/at most 100 total pages/i);
+      expect(providerCalls).toBe(0);
+    });
+
+    it('requires admin auth for manual wiki ingress commits', async () => {
+      process.env[AUTH_TOKEN_ENV] = 'vnext-status-token';
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      const db = new Database(':memory:');
+      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 39);
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualWikiCommitProvider: () => {
+          throw new Error('provider must not run without admin auth');
+        },
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-wiki-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-status-token')
+        .send({
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_pages: [
+            {
+              event_index_id: 'synthetic-event-index-id',
+              pages: [
+                {
+                  path: 'projects/manual-wiki.md',
+                  title: 'Manual Wiki',
+                  content: 'operator-authored wiki summary',
+                },
+              ],
+            },
+          ],
+        });
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        error: true,
+        code: 'UNAUTHORIZED',
+      });
+      expect(db.prepare('SELECT COUNT(*) AS count FROM vnext_operator_commits').get()).toEqual({
+        count: 0,
+      });
+
+      db.close();
+    });
+
+    it('rejects manual wiki ingress commit requests that try to supply source refs', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      let providerCalls = 0;
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualWikiCommitProvider: () => {
+          providerCalls += 1;
+          throw new Error('provider must not run when source refs are supplied');
+        },
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-wiki-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send({
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_pages: [
+            {
+              event_index_id: 'synthetic-event-index-id',
+              pages: [
+                {
+                  path: 'projects/manual-wiki.md',
+                  title: 'Manual Wiki',
+                  content: 'operator-authored wiki summary',
+                  source_refs: ['raw:slack:synthetic-event-index-id'],
+                },
+              ],
+            },
+          ],
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'vnext_ingress_manual_wiki_commit_invalid_request',
+      });
+      expect(providerCalls).toBe(0);
     });
 
     it('rejects manual no-update ingress commit requests that try to supply changed refs', async () => {

--- a/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
+++ b/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
@@ -1063,6 +1063,47 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
       expect(providerCalls).toBe(0);
     });
 
+    it('rejects manual wiki ingress commit requests that try to supply page changed refs', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      let providerCalls = 0;
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualWikiCommitProvider: () => {
+          providerCalls += 1;
+          throw new Error('provider must not run when page changed refs are supplied');
+        },
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-wiki-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send({
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_pages: [
+            {
+              event_index_id: 'synthetic-event-index-id',
+              pages: [
+                {
+                  path: 'projects/manual-wiki.md',
+                  title: 'Manual Wiki',
+                  content: 'operator-authored wiki summary',
+                  changed_refs: ['wiki_page:projects/caller-supplied.md'],
+                },
+              ],
+            },
+          ],
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'vnext_ingress_manual_wiki_commit_invalid_request',
+      });
+      expect(providerCalls).toBe(0);
+    });
+
     it('rejects manual no-update ingress commit requests that try to supply changed refs', async () => {
       process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
       const db = new Database(':memory:');


### PR DESCRIPTION
## Summary

Adds the vNext manual wiki ingress commit path for reviewed connector events.

- Adds an admin-only `POST /api/vnext/ingress/manual-wiki-commit` endpoint.
- Commits reviewed connector events into wiki artifacts through the vNext `WikiPublishAdapter`.
- Advances connector cursor state and changed commits inside the same DB transaction after validation.
- Derives source refs only from reviewed raw connector events; request-supplied `sourceRefs`, `source_refs`, `sourceIds`, `source_ids`, `changedRefs`, and `changed_refs` are rejected.
- Returns an allowlisted response shape without raw content, user metadata, local filesystem paths, or connector event payloads.
- Extracts reviewed-event lookup/cursor validation into a shared helper used by manual no-update and manual wiki commits.

## Hardening

- Preflights all page validation before durable writes.
- Rejects invalid page fields, excessive page counts, and duplicate normalized wiki paths across reviewed events before committing.
- Caps aggregate manual wiki payloads at the wiki publish page limit.
- Aligns the API JSON body limit with the accepted max decoded wiki content size plus JSON escape overhead.
- Guards against non-vNext wiki adapters and verifies the stored artifact count matches the changed commit refs.

## Verification

- `MAMA_FORCE_TIER_3=true pnpm --dir packages/standalone exec vitest run tests/operator-vnext/connector-ingress-manual-wiki-commit.test.ts tests/operator-vnext/connector-ingress-manual-commit.test.ts tests/runtime-vnext/bootstrap-api.test.ts`
- `MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os test`
- `pnpm --filter @jungjaehoon/mama-os build`
- Commit hook re-ran lint-staged, gitleaks, doc version sync, typecheck, package build, and changed-package tests successfully.

## Public/Privacy Audit

- `./scripts/check-pii.sh` passed.
- `git diff --check` and `git diff --cached --check` passed.
- Changed-file `gitleaks detect --no-git --redact --verbose` passed with no leaks.
- Changed-file keyword audit found only synthetic test tokens, public connector fixture names, env var names, and existing generic runtime/auth terminology; no real personal data, project-private paths, API keys, or internal-only content in this diff.
- Full-repo `gitleaks detect --no-git --source . --redact --verbose` still reports 6 pre-existing non-diff findings in docs/test fixtures; none are introduced or touched by this PR.

## Review Notes

Pre-PR reviews raised and this branch fixed:

- Partial commits when later wiki pages were invalid.
- Accepting arbitrary wiki adapters and not checking stored artifact counts.
- Page count validation happening after earlier writes.
- Duplicate normalized wiki paths across multiple reviewed events losing provenance.
- JSON body limit rejecting valid max-size escaped content.

Final pre-PR review found no actionable issues attributable to this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new admin-protected vNext endpoint for manual wiki commits.
  * Manual wiki commits now support validated page batches, size limits, and sanitized responses.
  * Added safer handling for reviewed event ingestion and cursor-checked batch processing.

* **Bug Fixes**
  * Rejected invalid wiki page data, duplicate paths, unsupported types, and oversized requests before any write occurs.
  * Improved commit consistency so in-flight or stale cursor states are revalidated before finalizing updates.

* **Tests**
  * Expanded coverage for access control, payload limits, validation errors, and successful wiki commit flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->