### PR TITLE
feat: add vNext manual memory commit

### DIFF
--- a/docs/architecture/mama-vnext-primary-operator-rebuild.md
+++ b/docs/architecture/mama-vnext-primary-operator-rebuild.md
@@ -780,6 +780,77 @@ MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run \
   tests/runtime-vnext/legacy-fanout-disabled.test.ts
 ```
 
+### PR 13: Manual Memory Commit From Reviewed Ingress
+
+Goal:
+
+- Add an authenticated, operator-owned path that commits manually reviewed
+  connector events into MAMA memory.
+- Save approved memories as staged records first, then promote them only after the
+  primary operator cursor commit succeeds.
+- Make retries idempotent by recording memory commit intents keyed to the operator
+  cursor idempotency key.
+
+Files:
+
+- Create: `packages/mama-core/db/migrations/040-create-operator-memory-commit-intents.sql`
+- Create: `packages/standalone/src/operator-vnext/connector-ingress-manual-memory-commit.ts`
+- Modify: `packages/standalone/src/cli/commands/start.ts`
+- Modify: `packages/standalone/src/operator-vnext/schema.ts`
+- Modify: `packages/mama-core/src/db-adapter/node-sqlite-adapter.ts`
+- Create: `packages/standalone/tests/operator-vnext/connector-ingress-manual-memory-commit.test.ts`
+- Modify: `packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts`
+- Modify: `packages/standalone/tests/operator-vnext/schema.test.ts`
+- Modify: `packages/mama-core/tests/cases/migration-runner-duplicate-column.test.ts`
+
+Authenticated manual memory endpoint:
+
+```text
+POST /api/vnext/ingress/manual-memory-commit
+```
+
+Rules:
+
+- Manual memory commit is locked to the configured connector/channel.
+- Requests provide only reviewed event ids and memory payloads; source refs and
+  provenance are derived from reviewed raw events.
+- Request-supplied source refs, provenance, gateway call ids, agent ids, or model
+  run ids are rejected before durable writes.
+- The HTTP response is allowlisted and must not expose raw connector events,
+  source message bodies, local paths, memory ids, or internal provider fields.
+- Saved memories remain `stale` and suppress `memory_truth` projection until the
+  primary operator commit succeeds, so staged memories cannot enter normal truth
+  snapshots before cursor commit.
+- After cursor commit, each memory is promoted to its requested final status
+  through the normal memory evolution path, including `supersedes` chain updates.
+- If status promotion fails after the cursor commit, the response is still
+  `committed` with `promotionPending: true`; the intent stays `saved` so the
+  next idempotent replay can finish promotion without saving duplicate memories.
+- Duplicate committed replays must not re-save memories or re-promote memory
+  statuses.
+- Concurrent or cross-process attempts use
+  `operator_memory_commit_intents.status` and `claim_token` so only the current
+  save owner can update memory ids or advance the intent state.
+- A durable `saving` intent is a bounded lease, not a permanent lock. After the
+  lease expires, replay may CAS-take the claim and recover already-saved memory
+  ids from deterministic `gateway_call_id` provenance before saving anything new.
+- Partial failures must not advance the operator cursor.
+
+Verify:
+
+```bash
+MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run \
+  tests/operator-vnext/connector-ingress-manual-memory-commit.test.ts \
+  tests/runtime-vnext/bootstrap-api.test.ts \
+  tests/operator-vnext/schema.test.ts
+
+MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-core exec vitest run \
+  tests/memory/memory-provenance.test.ts \
+  tests/memory/memory-promotion-semantic.test.ts \
+  tests/cases/migration-runner-duplicate-column.test.ts \
+  tests/cases/migration-chain.test.ts
+```
+
 ## Global Regression Checklist
 
 - legacy mode behavior unchanged
@@ -802,6 +873,18 @@ MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run \
 - DB busy retry is bounded
 - migration dry run does not write operator commits, cursors, or no-update rows
 - migration dry run does not promote unverified legacy artifacts
+- manual memory commit rejects caller-supplied refs/provenance before durable writes
+- manual memory commit keeps saved memories staged until cursor commit succeeds
+- manual memory commit staged saves do not project to `memory_truth` until promotion
+- manual memory commit duplicate replay does not duplicate saves or status promotion
+- manual memory commit partial failure does not expose raw connector content
+- manual memory commit HTTP responses are explicit allowlists
+- manual memory commit promotion failure is recoverable with `promotionPending`
+- manual memory commit stale save owners cannot overwrite promoted intents
+- manual memory commit stale `saving` leases recover saved memory ids without
+  duplicate saves
+- manual memory promotion writes both `supersedes` and `superseded_by` chain
+  fields
 
 ## Parallelization
 

--- a/docs/architecture/mama-vnext-primary-operator-rebuild.md
+++ b/docs/architecture/mama-vnext-primary-operator-rebuild.md
@@ -825,16 +825,17 @@ Rules:
   through the normal memory evolution path, including `supersedes` chain updates.
 - If status promotion fails after the cursor commit, the response is still
   `committed` with `promotionPending: true`; the intent stays `saved` so the
-  next idempotent replay can finish promotion without saving duplicate memories.
-- Duplicate committed replays must not re-save memories or re-promote memory
-  statuses.
+  first idempotent replay after the committed cursor can finish promotion
+  without saving duplicate memories.
+- Later duplicate committed replays, after the intent reaches `promoted`, must
+  not re-save memories or re-promote memory statuses.
 - Concurrent or cross-process attempts use
   `operator_memory_commit_intents.status` and `claim_token` so only the current
   save owner can update memory ids or advance the intent state.
 - A durable `saving` intent is a bounded lease, not a permanent lock. After the
   lease expires, replay may CAS-take the claim and recover already-saved memory
   ids from deterministic `gateway_call_id` provenance before saving anything new.
-- Partial failures must not advance the operator cursor.
+- Partial failures before cursor commit must not advance the operator cursor.
 
 Verify:
 

--- a/packages/mama-core/db/migrations/040-create-operator-memory-commit-intents.sql
+++ b/packages/mama-core/db/migrations/040-create-operator-memory-commit-intents.sql
@@ -15,8 +15,5 @@ CREATE TABLE IF NOT EXISTS operator_memory_commit_intents (
 CREATE INDEX IF NOT EXISTS idx_operator_memory_commit_intents_cursor_created
   ON operator_memory_commit_intents(cursor_name, created_at_ms DESC);
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_operator_memory_commit_intents_idempotency_key
-  ON operator_memory_commit_intents(idempotency_key);
-
 INSERT OR IGNORE INTO schema_version (version, description)
 VALUES (40, 'Create operator memory commit intents');

--- a/packages/mama-core/db/migrations/040-create-operator-memory-commit-intents.sql
+++ b/packages/mama-core/db/migrations/040-create-operator-memory-commit-intents.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS operator_memory_commit_intents (
+  intent_id TEXT PRIMARY KEY,
+  cursor_name TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL UNIQUE,
+  expected_memory_count INTEGER NOT NULL CHECK (expected_memory_count > 0),
+  memory_payload_hash TEXT NOT NULL CHECK (memory_payload_hash LIKE 'sha256:%'),
+  memory_ids_json TEXT NOT NULL CHECK (json_valid(memory_ids_json)),
+  source_refs_json TEXT NOT NULL CHECK (json_valid(source_refs_json)),
+  status TEXT NOT NULL CHECK (status IN ('pending', 'saving', 'saved', 'promoted')),
+  claim_token TEXT,
+  created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+  updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms)
+);
+
+CREATE INDEX IF NOT EXISTS idx_operator_memory_commit_intents_cursor_created
+  ON operator_memory_commit_intents(cursor_name, created_at_ms DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_operator_memory_commit_intents_idempotency_key
+  ON operator_memory_commit_intents(idempotency_key);
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES (40, 'Create operator memory commit intents');

--- a/packages/mama-core/db/migrations/041-enforce-operator-memory-commit-claim-invariant.sql
+++ b/packages/mama-core/db/migrations/041-enforce-operator-memory-commit-claim-invariant.sql
@@ -1,0 +1,74 @@
+CREATE TABLE IF NOT EXISTS operator_memory_commit_intents (
+  intent_id TEXT PRIMARY KEY,
+  cursor_name TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL UNIQUE,
+  expected_memory_count INTEGER NOT NULL CHECK (expected_memory_count > 0),
+  memory_payload_hash TEXT NOT NULL CHECK (memory_payload_hash LIKE 'sha256:%'),
+  memory_ids_json TEXT NOT NULL CHECK (json_valid(memory_ids_json)),
+  source_refs_json TEXT NOT NULL CHECK (json_valid(source_refs_json)),
+  status TEXT NOT NULL CHECK (status IN ('pending', 'saving', 'saved', 'promoted')),
+  claim_token TEXT,
+  created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+  updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms)
+);
+
+DROP TABLE IF EXISTS operator_memory_commit_intents_v041;
+
+CREATE TABLE operator_memory_commit_intents_v041 (
+  intent_id TEXT PRIMARY KEY,
+  cursor_name TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL UNIQUE,
+  expected_memory_count INTEGER NOT NULL CHECK (expected_memory_count > 0),
+  memory_payload_hash TEXT NOT NULL CHECK (memory_payload_hash LIKE 'sha256:%'),
+  memory_ids_json TEXT NOT NULL CHECK (json_valid(memory_ids_json)),
+  source_refs_json TEXT NOT NULL CHECK (json_valid(source_refs_json)),
+  status TEXT NOT NULL CHECK (status IN ('pending', 'saving', 'saved', 'promoted')),
+  claim_token TEXT CHECK (
+    (status = 'saving' AND claim_token IS NOT NULL) OR
+    (status != 'saving' AND claim_token IS NULL)
+  ),
+  created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+  updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms)
+);
+
+INSERT INTO operator_memory_commit_intents_v041 (
+  intent_id,
+  cursor_name,
+  idempotency_key,
+  expected_memory_count,
+  memory_payload_hash,
+  memory_ids_json,
+  source_refs_json,
+  status,
+  claim_token,
+  created_at_ms,
+  updated_at_ms
+)
+SELECT
+  intent_id,
+  cursor_name,
+  idempotency_key,
+  expected_memory_count,
+  memory_payload_hash,
+  memory_ids_json,
+  source_refs_json,
+  CASE
+    WHEN status = 'saving' AND claim_token IS NULL THEN 'pending'
+    ELSE status
+  END,
+  CASE
+    WHEN status = 'saving' AND claim_token IS NOT NULL THEN claim_token
+    ELSE NULL
+  END,
+  created_at_ms,
+  updated_at_ms
+FROM operator_memory_commit_intents;
+
+DROP TABLE operator_memory_commit_intents;
+ALTER TABLE operator_memory_commit_intents_v041 RENAME TO operator_memory_commit_intents;
+
+CREATE INDEX IF NOT EXISTS idx_operator_memory_commit_intents_cursor_created
+  ON operator_memory_commit_intents(cursor_name, created_at_ms DESC);
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES (41, 'Enforce operator memory commit claim invariant');

--- a/packages/mama-core/src/db-adapter/node-sqlite-adapter.ts
+++ b/packages/mama-core/src/db-adapter/node-sqlite-adapter.ts
@@ -593,8 +593,7 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
 
     if (
       !this.tableExists('operator_memory_commit_intents') ||
-      !this.indexExists('idx_operator_memory_commit_intents_cursor_created') ||
-      !this.indexExists('idx_operator_memory_commit_intents_idempotency_key')
+      !this.indexExists('idx_operator_memory_commit_intents_cursor_created')
     ) {
       this.applyRepairMigration(
         migrationsDir,
@@ -652,19 +651,10 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
       }
     }
 
-    for (const indexName of [
-      'idx_operator_memory_commit_intents_cursor_created',
-      'idx_operator_memory_commit_intents_idempotency_key',
-    ]) {
+    for (const indexName of ['idx_operator_memory_commit_intents_cursor_created']) {
       if (!this.indexExists(indexName)) {
         throw new Error(`Migration 040 recovery failed: missing index ${indexName}`);
       }
-    }
-    const idempotencyIndex = this.prepare(
-      "SELECT sql FROM sqlite_master WHERE type='index' AND name = 'idx_operator_memory_commit_intents_idempotency_key'"
-    ).get() as { sql?: string } | undefined;
-    if (!idempotencyIndex?.sql?.includes('CREATE UNIQUE INDEX')) {
-      throw new Error('Migration 040 recovery failed: idempotency key index must be unique');
     }
 
     const tableDefinition = this.prepare(

--- a/packages/mama-core/src/db-adapter/node-sqlite-adapter.ts
+++ b/packages/mama-core/src/db-adapter/node-sqlite-adapter.ts
@@ -442,6 +442,12 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
           continue;
         }
 
+        if (message.includes('duplicate column') && version === 39) {
+          this.recoverConnectorEventOperatorSeqMigration039();
+          info(`[node-sqlite-adapter] Migration ${file} recovered successfully`);
+          continue;
+        }
+
         if (message.includes('duplicate column')) {
           warn(
             `[node-sqlite-adapter] Migration ${file} skipped (duplicate column - already applied)`
@@ -532,6 +538,21 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
         this.recoverConnectorEventScopeMigration034();
         info('[node-sqlite-adapter] Repaired skipped connector event scope migration');
       }
+
+      const connectorColumnsAfterScopeRepair = this.tableColumns('connector_event_index');
+      const hasMissingOperatorSeqFeature =
+        !connectorColumnsAfterScopeRepair.has('operator_ingest_seq') ||
+        !this.tableExists('connector_event_index_operator_seq_cursors') ||
+        !this.indexExists('idx_connector_event_index_operator_scope_seq') ||
+        !this.indexExists('idx_connector_event_index_operator_cursor_order') ||
+        !this.triggerExists('trg_connector_event_index_operator_ingest_seq_ai') ||
+        !this.triggerExists('trg_connector_event_index_operator_ingest_seq_explicit_ai') ||
+        !this.schemaVersionExists(39);
+
+      if (hasMissingOperatorSeqFeature) {
+        this.recoverConnectorEventOperatorSeqMigration039();
+        info('[node-sqlite-adapter] Repaired skipped connector event operator sequence migration');
+      }
     }
 
     if (!this.tableExists('twin_edges')) {
@@ -569,6 +590,19 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
         'vNext operator contracts'
       );
     }
+
+    if (
+      !this.tableExists('operator_memory_commit_intents') ||
+      !this.indexExists('idx_operator_memory_commit_intents_cursor_created') ||
+      !this.indexExists('idx_operator_memory_commit_intents_idempotency_key')
+    ) {
+      this.applyRepairMigration(
+        migrationsDir,
+        '040-create-operator-memory-commit-intents.sql',
+        'operator memory commit intents'
+      );
+    }
+    this.assertMigration040Complete();
   }
 
   private applyRepairMigration(migrationsDir: string, fileName: string, label: string): void {
@@ -587,6 +621,71 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       throw new Error(`Repair migration ${fileName} failed: ${message}`);
+    }
+  }
+
+  private assertMigration040Complete(): void {
+    if (!this.tableExists('operator_memory_commit_intents')) {
+      throw new Error(
+        'Migration 040 recovery failed: missing table operator_memory_commit_intents'
+      );
+    }
+
+    const columns = this.tableColumns('operator_memory_commit_intents');
+    for (const column of [
+      'intent_id',
+      'cursor_name',
+      'idempotency_key',
+      'expected_memory_count',
+      'memory_payload_hash',
+      'memory_ids_json',
+      'source_refs_json',
+      'status',
+      'claim_token',
+      'created_at_ms',
+      'updated_at_ms',
+    ]) {
+      if (!columns.has(column)) {
+        throw new Error(
+          `Migration 040 recovery failed: missing operator_memory_commit_intents.${column}`
+        );
+      }
+    }
+
+    for (const indexName of [
+      'idx_operator_memory_commit_intents_cursor_created',
+      'idx_operator_memory_commit_intents_idempotency_key',
+    ]) {
+      if (!this.indexExists(indexName)) {
+        throw new Error(`Migration 040 recovery failed: missing index ${indexName}`);
+      }
+    }
+    const idempotencyIndex = this.prepare(
+      "SELECT sql FROM sqlite_master WHERE type='index' AND name = 'idx_operator_memory_commit_intents_idempotency_key'"
+    ).get() as { sql?: string } | undefined;
+    if (!idempotencyIndex?.sql?.includes('CREATE UNIQUE INDEX')) {
+      throw new Error('Migration 040 recovery failed: idempotency key index must be unique');
+    }
+
+    const tableDefinition = this.prepare(
+      "SELECT sql FROM sqlite_master WHERE type='table' AND name = 'operator_memory_commit_intents'"
+    ).get() as { sql?: string } | undefined;
+    const sql = tableDefinition?.sql ?? '';
+    for (const fragment of [
+      'idempotency_key TEXT NOT NULL UNIQUE',
+      'expected_memory_count INTEGER NOT NULL CHECK (expected_memory_count > 0)',
+      "memory_payload_hash TEXT NOT NULL CHECK (memory_payload_hash LIKE 'sha256:%')",
+      'memory_ids_json TEXT NOT NULL CHECK (json_valid(memory_ids_json))',
+      'source_refs_json TEXT NOT NULL CHECK (json_valid(source_refs_json))',
+      "status TEXT NOT NULL CHECK (status IN ('pending', 'saving', 'saved', 'promoted'))",
+      'created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0)',
+      'updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms)',
+    ]) {
+      if (!sql.includes(fragment)) {
+        throw new Error(
+          `Migration 040 recovery failed: incompatible operator_memory_commit_intents table definition missing ${fragment}`
+        );
+      }
     }
   }
 
@@ -715,6 +814,153 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
     }
   }
 
+  private recoverConnectorEventOperatorSeqMigration039(): void {
+    this.transaction(() => {
+      const columns = this.tableColumns('connector_event_index');
+      if (!columns.has('operator_ingest_seq')) {
+        this.exec(`
+          ALTER TABLE connector_event_index
+            ADD COLUMN operator_ingest_seq INTEGER CHECK (
+              operator_ingest_seq IS NULL OR operator_ingest_seq >= 1
+            )
+        `);
+      }
+
+      this.exec(`
+        CREATE TABLE IF NOT EXISTS connector_event_index_operator_seq_cursors (
+          source_connector TEXT NOT NULL,
+          channel TEXT NOT NULL DEFAULT '',
+          next_seq INTEGER NOT NULL CHECK (next_seq >= 1),
+          PRIMARY KEY (source_connector, channel)
+        )
+      `);
+      this.exec(`
+        WITH ranked_events AS (
+          SELECT
+            event_index_id,
+            ROW_NUMBER() OVER (
+              PARTITION BY source_connector, COALESCE(channel, '')
+              ORDER BY rowid ASC
+            ) AS operator_seq
+          FROM connector_event_index
+        )
+        UPDATE connector_event_index
+        SET operator_ingest_seq = (
+          SELECT operator_seq
+          FROM ranked_events
+          WHERE ranked_events.event_index_id = connector_event_index.event_index_id
+        )
+        WHERE operator_ingest_seq IS NULL
+      `);
+      this.exec(`
+        INSERT OR IGNORE INTO connector_event_index_operator_seq_cursors (
+          source_connector,
+          channel,
+          next_seq
+        )
+        SELECT
+          source_connector,
+          COALESCE(channel, ''),
+          COALESCE(MAX(operator_ingest_seq), 0) + 1
+        FROM connector_event_index
+        GROUP BY source_connector, COALESCE(channel, '')
+      `);
+      this.exec(`
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_connector_event_index_operator_scope_seq
+          ON connector_event_index(source_connector, COALESCE(channel, ''), operator_ingest_seq)
+          WHERE operator_ingest_seq IS NOT NULL
+      `);
+      this.exec(`
+        CREATE INDEX IF NOT EXISTS idx_connector_event_index_operator_cursor_order
+          ON connector_event_index(source_connector, channel, operator_ingest_seq)
+      `);
+      this.exec(`
+        CREATE TRIGGER IF NOT EXISTS trg_connector_event_index_operator_ingest_seq_ai
+        AFTER INSERT ON connector_event_index
+        WHEN NEW.operator_ingest_seq IS NULL
+        BEGIN
+          INSERT OR IGNORE INTO connector_event_index_operator_seq_cursors (
+            source_connector,
+            channel,
+            next_seq
+          )
+          VALUES (NEW.source_connector, COALESCE(NEW.channel, ''), 1);
+
+          UPDATE connector_event_index
+          SET operator_ingest_seq = (
+            SELECT next_seq
+            FROM connector_event_index_operator_seq_cursors
+            WHERE source_connector = NEW.source_connector
+              AND channel = COALESCE(NEW.channel, '')
+          )
+          WHERE event_index_id = NEW.event_index_id;
+
+          UPDATE connector_event_index_operator_seq_cursors
+          SET next_seq = next_seq + 1
+          WHERE source_connector = NEW.source_connector
+            AND channel = COALESCE(NEW.channel, '');
+        END
+      `);
+      this.exec(`
+        CREATE TRIGGER IF NOT EXISTS trg_connector_event_index_operator_ingest_seq_explicit_ai
+        AFTER INSERT ON connector_event_index
+        WHEN NEW.operator_ingest_seq IS NOT NULL
+        BEGIN
+          INSERT OR IGNORE INTO connector_event_index_operator_seq_cursors (
+            source_connector,
+            channel,
+            next_seq
+          )
+          VALUES (NEW.source_connector, COALESCE(NEW.channel, ''), 1);
+
+          UPDATE connector_event_index_operator_seq_cursors
+          SET next_seq = CASE
+            WHEN next_seq <= NEW.operator_ingest_seq THEN NEW.operator_ingest_seq + 1
+            ELSE next_seq
+          END
+          WHERE source_connector = NEW.source_connector
+            AND channel = COALESCE(NEW.channel, '');
+        END
+      `);
+
+      this.assertMigration039Complete();
+      this.prepare('INSERT OR IGNORE INTO schema_version (version, description) VALUES (?, ?)').run(
+        39,
+        'Add connector event operator ingest sequence'
+      );
+    });
+  }
+
+  private assertMigration039Complete(): void {
+    const columns = this.tableColumns('connector_event_index');
+    if (!columns.has('operator_ingest_seq')) {
+      throw new Error(
+        'Migration 039 recovery failed: missing connector_event_index.operator_ingest_seq'
+      );
+    }
+    if (!this.tableExists('connector_event_index_operator_seq_cursors')) {
+      throw new Error(
+        'Migration 039 recovery failed: missing connector_event_index_operator_seq_cursors'
+      );
+    }
+    for (const indexName of [
+      'idx_connector_event_index_operator_scope_seq',
+      'idx_connector_event_index_operator_cursor_order',
+    ]) {
+      if (!this.indexExists(indexName)) {
+        throw new Error(`Migration 039 recovery failed: missing index ${indexName}`);
+      }
+    }
+    for (const triggerName of [
+      'trg_connector_event_index_operator_ingest_seq_ai',
+      'trg_connector_event_index_operator_ingest_seq_explicit_ai',
+    ]) {
+      if (!this.triggerExists(triggerName)) {
+        throw new Error(`Migration 039 recovery failed: missing trigger ${triggerName}`);
+      }
+    }
+  }
+
   private tableColumns(tableName: string): Set<string> {
     if (!SQLITE_IDENTIFIER_PATTERN.test(tableName)) {
       throw new Error('Invalid SQLite table identifier');
@@ -740,6 +986,23 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
       indexName
     ) as { name?: string } | undefined;
     return row?.name === indexName;
+  }
+
+  private triggerExists(triggerName: string): boolean {
+    const row = this.prepare(
+      "SELECT name FROM sqlite_master WHERE type='trigger' AND name = ?"
+    ).get(triggerName) as { name?: string } | undefined;
+    return row?.name === triggerName;
+  }
+
+  private schemaVersionExists(version: number): boolean {
+    if (!this.tableExists('schema_version')) {
+      return false;
+    }
+    const row = this.prepare('SELECT version FROM schema_version WHERE version = ?').get(
+      version
+    ) as { version?: number } | undefined;
+    return row?.version === version;
   }
 
   private migrateFromVssMemories(): void {

--- a/packages/mama-core/src/db-adapter/node-sqlite-adapter.ts
+++ b/packages/mama-core/src/db-adapter/node-sqlite-adapter.ts
@@ -601,7 +601,15 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
         'operator memory commit intents'
       );
     }
-    this.assertMigration040Complete();
+    this.assertMigration040BaseComplete();
+    if (!this.hasOperatorMemoryCommitIntentClaimInvariant()) {
+      this.applyRepairMigration(
+        migrationsDir,
+        '041-enforce-operator-memory-commit-claim-invariant.sql',
+        'operator memory commit claim invariant'
+      );
+    }
+    this.assertMigration041Complete();
   }
 
   private applyRepairMigration(migrationsDir: string, fileName: string, label: string): void {
@@ -623,7 +631,22 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
     }
   }
 
-  private assertMigration040Complete(): void {
+  private operatorMemoryCommitIntentTableSql(): string {
+    const tableDefinition = this.prepare(
+      "SELECT sql FROM sqlite_master WHERE type='table' AND name = 'operator_memory_commit_intents'"
+    ).get() as { sql?: string } | undefined;
+    return tableDefinition?.sql ?? '';
+  }
+
+  private hasOperatorMemoryCommitIntentClaimInvariant(): boolean {
+    const sql = this.operatorMemoryCommitIntentTableSql();
+    return (
+      sql.includes("(status = 'saving' AND claim_token IS NOT NULL)") &&
+      sql.includes("(status != 'saving' AND claim_token IS NULL)")
+    );
+  }
+
+  private assertMigration040BaseComplete(): void {
     if (!this.tableExists('operator_memory_commit_intents')) {
       throw new Error(
         'Migration 040 recovery failed: missing table operator_memory_commit_intents'
@@ -657,10 +680,7 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
       }
     }
 
-    const tableDefinition = this.prepare(
-      "SELECT sql FROM sqlite_master WHERE type='table' AND name = 'operator_memory_commit_intents'"
-    ).get() as { sql?: string } | undefined;
-    const sql = tableDefinition?.sql ?? '';
+    const sql = this.operatorMemoryCommitIntentTableSql();
     for (const fragment of [
       'idempotency_key TEXT NOT NULL UNIQUE',
       'expected_memory_count INTEGER NOT NULL CHECK (expected_memory_count > 0)',
@@ -676,6 +696,15 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
           `Migration 040 recovery failed: incompatible operator_memory_commit_intents table definition missing ${fragment}`
         );
       }
+    }
+  }
+
+  private assertMigration041Complete(): void {
+    this.assertMigration040BaseComplete();
+    if (!this.hasOperatorMemoryCommitIntentClaimInvariant()) {
+      throw new Error(
+        'Migration 041 recovery failed: incompatible operator_memory_commit_intents table definition missing claim invariant'
+      );
     }
   }
 

--- a/packages/mama-core/src/index.ts
+++ b/packages/mama-core/src/index.ts
@@ -112,6 +112,7 @@ export {
 export {
   saveMemory,
   saveMemoryWithTrustedProvenance,
+  promoteMemoryStatus,
   recallMemory,
   buildProfile,
   ingestMemory,

--- a/packages/mama-core/src/memory/api.ts
+++ b/packages/mama-core/src/memory/api.ts
@@ -642,11 +642,15 @@ async function saveMemoryInternal(
   const id = buildDecisionId(input.topic);
   const now = Date.now();
   const provenance = normalizeMemoryWriteProvenance(options);
+  const targetStatus = input.status ?? 'active';
+  const shouldApplyEvolution = targetStatus === 'active';
   // Find evolution candidates: exact topic match first, then semantic search fallback
   const primaryScope = input.scopes.length > 0 ? input.scopes[0] : null;
   const excludeIds = new Set(input.excludeIds ?? []);
   let existingCandidates: Array<{ id: string; topic: string; summary: string; kind: string }>;
-  if (primaryScope) {
+  if (!shouldApplyEvolution) {
+    existingCandidates = [];
+  } else if (primaryScope) {
     const scopeId = await ensureMemoryScope(primaryScope.kind, primaryScope.id);
     existingCandidates = (
       adapter
@@ -688,7 +692,7 @@ async function saveMemoryInternal(
   }
 
   // Semantic fallback: if no exact topic match, find similar memories via vector search
-  if (existingCandidates.length === 0) {
+  if (shouldApplyEvolution && existingCandidates.length === 0) {
     try {
       const queryText = `${input.topic} ${input.summary}`;
       const embedding = await generateEmbedding(queryText);
@@ -724,13 +728,15 @@ async function saveMemoryInternal(
     }
   }
 
-  const evolution = resolveMemoryEvolution({
-    incoming: { topic: input.topic, summary: input.summary, kind: input.kind },
-    existing: existingCandidates.map((c) => ({
-      ...c,
-      kind: (c.kind || 'fact') as MemoryRecord['kind'],
-    })),
-  });
+  const evolution = shouldApplyEvolution
+    ? resolveMemoryEvolution({
+        incoming: { topic: input.topic, summary: input.summary, kind: input.kind },
+        existing: existingCandidates.map((c) => ({
+          ...c,
+          kind: (c.kind || 'fact') as MemoryRecord['kind'],
+        })),
+      })
+    : { edges: [] };
   const supersedesTarget =
     evolution.edges.find((edge) => edge.type === 'supersedes')?.to_id ?? null;
 
@@ -786,7 +792,7 @@ async function saveMemoryInternal(
         )
         .run(
           input.kind,
-          input.status ?? 'active',
+          targetStatus,
           input.summary,
           input.kind === 'preference' || input.kind === 'constraint' ? 1 : 0,
           JSON.stringify({ source: input.source }),
@@ -861,21 +867,23 @@ async function saveMemoryInternal(
     throw rollbackError;
   }
 
-  // Project to memory_truth table (best-effort; failure should not break save)
-  try {
-    await projectMemoryTruth({
-      memory_id: id,
-      topic: input.topic,
-      truth_status: (input.status ?? 'active') as MemoryTruthRow['truth_status'],
-      effective_summary: input.summary,
-      effective_details: input.details,
-      trust_score: input.confidence ?? 0.5,
-      scope_refs: input.scopes,
-      supporting_event_ids: [],
-      superseded_by: undefined,
-    });
-  } catch {
-    // Truth projection is best-effort; do not fail the save
+  if (options?.projectTruth !== false) {
+    // Project to memory_truth table (best-effort; failure should not break save)
+    try {
+      await projectMemoryTruth({
+        memory_id: id,
+        topic: input.topic,
+        truth_status: targetStatus as MemoryTruthRow['truth_status'],
+        effective_summary: input.summary,
+        effective_details: input.details,
+        trust_score: input.confidence ?? 0.5,
+        scope_refs: input.scopes,
+        supporting_event_ids: [],
+        superseded_by: undefined,
+      });
+    } catch {
+      // Truth projection is best-effort; do not fail the save
+    }
   }
 
   return {
@@ -896,6 +904,203 @@ export async function saveMemoryWithTrustedProvenance(
   options: TrustedMemoryWriteOptions
 ): Promise<SaveMemoryResult> {
   return saveMemoryInternal(sanitizePublicSaveMemoryInput(input), options);
+}
+
+export async function promoteMemoryStatus(input: {
+  memoryId: string;
+  status: MemoryStatus;
+  nowMs?: number;
+}): Promise<void> {
+  await initDB();
+  const adapter = getAdapter();
+  const memoryId = input.memoryId;
+  const now = input.nowMs ?? Date.now();
+  const targetStatus = input.status;
+  const row = adapter
+    .prepare(
+      `
+        SELECT id, topic, decision, reasoning, confidence, kind, summary, supersedes
+        FROM decisions
+        WHERE id = ?
+      `
+    )
+    .get(memoryId) as
+    | {
+        id: string;
+        topic: string;
+        decision: string;
+        reasoning: string | null;
+        confidence: number | null;
+        kind: string | null;
+        summary: string | null;
+        supersedes: string | null;
+      }
+    | undefined;
+
+  if (!row) {
+    throw new Error(`Cannot promote missing memory ${memoryId}`);
+  }
+
+  const topic = String(row.topic);
+  const summary = String(row.summary ?? row.decision ?? '');
+  const details = String(row.reasoning ?? row.decision ?? '');
+  const kind = ((row.kind ?? 'fact') as MemoryKind) || 'fact';
+  const scopes = batchLoadScopes(adapter, [memoryId]).get(memoryId) ?? [];
+  let evolution: ReturnType<typeof resolveMemoryEvolution> = { edges: [] };
+
+  if (targetStatus === 'active') {
+    const primaryScope = scopes[0] ?? null;
+    let existingCandidates: Array<{ id: string; topic: string; summary: string; kind: string }>;
+    if (primaryScope) {
+      const scopeId = await ensureMemoryScope(primaryScope.kind, primaryScope.id);
+      existingCandidates = adapter
+        .prepare(
+          `
+            SELECT d.id, d.topic, d.summary, d.kind
+            FROM decisions d
+            JOIN memory_scope_bindings msb ON msb.memory_id = d.id
+            WHERE d.topic = ? AND msb.scope_id = ? AND d.id <> ?
+              AND (d.status = 'active' OR d.status IS NULL)
+              AND d.superseded_by IS NULL
+            ORDER BY d.created_at DESC
+            LIMIT 5
+          `
+        )
+        .all(topic, scopeId, memoryId) as Array<{
+        id: string;
+        topic: string;
+        summary: string;
+        kind: string;
+      }>;
+    } else {
+      existingCandidates = adapter
+        .prepare(
+          `
+            SELECT id, topic, summary, kind
+            FROM decisions
+            WHERE topic = ? AND id <> ?
+              AND (status = 'active' OR status IS NULL)
+              AND superseded_by IS NULL
+            ORDER BY created_at DESC
+            LIMIT 5
+          `
+        )
+        .all(topic, memoryId) as Array<{
+        id: string;
+        topic: string;
+        summary: string;
+        kind: string;
+      }>;
+    }
+
+    if (existingCandidates.length === 0) {
+      try {
+        const queryText = `${topic} ${summary}`;
+        const embedding = await generateEmbedding(queryText);
+        const semanticResults = await vectorSearch(embedding, 3, 0.82);
+
+        let scopeFiltered = semanticResults;
+        if (primaryScope) {
+          const semIds = semanticResults.map((result) => String(result.id));
+          const semScopeMap = batchLoadScopes(adapter, semIds);
+          const scopeKey = `${primaryScope.kind}:${primaryScope.id}`;
+          scopeFiltered = semanticResults.filter((result) => {
+            const resultScopes = semScopeMap.get(String(result.id)) ?? [];
+            return (
+              resultScopes.length === 0 ||
+              resultScopes.some((scope) => `${scope.kind}:${scope.id}` === scopeKey)
+            );
+          });
+        }
+
+        existingCandidates = scopeFiltered
+          .filter((result) => String(result.id) !== memoryId)
+          .filter((result) => {
+            const status = String((result as { status?: unknown }).status || '');
+            return !status || status === 'active' || status === '';
+          })
+          .map((result) => ({
+            id: String(result.id),
+            topic: String(result.topic || ''),
+            summary: String(result.decision || ''),
+            kind: 'fact' as const,
+            _semanticMatch: true,
+          }));
+      } catch {
+        // Semantic search unavailable — proceed with exact-match candidates only.
+      }
+    }
+
+    evolution = resolveMemoryEvolution({
+      incoming: { topic, summary, kind },
+      existing: existingCandidates.map((candidate) => ({
+        ...candidate,
+        kind: (candidate.kind || 'fact') as MemoryRecord['kind'],
+      })),
+    });
+  }
+  const existingSupersedesTarget =
+    typeof row.supersedes === 'string' && row.supersedes.length > 0 ? row.supersedes : null;
+  const supersedesTarget =
+    evolution.edges.find((edge) => edge.type === 'supersedes')?.to_id ??
+    (targetStatus === 'active' ? existingSupersedesTarget : null);
+
+  adapter.transaction(() => {
+    const updated = adapter
+      .prepare('UPDATE decisions SET status = ?, supersedes = ?, updated_at = ? WHERE id = ?')
+      .run(targetStatus, supersedesTarget, now, memoryId);
+    if (updated.changes !== 1) {
+      throw new Error(`Cannot promote missing memory ${memoryId}`);
+    }
+
+    adapter
+      .prepare(
+        `
+          INSERT OR REPLACE INTO memory_truth (
+            memory_id, topic, truth_status, effective_summary, effective_details, trust_score,
+            scope_refs, supporting_event_ids, superseded_by, contradicted_by, created_at, updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, COALESCE((SELECT supporting_event_ids FROM memory_truth WHERE memory_id = ?), '[]'), NULL, NULL, COALESCE((SELECT created_at FROM memory_truth WHERE memory_id = ?), ?), ?)
+        `
+      )
+      .run(
+        memoryId,
+        topic,
+        targetStatus,
+        summary,
+        details,
+        row.confidence ?? 0.5,
+        JSON.stringify(scopes),
+        memoryId,
+        memoryId,
+        now,
+        now
+      );
+
+    for (const edge of evolution.edges) {
+      if (edge.type === 'supersedes') {
+        adapter
+          .prepare(
+            `UPDATE decisions SET superseded_by = ?, status = 'superseded', updated_at = ? WHERE id = ?`
+          )
+          .run(memoryId, now, edge.to_id);
+        adapter
+          .prepare(
+            `UPDATE memory_truth SET truth_status = 'superseded', superseded_by = ?, updated_at = ? WHERE memory_id = ?`
+          )
+          .run(memoryId, now, edge.to_id);
+      }
+
+      adapter
+        .prepare(
+          `
+            INSERT OR REPLACE INTO decision_edges (from_id, to_id, relationship, reason, weight, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+          `
+        )
+        .run(memoryId, edge.to_id, edge.type, edge.reason ?? null, 1.0, now);
+    }
+  });
 }
 
 export async function buildProfile(scopes: MemoryScopeRef[]): Promise<ProfileSnapshot> {

--- a/packages/mama-core/src/memory/provenance.ts
+++ b/packages/mama-core/src/memory/provenance.ts
@@ -28,6 +28,7 @@ export interface TrustedProvenanceCapability {
 export interface TrustedMemoryWriteOptions {
   provenance: MemoryWriteProvenance;
   capability: TrustedProvenanceCapability;
+  projectTruth?: boolean;
 }
 
 export interface NormalizedMemoryProvenance {
@@ -135,6 +136,7 @@ export function appendProvenanceSourceRefs(
   assertTrustedProvenanceCapability(options.capability);
   return {
     capability: options.capability,
+    projectTruth: options.projectTruth,
     provenance: {
       ...options.provenance,
       source_refs: [...(options.provenance.source_refs ?? []), ...refs],

--- a/packages/mama-core/tests/cases/migration-runner-duplicate-column.test.ts
+++ b/packages/mama-core/tests/cases/migration-runner-duplicate-column.test.ts
@@ -49,6 +49,13 @@ function indexExists(db: Database.Database, indexName: string): boolean {
   return Boolean(row?.name);
 }
 
+function tableSql(db: Database.Database, tableName: string): string {
+  const row = db
+    .prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name = ?")
+    .get(tableName) as { sql?: string } | undefined;
+  return row?.sql ?? '';
+}
+
 function triggerExists(db: Database.Database, triggerName: string): boolean {
   const row = db
     .prepare("SELECT name FROM sqlite_master WHERE type='trigger' AND name = ?")
@@ -300,6 +307,123 @@ describe('Story M2.4: Legacy high schema-version structural recovery', () => {
           .prepare('SELECT version FROM schema_version WHERE version = 40')
           .get() as { version: number } | undefined;
         expect(memoryIntentRow?.version).toBe(40);
+        const memoryIntentClaimRow = db
+          .prepare('SELECT version FROM schema_version WHERE version = 41')
+          .get() as { version: number } | undefined;
+        expect(memoryIntentClaimRow?.version).toBe(41);
+        db.close();
+      });
+
+      it('upgrades existing migration 040 intent tables with the claim invariant', () => {
+        tempDir = mkdtempSync(join(tmpdir(), 'mama-migration-upgrade-040-'));
+        const dbPath = join(tempDir, 'upgrade-040.db');
+        const setupDb = new Database(dbPath);
+        setupDb.pragma('foreign_keys = ON');
+        setupDb.exec(`
+          CREATE TABLE schema_version (
+            version INTEGER PRIMARY KEY,
+            description TEXT
+          );
+          INSERT INTO schema_version (version, description)
+          VALUES (40, 'Create operator memory commit intents');
+
+          CREATE TABLE embeddings (
+            rowid INTEGER PRIMARY KEY,
+            embedding BLOB NOT NULL
+          );
+          CREATE TABLE decisions (
+            id TEXT PRIMARY KEY,
+            topic TEXT NOT NULL
+          );
+          CREATE TABLE memory_events (
+            id INTEGER PRIMARY KEY,
+            memory_id TEXT NOT NULL,
+            topic TEXT,
+            created_at INTEGER NOT NULL
+          );
+
+          CREATE TABLE operator_memory_commit_intents (
+            intent_id TEXT PRIMARY KEY,
+            cursor_name TEXT NOT NULL,
+            idempotency_key TEXT NOT NULL UNIQUE,
+            expected_memory_count INTEGER NOT NULL CHECK (expected_memory_count > 0),
+            memory_payload_hash TEXT NOT NULL CHECK (memory_payload_hash LIKE 'sha256:%'),
+            memory_ids_json TEXT NOT NULL CHECK (json_valid(memory_ids_json)),
+            source_refs_json TEXT NOT NULL CHECK (json_valid(source_refs_json)),
+            status TEXT NOT NULL CHECK (status IN ('pending', 'saving', 'saved', 'promoted')),
+            claim_token TEXT,
+            created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+            updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms)
+          );
+          CREATE INDEX idx_operator_memory_commit_intents_cursor_created
+            ON operator_memory_commit_intents(cursor_name, created_at_ms DESC);
+
+          INSERT INTO operator_memory_commit_intents (
+            intent_id, cursor_name, idempotency_key, expected_memory_count,
+            memory_payload_hash, memory_ids_json, source_refs_json, status, claim_token,
+            created_at_ms, updated_at_ms
+          )
+          VALUES
+            (
+              'intent:legacy-saving-without-claim',
+              'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+              'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:1-1',
+              1,
+              'sha256:legacy-saving-without-claim',
+              '[null]',
+              '["raw:slack:synthetic-event-index-id"]',
+              'saving',
+              NULL,
+              1710000000000,
+              1710000000000
+            ),
+            (
+              'intent:legacy-pending-with-claim',
+              'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+              'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:2-2',
+              1,
+              'sha256:legacy-pending-with-claim',
+              '[null]',
+              '["raw:slack:synthetic-event-index-id"]',
+              'pending',
+              'claim:legacy',
+              1710000000000,
+              1710000000000
+            );
+        `);
+        setupDb.close();
+
+        const adapter = new NodeSQLiteAdapter({ dbPath });
+        adapter.connect();
+        adapter.runMigrations(MIGRATIONS_DIR);
+        adapter.disconnect();
+
+        const db = new Database(dbPath);
+        const sql = tableSql(db, 'operator_memory_commit_intents');
+        expect(sql).toContain("(status = 'saving' AND claim_token IS NOT NULL)");
+        expect(sql).toContain("(status != 'saving' AND claim_token IS NULL)");
+        expect(
+          db
+            .prepare(
+              `SELECT status, claim_token
+               FROM operator_memory_commit_intents
+               WHERE intent_id = 'intent:legacy-saving-without-claim'`
+            )
+            .get()
+        ).toEqual({ status: 'pending', claim_token: null });
+        expect(
+          db
+            .prepare(
+              `SELECT status, claim_token
+               FROM operator_memory_commit_intents
+               WHERE intent_id = 'intent:legacy-pending-with-claim'`
+            )
+            .get()
+        ).toEqual({ status: 'pending', claim_token: null });
+        const row = db.prepare('SELECT version FROM schema_version WHERE version = 41').get() as
+          | { version: number }
+          | undefined;
+        expect(row?.version).toBe(41);
         db.close();
       });
 

--- a/packages/mama-core/tests/cases/migration-runner-duplicate-column.test.ts
+++ b/packages/mama-core/tests/cases/migration-runner-duplicate-column.test.ts
@@ -287,7 +287,6 @@ describe('Story M2.4: Legacy high schema-version structural recovery', () => {
         expect(indexExists(db, 'idx_operator_no_updates_scope_created')).toBe(true);
         expect(indexExists(db, 'idx_worker_proposals_status_kind')).toBe(true);
         expect(indexExists(db, 'idx_operator_memory_commit_intents_cursor_created')).toBe(true);
-        expect(indexExists(db, 'idx_operator_memory_commit_intents_idempotency_key')).toBe(true);
 
         const row = db.prepare('SELECT version FROM schema_version WHERE version = 38').get() as
           | { version: number }

--- a/packages/mama-core/tests/cases/migration-runner-duplicate-column.test.ts
+++ b/packages/mama-core/tests/cases/migration-runner-duplicate-column.test.ts
@@ -49,6 +49,13 @@ function indexExists(db: Database.Database, indexName: string): boolean {
   return Boolean(row?.name);
 }
 
+function triggerExists(db: Database.Database, triggerName: string): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='trigger' AND name = ?")
+    .get(triggerName) as { name?: string } | undefined;
+  return Boolean(row?.name);
+}
+
 describe('Story M2.1: Migration 032 duplicate-column recovery', () => {
   afterEach(cleanupTempDir);
 
@@ -136,6 +143,50 @@ describe('Story M2.3: Migration 034 duplicate-column recovery', () => {
   });
 });
 
+describe('Story M2.4: Migration 039 duplicate-column recovery', () => {
+  afterEach(cleanupTempDir);
+
+  describe('Acceptance Criteria', () => {
+    describe('AC #1: partial connector operator sequence migration recovery', () => {
+      it('repairs a partially applied 039 migration when operator_ingest_seq already exists', () => {
+        tempDir = mkdtempSync(join(tmpdir(), 'mama-migration-039-'));
+        const dbPath = join(tempDir, 'partial-039.db');
+        const setupDb = new Database(dbPath);
+        setupDb.pragma('foreign_keys = ON');
+        applyThrough(setupDb, 38);
+        setupDb.exec(`
+          ALTER TABLE connector_event_index
+            ADD COLUMN operator_ingest_seq INTEGER CHECK (
+              operator_ingest_seq IS NULL OR operator_ingest_seq >= 1
+            )
+        `);
+        setupDb.close();
+
+        const adapter = new NodeSQLiteAdapter({ dbPath });
+        adapter.connect();
+        adapter.runMigrations(MIGRATIONS_DIR);
+        adapter.disconnect();
+
+        const db = new Database(dbPath);
+        expect(columnExists(db, 'connector_event_index', 'operator_ingest_seq')).toBe(true);
+        expect(tableExists(db, 'connector_event_index_operator_seq_cursors')).toBe(true);
+        expect(indexExists(db, 'idx_connector_event_index_operator_scope_seq')).toBe(true);
+        expect(indexExists(db, 'idx_connector_event_index_operator_cursor_order')).toBe(true);
+        expect(triggerExists(db, 'trg_connector_event_index_operator_ingest_seq_ai')).toBe(true);
+        expect(triggerExists(db, 'trg_connector_event_index_operator_ingest_seq_explicit_ai')).toBe(
+          true
+        );
+
+        const row = db.prepare('SELECT version FROM schema_version WHERE version = 39').get() as
+          | { version: number }
+          | undefined;
+        expect(row?.version).toBe(39);
+        db.close();
+      });
+    });
+  });
+});
+
 describe('Story M2.4: Legacy high schema-version structural recovery', () => {
   afterEach(cleanupTempDir);
 
@@ -170,7 +221,8 @@ describe('Story M2.4: Legacy high schema-version structural recovery', () => {
           );
           CREATE TABLE connector_event_index (
             event_index_id TEXT PRIMARY KEY,
-            source_connector TEXT NOT NULL
+            source_connector TEXT NOT NULL,
+            channel TEXT
           );
         `);
         setupDb.close();
@@ -192,6 +244,7 @@ describe('Story M2.4: Legacy high schema-version structural recovery', () => {
           'vnext_operator_commits',
           'operator_no_updates',
           'worker_proposals',
+          'operator_memory_commit_intents',
         ]) {
           expect(tableExists(db, table)).toBe(true);
         }
@@ -211,9 +264,11 @@ describe('Story M2.4: Legacy high schema-version structural recovery', () => {
           'project_id',
           'memory_scope_kind',
           'memory_scope_id',
+          'operator_ingest_seq',
         ]) {
           expect(columnExists(db, 'connector_event_index', column)).toBe(true);
         }
+        expect(tableExists(db, 'connector_event_index_operator_seq_cursors')).toBe(true);
         expect(indexExists(db, 'idx_model_runs_envelope_hash')).toBe(true);
         expect(indexExists(db, 'idx_tool_traces_model_run_id')).toBe(true);
         expect(indexExists(db, 'idx_decisions_envelope_hash')).toBe(true);
@@ -221,16 +276,84 @@ describe('Story M2.4: Legacy high schema-version structural recovery', () => {
         expect(indexExists(db, 'idx_decisions_gateway_call_id')).toBe(true);
         expect(indexExists(db, 'idx_memory_events_memory_created')).toBe(true);
         expect(indexExists(db, 'idx_connector_event_source_cursor')).toBe(true);
+        expect(indexExists(db, 'idx_connector_event_index_operator_scope_seq')).toBe(true);
+        expect(indexExists(db, 'idx_connector_event_index_operator_cursor_order')).toBe(true);
+        expect(triggerExists(db, 'trg_connector_event_index_operator_ingest_seq_ai')).toBe(true);
+        expect(triggerExists(db, 'trg_connector_event_index_operator_ingest_seq_explicit_ai')).toBe(
+          true
+        );
         expect(indexExists(db, 'idx_context_packets_scope_hash')).toBe(true);
         expect(indexExists(db, 'idx_vnext_operator_commits_cursor_seq')).toBe(true);
         expect(indexExists(db, 'idx_operator_no_updates_scope_created')).toBe(true);
         expect(indexExists(db, 'idx_worker_proposals_status_kind')).toBe(true);
+        expect(indexExists(db, 'idx_operator_memory_commit_intents_cursor_created')).toBe(true);
+        expect(indexExists(db, 'idx_operator_memory_commit_intents_idempotency_key')).toBe(true);
 
         const row = db.prepare('SELECT version FROM schema_version WHERE version = 38').get() as
           | { version: number }
           | undefined;
         expect(row?.version).toBe(38);
+        const operatorSeqRow = db
+          .prepare('SELECT version FROM schema_version WHERE version = 39')
+          .get() as { version: number } | undefined;
+        expect(operatorSeqRow?.version).toBe(39);
+        const memoryIntentRow = db
+          .prepare('SELECT version FROM schema_version WHERE version = 40')
+          .get() as { version: number } | undefined;
+        expect(memoryIntentRow?.version).toBe(40);
         db.close();
+      });
+
+      it('rejects partial operator memory intent tables when schema_version is already newer', () => {
+        tempDir = mkdtempSync(join(tmpdir(), 'mama-migration-partial-040-'));
+        const dbPath = join(tempDir, 'partial-040.db');
+        const setupDb = new Database(dbPath);
+        setupDb.pragma('foreign_keys = ON');
+        setupDb.exec(`
+          CREATE TABLE schema_version (
+            version INTEGER PRIMARY KEY,
+            description TEXT
+          );
+          INSERT INTO schema_version (version, description)
+          VALUES (58, 'Legacy branch migration ahead of operator memory intents');
+
+          CREATE TABLE embeddings (
+            rowid INTEGER PRIMARY KEY,
+            embedding BLOB NOT NULL
+          );
+          CREATE TABLE decisions (
+            id TEXT PRIMARY KEY,
+            topic TEXT NOT NULL
+          );
+          CREATE TABLE memory_events (
+            id INTEGER PRIMARY KEY,
+            memory_id TEXT NOT NULL,
+            topic TEXT,
+            created_at INTEGER NOT NULL
+          );
+
+          CREATE TABLE operator_memory_commit_intents (
+            intent_id TEXT PRIMARY KEY,
+            cursor_name TEXT NOT NULL,
+            idempotency_key TEXT NOT NULL,
+            expected_memory_count INTEGER NOT NULL,
+            memory_payload_hash TEXT NOT NULL,
+            memory_ids_json TEXT NOT NULL,
+            source_refs_json TEXT NOT NULL,
+            status TEXT NOT NULL,
+            claim_token TEXT,
+            created_at_ms INTEGER NOT NULL,
+            updated_at_ms INTEGER NOT NULL
+          );
+        `);
+        setupDb.close();
+
+        const adapter = new NodeSQLiteAdapter({ dbPath });
+        adapter.connect();
+        expect(() => adapter.runMigrations(MIGRATIONS_DIR)).toThrow(
+          /incompatible operator_memory_commit_intents table definition/i
+        );
+        adapter.disconnect();
       });
     });
   });

--- a/packages/mama-core/tests/memory/memory-promotion-semantic.test.ts
+++ b/packages/mama-core/tests/memory/memory-promotion-semantic.test.ts
@@ -1,0 +1,125 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/embeddings.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../src/embeddings.js')>('../../src/embeddings.js');
+  return {
+    ...actual,
+    generateEmbedding: vi.fn(async () => new Float32Array([0.1, 0.2, 0.3])),
+  };
+});
+
+vi.mock('../../src/db-manager.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../src/db-manager.js')>('../../src/db-manager.js');
+  return {
+    ...actual,
+    vectorSearch: vi.fn(),
+  };
+});
+
+import { closeDB, getAdapter, vectorSearch } from '../../src/db-manager.js';
+import {
+  promoteMemoryStatus,
+  saveMemory,
+  saveMemoryWithTrustedProvenance,
+} from '../../src/memory/api.js';
+import { createTrustedProvenanceCapability } from '../../src/memory/provenance.js';
+
+const TEST_DB = path.join(os.tmpdir(), `test-memory-promotion-semantic-${randomUUID()}.db`);
+const PROJECT_SCOPE = { kind: 'project' as const, id: 'repo:promotion-semantic' };
+
+function cleanupDb(): void {
+  for (const file of [TEST_DB, `${TEST_DB}-journal`, `${TEST_DB}-wal`, `${TEST_DB}-shm`]) {
+    try {
+      fs.unlinkSync(file);
+    } catch {
+      // cleanup best effort
+    }
+  }
+}
+
+describe('Story M2.1: staged memory promotion semantic evolution', () => {
+  beforeEach(async () => {
+    await closeDB();
+    cleanupDb();
+    process.env.MAMA_DB_PATH = TEST_DB;
+    process.env.MAMA_FORCE_TIER_3 = 'true';
+    vi.mocked(vectorSearch).mockReset();
+    vi.mocked(vectorSearch).mockResolvedValue([]);
+  });
+
+  afterEach(async () => {
+    await closeDB();
+    delete process.env.MAMA_DB_PATH;
+    delete process.env.MAMA_FORCE_TIER_3;
+    cleanupDb();
+  });
+
+  it('uses semantic candidates when promoting a staged memory to active', async () => {
+    const oldMemory = await saveMemory({
+      topic: 'sqlite_memory_store',
+      kind: 'decision',
+      summary: 'Use SQLite for the memory store',
+      details: 'Existing operator decision',
+      confidence: 0.8,
+      scopes: [PROJECT_SCOPE],
+      source: { package: 'mama-core', source_type: 'test', project_id: PROJECT_SCOPE.id },
+    });
+    const stagedMemory = await saveMemoryWithTrustedProvenance(
+      {
+        topic: 'reviewed_manual_memory_store',
+        kind: 'decision',
+        summary: 'Use SQLite for the memory store with reviewed provenance',
+        details: 'Manual operator review approved the replacement memory.',
+        confidence: 0.9,
+        status: 'stale',
+        scopes: [PROJECT_SCOPE],
+        source: { package: 'mama-core', source_type: 'test', project_id: PROJECT_SCOPE.id },
+      },
+      {
+        capability: createTrustedProvenanceCapability(),
+        projectTruth: false,
+        provenance: {
+          actor: 'user',
+          agent_id: 'operator:manual-admin',
+          tool_name: 'mama_save',
+          gateway_call_id: 'manual-promotion-semantic:memory:0',
+          source_refs: ['raw:slack:manual-promotion-semantic'],
+        },
+      }
+    );
+
+    vi.mocked(vectorSearch).mockResolvedValueOnce([
+      {
+        id: oldMemory.id,
+        topic: 'sqlite_memory_store',
+        decision: 'Use SQLite for the memory store',
+        status: 'active',
+      } as never,
+    ]);
+
+    await promoteMemoryStatus({ memoryId: stagedMemory.id, status: 'active' });
+
+    expect(
+      getAdapter()
+        .prepare('SELECT status, superseded_by FROM decisions WHERE id = ?')
+        .get(oldMemory.id)
+    ).toEqual({ status: 'active', superseded_by: null });
+    expect(
+      getAdapter()
+        .prepare('SELECT status, supersedes FROM decisions WHERE id = ?')
+        .get(stagedMemory.id)
+    ).toEqual({ status: 'active', supersedes: null });
+    expect(
+      getAdapter()
+        .prepare('SELECT relationship FROM decision_edges WHERE from_id = ? AND to_id = ?')
+        .get(stagedMemory.id, oldMemory.id)
+    ).toEqual({ relationship: 'builds_on' });
+  });
+});

--- a/packages/mama-core/tests/memory/memory-promotion-semantic.test.ts
+++ b/packages/mama-core/tests/memory/memory-promotion-semantic.test.ts
@@ -3,27 +3,9 @@ import os from 'node:os';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-vi.mock('../../src/embeddings.js', async () => {
-  const actual =
-    await vi.importActual<typeof import('../../src/embeddings.js')>('../../src/embeddings.js');
-  return {
-    ...actual,
-    generateEmbedding: vi.fn(async () => new Float32Array([0.1, 0.2, 0.3])),
-  };
-});
-
-vi.mock('../../src/db-manager.js', async () => {
-  const actual =
-    await vi.importActual<typeof import('../../src/db-manager.js')>('../../src/db-manager.js');
-  return {
-    ...actual,
-    vectorSearch: vi.fn(),
-  };
-});
-
-import { closeDB, getAdapter, vectorSearch } from '../../src/db-manager.js';
+import { closeDB, getAdapter } from '../../src/db-manager.js';
 import {
   promoteMemoryStatus,
   saveMemory,
@@ -50,8 +32,6 @@ describe('Story M2.1: staged memory promotion semantic evolution', () => {
     cleanupDb();
     process.env.MAMA_DB_PATH = TEST_DB;
     process.env.MAMA_FORCE_TIER_3 = 'true';
-    vi.mocked(vectorSearch).mockReset();
-    vi.mocked(vectorSearch).mockResolvedValue([]);
   });
 
   afterEach(async () => {
@@ -61,7 +41,7 @@ describe('Story M2.1: staged memory promotion semantic evolution', () => {
     cleanupDb();
   });
 
-  it('uses semantic candidates when promoting a staged memory to active', async () => {
+  it('applies evolution candidates when promoting a staged memory to active', async () => {
     const oldMemory = await saveMemory({
       topic: 'sqlite_memory_store',
       kind: 'decision',
@@ -73,7 +53,7 @@ describe('Story M2.1: staged memory promotion semantic evolution', () => {
     });
     const stagedMemory = await saveMemoryWithTrustedProvenance(
       {
-        topic: 'reviewed_manual_memory_store',
+        topic: 'sqlite_memory_store',
         kind: 'decision',
         summary: 'Use SQLite for the memory store with reviewed provenance',
         details: 'Manual operator review approved the replacement memory.',
@@ -95,31 +75,22 @@ describe('Story M2.1: staged memory promotion semantic evolution', () => {
       }
     );
 
-    vi.mocked(vectorSearch).mockResolvedValueOnce([
-      {
-        id: oldMemory.id,
-        topic: 'sqlite_memory_store',
-        decision: 'Use SQLite for the memory store',
-        status: 'active',
-      } as never,
-    ]);
-
     await promoteMemoryStatus({ memoryId: stagedMemory.id, status: 'active' });
 
     expect(
       getAdapter()
         .prepare('SELECT status, superseded_by FROM decisions WHERE id = ?')
         .get(oldMemory.id)
-    ).toEqual({ status: 'active', superseded_by: null });
+    ).toEqual({ status: 'superseded', superseded_by: stagedMemory.id });
     expect(
       getAdapter()
-        .prepare('SELECT status, supersedes FROM decisions WHERE id = ?')
+        .prepare('SELECT status, supersedes, superseded_by FROM decisions WHERE id = ?')
         .get(stagedMemory.id)
-    ).toEqual({ status: 'active', supersedes: null });
+    ).toEqual({ status: 'active', supersedes: oldMemory.id, superseded_by: null });
     expect(
       getAdapter()
         .prepare('SELECT relationship FROM decision_edges WHERE from_id = ? AND to_id = ?')
         .get(stagedMemory.id, oldMemory.id)
-    ).toEqual({ relationship: 'builds_on' });
+    ).toEqual({ relationship: 'supersedes' });
   });
 });

--- a/packages/mama-core/tests/memory/memory-provenance.test.ts
+++ b/packages/mama-core/tests/memory/memory-provenance.test.ts
@@ -10,6 +10,7 @@ import {
   ingestConversation,
   ingestConversationWithTrustedProvenance,
   ingestMemory,
+  promoteMemoryStatus,
   saveMemory,
   saveMemoryWithTrustedProvenance,
   setExtractionFn,
@@ -20,6 +21,7 @@ import {
 } from '../../src/memory/provenance-query.js';
 import { createTrustedProvenanceCapability } from '../../src/memory/provenance.js';
 import { listMemoryEventsForMemory } from '../../src/memory/event-store.js';
+import { queryRelevantTruth } from '../../src/memory/truth-store.js';
 import mama from '../../src/mama-api.js';
 
 const TEST_DB = path.join(os.tmpdir(), `test-memory-provenance-${randomUUID()}.db`);
@@ -193,6 +195,136 @@ describe('Story M2.1: Memory Write Provenance Foundation', () => {
       expect(JSON.parse(row.provenance_json)).toMatchObject({
         context_packet_id: 'ctxp_trusted_packet',
       });
+    });
+
+    it('applies evolution semantics when a staged memory is promoted to active', async () => {
+      const oldMemory = await saveMemory({
+        topic: 'manual_promotion_evolution_contract',
+        kind: 'decision',
+        summary: 'Use SQLite for the memory store',
+        details: 'Initial operator decision',
+        confidence: 0.8,
+        scopes: [PROJECT_SCOPE],
+        source: { package: 'mama-core', source_type: 'test', project_id: PROJECT_SCOPE.id },
+      });
+      const stagedMemory = await saveMemory({
+        topic: 'manual_promotion_evolution_contract',
+        kind: 'decision',
+        summary: 'Use SQLite for the memory store with reviewed operator provenance',
+        details: 'Manual ingress review approved the replacement memory',
+        confidence: 0.9,
+        status: 'stale',
+        scopes: [PROJECT_SCOPE],
+        source: { package: 'mama-core', source_type: 'test', project_id: PROJECT_SCOPE.id },
+      });
+
+      await promoteMemoryStatus({ memoryId: stagedMemory.id, status: 'active' });
+
+      expect(
+        getAdapter()
+          .prepare('SELECT status, superseded_by FROM decisions WHERE id = ?')
+          .get(oldMemory.id)
+      ).toEqual({ status: 'superseded', superseded_by: stagedMemory.id });
+      expect(
+        getAdapter()
+          .prepare('SELECT status, supersedes, superseded_by FROM decisions WHERE id = ?')
+          .get(stagedMemory.id)
+      ).toEqual({ status: 'active', supersedes: oldMemory.id, superseded_by: null });
+      expect(
+        getAdapter()
+          .prepare(`SELECT relationship FROM decision_edges WHERE from_id = ? AND to_id = ?`)
+          .get(stagedMemory.id, oldMemory.id)
+      ).toEqual({ relationship: 'supersedes' });
+      expect(
+        getAdapter()
+          .prepare('SELECT truth_status, superseded_by FROM memory_truth WHERE memory_id = ?')
+          .get(oldMemory.id)
+      ).toEqual({ truth_status: 'superseded', superseded_by: stagedMemory.id });
+      expect(
+        getAdapter()
+          .prepare('SELECT truth_status, superseded_by FROM memory_truth WHERE memory_id = ?')
+          .get(stagedMemory.id)
+      ).toEqual({ truth_status: 'active', superseded_by: null });
+
+      await promoteMemoryStatus({ memoryId: stagedMemory.id, status: 'active' });
+
+      expect(
+        getAdapter()
+          .prepare('SELECT status, superseded_by FROM decisions WHERE id = ?')
+          .get(oldMemory.id)
+      ).toEqual({ status: 'superseded', superseded_by: stagedMemory.id });
+      expect(
+        getAdapter()
+          .prepare('SELECT status, supersedes, superseded_by FROM decisions WHERE id = ?')
+          .get(stagedMemory.id)
+      ).toEqual({ status: 'active', supersedes: oldMemory.id, superseded_by: null });
+      expect(
+        getAdapter()
+          .prepare('SELECT truth_status, superseded_by FROM memory_truth WHERE memory_id = ?')
+          .get(oldMemory.id)
+      ).toEqual({ truth_status: 'superseded', superseded_by: stagedMemory.id });
+    });
+
+    it('keeps trusted staged writes out of truth projection until promotion', async () => {
+      const capability = createTrustedProvenanceCapability();
+      const stagedMemory = await saveMemoryWithTrustedProvenance(
+        {
+          topic: 'manual_staged_truth_projection_contract',
+          kind: 'decision',
+          summary: 'Stage reviewed manual memory before cursor commit',
+          details: 'The staged memory must not appear in truth snapshots before promotion.',
+          confidence: 0.9,
+          status: 'stale',
+          scopes: [PROJECT_SCOPE],
+          source: { package: 'mama-core', source_type: 'test', project_id: PROJECT_SCOPE.id },
+        },
+        {
+          capability,
+          projectTruth: false,
+          provenance: {
+            actor: 'user',
+            agent_id: 'operator:manual-admin',
+            tool_name: 'mama_save',
+            gateway_call_id: 'manual-staged-truth:memory:0',
+            source_refs: ['raw:slack:manual-staged-truth'],
+          },
+        }
+      );
+
+      expect(
+        getAdapter().prepare('SELECT status FROM decisions WHERE id = ?').get(stagedMemory.id)
+      ).toEqual({ status: 'stale' });
+      expect(
+        getAdapter()
+          .prepare('SELECT COUNT(*) AS count FROM memory_truth WHERE memory_id = ?')
+          .get(stagedMemory.id)
+      ).toEqual({ count: 0 });
+      expect(
+        (
+          await queryRelevantTruth({
+            query: 'manual staged truth projection',
+            scopes: [PROJECT_SCOPE],
+            includeHistory: true,
+          })
+        ).some((row) => row.memory_id === stagedMemory.id)
+      ).toBe(false);
+
+      await promoteMemoryStatus({ memoryId: stagedMemory.id, status: 'active' });
+
+      expect(
+        getAdapter()
+          .prepare('SELECT truth_status FROM memory_truth WHERE memory_id = ?')
+          .get(stagedMemory.id)
+      ).toEqual({ truth_status: 'active' });
+      expect(
+        (
+          await queryRelevantTruth({
+            query: 'manual staged truth projection',
+            scopes: [PROJECT_SCOPE],
+            includeHistory: true,
+          })
+        ).some((row) => row.memory_id === stagedMemory.id)
+      ).toBe(true);
     });
   });
 

--- a/packages/standalone/src/agent/types.ts
+++ b/packages/standalone/src/agent/types.ts
@@ -1232,6 +1232,7 @@ export interface MemoryWriteProvenance {
 export interface TrustedMemoryWriteOptions {
   provenance: MemoryWriteProvenance;
   capability: unknown;
+  projectTruth?: boolean;
 }
 
 /**

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -102,6 +102,12 @@ import {
   type ConnectorIngressManualCommitResult,
 } from '../../operator-vnext/connector-ingress-manual-commit.js';
 import {
+  createDefaultConnectorIngressManualMemoryCommitProvider,
+  MAX_MANUAL_MEMORY_COMMIT_TOTAL_MEMORIES,
+  type ConnectorIngressManualMemoryCommitResult,
+  type ManualMemorySaveInput,
+} from '../../operator-vnext/connector-ingress-manual-memory-commit.js';
+import {
   createConnectorIngressManualWikiCommitProvider,
   MAX_MANUAL_WIKI_COMMIT_TOTAL_PAGES,
   type ConnectorIngressManualWikiCommitResult,
@@ -614,6 +620,16 @@ export interface VNextIngressManualWikiCommitRequest {
   }>;
 }
 
+export interface VNextIngressManualMemoryCommitRequest {
+  connector: string;
+  channel: string;
+  expectedAdvancedThroughSeq: number;
+  eventMemories: Array<{
+    eventIndexId: string;
+    memories: ManualMemorySaveInput[];
+  }>;
+}
+
 export interface VNextBootstrapApiServerOptions {
   ingressPreviewProvider?: (input: VNextIngressPreviewRequest) => ConnectorEventIngressPreview;
   ingressMigrationDryRunProvider?: (
@@ -625,6 +641,9 @@ export interface VNextBootstrapApiServerOptions {
   ingressManualWikiCommitProvider?: (
     input: VNextIngressManualWikiCommitRequest
   ) => Promise<ConnectorIngressManualWikiCommitResult> | ConnectorIngressManualWikiCommitResult;
+  ingressManualMemoryCommitProvider?: (
+    input: VNextIngressManualMemoryCommitRequest
+  ) => Promise<ConnectorIngressManualMemoryCommitResult> | ConnectorIngressManualMemoryCommitResult;
 }
 
 function firstQueryString(value: unknown): string | null {
@@ -761,6 +780,124 @@ function bodyManualWikiEventPages(
   return parsed;
 }
 
+function bodyMemoryScopes(value: unknown): MemoryScopeRef[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error('memories[].scopes must be a non-empty array');
+  }
+  return value.map((item) => {
+    const scope = requireRequestBodyRecord(item);
+    const kind = bodyString(scope, 'kind');
+    if (kind !== 'global' && kind !== 'user' && kind !== 'channel' && kind !== 'project') {
+      throw new Error(`Unsupported memory scope kind: ${kind}`);
+    }
+    return {
+      kind,
+      id: bodyString(scope, 'id'),
+    };
+  });
+}
+
+function rejectManualMemoryDerivedFields(memory: Record<string, unknown>): void {
+  const forbiddenKeys = [
+    'source',
+    'provenance',
+    'sourceRefs',
+    'source_refs',
+    'sourceIds',
+    'source_ids',
+    'changedRefs',
+    'changed_refs',
+    'gatewayCallId',
+    'gateway_call_id',
+    'agentId',
+    'agent_id',
+    'modelRunId',
+    'model_run_id',
+    'envelopeHash',
+    'envelope_hash',
+    'timelineEvent',
+    'timeline_event',
+    'entityObservationIds',
+    'entity_observation_ids',
+  ];
+  if (forbiddenKeys.some((key) => Object.prototype.hasOwnProperty.call(memory, key))) {
+    throw new Error('manual memory commits derive source and provenance refs from reviewed events');
+  }
+}
+
+function bodyManualMemory(value: unknown): ManualMemorySaveInput {
+  const memory = requireRequestBodyRecord(value);
+  rejectManualMemoryDerivedFields(memory);
+  const parsed: ManualMemorySaveInput = {
+    topic: bodyString(memory, 'topic'),
+    kind: bodyString(memory, 'kind') as ManualMemorySaveInput['kind'],
+    summary: bodyString(memory, 'summary'),
+    details: bodyString(memory, 'details'),
+    scopes: bodyMemoryScopes(memory.scopes),
+  };
+  const confidence = memory.confidence;
+  if (confidence !== undefined) {
+    if (typeof confidence !== 'number' || !Number.isFinite(confidence)) {
+      throw new Error('confidence must be a number');
+    }
+    parsed.confidence = confidence;
+  }
+  const status = memory.status;
+  if (status !== undefined) {
+    parsed.status = bodyString(memory, 'status') as ManualMemorySaveInput['status'];
+  }
+  const eventDate = memory.event_date ?? memory.eventDate;
+  if (eventDate !== undefined) {
+    if (typeof eventDate !== 'string' || eventDate.trim().length === 0) {
+      throw new Error('event_date must be a non-empty string');
+    }
+    parsed.eventDate = eventDate.trim();
+  }
+  const eventDateTime = memory.event_datetime ?? memory.eventDateTime;
+  if (eventDateTime !== undefined) {
+    if (typeof eventDateTime !== 'number' || !Number.isFinite(eventDateTime)) {
+      throw new Error('event_datetime must be a number');
+    }
+    parsed.eventDateTime = eventDateTime;
+  }
+  return parsed;
+}
+
+function bodyManualMemoryEventMemories(
+  body: Record<string, unknown>
+): VNextIngressManualMemoryCommitRequest['eventMemories'] {
+  const value = body.event_memories;
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error('event_memories must be a non-empty array');
+  }
+  if (value.length > MAX_MANUAL_NO_UPDATE_EVENT_INDEX_IDS) {
+    throw new Error(
+      `event_memories must contain at most ${MAX_MANUAL_NO_UPDATE_EVENT_INDEX_IDS} items`
+    );
+  }
+  const parsed = value.map((item) => {
+    const eventMemory = requireRequestBodyRecord(item);
+    const memories = eventMemory.memories;
+    if (!Array.isArray(memories) || memories.length === 0) {
+      throw new Error('event_memories[].memories must be a non-empty array');
+    }
+    return {
+      eventIndexId: bodyString(eventMemory, 'event_index_id'),
+      memories: memories.map((memory) => bodyManualMemory(memory)),
+    };
+  });
+  const totalMemories = parsed.reduce(
+    (total, eventMemory) => total + eventMemory.memories.length,
+    0
+  );
+  if (totalMemories > MAX_MANUAL_MEMORY_COMMIT_TOTAL_MEMORIES) {
+    throw new Error(
+      `event_memories must contain at most ${MAX_MANUAL_MEMORY_COMMIT_TOTAL_MEMORIES} total memories`
+    );
+  }
+  return parsed;
+}
+
 function parseManualNoUpdateCommitBody(rawBody: unknown): VNextIngressManualNoUpdateCommitRequest {
   const body = requireRequestBodyRecord(rawBody);
   if (
@@ -790,6 +927,66 @@ function parseManualWikiCommitBody(rawBody: unknown): VNextIngressManualWikiComm
     channel: bodyString(body, 'channel'),
     expectedAdvancedThroughSeq: bodyNonNegativeInteger(body, 'expected_advanced_through_seq'),
     eventPages: bodyManualWikiEventPages(body),
+  };
+}
+
+function parseManualMemoryCommitBody(rawBody: unknown): VNextIngressManualMemoryCommitRequest {
+  const body = requireRequestBodyRecord(rawBody);
+  if (
+    Object.prototype.hasOwnProperty.call(body, 'changedRefs') ||
+    Object.prototype.hasOwnProperty.call(body, 'changed_refs') ||
+    Object.prototype.hasOwnProperty.call(body, 'sourceRefs') ||
+    Object.prototype.hasOwnProperty.call(body, 'source_refs') ||
+    Object.prototype.hasOwnProperty.call(body, 'source') ||
+    Object.prototype.hasOwnProperty.call(body, 'provenance') ||
+    Object.prototype.hasOwnProperty.call(body, 'gatewayCallId') ||
+    Object.prototype.hasOwnProperty.call(body, 'gateway_call_id') ||
+    Object.prototype.hasOwnProperty.call(body, 'agentId') ||
+    Object.prototype.hasOwnProperty.call(body, 'agent_id') ||
+    Object.prototype.hasOwnProperty.call(body, 'modelRunId') ||
+    Object.prototype.hasOwnProperty.call(body, 'model_run_id') ||
+    Object.prototype.hasOwnProperty.call(body, 'envelopeHash') ||
+    Object.prototype.hasOwnProperty.call(body, 'envelope_hash')
+  ) {
+    throw new Error('manual memory commits do not accept request-supplied refs or provenance');
+  }
+  return {
+    connector: bodyString(body, 'connector'),
+    channel: bodyString(body, 'channel'),
+    expectedAdvancedThroughSeq: bodyNonNegativeInteger(body, 'expected_advanced_through_seq'),
+    eventMemories: bodyManualMemoryEventMemories(body),
+  };
+}
+
+const SAFE_MANUAL_MEMORY_COMMIT_PARTIAL_FAILURE_ERROR = 'Manual memory commit partially failed.';
+
+function manualMemoryCommitResponse(
+  result: ConnectorIngressManualMemoryCommitResult
+): ConnectorIngressManualMemoryCommitResult {
+  return {
+    ok: result.ok,
+    mode: 'manual_memory_commit',
+    status: result.status,
+    cursorName: result.cursorName,
+    connector: result.connector,
+    channel: result.channel,
+    requestedCount: result.requestedCount,
+    processed: result.processed,
+    advancedThroughSeq: result.advancedThroughSeq,
+    firstSeq: result.firstSeq,
+    lastSeq: result.lastSeq,
+    memoriesSaved: result.memoriesSaved,
+    ...(result.promotionPending === true ? { promotionPending: true } : {}),
+    commits: result.commits.map((commit) => ({
+      seq: commit.seq,
+      status: 'changed',
+      outcome: commit.outcome,
+      cursorAdvanced: commit.cursorAdvanced,
+    })),
+    ...(result.failedSeq !== undefined ? { failedSeq: result.failedSeq } : {}),
+    ...(result.error !== undefined
+      ? { error: SAFE_MANUAL_MEMORY_COMMIT_PARTIAL_FAILURE_ERROR }
+      : {}),
   };
 }
 
@@ -1068,6 +1265,52 @@ export function createVNextBootstrapApiServer(
     }
   );
   app.use('/api/vnext/ingress/manual-wiki-commit', handleVNextManualCommitJsonError);
+  app.post(
+    '/api/vnext/ingress/manual-memory-commit',
+    requireAdminAuth,
+    jsonBodyParser,
+    async (req, res) => {
+      if (!options.ingressManualMemoryCommitProvider) {
+        res.status(404).json({
+          ok: false,
+          code: 'vnext_ingress_manual_memory_commit_unavailable',
+          error: 'vNext manual memory ingress commit is not configured.',
+        });
+        return;
+      }
+
+      let input: VNextIngressManualMemoryCommitRequest;
+      try {
+        input = parseManualMemoryCommitBody(req.body);
+      } catch (error) {
+        res.status(400).json({
+          ok: false,
+          code: 'vnext_ingress_manual_memory_commit_invalid_request',
+          error: error instanceof Error ? error.message : 'Invalid manual memory commit request.',
+        });
+        return;
+      }
+
+      try {
+        const result = await options.ingressManualMemoryCommitProvider(input);
+        res.status(result.ok ? 200 : 409).json(manualMemoryCommitResponse(result));
+      } catch (error) {
+        const clientError = isVNextManualCommitClientError(error);
+        res.status(clientError ? 400 : 500).json({
+          ok: false,
+          code: clientError
+            ? 'vnext_ingress_manual_memory_commit_invalid_request'
+            : 'vnext_ingress_manual_memory_commit_failed',
+          error: clientError
+            ? error instanceof Error
+              ? error.message
+              : 'Invalid manual memory commit request.'
+            : 'vNext manual memory ingress commit failed.',
+        });
+      }
+    }
+  );
+  app.use('/api/vnext/ingress/manual-memory-commit', handleVNextManualCommitJsonError);
   app.use(jsonBodyParser);
   app.use('/api', requireAuth);
   app.get('/api/vnext/status', (_req, res) => {
@@ -1378,6 +1621,13 @@ export async function runAgentLoop(
             connector: vNextIngressConfig.connector,
             channel: vNextIngressConfig.channel,
           }),
+          ingressManualMemoryCommitProvider:
+            createDefaultConnectorIngressManualMemoryCommitProvider({
+              rawAdapter: vNextRawAdapter,
+              operatorDb: vNextOperatorDb,
+              connector: vNextIngressConfig.connector,
+              channel: vNextIngressConfig.channel,
+            }),
         });
       },
       installShutdownHandlers: installVNextBootstrapShutdownHandlers,

--- a/packages/standalone/src/operator-vnext/connector-event-ingress.ts
+++ b/packages/standalone/src/operator-vnext/connector-event-ingress.ts
@@ -194,9 +194,7 @@ export function createConnectorEventIngressPreviewProvider(
     const requestedConnector = requiredString(input.connector, 'connector');
     const requestedChannel = requiredString(input.channel, 'channel');
     if (requestedConnector !== connector || requestedChannel !== channel) {
-      throw new Error(
-        `Connector ingress preview is locked to the configured connector/channel: ${connector}/${channel}`
-      );
+      throw new Error('Connector ingress preview is locked to the configured connector/channel');
     }
     return buildConnectorEventIngressPreview({
       rawAdapter: options.rawAdapter,

--- a/packages/standalone/src/operator-vnext/connector-ingress-manual-commit.ts
+++ b/packages/standalone/src/operator-vnext/connector-ingress-manual-commit.ts
@@ -216,7 +216,7 @@ export function createConnectorIngressManualNoUpdateCommitProvider(
     const requestedChannel = requiredString(input.channel, 'channel');
     if (requestedConnector !== connector || requestedChannel !== channel) {
       throw requestError(
-        `Connector ingress manual commit is locked to the configured connector/channel: ${connector}/${channel}`
+        'Connector ingress manual commit is locked to the configured connector/channel'
       );
     }
     return commitConnectorIngressNoUpdateBatch({

--- a/packages/standalone/src/operator-vnext/connector-ingress-manual-memory-commit.ts
+++ b/packages/standalone/src/operator-vnext/connector-ingress-manual-memory-commit.ts
@@ -1,6 +1,8 @@
 import crypto from 'node:crypto';
 import {
+  DebugLogger,
   MEMORY_KINDS,
+  MEMORY_SCOPE_KINDS,
   MEMORY_STATUSES,
   createTrustedProvenanceCapability,
   listMemoriesByGatewayCallId,
@@ -156,7 +158,19 @@ const MEMORY_COMMIT_SAVING_LEASE_MS = 15 * 60 * 1000;
 const MEMORY_COMMIT_SAVING_HEARTBEAT_MS = Math.floor(MEMORY_COMMIT_SAVING_LEASE_MS / 3);
 const MEMORY_KIND_SET = new Set<string>(MEMORY_KINDS);
 const MEMORY_STATUS_SET = new Set<string>(MEMORY_STATUSES);
-const MEMORY_SCOPE_KIND_SET = new Set<string>(['global', 'user', 'channel', 'project']);
+const MEMORY_SCOPE_KIND_SET = new Set<string>(MEMORY_SCOPE_KINDS);
+const manualMemoryCommitLogger = new DebugLogger('VNextManualMemoryCommit');
+
+function formatErrorForLog(error: unknown): string {
+  if (error instanceof Error) {
+    return error.name;
+  }
+  return typeof error;
+}
+
+function logManualMemoryCommitFailure(context: string, error: unknown): void {
+  manualMemoryCommitLogger.error(`${context}: ${formatErrorForLog(error)}`);
+}
 
 function requestError(message: string): ConnectorIngressManualCommitRequestError {
   return new ConnectorIngressManualCommitRequestError(message);
@@ -1148,7 +1162,8 @@ async function tryPromoteSavedMemories(input: {
       nowMs: input.nowMs,
     });
     return true;
-  } catch {
+  } catch (error) {
+    logManualMemoryCommitFailure('memory promotion failed', error);
     return false;
   }
 }
@@ -1263,7 +1278,8 @@ export async function commitConnectorIngressMemoryBatch(
           memoryIds: memoryCommit.memoryIds,
           intentStatus: memoryCommit.intentStatus,
         });
-      } catch {
+      } catch (error) {
+        logManualMemoryCommitFailure(`memory save failed at seq ${seq}`, error);
         return batchResult({
           ok: false,
           status: 'partial_failure',
@@ -1321,7 +1337,11 @@ export async function commitConnectorIngressMemoryBatch(
       const committed = commitPreparedBatch();
       commits.push(...committed.commits);
       advancedThroughSeq = committed.advancedThroughSeq;
-    } catch {
+    } catch (error) {
+      logManualMemoryCommitFailure(
+        `operator cursor commit failed at seq ${commitFailureSeq}`,
+        error
+      );
       return batchResult({
         ok: false,
         status: 'partial_failure',

--- a/packages/standalone/src/operator-vnext/connector-ingress-manual-memory-commit.ts
+++ b/packages/standalone/src/operator-vnext/connector-ingress-manual-memory-commit.ts
@@ -1,0 +1,1441 @@
+import crypto from 'node:crypto';
+import {
+  MEMORY_KINDS,
+  MEMORY_STATUSES,
+  createTrustedProvenanceCapability,
+  listMemoriesByGatewayCallId,
+  promoteMemoryStatus,
+  saveMemoryWithTrustedProvenance,
+  type MemoryKind,
+  type MemoryProvenanceRecord,
+  type MemoryScopeRef,
+  type MemoryStatus,
+  type PublicSaveMemoryInput,
+  type TrustedMemoryWriteOptions,
+} from '@jungjaehoon/mama-core';
+import type { SourceRef } from '@jungjaehoon/mama-core/provenance/source-ref';
+import { serializeSourceRef } from '@jungjaehoon/mama-core/provenance/source-ref';
+
+import type { SQLiteDatabase } from '../sqlite.js';
+import {
+  buildConnectorOperatorCursorName,
+  type ConnectorEventIngressAdapter,
+} from './connector-event-ingress.js';
+import {
+  assertReviewedConnectorIngressSeqs,
+  MAX_REVIEWED_CONNECTOR_INGRESS_EVENTS,
+  readConnectorOperatorCursorSeq,
+  readReviewedConnectorIngressEvents,
+} from './connector-ingress-reviewed-events.js';
+import { ConnectorIngressManualCommitRequestError } from './connector-ingress-manual-commit.js';
+import {
+  runWithPrimaryOperatorCursorLock,
+  type PrimaryOperatorBatchResult,
+  type PrimaryOperatorEvent,
+} from './primary-operator-runtime.js';
+import {
+  buildConnectorIdempotencyKey,
+  buildCursorScopedIdempotencyKey,
+  commitOperatorCursor,
+} from './operator-cursor-commit.js';
+import { nonNegativeInteger, requiredString } from './validation.js';
+
+interface ExistingOperatorCommitRow {
+  idempotency_key: string;
+  status: string;
+  changed_refs_json: string;
+}
+
+interface ExistingMemoryOperatorCommitRow extends ExistingOperatorCommitRow {
+  source_refs_json: string;
+  first_change_seq: number;
+  last_change_seq: number;
+}
+
+type MemoryCommitIntentStatus = 'pending' | 'saving' | 'saved' | 'promoted';
+
+interface MemoryCommitIntentRow {
+  intent_id: string;
+  cursor_name: string;
+  idempotency_key: string;
+  expected_memory_count: number;
+  memory_payload_hash: string;
+  memory_ids_json: string;
+  source_refs_json: string;
+  status: MemoryCommitIntentStatus;
+  claim_token: string | null;
+  created_at_ms: number;
+  updated_at_ms: number;
+}
+
+interface PreparedMemoryCursorCommit {
+  seq: number;
+  idempotencyKey: string;
+  sourceRefs: readonly SourceRef[];
+  memories: readonly ManualMemorySaveInput[];
+  changedRefs: SourceRef[];
+  memoryIds: string[];
+  intentStatus: MemoryCommitIntentStatus;
+}
+
+export interface ManualMemorySaveInput {
+  topic: string;
+  kind: MemoryKind;
+  summary: string;
+  details: string;
+  confidence?: number;
+  status?: MemoryStatus;
+  scopes: MemoryScopeRef[];
+  eventDate?: string;
+  eventDateTime?: number;
+}
+
+export interface ConnectorIngressManualMemoryEventMemories {
+  eventIndexId: string;
+  memories: readonly ManualMemorySaveInput[];
+}
+
+export interface ConnectorIngressManualMemoryCommitInput {
+  rawAdapter: ConnectorEventIngressAdapter;
+  operatorDb: SQLiteDatabase;
+  connector: string;
+  channel: string;
+  expectedAdvancedThroughSeq: number;
+  eventMemories: readonly ConnectorIngressManualMemoryEventMemories[];
+  saveMemory: (
+    input: PublicSaveMemoryInput,
+    options: TrustedMemoryWriteOptions
+  ) => Promise<{ success: boolean; id: string }>;
+  createTrustedProvenanceCapability: () => TrustedMemoryWriteOptions['capability'];
+  listMemoriesByGatewayCallId: (gatewayCallId: string) => Promise<MemoryProvenanceRecord[]>;
+  setMemoryStatus: (input: { memoryId: string; status: MemoryStatus }) => Promise<void> | void;
+  nowMs?: () => number;
+}
+
+export interface ConnectorIngressManualMemoryCommitResult {
+  ok: boolean;
+  mode: 'manual_memory_commit';
+  status: PrimaryOperatorBatchResult['status'];
+  cursorName: string;
+  connector: string;
+  channel: string;
+  requestedCount: number;
+  processed: number;
+  advancedThroughSeq: number;
+  firstSeq: number | null;
+  lastSeq: number | null;
+  memoriesSaved: number;
+  promotionPending?: boolean;
+  commits: Array<{
+    seq: number;
+    status: 'changed';
+    outcome: 'committed' | 'already_committed' | 'recovered';
+    cursorAdvanced: boolean;
+  }>;
+  failedSeq?: number;
+  error?: string;
+}
+
+export type ConnectorIngressManualMemoryCommitProvider = (
+  input: Omit<
+    ConnectorIngressManualMemoryCommitInput,
+    | 'rawAdapter'
+    | 'operatorDb'
+    | 'saveMemory'
+    | 'createTrustedProvenanceCapability'
+    | 'listMemoriesByGatewayCallId'
+    | 'setMemoryStatus'
+    | 'nowMs'
+  >
+) => Promise<ConnectorIngressManualMemoryCommitResult>;
+
+export const MAX_MANUAL_MEMORY_COMMIT_TOTAL_MEMORIES = MAX_REVIEWED_CONNECTOR_INGRESS_EVENTS;
+
+const PARTIAL_FAILURE_MESSAGE = 'Manual memory commit partially failed.';
+const MEMORY_COMMIT_SAVING_LEASE_MS = 15 * 60 * 1000;
+const MEMORY_COMMIT_SAVING_HEARTBEAT_MS = Math.floor(MEMORY_COMMIT_SAVING_LEASE_MS / 3);
+const MEMORY_KIND_SET = new Set<string>(MEMORY_KINDS);
+const MEMORY_STATUS_SET = new Set<string>(MEMORY_STATUSES);
+const MEMORY_SCOPE_KIND_SET = new Set<string>(['global', 'user', 'channel', 'project']);
+
+function requestError(message: string): ConnectorIngressManualCommitRequestError {
+  return new ConnectorIngressManualCommitRequestError(message);
+}
+
+function readReviewedEvents(input: {
+  rawAdapter: ConnectorEventIngressAdapter;
+  connector: string;
+  channel: string;
+  eventIndexIds: readonly string[];
+}): PrimaryOperatorEvent[] {
+  return readReviewedConnectorIngressEvents({
+    rawAdapter: input.rawAdapter,
+    connector: input.connector,
+    channel: input.channel,
+    eventIndexIds: input.eventIndexIds,
+    requestError,
+  });
+}
+
+function rejectManualMemoryInput(): never {
+  throw requestError(
+    'Manual memory source and refs are derived from reviewed events, not request payloads'
+  );
+}
+
+function requiredMemoryString(value: unknown, field: string): string {
+  if (typeof value !== 'string') {
+    throw requestError(`${field} must be a non-empty string`);
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw requestError(`${field} must be a non-empty string`);
+  }
+  return trimmed;
+}
+
+function optionalMemoryString(value: unknown, field: string): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return requiredMemoryString(value, field);
+}
+
+function normalizeConfidence(value: unknown): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 1) {
+    throw requestError('confidence must be a number between 0 and 1');
+  }
+  return value;
+}
+
+function normalizeEventDate(value: unknown): string | undefined {
+  const eventDate = optionalMemoryString(value, 'eventDate');
+  if (eventDate === undefined) {
+    return undefined;
+  }
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(eventDate);
+  if (!match) {
+    throw requestError('eventDate must be an ISO 8601 YYYY-MM-DD date');
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    throw requestError('eventDate must be an ISO 8601 YYYY-MM-DD date');
+  }
+  return eventDate;
+}
+
+function normalizeEventDateTime(value: unknown): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    throw requestError('eventDateTime must be a positive millisecond timestamp');
+  }
+  return value;
+}
+
+function normalizeKind(value: unknown): MemoryKind {
+  const kind = requiredMemoryString(value, 'kind');
+  if (!MEMORY_KIND_SET.has(kind)) {
+    throw requestError(`Unsupported memory kind: ${kind}`);
+  }
+  return kind as MemoryKind;
+}
+
+function normalizeStatus(value: unknown): MemoryStatus | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const status = requiredMemoryString(value, 'status');
+  if (!MEMORY_STATUS_SET.has(status)) {
+    throw requestError(`Unsupported memory status: ${status}`);
+  }
+  return status as MemoryStatus;
+}
+
+function normalizeScopes(value: unknown): MemoryScopeRef[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw requestError('scopes must be a non-empty array');
+  }
+  return value.map((rawScope, index) => {
+    if (typeof rawScope !== 'object' || rawScope === null || Array.isArray(rawScope)) {
+      throw requestError('scopes must contain objects');
+    }
+    const scope = rawScope as Record<string, unknown>;
+    const kind = requiredMemoryString(scope.kind, `scopes[${index}].kind`);
+    if (!MEMORY_SCOPE_KIND_SET.has(kind)) {
+      throw requestError(`Unsupported memory scope kind: ${kind}`);
+    }
+    return {
+      kind: kind as MemoryScopeRef['kind'],
+      id: requiredMemoryString(scope.id, `scopes[${index}].id`),
+    };
+  });
+}
+
+function assertNoCallerSuppliedSourceOrRefs(rawMemory: Record<string, unknown>): void {
+  const forbiddenKeys = [
+    'source',
+    'provenance',
+    'sourceRefs',
+    'source_refs',
+    'sourceIds',
+    'source_ids',
+    'changedRefs',
+    'changed_refs',
+    'gatewayCallId',
+    'gateway_call_id',
+    'agentId',
+    'agent_id',
+    'modelRunId',
+    'model_run_id',
+    'envelopeHash',
+    'envelope_hash',
+    'timelineEvent',
+    'timeline_event',
+    'entityObservationIds',
+    'entity_observation_ids',
+  ];
+  if (forbiddenKeys.some((key) => Object.prototype.hasOwnProperty.call(rawMemory, key))) {
+    rejectManualMemoryInput();
+  }
+}
+
+function normalizeManualMemory(memory: ManualMemorySaveInput): ManualMemorySaveInput {
+  if (typeof memory !== 'object' || memory === null || Array.isArray(memory)) {
+    throw requestError('event_memories[].memories[] must be a non-null object');
+  }
+  const rawMemory = memory as unknown as Record<string, unknown>;
+  assertNoCallerSuppliedSourceOrRefs(rawMemory);
+  const normalized: ManualMemorySaveInput = {
+    topic: requiredMemoryString(rawMemory.topic, 'topic'),
+    kind: normalizeKind(rawMemory.kind),
+    summary: requiredMemoryString(rawMemory.summary, 'summary'),
+    details: requiredMemoryString(rawMemory.details, 'details'),
+    scopes: normalizeScopes(rawMemory.scopes),
+  };
+  const confidence = normalizeConfidence(rawMemory.confidence);
+  if (confidence !== undefined) {
+    normalized.confidence = confidence;
+  }
+  const status = normalizeStatus(rawMemory.status);
+  if (status !== undefined) {
+    normalized.status = status;
+  }
+  const eventDate = normalizeEventDate(rawMemory.eventDate);
+  if (eventDate !== undefined) {
+    normalized.eventDate = eventDate;
+  }
+  const eventDateTime = normalizeEventDateTime(rawMemory.eventDateTime);
+  if (eventDateTime !== undefined) {
+    normalized.eventDateTime = eventDateTime;
+  }
+  return normalized;
+}
+
+function normalizeEventMemories(
+  eventMemories: readonly ConnectorIngressManualMemoryEventMemories[]
+): {
+  eventIndexIds: string[];
+  memoriesByEventIndexId: Map<string, readonly ManualMemorySaveInput[]>;
+} {
+  if (!Array.isArray(eventMemories) || eventMemories.length === 0) {
+    throw requestError('event_memories must not be empty');
+  }
+  if (eventMemories.length > MAX_REVIEWED_CONNECTOR_INGRESS_EVENTS) {
+    throw requestError(
+      `event_memories must contain at most ${MAX_REVIEWED_CONNECTOR_INGRESS_EVENTS} items`
+    );
+  }
+  const eventIndexIds: string[] = [];
+  const memoriesByEventIndexId = new Map<string, readonly ManualMemorySaveInput[]>();
+  let totalMemories = 0;
+  for (const eventMemory of eventMemories) {
+    const eventIndexId = requiredString(
+      eventMemory.eventIndexId,
+      'event_memories[].event_index_id'
+    );
+    if (memoriesByEventIndexId.has(eventIndexId)) {
+      throw requestError('event_memories must not contain duplicate event_index_id values');
+    }
+    if (!Array.isArray(eventMemory.memories) || eventMemory.memories.length === 0) {
+      throw requestError('event_memories[].memories must not be empty');
+    }
+    totalMemories += eventMemory.memories.length;
+    if (totalMemories > MAX_MANUAL_MEMORY_COMMIT_TOTAL_MEMORIES) {
+      throw requestError(
+        `event_memories must contain at most ${MAX_MANUAL_MEMORY_COMMIT_TOTAL_MEMORIES} total memories`
+      );
+    }
+    eventIndexIds.push(eventIndexId);
+    memoriesByEventIndexId.set(
+      eventIndexId,
+      eventMemory.memories.map((memory: ManualMemorySaveInput) => normalizeManualMemory(memory))
+    );
+  }
+  return { eventIndexIds, memoriesByEventIndexId };
+}
+
+function memoriesForEvent(
+  memoriesByEventIndexId: Map<string, readonly ManualMemorySaveInput[]>,
+  event: PrimaryOperatorEvent
+): readonly ManualMemorySaveInput[] {
+  const memories = memoriesByEventIndexId.get(event.sourceRef.id);
+  if (!memories || memories.length === 0) {
+    throw requestError('Reviewed event is missing manual memories');
+  }
+  return memories;
+}
+
+function parseStringArrayJson(value: string, field: string): string[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error(`${field} must be valid JSON`);
+  }
+  if (!Array.isArray(parsed) || !parsed.every((item) => typeof item === 'string')) {
+    throw new Error(`${field} must be a string array`);
+  }
+  return parsed;
+}
+
+function parseMemoryIdsJson(value: string, expectedMemoryCount: number): Array<string | null> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error('memory_ids_json must be valid JSON');
+  }
+  if (
+    !Array.isArray(parsed) ||
+    parsed.length !== expectedMemoryCount ||
+    !parsed.every((item) => item === null || (typeof item === 'string' && item.length > 0))
+  ) {
+    throw new Error('memory_ids_json does not match the expected memory count');
+  }
+  return parsed as Array<string | null>;
+}
+
+function assertResolvedMemoryIds(memoryIds: readonly (string | null)[]): string[] {
+  if (memoryIds.some((id) => id === null)) {
+    throw requestError('Manual memory commit replay has unresolved memory ids');
+  }
+  return memoryIds.map((id) => id!);
+}
+
+function isSavedMemoryCommitStatus(status: MemoryCommitIntentStatus): boolean {
+  return status === 'saved' || status === 'promoted';
+}
+
+function sourceRefsJson(sourceRefs: readonly SourceRef[]): string {
+  return JSON.stringify(sourceRefs.map((ref) => serializeSourceRef(ref)));
+}
+
+function canonicalMemoryPayload(memory: ManualMemorySaveInput): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    topic: memory.topic,
+    kind: memory.kind,
+    summary: memory.summary,
+    details: memory.details,
+    scopes: memory.scopes.map((scope) => ({ kind: scope.kind, id: scope.id })),
+  };
+  if (memory.confidence !== undefined) {
+    payload.confidence = memory.confidence;
+  }
+  if (memory.status !== undefined) {
+    payload.status = memory.status;
+  }
+  if (memory.eventDate !== undefined) {
+    payload.eventDate = memory.eventDate;
+  }
+  if (memory.eventDateTime !== undefined) {
+    payload.eventDateTime = memory.eventDateTime;
+  }
+  return payload;
+}
+
+function memoryPayloadHash(memories: readonly ManualMemorySaveInput[]): string {
+  const payloadJson = JSON.stringify(memories.map((memory) => canonicalMemoryPayload(memory)));
+  return `sha256:${crypto.createHash('sha256').update(payloadJson).digest('hex')}`;
+}
+
+function assertNoExistingNonMemoryCommits(input: {
+  operatorDb: SQLiteDatabase;
+  cursorName: string;
+  connector: string;
+  events: readonly PrimaryOperatorEvent[];
+}): void {
+  if (input.events.length === 0) {
+    return;
+  }
+  const idempotencyKeys: string[] = [];
+  for (const event of input.events) {
+    idempotencyKeys.push(
+      buildCursorScopedIdempotencyKey(input.cursorName, event.seq, event.seq),
+      buildConnectorIdempotencyKey(input.connector, event.seq, event.seq)
+    );
+  }
+  const placeholders = idempotencyKeys.map(() => '?').join(', ');
+  const rows = input.operatorDb
+    .prepare(
+      `SELECT idempotency_key, status, changed_refs_json
+       FROM vnext_operator_commits
+       WHERE cursor_name = ?
+         AND idempotency_key IN (${placeholders})`
+    )
+    .all(input.cursorName, ...idempotencyKeys) as ExistingOperatorCommitRow[];
+  for (const row of rows) {
+    if (row.status !== 'changed') {
+      throw requestError('Manual memory commit cannot replace a non-changed operator commit');
+    }
+    const changedRefs = parseStringArrayJson(row.changed_refs_json, 'changed_refs_json');
+    if (changedRefs.length === 0 || changedRefs.some((ref) => !ref.startsWith('memory:'))) {
+      throw requestError(
+        'Manual memory commit cannot replace a non-memory changed operator commit'
+      );
+    }
+  }
+}
+
+function getMemoryCommitIntent(
+  db: SQLiteDatabase,
+  idempotencyKey: string
+): MemoryCommitIntentRow | undefined {
+  return db
+    .prepare(
+      `SELECT intent_id, cursor_name, idempotency_key, expected_memory_count,
+              memory_payload_hash, memory_ids_json, source_refs_json,
+              status, claim_token, created_at_ms, updated_at_ms
+       FROM operator_memory_commit_intents
+       WHERE idempotency_key = ?`
+    )
+    .get(idempotencyKey) as MemoryCommitIntentRow | undefined;
+}
+
+function assertMemoryCommitIntentMatches(input: {
+  intent: MemoryCommitIntentRow;
+  cursorName: string;
+  expectedMemoryCount: number;
+  memoryPayloadHash: string;
+  sourceRefs: readonly SourceRef[];
+}): void {
+  if (
+    input.intent.cursor_name !== input.cursorName ||
+    input.intent.expected_memory_count !== input.expectedMemoryCount ||
+    input.intent.memory_payload_hash !== input.memoryPayloadHash ||
+    input.intent.source_refs_json !== sourceRefsJson(input.sourceRefs)
+  ) {
+    throw requestError('Manual memory commit replay memory payload does not match the original');
+  }
+}
+
+function assertExistingMemoryCommitPayloads(input: {
+  operatorDb: SQLiteDatabase;
+  cursorName: string;
+  connector: string;
+  events: readonly PrimaryOperatorEvent[];
+  memoriesByEventIndexId: Map<string, readonly ManualMemorySaveInput[]>;
+}): void {
+  for (const event of input.events) {
+    const seq = nonNegativeInteger(event.seq, 'event.seq');
+    const idempotencyKeys = [
+      buildCursorScopedIdempotencyKey(input.cursorName, seq, seq),
+      buildConnectorIdempotencyKey(input.connector, seq, seq),
+    ];
+    const memories = memoriesForEvent(input.memoriesByEventIndexId, event);
+    const payloadHash = memoryPayloadHash(memories);
+    const sourceRefs = [event.sourceRef];
+    for (const idempotencyKey of idempotencyKeys) {
+      const commit = input.operatorDb
+        .prepare(
+          `SELECT idempotency_key, status, changed_refs_json
+           FROM vnext_operator_commits
+           WHERE cursor_name = ? AND idempotency_key = ?`
+        )
+        .get(input.cursorName, idempotencyKey) as ExistingOperatorCommitRow | undefined;
+      const intent = getMemoryCommitIntent(input.operatorDb, idempotencyKey);
+      if (intent) {
+        assertMemoryCommitIntentMatches({
+          intent,
+          cursorName: input.cursorName,
+          expectedMemoryCount: memories.length,
+          memoryPayloadHash: payloadHash,
+          sourceRefs,
+        });
+      }
+      if (commit) {
+        if (!intent || !isSavedMemoryCommitStatus(intent.status)) {
+          throw requestError('Manual memory commit replay is missing saved memory intent details');
+        }
+        const changedRefs = parseStringArrayJson(commit.changed_refs_json, 'changed_refs_json');
+        const memoryIds = parseMemoryIdsJson(intent.memory_ids_json, memories.length);
+        if (
+          commit.status !== 'changed' ||
+          changedRefs.length !== memoryIds.length ||
+          changedRefs.some((ref, index) => ref !== `memory:${memoryIds[index]}`)
+        ) {
+          throw requestError('Manual memory commit replay does not match saved memory refs');
+        }
+      }
+    }
+  }
+}
+
+function readExistingMemoryOperatorCommit(input: {
+  operatorDb: SQLiteDatabase;
+  cursorName: string;
+  idempotencyKeys: readonly string[];
+  sourceRefs: readonly SourceRef[];
+}): ExistingMemoryOperatorCommitRow | null {
+  const expectedSourceRefsJson = sourceRefsJson(input.sourceRefs);
+  for (const idempotencyKey of input.idempotencyKeys) {
+    const row = input.operatorDb
+      .prepare(
+        `SELECT
+          idempotency_key, status, changed_refs_json, source_refs_json,
+          first_change_seq, last_change_seq
+         FROM vnext_operator_commits
+         WHERE cursor_name = ? AND idempotency_key = ?`
+      )
+      .get(input.cursorName, idempotencyKey) as ExistingMemoryOperatorCommitRow | undefined;
+    if (!row) {
+      continue;
+    }
+    if (row.status !== 'changed') {
+      throw requestError('Manual memory commit cannot replace a non-changed operator commit');
+    }
+    if (row.source_refs_json !== expectedSourceRefsJson) {
+      throw requestError('Manual memory commit replay source refs do not match the original');
+    }
+    return row;
+  }
+  return null;
+}
+
+function upsertMemoryCommitIntent(input: {
+  db: SQLiteDatabase;
+  cursorName: string;
+  idempotencyKey: string;
+  expectedMemoryCount: number;
+  memoryPayloadHash: string;
+  sourceRefs: readonly SourceRef[];
+  nowMs: number;
+}): Array<string | null> {
+  const expectedSourceRefsJson = sourceRefsJson(input.sourceRefs);
+  const memoryIds = Array.from({ length: input.expectedMemoryCount }, () => null);
+  input.db
+    .prepare(
+      `INSERT OR IGNORE INTO operator_memory_commit_intents (
+        intent_id, cursor_name, idempotency_key, expected_memory_count,
+        memory_payload_hash, memory_ids_json, source_refs_json, status, claim_token, created_at_ms, updated_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .run(
+      `memory-intent:${input.idempotencyKey}`,
+      input.cursorName,
+      input.idempotencyKey,
+      input.expectedMemoryCount,
+      input.memoryPayloadHash,
+      JSON.stringify(memoryIds),
+      expectedSourceRefsJson,
+      'pending',
+      null,
+      input.nowMs,
+      input.nowMs
+    );
+  const intent = getMemoryCommitIntent(input.db, input.idempotencyKey);
+  if (!intent) {
+    throw new Error('Manual memory commit intent was not initialized');
+  }
+  if (
+    intent.cursor_name !== input.cursorName ||
+    intent.expected_memory_count !== input.expectedMemoryCount ||
+    intent.memory_payload_hash !== input.memoryPayloadHash ||
+    intent.source_refs_json !== expectedSourceRefsJson
+  ) {
+    throw requestError('Manual memory commit replay memory payload does not match the original');
+  }
+  return parseMemoryIdsJson(intent.memory_ids_json, input.expectedMemoryCount);
+}
+
+function updateMemoryCommitIntent(input: {
+  db: SQLiteDatabase;
+  idempotencyKey: string;
+  claimToken: string;
+  memoryIds: readonly (string | null)[];
+  status: MemoryCommitIntentStatus;
+  nowMs: number;
+}): void {
+  const result = input.db
+    .prepare(
+      `UPDATE operator_memory_commit_intents
+       SET memory_ids_json = ?, status = ?, claim_token = ?, updated_at_ms = ?
+       WHERE idempotency_key = ? AND status = 'saving' AND claim_token = ?`
+    )
+    .run(
+      JSON.stringify(input.memoryIds),
+      input.status,
+      input.status === 'saving' ? input.claimToken : null,
+      input.nowMs,
+      input.idempotencyKey,
+      input.claimToken
+    );
+  if (result.changes !== 1) {
+    throw new Error('Manual memory commit lost save claim');
+  }
+}
+
+function refreshMemoryCommitIntentLease(input: {
+  db: SQLiteDatabase;
+  idempotencyKey: string;
+  claimToken: string;
+  memoryIds: readonly (string | null)[];
+  nowMs: () => number;
+}): void {
+  updateMemoryCommitIntent({
+    db: input.db,
+    idempotencyKey: input.idempotencyKey,
+    claimToken: input.claimToken,
+    memoryIds: input.memoryIds,
+    status: 'saving',
+    nowMs: input.nowMs(),
+  });
+}
+
+async function runWithMemoryCommitLeaseHeartbeat<T>(
+  input: {
+    db: SQLiteDatabase;
+    idempotencyKey: string;
+    claimToken: string;
+    memoryIds: readonly (string | null)[];
+    nowMs: () => number;
+  },
+  work: () => Promise<T>
+): Promise<T> {
+  let heartbeatError: unknown = null;
+  refreshMemoryCommitIntentLease(input);
+  const heartbeat = setInterval(() => {
+    try {
+      refreshMemoryCommitIntentLease(input);
+    } catch (error) {
+      heartbeatError = error;
+      clearInterval(heartbeat);
+    }
+  }, MEMORY_COMMIT_SAVING_HEARTBEAT_MS);
+  heartbeat.unref?.();
+
+  try {
+    const result = await work();
+    if (heartbeatError) {
+      throw heartbeatError;
+    }
+    refreshMemoryCommitIntentLease(input);
+    return result;
+  } finally {
+    clearInterval(heartbeat);
+  }
+}
+
+function releaseMemoryCommitIntentAfterSaveFailure(input: {
+  db: SQLiteDatabase;
+  idempotencyKey: string;
+  claimToken: string;
+  memoryIds: readonly (string | null)[];
+  nowMs: number;
+}): void {
+  input.db
+    .prepare(
+      `UPDATE operator_memory_commit_intents
+       SET memory_ids_json = ?, status = 'pending', claim_token = NULL, updated_at_ms = ?
+       WHERE idempotency_key = ? AND status = 'saving' AND claim_token = ?`
+    )
+    .run(JSON.stringify(input.memoryIds), input.nowMs, input.idempotencyKey, input.claimToken);
+}
+
+function markMemoryCommitIntentStatus(input: {
+  db: SQLiteDatabase;
+  idempotencyKey: string;
+  status: MemoryCommitIntentStatus;
+  expectedStatus?: MemoryCommitIntentStatus;
+  nowMs: number;
+}): void {
+  const result =
+    input.expectedStatus === undefined
+      ? input.db
+          .prepare(
+            `UPDATE operator_memory_commit_intents
+             SET status = ?, claim_token = NULL, updated_at_ms = ?
+             WHERE idempotency_key = ?`
+          )
+          .run(input.status, input.nowMs, input.idempotencyKey)
+      : input.db
+          .prepare(
+            `UPDATE operator_memory_commit_intents
+             SET status = ?, claim_token = NULL, updated_at_ms = ?
+             WHERE idempotency_key = ? AND status = ?`
+          )
+          .run(input.status, input.nowMs, input.idempotencyKey, input.expectedStatus);
+  if (result.changes !== 1 && input.expectedStatus !== undefined) {
+    const intent = getMemoryCommitIntent(input.db, input.idempotencyKey);
+    if (intent?.status !== input.status) {
+      throw new Error('Manual memory commit intent status changed concurrently');
+    }
+  }
+}
+
+function claimMemoryCommitIntentForSaving(input: {
+  db: SQLiteDatabase;
+  idempotencyKey: string;
+  expectedMemoryCount: number;
+  nowMs: number;
+}): {
+  memoryIds: Array<string | null>;
+  status: MemoryCommitIntentStatus;
+  canSave: boolean;
+  claimToken?: string;
+} {
+  const intent = getMemoryCommitIntent(input.db, input.idempotencyKey);
+  if (!intent) {
+    throw new Error('Manual memory commit intent was not initialized');
+  }
+  const memoryIds = parseMemoryIdsJson(intent.memory_ids_json, input.expectedMemoryCount);
+  if (isSavedMemoryCommitStatus(intent.status)) {
+    return { memoryIds, status: intent.status, canSave: false };
+  }
+  if (intent.status === 'saving') {
+    if (input.nowMs - intent.updated_at_ms < MEMORY_COMMIT_SAVING_LEASE_MS) {
+      throw new Error('Manual memory commit is already saving');
+    }
+    const claimToken = `claim:${crypto.randomUUID()}`;
+    const result =
+      intent.claim_token === null
+        ? input.db
+            .prepare(
+              `UPDATE operator_memory_commit_intents
+               SET claim_token = ?, updated_at_ms = ?
+               WHERE idempotency_key = ? AND status = 'saving'
+                 AND updated_at_ms = ? AND claim_token IS NULL`
+            )
+            .run(claimToken, input.nowMs, input.idempotencyKey, intent.updated_at_ms)
+        : input.db
+            .prepare(
+              `UPDATE operator_memory_commit_intents
+               SET claim_token = ?, updated_at_ms = ?
+               WHERE idempotency_key = ? AND status = 'saving'
+                 AND updated_at_ms = ? AND claim_token = ?`
+            )
+            .run(
+              claimToken,
+              input.nowMs,
+              input.idempotencyKey,
+              intent.updated_at_ms,
+              intent.claim_token
+            );
+    if (result.changes !== 1) {
+      throw new Error('Manual memory commit is already saving');
+    }
+    return { memoryIds, status: 'saving', canSave: true, claimToken };
+  }
+  const expectedStatus = intent.status;
+  const claimToken = `claim:${crypto.randomUUID()}`;
+  const result = input.db
+    .prepare(
+      `UPDATE operator_memory_commit_intents
+       SET status = 'saving', claim_token = ?, updated_at_ms = ?
+       WHERE idempotency_key = ? AND status = ? AND updated_at_ms = ? AND claim_token IS NULL`
+    )
+    .run(claimToken, input.nowMs, input.idempotencyKey, expectedStatus, intent.updated_at_ms);
+  if (result.changes !== 1) {
+    throw new Error('Manual memory commit is already saving');
+  }
+  return { memoryIds, status: 'saving', canSave: true, claimToken };
+}
+
+function readSavedMemoryIntentForReplay(input: {
+  db: SQLiteDatabase;
+  idempotencyKey: string;
+  expectedMemoryCount: number;
+}): { memoryIds: string[]; status: MemoryCommitIntentStatus } {
+  const intent = getMemoryCommitIntent(input.db, input.idempotencyKey);
+  if (!intent || !isSavedMemoryCommitStatus(intent.status)) {
+    throw requestError('Manual memory commit replay is missing saved memory intent details');
+  }
+  return {
+    memoryIds: assertResolvedMemoryIds(
+      parseMemoryIdsJson(intent.memory_ids_json, input.expectedMemoryCount)
+    ),
+    status: intent.status,
+  };
+}
+
+function buildMemoryGatewayCallId(idempotencyKey: string, index: number): string {
+  return `${idempotencyKey}:memory:${index}`;
+}
+
+function buildMemorySaveInput(input: {
+  memory: ManualMemorySaveInput;
+  channel: string;
+}): PublicSaveMemoryInput {
+  return {
+    ...input.memory,
+    status: 'stale',
+    source: {
+      package: 'standalone',
+      source_type: 'manual-connector-ingress-memory',
+      channel_id: input.channel,
+    },
+  };
+}
+
+function targetMemoryStatus(memory: ManualMemorySaveInput): MemoryStatus {
+  return memory.status ?? 'active';
+}
+
+async function setDefaultMemoryStatus(input: {
+  memoryId: string;
+  status: MemoryStatus;
+}): Promise<void> {
+  await promoteMemoryStatus(input);
+}
+
+async function promoteMemoryStatuses(input: {
+  memoryIds: readonly string[];
+  memories: readonly ManualMemorySaveInput[];
+  setMemoryStatus: ConnectorIngressManualMemoryCommitInput['setMemoryStatus'];
+}): Promise<void> {
+  if (input.memoryIds.length !== input.memories.length) {
+    throw new Error('Manual memory commit memory ids do not match memory payloads');
+  }
+  for (const [index, memoryId] of input.memoryIds.entries()) {
+    await input.setMemoryStatus({
+      memoryId,
+      status: targetMemoryStatus(input.memories[index]!),
+    });
+  }
+}
+
+function matchingRecoveredMemories(input: {
+  records: readonly MemoryProvenanceRecord[];
+  sourceRefs: readonly SourceRef[];
+}): MemoryProvenanceRecord[] {
+  const expectedSourceRefs = sourceRefsJson(input.sourceRefs);
+  return input.records.filter(
+    (record) => JSON.stringify(record.source_refs) === expectedSourceRefs
+  );
+}
+
+async function resolveMemoryId(input: {
+  memory: ManualMemorySaveInput;
+  index: number;
+  channel: string;
+  sourceRefs: readonly SourceRef[];
+  idempotencyKey: string;
+  saveMemory: ConnectorIngressManualMemoryCommitInput['saveMemory'];
+  createTrustedProvenanceCapability: ConnectorIngressManualMemoryCommitInput['createTrustedProvenanceCapability'];
+  listMemoriesByGatewayCallId: ConnectorIngressManualMemoryCommitInput['listMemoriesByGatewayCallId'];
+}): Promise<{ memoryId: string; saved: boolean }> {
+  const gatewayCallId = buildMemoryGatewayCallId(input.idempotencyKey, input.index);
+  const recovered = matchingRecoveredMemories({
+    records: await input.listMemoriesByGatewayCallId(gatewayCallId),
+    sourceRefs: input.sourceRefs,
+  });
+  if (recovered.length > 1) {
+    throw new Error('Manual memory commit recovered duplicate memories for one gateway call');
+  }
+  if (recovered.length === 1) {
+    return { memoryId: recovered[0].memory_id, saved: false };
+  }
+  const result = await input.saveMemory(buildMemorySaveInput(input), {
+    capability: input.createTrustedProvenanceCapability(),
+    projectTruth: false,
+    provenance: {
+      actor: 'user',
+      agent_id: 'operator:manual-admin',
+      tool_name: 'mama_save',
+      gateway_call_id: gatewayCallId,
+      source_refs: input.sourceRefs.map((ref) => serializeSourceRef(ref)),
+    },
+  });
+  if (result.success !== true || typeof result.id !== 'string' || result.id.length === 0) {
+    throw new Error('Manual memory commit save failed');
+  }
+  return { memoryId: result.id, saved: true };
+}
+
+async function commitMemoriesForEvent(input: {
+  operatorDb: SQLiteDatabase;
+  cursorName: string;
+  channel: string;
+  idempotencyKey: string;
+  sourceRefs: readonly SourceRef[];
+  memories: readonly ManualMemorySaveInput[];
+  memoryPayloadHash: string;
+  saveMemory: ConnectorIngressManualMemoryCommitInput['saveMemory'];
+  createTrustedProvenanceCapability: ConnectorIngressManualMemoryCommitInput['createTrustedProvenanceCapability'];
+  listMemoriesByGatewayCallId: ConnectorIngressManualMemoryCommitInput['listMemoriesByGatewayCallId'];
+  nowMs: () => number;
+}): Promise<{
+  changedRefs: SourceRef[];
+  memoryIds: string[];
+  saved: number;
+  intentStatus: MemoryCommitIntentStatus;
+}> {
+  upsertMemoryCommitIntent({
+    db: input.operatorDb,
+    cursorName: input.cursorName,
+    idempotencyKey: input.idempotencyKey,
+    expectedMemoryCount: input.memories.length,
+    memoryPayloadHash: input.memoryPayloadHash,
+    sourceRefs: input.sourceRefs,
+    nowMs: input.nowMs(),
+  });
+  const claim = claimMemoryCommitIntentForSaving({
+    db: input.operatorDb,
+    idempotencyKey: input.idempotencyKey,
+    expectedMemoryCount: input.memories.length,
+    nowMs: input.nowMs(),
+  });
+  const memoryIds = claim.memoryIds;
+  let saved = 0;
+  if (!claim.canSave) {
+    const resolvedMemoryIds = assertResolvedMemoryIds(memoryIds);
+    return {
+      changedRefs: resolvedMemoryIds.map((id) => ({ kind: 'memory', id }) satisfies SourceRef),
+      memoryIds: resolvedMemoryIds,
+      saved,
+      intentStatus: claim.status,
+    };
+  }
+  if (!claim.claimToken) {
+    throw new Error('Manual memory commit save claim missing token');
+  }
+
+  try {
+    for (const [index, memory] of input.memories.entries()) {
+      if (memoryIds[index]) {
+        continue;
+      }
+      const resolved = await runWithMemoryCommitLeaseHeartbeat(
+        {
+          db: input.operatorDb,
+          idempotencyKey: input.idempotencyKey,
+          claimToken: claim.claimToken,
+          memoryIds,
+          nowMs: input.nowMs,
+        },
+        () =>
+          resolveMemoryId({
+            memory,
+            index,
+            channel: input.channel,
+            sourceRefs: input.sourceRefs,
+            idempotencyKey: input.idempotencyKey,
+            saveMemory: input.saveMemory,
+            createTrustedProvenanceCapability: input.createTrustedProvenanceCapability,
+            listMemoriesByGatewayCallId: input.listMemoriesByGatewayCallId,
+          })
+      );
+      memoryIds[index] = resolved.memoryId;
+      if (resolved.saved) {
+        saved += 1;
+      }
+      updateMemoryCommitIntent({
+        db: input.operatorDb,
+        idempotencyKey: input.idempotencyKey,
+        claimToken: claim.claimToken,
+        memoryIds,
+        status: 'saving',
+        nowMs: input.nowMs(),
+      });
+    }
+  } catch (error) {
+    releaseMemoryCommitIntentAfterSaveFailure({
+      db: input.operatorDb,
+      idempotencyKey: input.idempotencyKey,
+      claimToken: claim.claimToken,
+      memoryIds,
+      nowMs: input.nowMs(),
+    });
+    throw error;
+  }
+  if (memoryIds.some((id) => id === null)) {
+    throw new Error('Manual memory commit did not resolve every memory id');
+  }
+  updateMemoryCommitIntent({
+    db: input.operatorDb,
+    idempotencyKey: input.idempotencyKey,
+    claimToken: claim.claimToken,
+    memoryIds,
+    status: 'saved',
+    nowMs: input.nowMs(),
+  });
+  const resolvedMemoryIds = memoryIds.map((id) => id!);
+  return {
+    changedRefs: resolvedMemoryIds.map((id) => ({ kind: 'memory', id }) satisfies SourceRef),
+    memoryIds: resolvedMemoryIds,
+    saved,
+    intentStatus: 'saved',
+  };
+}
+
+function batchResult(input: {
+  ok: boolean;
+  status: PrimaryOperatorBatchResult['status'];
+  cursorName: string;
+  connector: string;
+  channel: string;
+  requestedCount: number;
+  processed: number;
+  advancedThroughSeq: number;
+  firstSeq: number | null;
+  lastSeq: number | null;
+  memoriesSaved: number;
+  promotionPending?: boolean;
+  commits: ConnectorIngressManualMemoryCommitResult['commits'];
+  failedSeq?: number;
+  error?: string;
+}): ConnectorIngressManualMemoryCommitResult {
+  return {
+    ok: input.ok,
+    mode: 'manual_memory_commit',
+    status: input.status,
+    cursorName: input.cursorName,
+    connector: input.connector,
+    channel: input.channel,
+    requestedCount: input.requestedCount,
+    processed: input.processed,
+    advancedThroughSeq: input.advancedThroughSeq,
+    firstSeq: input.firstSeq,
+    lastSeq: input.lastSeq,
+    memoriesSaved: input.memoriesSaved,
+    ...(input.promotionPending === true ? { promotionPending: true } : {}),
+    commits: input.commits,
+    ...(input.failedSeq !== undefined ? { failedSeq: input.failedSeq } : {}),
+    ...(input.error !== undefined ? { error: input.error } : {}),
+  };
+}
+
+async function tryPromoteSavedMemories(input: {
+  operatorDb: SQLiteDatabase;
+  idempotencyKey: string;
+  memoryIds: readonly string[];
+  memories: readonly ManualMemorySaveInput[];
+  setMemoryStatus: ConnectorIngressManualMemoryCommitInput['setMemoryStatus'];
+  nowMs: number;
+}): Promise<boolean> {
+  try {
+    await promoteMemoryStatuses({
+      memoryIds: input.memoryIds,
+      memories: input.memories,
+      setMemoryStatus: input.setMemoryStatus,
+    });
+    markMemoryCommitIntentStatus({
+      db: input.operatorDb,
+      idempotencyKey: input.idempotencyKey,
+      status: 'promoted',
+      expectedStatus: 'saved',
+      nowMs: input.nowMs,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function commitConnectorIngressMemoryBatch(
+  input: ConnectorIngressManualMemoryCommitInput
+): Promise<ConnectorIngressManualMemoryCommitResult> {
+  const connector = requiredString(input.connector, 'connector');
+  const channel = requiredString(input.channel, 'channel');
+  const cursorName = buildConnectorOperatorCursorName({ connector, channel });
+  const { eventIndexIds, memoriesByEventIndexId } = normalizeEventMemories(input.eventMemories);
+
+  return runWithPrimaryOperatorCursorLock(cursorName, async () => {
+    const events = readReviewedEvents({
+      rawAdapter: input.rawAdapter,
+      connector,
+      channel,
+      eventIndexIds,
+    });
+    assertReviewedConnectorIngressSeqs(
+      {
+        rawAdapter: input.rawAdapter,
+        connector,
+        channel,
+      },
+      events,
+      input.expectedAdvancedThroughSeq,
+      readConnectorOperatorCursorSeq(input.operatorDb, cursorName),
+      requestError
+    );
+    assertNoExistingNonMemoryCommits({
+      operatorDb: input.operatorDb,
+      cursorName,
+      connector,
+      events,
+    });
+    assertExistingMemoryCommitPayloads({
+      operatorDb: input.operatorDb,
+      cursorName,
+      connector,
+      events,
+      memoriesByEventIndexId,
+    });
+
+    const firstSeq = events[0]?.seq ?? null;
+    const lastSeq = events[events.length - 1]?.seq ?? null;
+    const commits: ConnectorIngressManualMemoryCommitResult['commits'] = [];
+    const preparedCommits: PreparedMemoryCursorCommit[] = [];
+    let advancedThroughSeq = readConnectorOperatorCursorSeq(input.operatorDb, cursorName);
+    let memoriesSaved = 0;
+
+    for (const event of events) {
+      const seq = nonNegativeInteger(event.seq, 'event.seq');
+      const idempotencyKey = buildCursorScopedIdempotencyKey(cursorName, seq, seq);
+      const legacyIdempotencyKey = buildConnectorIdempotencyKey(connector, seq, seq);
+      const fallbackIdempotencyKeys =
+        legacyIdempotencyKey === idempotencyKey ? [] : [legacyIdempotencyKey];
+      const sourceRefs = [event.sourceRef];
+      const memories = memoriesForEvent(memoriesByEventIndexId, event);
+      const payloadHash = memoryPayloadHash(memories);
+      try {
+        const existingCommit = readExistingMemoryOperatorCommit({
+          operatorDb: input.operatorDb,
+          cursorName,
+          idempotencyKeys: [idempotencyKey, ...fallbackIdempotencyKeys],
+          sourceRefs,
+        });
+        if (existingCommit) {
+          const savedIntent = readSavedMemoryIntentForReplay({
+            db: input.operatorDb,
+            idempotencyKey: existingCommit.idempotency_key,
+            expectedMemoryCount: memories.length,
+          });
+          preparedCommits.push({
+            seq,
+            idempotencyKey: existingCommit.idempotency_key,
+            sourceRefs,
+            memories,
+            changedRefs: savedIntent.memoryIds.map(
+              (id) => ({ kind: 'memory', id }) satisfies SourceRef
+            ),
+            memoryIds: savedIntent.memoryIds,
+            intentStatus: savedIntent.status,
+          });
+          continue;
+        }
+        if (seq <= advancedThroughSeq) {
+          throw new Error(
+            `Operator events must advance cursor; current seq ${advancedThroughSeq}, got ${seq}`
+          );
+        }
+        const memoryCommit = await commitMemoriesForEvent({
+          operatorDb: input.operatorDb,
+          cursorName,
+          channel,
+          idempotencyKey,
+          sourceRefs,
+          memories,
+          memoryPayloadHash: payloadHash,
+          saveMemory: input.saveMemory,
+          createTrustedProvenanceCapability: input.createTrustedProvenanceCapability,
+          listMemoriesByGatewayCallId: input.listMemoriesByGatewayCallId,
+          nowMs: () => input.nowMs?.() ?? Date.now(),
+        });
+        memoriesSaved += memoryCommit.saved;
+        preparedCommits.push({
+          seq,
+          idempotencyKey,
+          sourceRefs,
+          memories,
+          changedRefs: memoryCommit.changedRefs,
+          memoryIds: memoryCommit.memoryIds,
+          intentStatus: memoryCommit.intentStatus,
+        });
+      } catch {
+        return batchResult({
+          ok: false,
+          status: 'partial_failure',
+          cursorName,
+          connector,
+          channel,
+          requestedCount: input.eventMemories.length,
+          processed: 0,
+          advancedThroughSeq,
+          firstSeq,
+          lastSeq,
+          memoriesSaved,
+          commits: [],
+          failedSeq: seq,
+          error: PARTIAL_FAILURE_MESSAGE,
+        });
+      }
+    }
+
+    let commitFailureSeq = preparedCommits[0]?.seq ?? firstSeq ?? 0;
+    try {
+      const commitPreparedBatch = input.operatorDb.transaction(() => {
+        const committed: ConnectorIngressManualMemoryCommitResult['commits'] = [];
+        let transactionAdvancedThroughSeq = advancedThroughSeq;
+        for (const prepared of preparedCommits) {
+          commitFailureSeq = prepared.seq;
+          const commitNowMs = input.nowMs?.() ?? Date.now();
+          const commit = commitOperatorCursor(input.operatorDb, {
+            cursorName,
+            firstChangeSeq: prepared.seq,
+            lastChangeSeq: prepared.seq,
+            idempotencyKey: prepared.idempotencyKey,
+            status: 'changed',
+            changedRefs: prepared.changedRefs,
+            sourceRefs: prepared.sourceRefs,
+            nowMs: commitNowMs,
+            allowSeqGaps: true,
+          });
+          committed.push({
+            seq: commit.lastChangeSeq,
+            status: 'changed',
+            outcome: commit.outcome,
+            cursorAdvanced: commit.cursorAdvanced,
+          });
+          transactionAdvancedThroughSeq = Math.max(
+            transactionAdvancedThroughSeq,
+            commit.lastChangeSeq
+          );
+        }
+        return {
+          commits: committed,
+          advancedThroughSeq: transactionAdvancedThroughSeq,
+        };
+      });
+      const committed = commitPreparedBatch();
+      commits.push(...committed.commits);
+      advancedThroughSeq = committed.advancedThroughSeq;
+    } catch {
+      return batchResult({
+        ok: false,
+        status: 'partial_failure',
+        cursorName,
+        connector,
+        channel,
+        requestedCount: input.eventMemories.length,
+        processed: 0,
+        advancedThroughSeq,
+        firstSeq,
+        lastSeq,
+        memoriesSaved,
+        commits: [],
+        failedSeq: commitFailureSeq,
+        error: PARTIAL_FAILURE_MESSAGE,
+      });
+    }
+
+    for (const prepared of preparedCommits) {
+      if (prepared.intentStatus === 'promoted') {
+        continue;
+      }
+      const promoted = await tryPromoteSavedMemories({
+        operatorDb: input.operatorDb,
+        idempotencyKey: prepared.idempotencyKey,
+        memoryIds: prepared.memoryIds,
+        memories: prepared.memories,
+        setMemoryStatus: input.setMemoryStatus,
+        nowMs: input.nowMs?.() ?? Date.now(),
+      });
+      if (!promoted) {
+        return batchResult({
+          ok: true,
+          status: 'committed',
+          cursorName,
+          connector,
+          channel,
+          requestedCount: input.eventMemories.length,
+          processed: commits.length,
+          advancedThroughSeq,
+          firstSeq,
+          lastSeq,
+          memoriesSaved,
+          promotionPending: true,
+          commits,
+        });
+      }
+    }
+
+    return batchResult({
+      ok: true,
+      status: 'committed',
+      cursorName,
+      connector,
+      channel,
+      requestedCount: input.eventMemories.length,
+      processed: commits.length,
+      advancedThroughSeq,
+      firstSeq,
+      lastSeq,
+      memoriesSaved,
+      commits,
+    });
+  });
+}
+
+export function createConnectorIngressManualMemoryCommitProvider(
+  options: Omit<
+    ConnectorIngressManualMemoryCommitInput,
+    'expectedAdvancedThroughSeq' | 'eventMemories'
+  >
+): ConnectorIngressManualMemoryCommitProvider {
+  const connector = requiredString(options.connector, 'connector');
+  const channel = requiredString(options.channel, 'channel');
+  return async (input) => {
+    const requestedConnector = requiredString(input.connector, 'connector');
+    const requestedChannel = requiredString(input.channel, 'channel');
+    if (requestedConnector !== connector || requestedChannel !== channel) {
+      throw requestError(
+        'Connector ingress manual memory commit is locked to the configured connector/channel'
+      );
+    }
+    return commitConnectorIngressMemoryBatch({
+      rawAdapter: options.rawAdapter,
+      operatorDb: options.operatorDb,
+      connector,
+      channel,
+      expectedAdvancedThroughSeq: input.expectedAdvancedThroughSeq,
+      eventMemories: input.eventMemories,
+      saveMemory: options.saveMemory,
+      createTrustedProvenanceCapability: options.createTrustedProvenanceCapability,
+      listMemoriesByGatewayCallId: options.listMemoriesByGatewayCallId,
+      setMemoryStatus: options.setMemoryStatus,
+      nowMs: options.nowMs,
+    });
+  };
+}
+
+export function createDefaultConnectorIngressManualMemoryCommitProvider(
+  options: Omit<
+    ConnectorIngressManualMemoryCommitInput,
+    | 'expectedAdvancedThroughSeq'
+    | 'eventMemories'
+    | 'saveMemory'
+    | 'createTrustedProvenanceCapability'
+    | 'listMemoriesByGatewayCallId'
+    | 'setMemoryStatus'
+  >
+): ConnectorIngressManualMemoryCommitProvider {
+  return createConnectorIngressManualMemoryCommitProvider({
+    ...options,
+    saveMemory: saveMemoryWithTrustedProvenance,
+    createTrustedProvenanceCapability,
+    listMemoriesByGatewayCallId,
+    setMemoryStatus: setDefaultMemoryStatus,
+  });
+}

--- a/packages/standalone/src/operator-vnext/connector-ingress-manual-wiki-commit.ts
+++ b/packages/standalone/src/operator-vnext/connector-ingress-manual-wiki-commit.ts
@@ -372,7 +372,7 @@ export function createConnectorIngressManualWikiCommitProvider(
     const requestedChannel = requiredString(input.channel, 'channel');
     if (requestedConnector !== connector || requestedChannel !== channel) {
       throw requestError(
-        `Connector ingress manual wiki commit is locked to the configured connector/channel: ${connector}/${channel}`
+        'Connector ingress manual wiki commit is locked to the configured connector/channel'
       );
     }
     return commitConnectorIngressWikiBatch({

--- a/packages/standalone/src/operator-vnext/connector-ingress-migration-dry-run.ts
+++ b/packages/standalone/src/operator-vnext/connector-ingress-migration-dry-run.ts
@@ -94,7 +94,7 @@ export function createConnectorIngressMigrationDryRunProvider(
     const requestedChannel = requiredString(input.channel, 'channel');
     if (requestedConnector !== connector || requestedChannel !== channel) {
       throw new Error(
-        `Connector ingress migration dry-run is locked to the configured connector/channel: ${connector}/${channel}`
+        'Connector ingress migration dry-run is locked to the configured connector/channel'
       );
     }
     return buildConnectorIngressMigrationDryRun({

--- a/packages/standalone/src/operator-vnext/primary-operator-runtime.ts
+++ b/packages/standalone/src/operator-vnext/primary-operator-runtime.ts
@@ -120,6 +120,13 @@ async function withCursorLock<T>(cursorName: string, operation: () => Promise<T>
   }
 }
 
+export async function runWithPrimaryOperatorCursorLock<T>(
+  cursorName: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  return withCursorLock(cursorName, operation);
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }

--- a/packages/standalone/src/operator-vnext/schema.ts
+++ b/packages/standalone/src/operator-vnext/schema.ts
@@ -65,9 +65,7 @@ const REQUIRED_INDEXES = [
   'idx_operator_no_updates_scope_created',
   'idx_worker_proposals_status_kind',
   'idx_operator_memory_commit_intents_cursor_created',
-  'idx_operator_memory_commit_intents_idempotency_key',
 ] as const;
-const REQUIRED_UNIQUE_INDEXES = ['idx_operator_memory_commit_intents_idempotency_key'] as const;
 const REQUIRED_TABLE_SQL_FRAGMENTS: Partial<
   Record<(typeof REQUIRED_OPERATOR_TABLES)[number], readonly string[]>
 > = {
@@ -159,9 +157,6 @@ CREATE TABLE IF NOT EXISTS operator_memory_commit_intents (
 
 CREATE INDEX IF NOT EXISTS idx_operator_memory_commit_intents_cursor_created
   ON operator_memory_commit_intents(cursor_name, created_at_ms DESC);
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_operator_memory_commit_intents_idempotency_key
-  ON operator_memory_commit_intents(idempotency_key);
 `;
 
 export interface VNextOperatorSchemaOptions {
@@ -190,13 +185,6 @@ function indexExists(db: SQLiteDatabase, indexName: string): boolean {
     .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?")
     .get(indexName);
   return row !== undefined;
-}
-
-function indexSql(db: SQLiteDatabase, indexName: string): string {
-  const row = db
-    .prepare("SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?")
-    .get(indexName) as { sql?: string } | undefined;
-  return row?.sql ?? '';
 }
 
 function tableColumns(db: SQLiteDatabase, tableName: string): Set<string> {
@@ -248,11 +236,6 @@ function assertOperatorSchemaCompatible(db: SQLiteDatabase): void {
   for (const index of REQUIRED_INDEXES) {
     if (!indexExists(db, index)) {
       throw new Error(`vNext operator schema is missing index ${index}`);
-    }
-  }
-  for (const index of REQUIRED_UNIQUE_INDEXES) {
-    if (!indexSql(db, index).includes('CREATE UNIQUE INDEX')) {
-      throw new Error(`vNext operator schema index ${index} must be unique`);
     }
   }
 }

--- a/packages/standalone/src/operator-vnext/schema.ts
+++ b/packages/standalone/src/operator-vnext/schema.ts
@@ -7,6 +7,7 @@ const REQUIRED_OPERATOR_TABLES = [
   'vnext_operator_commits',
   'operator_no_updates',
   'worker_proposals',
+  'operator_memory_commit_intents',
 ] as const;
 const REQUIRED_COLUMNS: Record<(typeof REQUIRED_OPERATOR_TABLES)[number], readonly string[]> = {
   vnext_operator_cursors: [
@@ -45,12 +46,42 @@ const REQUIRED_COLUMNS: Record<(typeof REQUIRED_OPERATOR_TABLES)[number], readon
     'created_at_ms',
     'accepted_at_ms',
   ],
+  operator_memory_commit_intents: [
+    'intent_id',
+    'cursor_name',
+    'idempotency_key',
+    'expected_memory_count',
+    'memory_payload_hash',
+    'memory_ids_json',
+    'source_refs_json',
+    'status',
+    'claim_token',
+    'created_at_ms',
+    'updated_at_ms',
+  ],
 };
 const REQUIRED_INDEXES = [
   'idx_vnext_operator_commits_cursor_seq',
   'idx_operator_no_updates_scope_created',
   'idx_worker_proposals_status_kind',
+  'idx_operator_memory_commit_intents_cursor_created',
+  'idx_operator_memory_commit_intents_idempotency_key',
 ] as const;
+const REQUIRED_UNIQUE_INDEXES = ['idx_operator_memory_commit_intents_idempotency_key'] as const;
+const REQUIRED_TABLE_SQL_FRAGMENTS: Partial<
+  Record<(typeof REQUIRED_OPERATOR_TABLES)[number], readonly string[]>
+> = {
+  operator_memory_commit_intents: [
+    'idempotency_key TEXT NOT NULL UNIQUE',
+    'expected_memory_count INTEGER NOT NULL CHECK (expected_memory_count > 0)',
+    "memory_payload_hash TEXT NOT NULL CHECK (memory_payload_hash LIKE 'sha256:%')",
+    'memory_ids_json TEXT NOT NULL CHECK (json_valid(memory_ids_json))',
+    'source_refs_json TEXT NOT NULL CHECK (json_valid(source_refs_json))',
+    "status TEXT NOT NULL CHECK (status IN ('pending', 'saving', 'saved', 'promoted'))",
+    'created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0)',
+    'updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms)',
+  ],
+};
 const SQLITE_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 const VNEXT_OPERATOR_CONTRACTS_SQL = `
@@ -111,6 +142,26 @@ CREATE INDEX IF NOT EXISTS idx_worker_proposals_status_kind
 
 INSERT OR IGNORE INTO schema_version (version, description)
 VALUES (${VNEXT_OPERATOR_CONTRACTS_VERSION}, '${VNEXT_OPERATOR_CONTRACTS_DESCRIPTION}');
+
+CREATE TABLE IF NOT EXISTS operator_memory_commit_intents (
+  intent_id TEXT PRIMARY KEY,
+  cursor_name TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL UNIQUE,
+  expected_memory_count INTEGER NOT NULL CHECK (expected_memory_count > 0),
+  memory_payload_hash TEXT NOT NULL CHECK (memory_payload_hash LIKE 'sha256:%'),
+  memory_ids_json TEXT NOT NULL CHECK (json_valid(memory_ids_json)),
+  source_refs_json TEXT NOT NULL CHECK (json_valid(source_refs_json)),
+  status TEXT NOT NULL CHECK (status IN ('pending', 'saving', 'saved', 'promoted')),
+  claim_token TEXT,
+  created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+  updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms)
+);
+
+CREATE INDEX IF NOT EXISTS idx_operator_memory_commit_intents_cursor_created
+  ON operator_memory_commit_intents(cursor_name, created_at_ms DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_operator_memory_commit_intents_idempotency_key
+  ON operator_memory_commit_intents(idempotency_key);
 `;
 
 export interface VNextOperatorSchemaOptions {
@@ -141,12 +192,44 @@ function indexExists(db: SQLiteDatabase, indexName: string): boolean {
   return row !== undefined;
 }
 
+function indexSql(db: SQLiteDatabase, indexName: string): string {
+  const row = db
+    .prepare("SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?")
+    .get(indexName) as { sql?: string } | undefined;
+  return row?.sql ?? '';
+}
+
 function tableColumns(db: SQLiteDatabase, tableName: string): Set<string> {
   if (!SQLITE_IDENTIFIER_PATTERN.test(tableName)) {
     throw new Error(`Invalid SQLite identifier: ${tableName}`);
   }
   const columns = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>;
   return new Set(columns.map((column) => column.name));
+}
+
+function tableSql(db: SQLiteDatabase, tableName: string): string {
+  const row = db
+    .prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(tableName) as { sql?: string } | undefined;
+  return row?.sql ?? '';
+}
+
+function assertTableSqlCompatible(
+  db: SQLiteDatabase,
+  tableName: (typeof REQUIRED_OPERATOR_TABLES)[number]
+): void {
+  const fragments = REQUIRED_TABLE_SQL_FRAGMENTS[tableName] ?? [];
+  if (fragments.length === 0) {
+    return;
+  }
+  const sql = tableSql(db, tableName);
+  for (const fragment of fragments) {
+    if (!sql.includes(fragment)) {
+      throw new Error(
+        `vNext operator schema table ${tableName} is missing SQL fragment ${fragment}`
+      );
+    }
+  }
 }
 
 function assertOperatorSchemaCompatible(db: SQLiteDatabase): void {
@@ -160,11 +243,32 @@ function assertOperatorSchemaCompatible(db: SQLiteDatabase): void {
         throw new Error(`vNext operator schema table ${table} is missing column ${column}`);
       }
     }
+    assertTableSqlCompatible(db, table);
   }
   for (const index of REQUIRED_INDEXES) {
     if (!indexExists(db, index)) {
       throw new Error(`vNext operator schema is missing index ${index}`);
     }
+  }
+  for (const index of REQUIRED_UNIQUE_INDEXES) {
+    if (!indexSql(db, index).includes('CREATE UNIQUE INDEX')) {
+      throw new Error(`vNext operator schema index ${index} must be unique`);
+    }
+  }
+}
+
+function assertExistingOperatorTablesCompatible(db: SQLiteDatabase): void {
+  for (const table of REQUIRED_OPERATOR_TABLES) {
+    if (!tableExists(db, table)) {
+      continue;
+    }
+    const columns = tableColumns(db, table);
+    for (const column of REQUIRED_COLUMNS[table]) {
+      if (!columns.has(column)) {
+        throw new Error(`vNext operator schema table ${table} is missing column ${column}`);
+      }
+    }
+    assertTableSqlCompatible(db, table);
   }
 }
 
@@ -172,6 +276,7 @@ function hasInstalledOperatorSchema(db: SQLiteDatabase): boolean {
   if (!hasOperatorSchemaVersion(db)) {
     return false;
   }
+  assertExistingOperatorTablesCompatible(db);
   if (!REQUIRED_OPERATOR_TABLES.every((table) => tableExists(db, table))) {
     return false;
   }

--- a/packages/standalone/src/operator-vnext/schema.ts
+++ b/packages/standalone/src/operator-vnext/schema.ts
@@ -66,18 +66,26 @@ const REQUIRED_INDEXES = [
   'idx_worker_proposals_status_kind',
   'idx_operator_memory_commit_intents_cursor_created',
 ] as const;
+const OPERATOR_MEMORY_COMMIT_INTENT_BASE_SQL_FRAGMENTS = [
+  'idempotency_key TEXT NOT NULL UNIQUE',
+  'expected_memory_count INTEGER NOT NULL CHECK (expected_memory_count > 0)',
+  "memory_payload_hash TEXT NOT NULL CHECK (memory_payload_hash LIKE 'sha256:%')",
+  'memory_ids_json TEXT NOT NULL CHECK (json_valid(memory_ids_json))',
+  'source_refs_json TEXT NOT NULL CHECK (json_valid(source_refs_json))',
+  "status TEXT NOT NULL CHECK (status IN ('pending', 'saving', 'saved', 'promoted'))",
+  'created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0)',
+  'updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms)',
+] as const;
+const OPERATOR_MEMORY_COMMIT_INTENT_CLAIM_SQL_FRAGMENTS = [
+  "(status = 'saving' AND claim_token IS NOT NULL)",
+  "(status != 'saving' AND claim_token IS NULL)",
+] as const;
 const REQUIRED_TABLE_SQL_FRAGMENTS: Partial<
   Record<(typeof REQUIRED_OPERATOR_TABLES)[number], readonly string[]>
 > = {
   operator_memory_commit_intents: [
-    'idempotency_key TEXT NOT NULL UNIQUE',
-    'expected_memory_count INTEGER NOT NULL CHECK (expected_memory_count > 0)',
-    "memory_payload_hash TEXT NOT NULL CHECK (memory_payload_hash LIKE 'sha256:%')",
-    'memory_ids_json TEXT NOT NULL CHECK (json_valid(memory_ids_json))',
-    'source_refs_json TEXT NOT NULL CHECK (json_valid(source_refs_json))',
-    "status TEXT NOT NULL CHECK (status IN ('pending', 'saving', 'saved', 'promoted'))",
-    'created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0)',
-    'updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms)',
+    ...OPERATOR_MEMORY_COMMIT_INTENT_BASE_SQL_FRAGMENTS,
+    ...OPERATOR_MEMORY_COMMIT_INTENT_CLAIM_SQL_FRAGMENTS,
   ],
 };
 const SQLITE_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
@@ -150,10 +158,73 @@ CREATE TABLE IF NOT EXISTS operator_memory_commit_intents (
   memory_ids_json TEXT NOT NULL CHECK (json_valid(memory_ids_json)),
   source_refs_json TEXT NOT NULL CHECK (json_valid(source_refs_json)),
   status TEXT NOT NULL CHECK (status IN ('pending', 'saving', 'saved', 'promoted')),
-  claim_token TEXT,
+  claim_token TEXT CHECK (
+    (status = 'saving' AND claim_token IS NOT NULL) OR
+    (status != 'saving' AND claim_token IS NULL)
+  ),
   created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
   updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms)
 );
+
+CREATE INDEX IF NOT EXISTS idx_operator_memory_commit_intents_cursor_created
+  ON operator_memory_commit_intents(cursor_name, created_at_ms DESC);
+`;
+
+const OPERATOR_MEMORY_COMMIT_INTENT_CLAIM_MIGRATION_SQL = `
+DROP TABLE IF EXISTS operator_memory_commit_intents_v041;
+
+CREATE TABLE operator_memory_commit_intents_v041 (
+  intent_id TEXT PRIMARY KEY,
+  cursor_name TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL UNIQUE,
+  expected_memory_count INTEGER NOT NULL CHECK (expected_memory_count > 0),
+  memory_payload_hash TEXT NOT NULL CHECK (memory_payload_hash LIKE 'sha256:%'),
+  memory_ids_json TEXT NOT NULL CHECK (json_valid(memory_ids_json)),
+  source_refs_json TEXT NOT NULL CHECK (json_valid(source_refs_json)),
+  status TEXT NOT NULL CHECK (status IN ('pending', 'saving', 'saved', 'promoted')),
+  claim_token TEXT CHECK (
+    (status = 'saving' AND claim_token IS NOT NULL) OR
+    (status != 'saving' AND claim_token IS NULL)
+  ),
+  created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+  updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms)
+);
+
+INSERT INTO operator_memory_commit_intents_v041 (
+  intent_id,
+  cursor_name,
+  idempotency_key,
+  expected_memory_count,
+  memory_payload_hash,
+  memory_ids_json,
+  source_refs_json,
+  status,
+  claim_token,
+  created_at_ms,
+  updated_at_ms
+)
+SELECT
+  intent_id,
+  cursor_name,
+  idempotency_key,
+  expected_memory_count,
+  memory_payload_hash,
+  memory_ids_json,
+  source_refs_json,
+  CASE
+    WHEN status = 'saving' AND claim_token IS NULL THEN 'pending'
+    ELSE status
+  END,
+  CASE
+    WHEN status = 'saving' AND claim_token IS NOT NULL THEN claim_token
+    ELSE NULL
+  END,
+  created_at_ms,
+  updated_at_ms
+FROM operator_memory_commit_intents;
+
+DROP TABLE operator_memory_commit_intents;
+ALTER TABLE operator_memory_commit_intents_v041 RENAME TO operator_memory_commit_intents;
 
 CREATE INDEX IF NOT EXISTS idx_operator_memory_commit_intents_cursor_created
   ON operator_memory_commit_intents(cursor_name, created_at_ms DESC);
@@ -200,6 +271,33 @@ function tableSql(db: SQLiteDatabase, tableName: string): string {
     .prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?")
     .get(tableName) as { sql?: string } | undefined;
   return row?.sql ?? '';
+}
+
+function tableHasSqlFragments(
+  db: SQLiteDatabase,
+  tableName: (typeof REQUIRED_OPERATOR_TABLES)[number],
+  fragments: readonly string[]
+): boolean {
+  const sql = tableSql(db, tableName);
+  return fragments.every((fragment) => sql.includes(fragment));
+}
+
+function migrateOperatorMemoryCommitIntentClaimInvariant(db: SQLiteDatabase): void {
+  const tableName = 'operator_memory_commit_intents';
+  if (!tableExists(db, tableName)) {
+    return;
+  }
+  if (tableHasSqlFragments(db, tableName, OPERATOR_MEMORY_COMMIT_INTENT_CLAIM_SQL_FRAGMENTS)) {
+    return;
+  }
+  const columns = tableColumns(db, tableName);
+  if (!REQUIRED_COLUMNS[tableName].every((column) => columns.has(column))) {
+    return;
+  }
+  if (!tableHasSqlFragments(db, tableName, OPERATOR_MEMORY_COMMIT_INTENT_BASE_SQL_FRAGMENTS)) {
+    return;
+  }
+  db.exec(OPERATOR_MEMORY_COMMIT_INTENT_CLAIM_MIGRATION_SQL);
 }
 
 function assertTableSqlCompatible(
@@ -279,11 +377,6 @@ export function ensureVNextOperatorSchema(
   db: SQLiteDatabase,
   options: VNextOperatorSchemaOptions = {}
 ): void {
-  if (hasInstalledOperatorSchema(db)) {
-    return;
-  }
-
-  const migrationSql = options.readMigrationSql?.() ?? VNEXT_OPERATOR_CONTRACTS_SQL;
   const tx = db.transaction(() => {
     db.exec(`
       CREATE TABLE IF NOT EXISTS schema_version (
@@ -293,7 +386,13 @@ export function ensureVNextOperatorSchema(
       )
     `);
     ensureSchemaVersionDescriptionColumn(db);
+    migrateOperatorMemoryCommitIntentClaimInvariant(db);
+    if (hasInstalledOperatorSchema(db)) {
+      return;
+    }
+    const migrationSql = options.readMigrationSql?.() ?? VNEXT_OPERATOR_CONTRACTS_SQL;
     db.exec(migrationSql);
+    migrateOperatorMemoryCommitIntentClaimInvariant(db);
     assertOperatorSchemaCompatible(db);
   });
   tx();

--- a/packages/standalone/src/security/security-monitor.ts
+++ b/packages/standalone/src/security/security-monitor.ts
@@ -44,14 +44,17 @@ interface BanRecord {
 const banMap = new Map<string, BanRecord>();
 
 // Periodic cleanup (every hour)
-setInterval(() => {
-  const now = Date.now();
-  for (const [ip, rec] of banMap) {
-    if (now > rec.bannedUntil && now - rec.firstFailAt > AUTH_FAILURE_WINDOW_MS) {
-      banMap.delete(ip);
+setInterval(
+  () => {
+    const now = Date.now();
+    for (const [ip, rec] of banMap) {
+      if (now > rec.bannedUntil && now - rec.firstFailAt > AUTH_FAILURE_WINDOW_MS) {
+        banMap.delete(ip);
+      }
     }
-  }
-}, 60 * 60 * 1000).unref();
+  },
+  60 * 60 * 1000
+).unref();
 
 export function isIpBanned(clientAddress: string | null | undefined): boolean {
   if (!clientAddress || clientAddress === 'unknown' || isLocalAddress(clientAddress)) {
@@ -86,11 +89,15 @@ export function recordAuthFailure(clientAddress: string | null | undefined): voi
   }
 
   rec.failCount++;
-  logger.warn(`[SECURITY] Auth failure from ${clientAddress} (${rec.failCount}/${MAX_AUTH_FAILURES})`);
+  logger.warn(
+    `[SECURITY] Auth failure from ${clientAddress} (${rec.failCount}/${MAX_AUTH_FAILURES})`
+  );
 
   if (rec.failCount >= MAX_AUTH_FAILURES) {
     rec.bannedUntil = now + BAN_DURATION_MS;
-    logger.error(`[SECURITY] IP ${clientAddress} BANNED — ${rec.failCount} auth failures in ${AUTH_FAILURE_WINDOW_MS / 60000}min`);
+    logger.error(
+      `[SECURITY] IP ${clientAddress} BANNED — ${rec.failCount} auth failures in ${AUTH_FAILURE_WINDOW_MS / 60000}min`
+    );
   }
 }
 
@@ -744,6 +751,7 @@ export function setSecurityAlertSender(sender: SecurityAlertSender | null): void
 }
 
 export function resetSecurityMonitorForTests(): void {
+  banMap.clear();
   alertSender = null;
   lastAlertAt.clear();
   suspicionScores.clear();

--- a/packages/standalone/tests/operator-vnext/connector-ingress-manual-memory-commit.test.ts
+++ b/packages/standalone/tests/operator-vnext/connector-ingress-manual-memory-commit.test.ts
@@ -425,8 +425,9 @@ describe('STORY-VNEXT-PR13-MANUAL-MEMORY: connector ingress manual memory commit
       db.prepare(
         `INSERT INTO operator_memory_commit_intents (
           intent_id, cursor_name, idempotency_key, expected_memory_count,
-          memory_payload_hash, memory_ids_json, source_refs_json, status, created_at_ms, updated_at_ms
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+          memory_payload_hash, memory_ids_json, source_refs_json, status, claim_token,
+          created_at_ms, updated_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       ).run(
         `memory-intent:${idempotencyKey}`,
         'connector:slack:channel:C_PUBLIC_SYNTHETIC',
@@ -436,6 +437,7 @@ describe('STORY-VNEXT-PR13-MANUAL-MEMORY: connector ingress manual memory commit
         JSON.stringify([null]),
         JSON.stringify([`raw:slack:${first}`]),
         'saving',
+        'claim:other-owner',
         1710000000000,
         1710000000000
       );

--- a/packages/standalone/tests/operator-vnext/connector-ingress-manual-memory-commit.test.ts
+++ b/packages/standalone/tests/operator-vnext/connector-ingress-manual-memory-commit.test.ts
@@ -1,0 +1,1129 @@
+import { describe, expect, it, vi } from 'vitest';
+import crypto from 'node:crypto';
+
+process.env.MAMA_FORCE_TIER_3 ||= 'true';
+
+import { connectorEventIndexId } from '@jungjaehoon/mama-core/connectors/event-index';
+import type { MemoryProvenanceRecord, TrustedMemoryWriteOptions } from '@jungjaehoon/mama-core';
+
+import {
+  commitConnectorIngressMemoryBatch,
+  type ConnectorIngressManualMemoryCommitInput,
+  type ManualMemorySaveInput,
+} from '../../src/operator-vnext/connector-ingress-manual-memory-commit.js';
+import type { SQLiteDatabase } from '../../src/sqlite.js';
+import { countRows, makeOperatorVNextDb } from './fixtures.js';
+
+function insertRawEvent(
+  db: SQLiteDatabase,
+  overrides: {
+    connector?: string;
+    sourceId: string;
+    channel?: string;
+    timestampMs: number;
+  }
+): string {
+  const connector = overrides.connector ?? 'slack';
+  const channel = overrides.channel ?? 'C_PUBLIC_SYNTHETIC';
+  const eventIndexId = connectorEventIndexId(connector, overrides.sourceId);
+  db.prepare(
+    `INSERT INTO connector_event_index (
+      event_index_id, source_connector, source_type, source_id, source_locator,
+      channel, author, title, content, event_datetime, event_date, source_timestamp_ms,
+      metadata_json, content_hash, indexed_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    eventIndexId,
+    connector,
+    'message',
+    overrides.sourceId,
+    `${connector}:${channel}:${overrides.sourceId}`,
+    channel,
+    'synthetic-user',
+    null,
+    `synthetic public rollout event ${overrides.sourceId}`,
+    overrides.timestampMs,
+    new Date(overrides.timestampMs).toISOString().slice(0, 10),
+    overrides.timestampMs,
+    JSON.stringify({ synthetic: true }),
+    Buffer.alloc(32, 5),
+    '2026-07-03T00:00:00.000Z',
+    '2026-07-03T00:00:00.000Z'
+  );
+  return eventIndexId;
+}
+
+function makeMemory(overrides: Partial<ManualMemorySaveInput> = {}): ManualMemorySaveInput {
+  return {
+    topic: 'operator/manual-memory',
+    kind: 'decision',
+    summary: 'Manual reviewed memory should be committed through the operator.',
+    details: 'The admin reviewed the connector event and approved this memory.',
+    confidence: 0.82,
+    scopes: [{ kind: 'project', id: 'project_public_synthetic' }],
+    ...overrides,
+  };
+}
+
+function memoryPayloadHash(memories: readonly ManualMemorySaveInput[]): string {
+  const payloadJson = JSON.stringify(
+    memories.map((memory) => {
+      const payload: Record<string, unknown> = {
+        topic: memory.topic,
+        kind: memory.kind,
+        summary: memory.summary,
+        details: memory.details,
+        scopes: memory.scopes.map((scope) => ({ kind: scope.kind, id: scope.id })),
+      };
+      if (memory.confidence !== undefined) {
+        payload.confidence = memory.confidence;
+      }
+      if (memory.status !== undefined) {
+        payload.status = memory.status;
+      }
+      if (memory.eventDate !== undefined) {
+        payload.eventDate = memory.eventDate;
+      }
+      if (memory.eventDateTime !== undefined) {
+        payload.eventDateTime = memory.eventDateTime;
+      }
+      return payload;
+    })
+  );
+  return `sha256:${crypto.createHash('sha256').update(payloadJson).digest('hex')}`;
+}
+
+function makeCapability(): TrustedMemoryWriteOptions['capability'] {
+  return Object.freeze({
+    __trustedProvenanceCapability: 'mama-core',
+  }) as TrustedMemoryWriteOptions['capability'];
+}
+
+function makeInput(
+  db: SQLiteDatabase,
+  eventIndexIds: readonly string[],
+  overrides: Partial<ConnectorIngressManualMemoryCommitInput> = {}
+): ConnectorIngressManualMemoryCommitInput {
+  const saveMemory = vi
+    .fn()
+    .mockImplementation(async (_input: unknown, options: TrustedMemoryWriteOptions) => ({
+      success: true,
+      id: `memory-${String(options.provenance.gateway_call_id).split(':').pop()}`,
+    }));
+  return {
+    rawAdapter: db,
+    operatorDb: db,
+    connector: 'slack',
+    channel: 'C_PUBLIC_SYNTHETIC',
+    expectedAdvancedThroughSeq: 0,
+    eventMemories: eventIndexIds.map((eventIndexId) => ({
+      eventIndexId,
+      memories: [makeMemory()],
+    })),
+    saveMemory,
+    createTrustedProvenanceCapability: makeCapability,
+    listMemoriesByGatewayCallId: vi.fn().mockResolvedValue([]),
+    setMemoryStatus: vi.fn().mockResolvedValue(undefined),
+    nowMs: () => 1710000000000,
+    ...overrides,
+  };
+}
+
+function cursorRow(db: SQLiteDatabase) {
+  return db
+    .prepare(
+      `SELECT cursor_name, last_change_seq, last_idempotency_key
+       FROM vnext_operator_cursors
+       WHERE cursor_name = ?`
+    )
+    .get('connector:slack:channel:C_PUBLIC_SYNTHETIC');
+}
+
+describe('STORY-VNEXT-PR13-MANUAL-MEMORY: connector ingress manual memory commit', () => {
+  describe('AC: reviewed events commit source-linked memories through a recoverable operator path', () => {
+    it('commits reviewed event memories as changed operator commits without exposing raw content', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const second = insertRawEvent(db, { sourceId: 'msg-2', timestampMs: 1710000002000 });
+      const saveMemory = vi
+        .fn()
+        .mockResolvedValueOnce({ success: true, id: 'memory-first' })
+        .mockResolvedValueOnce({ success: true, id: 'memory-second' });
+      const setMemoryStatus = vi.fn().mockResolvedValue(undefined);
+
+      const result = await commitConnectorIngressMemoryBatch(
+        makeInput(db, [first, second], { saveMemory, setMemoryStatus })
+      );
+
+      expect(result).toEqual({
+        ok: true,
+        mode: 'manual_memory_commit',
+        status: 'committed',
+        cursorName: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        connector: 'slack',
+        channel: 'C_PUBLIC_SYNTHETIC',
+        requestedCount: 2,
+        processed: 2,
+        advancedThroughSeq: 2,
+        firstSeq: 1,
+        lastSeq: 2,
+        memoriesSaved: 2,
+        commits: [
+          { seq: 1, status: 'changed', outcome: 'committed', cursorAdvanced: true },
+          { seq: 2, status: 'changed', outcome: 'committed', cursorAdvanced: true },
+        ],
+      });
+      expect(JSON.stringify(result)).not.toContain('synthetic public rollout event');
+      expect(JSON.stringify(result)).not.toContain('synthetic-user');
+      expect(JSON.stringify(result)).not.toContain('metadata_json');
+      expect(saveMemory).toHaveBeenCalledTimes(2);
+      expect(saveMemory.mock.calls[0]?.[0]).toMatchObject({
+        topic: 'operator/manual-memory',
+        status: 'stale',
+        source: {
+          package: 'standalone',
+          source_type: 'manual-connector-ingress-memory',
+          channel_id: 'C_PUBLIC_SYNTHETIC',
+        },
+      });
+      expect(saveMemory.mock.calls[0]?.[1].provenance).toMatchObject({
+        actor: 'user',
+        agent_id: 'operator:manual-admin',
+        tool_name: 'mama_save',
+        gateway_call_id: 'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:1-1:memory:0',
+        source_refs: [`raw:slack:${first}`],
+      });
+      expect(setMemoryStatus).toHaveBeenCalledWith({
+        memoryId: 'memory-first',
+        status: 'active',
+      });
+      expect(setMemoryStatus).toHaveBeenCalledWith({
+        memoryId: 'memory-second',
+        status: 'active',
+      });
+      expect(cursorRow(db)).toEqual({
+        cursor_name: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        last_change_seq: 2,
+        last_idempotency_key: 'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:2-2',
+      });
+      expect(countRows(db, 'vnext_operator_commits')).toBe(2);
+      expect(countRows(db, 'operator_memory_commit_intents')).toBe(2);
+      expect(
+        db
+          .prepare(
+            `SELECT changed_refs_json, source_refs_json
+             FROM vnext_operator_commits
+             ORDER BY first_change_seq ASC`
+          )
+          .all()
+      ).toEqual([
+        {
+          changed_refs_json: JSON.stringify(['memory:memory-first']),
+          source_refs_json: JSON.stringify([`raw:slack:${first}`]),
+        },
+        {
+          changed_refs_json: JSON.stringify(['memory:memory-second']),
+          source_refs_json: JSON.stringify([`raw:slack:${second}`]),
+        },
+      ]);
+
+      db.close();
+    });
+
+    it('replays duplicate reviewed memory batches without saving duplicate memories', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const saveMemory = vi.fn().mockResolvedValue({ success: true, id: 'memory-first' });
+      const setMemoryStatus = vi.fn().mockResolvedValue(undefined);
+      const input = makeInput(db, [first], { saveMemory, setMemoryStatus });
+
+      await commitConnectorIngressMemoryBatch(input);
+      const replay = await commitConnectorIngressMemoryBatch(input);
+
+      expect(replay).toMatchObject({
+        ok: true,
+        status: 'committed',
+        requestedCount: 1,
+        processed: 1,
+        memoriesSaved: 0,
+        commits: [{ seq: 1, outcome: 'already_committed', cursorAdvanced: false }],
+      });
+      expect(saveMemory).toHaveBeenCalledTimes(1);
+      expect(setMemoryStatus).toHaveBeenCalledTimes(1);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(1);
+      expect(countRows(db, 'operator_memory_commit_intents')).toBe(1);
+
+      db.close();
+    });
+
+    it('rejects divergent replays for an already committed event before saving memory', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const saveMemory = vi.fn().mockResolvedValue({ success: true, id: 'memory-first' });
+
+      await commitConnectorIngressMemoryBatch(makeInput(db, [first], { saveMemory }));
+
+      await expect(
+        commitConnectorIngressMemoryBatch(
+          makeInput(db, [first], {
+            saveMemory,
+            eventMemories: [
+              {
+                eventIndexId: first,
+                memories: [
+                  makeMemory({
+                    summary: 'This divergent replay must not be treated as idempotent.',
+                  }),
+                ],
+              },
+            ],
+          })
+        )
+      ).rejects.toThrow(/memory payload/i);
+      expect(saveMemory).toHaveBeenCalledTimes(1);
+      expect(countRows(db, 'vnext_operator_commits')).toBe(1);
+
+      db.close();
+    });
+
+    it('recovers saved memory ids from deterministic gateway calls before committing the cursor', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const idempotencyKey = 'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:1-1';
+      db.prepare(
+        `INSERT INTO operator_memory_commit_intents (
+          intent_id, cursor_name, idempotency_key, expected_memory_count,
+          memory_payload_hash, memory_ids_json, source_refs_json, status, created_at_ms, updated_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        `memory-intent:${idempotencyKey}`,
+        'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        idempotencyKey,
+        1,
+        memoryPayloadHash([makeMemory()]),
+        JSON.stringify([null]),
+        JSON.stringify([`raw:slack:${first}`]),
+        'pending',
+        1710000000000,
+        1710000000000
+      );
+      const recovered: MemoryProvenanceRecord = {
+        memory_id: 'memory-recovered',
+        agent_id: 'operator:manual-admin',
+        model_run_id: null,
+        envelope_hash: null,
+        gateway_call_id: `${idempotencyKey}:memory:0`,
+        source_refs: [`raw:slack:${first}`],
+        provenance: {},
+      };
+      const saveMemory = vi.fn();
+
+      const result = await commitConnectorIngressMemoryBatch(
+        makeInput(db, [first], {
+          saveMemory,
+          listMemoriesByGatewayCallId: vi.fn().mockResolvedValue([recovered]),
+        })
+      );
+
+      expect(result).toMatchObject({
+        ok: true,
+        status: 'committed',
+        memoriesSaved: 0,
+        commits: [{ seq: 1, outcome: 'committed', cursorAdvanced: true }],
+      });
+      expect(saveMemory).not.toHaveBeenCalled();
+      expect(
+        db.prepare('SELECT memory_ids_json, status FROM operator_memory_commit_intents').get()
+      ).toEqual({
+        memory_ids_json: JSON.stringify(['memory-recovered']),
+        status: 'promoted',
+      });
+      expect(db.prepare('SELECT changed_refs_json FROM vnext_operator_commits').get()).toEqual({
+        changed_refs_json: JSON.stringify(['memory:memory-recovered']),
+      });
+
+      db.close();
+    });
+
+    it('recovers a stale saving intent after a process crash without duplicating saves', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const idempotencyKey = 'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:1-1';
+      db.prepare(
+        `INSERT INTO operator_memory_commit_intents (
+          intent_id, cursor_name, idempotency_key, expected_memory_count,
+          memory_payload_hash, memory_ids_json, source_refs_json, status,
+          claim_token, created_at_ms, updated_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        `memory-intent:${idempotencyKey}`,
+        'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        idempotencyKey,
+        1,
+        memoryPayloadHash([makeMemory()]),
+        JSON.stringify([null]),
+        JSON.stringify([`raw:slack:${first}`]),
+        'saving',
+        'claim:crashed-owner',
+        1710000000000,
+        1710000000000
+      );
+      const recovered: MemoryProvenanceRecord = {
+        memory_id: 'memory-recovered-after-crash',
+        agent_id: 'operator:manual-admin',
+        model_run_id: null,
+        envelope_hash: null,
+        gateway_call_id: `${idempotencyKey}:memory:0`,
+        source_refs: [`raw:slack:${first}`],
+        provenance: {},
+      };
+      const saveMemory = vi.fn();
+      const setMemoryStatus = vi.fn().mockResolvedValue(undefined);
+
+      const result = await commitConnectorIngressMemoryBatch(
+        makeInput(db, [first], {
+          saveMemory,
+          listMemoriesByGatewayCallId: vi.fn().mockResolvedValue([recovered]),
+          setMemoryStatus,
+          nowMs: () => 1710001000001,
+        })
+      );
+
+      expect(result).toMatchObject({
+        ok: true,
+        status: 'committed',
+        memoriesSaved: 0,
+        commits: [{ seq: 1, outcome: 'committed', cursorAdvanced: true }],
+      });
+      expect(saveMemory).not.toHaveBeenCalled();
+      expect(setMemoryStatus).toHaveBeenCalledWith({
+        memoryId: 'memory-recovered-after-crash',
+        status: 'active',
+      });
+      expect(
+        db
+          .prepare(
+            'SELECT memory_ids_json, status, claim_token FROM operator_memory_commit_intents'
+          )
+          .get()
+      ).toEqual({
+        memory_ids_json: JSON.stringify(['memory-recovered-after-crash']),
+        status: 'promoted',
+        claim_token: null,
+      });
+      expect(db.prepare('SELECT changed_refs_json FROM vnext_operator_commits').get()).toEqual({
+        changed_refs_json: JSON.stringify(['memory:memory-recovered-after-crash']),
+      });
+
+      db.close();
+    });
+
+    it('does not save duplicate memories when another process already owns the save intent', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const idempotencyKey = 'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:1-1';
+      db.prepare(
+        `INSERT INTO operator_memory_commit_intents (
+          intent_id, cursor_name, idempotency_key, expected_memory_count,
+          memory_payload_hash, memory_ids_json, source_refs_json, status, created_at_ms, updated_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        `memory-intent:${idempotencyKey}`,
+        'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        idempotencyKey,
+        1,
+        memoryPayloadHash([makeMemory()]),
+        JSON.stringify([null]),
+        JSON.stringify([`raw:slack:${first}`]),
+        'saving',
+        1710000000000,
+        1710000000000
+      );
+      const saveMemory = vi.fn().mockResolvedValue({ success: true, id: 'memory-first' });
+
+      const result = await commitConnectorIngressMemoryBatch(
+        makeInput(db, [first], { saveMemory })
+      );
+
+      expect(result).toMatchObject({
+        ok: false,
+        status: 'partial_failure',
+        processed: 0,
+        memoriesSaved: 0,
+        failedSeq: 1,
+        error: 'Manual memory commit partially failed.',
+      });
+      expect(saveMemory).not.toHaveBeenCalled();
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(cursorRow(db)).toBeUndefined();
+
+      db.close();
+    });
+
+    it('returns a safe partial failure when memory save fails before cursor commit', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const saveMemory = vi.fn().mockRejectedValue(new Error('raw sensitive marker save failed'));
+
+      const result = await commitConnectorIngressMemoryBatch(
+        makeInput(db, [first], { saveMemory })
+      );
+
+      expect(result).toMatchObject({
+        ok: false,
+        mode: 'manual_memory_commit',
+        status: 'partial_failure',
+        processed: 0,
+        advancedThroughSeq: 0,
+        failedSeq: 1,
+        error: 'Manual memory commit partially failed.',
+      });
+      expect(JSON.stringify(result)).not.toContain('raw sensitive marker');
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(cursorRow(db)).toBeUndefined();
+
+      db.close();
+    });
+
+    it('keeps a multi-event batch retryable when a later event save fails', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const second = insertRawEvent(db, { sourceId: 'msg-2', timestampMs: 1710000002000 });
+      const eventMemories = [
+        {
+          eventIndexId: first,
+          memories: [makeMemory({ topic: 'operator/manual-memory-first-event' })],
+        },
+        {
+          eventIndexId: second,
+          memories: [
+            makeMemory({
+              topic: 'operator/manual-memory-second-event',
+              summary: 'The second reviewed event should be committed on retry.',
+              details: 'The first batch attempt failed after the first event staged memory.',
+            }),
+          ],
+        },
+      ];
+      const firstAttemptSave = vi
+        .fn()
+        .mockResolvedValueOnce({ success: true, id: 'memory-first' })
+        .mockRejectedValueOnce(new Error('second event failed with synthetic marker'));
+      const firstAttemptSetMemoryStatus = vi.fn().mockResolvedValue(undefined);
+
+      const firstAttempt = await commitConnectorIngressMemoryBatch(
+        makeInput(db, [first, second], {
+          eventMemories,
+          saveMemory: firstAttemptSave,
+          setMemoryStatus: firstAttemptSetMemoryStatus,
+        })
+      );
+
+      expect(firstAttempt).toMatchObject({
+        ok: false,
+        status: 'partial_failure',
+        requestedCount: 2,
+        processed: 0,
+        advancedThroughSeq: 0,
+        memoriesSaved: 1,
+        commits: [],
+        failedSeq: 2,
+        error: 'Manual memory commit partially failed.',
+      });
+      expect(JSON.stringify(firstAttempt)).not.toContain('synthetic marker');
+      expect(firstAttemptSave).toHaveBeenCalledTimes(2);
+      expect(firstAttemptSetMemoryStatus).not.toHaveBeenCalled();
+      expect(cursorRow(db)).toBeUndefined();
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(
+        db
+          .prepare(
+            `SELECT idempotency_key, memory_ids_json, status
+             FROM operator_memory_commit_intents
+             ORDER BY idempotency_key ASC`
+          )
+          .all()
+      ).toEqual([
+        {
+          idempotency_key: 'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:1-1',
+          memory_ids_json: JSON.stringify(['memory-first']),
+          status: 'saved',
+        },
+        {
+          idempotency_key: 'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:2-2',
+          memory_ids_json: JSON.stringify([null]),
+          status: 'pending',
+        },
+      ]);
+
+      const retrySave = vi.fn().mockResolvedValue({ success: true, id: 'memory-second' });
+      const retrySetMemoryStatus = vi.fn().mockResolvedValue(undefined);
+      const retry = await commitConnectorIngressMemoryBatch(
+        makeInput(db, [first, second], {
+          eventMemories,
+          saveMemory: retrySave,
+          setMemoryStatus: retrySetMemoryStatus,
+        })
+      );
+
+      expect(retry).toMatchObject({
+        ok: true,
+        status: 'committed',
+        requestedCount: 2,
+        processed: 2,
+        advancedThroughSeq: 2,
+        memoriesSaved: 1,
+        commits: [
+          { seq: 1, status: 'changed', outcome: 'committed', cursorAdvanced: true },
+          { seq: 2, status: 'changed', outcome: 'committed', cursorAdvanced: true },
+        ],
+      });
+      expect(retrySave).toHaveBeenCalledTimes(1);
+      expect(retrySave.mock.calls[0]?.[0]).toMatchObject({
+        topic: 'operator/manual-memory-second-event',
+      });
+      expect(retrySetMemoryStatus).toHaveBeenCalledWith({
+        memoryId: 'memory-first',
+        status: 'active',
+      });
+      expect(retrySetMemoryStatus).toHaveBeenCalledWith({
+        memoryId: 'memory-second',
+        status: 'active',
+      });
+      expect(cursorRow(db)).toEqual({
+        cursor_name: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        last_change_seq: 2,
+        last_idempotency_key: 'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:2-2',
+      });
+      expect(countRows(db, 'vnext_operator_commits')).toBe(2);
+
+      db.close();
+    });
+
+    it('keeps saved memories staged when cursor commit fails after memory save', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const setMemoryStatus = vi.fn().mockResolvedValue(undefined);
+      const saveMemory = vi.fn().mockImplementation(async (_memory, options) => {
+        const gatewayCallId = String(options.provenance.gateway_call_id);
+        const idempotencyKey = gatewayCallId.replace(/:memory:\d+$/, '');
+        db.prepare(
+          `INSERT INTO vnext_operator_cursors (
+            cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+          ) VALUES (?, ?, ?, ?)`
+        ).run('connector:slack:channel:C_PUBLIC_SYNTHETIC', 0, null, 1710000000000);
+        db.prepare(
+          `INSERT INTO vnext_operator_commits (
+            commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+            status, changed_refs_json, source_refs_json, created_at_ms
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        ).run(
+          'commit:conflicting-memory',
+          'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+          idempotencyKey,
+          1,
+          1,
+          'changed',
+          JSON.stringify(['memory:conflicting-memory']),
+          JSON.stringify(options.provenance.source_refs),
+          1710000000000
+        );
+        return { success: true, id: 'memory-first' };
+      });
+
+      const result = await commitConnectorIngressMemoryBatch(
+        makeInput(db, [first], { saveMemory, setMemoryStatus })
+      );
+
+      expect(result).toMatchObject({
+        ok: false,
+        status: 'partial_failure',
+        processed: 0,
+        memoriesSaved: 1,
+        failedSeq: 1,
+      });
+      expect(saveMemory.mock.calls[0]?.[0]).toMatchObject({ status: 'stale' });
+      expect(saveMemory.mock.calls[0]?.[1]).toMatchObject({ projectTruth: false });
+      expect(setMemoryStatus).not.toHaveBeenCalled();
+
+      db.close();
+    });
+
+    it('reports committed promotion-pending state when status promotion fails after cursor commit', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const saveMemory = vi.fn().mockResolvedValue({ success: true, id: 'memory-first' });
+      const setMemoryStatus = vi.fn().mockRejectedValue(new Error('promotion failed'));
+      const input = makeInput(db, [first], { saveMemory, setMemoryStatus });
+
+      const result = await commitConnectorIngressMemoryBatch(input);
+
+      expect(result).toMatchObject({
+        ok: true,
+        status: 'committed',
+        processed: 1,
+        advancedThroughSeq: 1,
+        memoriesSaved: 1,
+        promotionPending: true,
+        commits: [{ seq: 1, outcome: 'committed', cursorAdvanced: true }],
+      });
+      expect(cursorRow(db)).toEqual({
+        cursor_name: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        last_change_seq: 1,
+        last_idempotency_key: 'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:1-1',
+      });
+      expect(
+        db.prepare('SELECT memory_ids_json, status FROM operator_memory_commit_intents').get()
+      ).toEqual({
+        memory_ids_json: JSON.stringify(['memory-first']),
+        status: 'saved',
+      });
+
+      setMemoryStatus.mockReset();
+      setMemoryStatus.mockResolvedValue(undefined);
+      const replay = await commitConnectorIngressMemoryBatch(input);
+
+      expect(replay).toMatchObject({
+        ok: true,
+        status: 'committed',
+        processed: 1,
+        memoriesSaved: 0,
+        commits: [{ seq: 1, outcome: 'already_committed', cursorAdvanced: false }],
+      });
+      expect(replay).not.toHaveProperty('promotionPending');
+      expect(setMemoryStatus).toHaveBeenCalledWith({
+        memoryId: 'memory-first',
+        status: 'active',
+      });
+      expect(
+        db.prepare('SELECT memory_ids_json, status FROM operator_memory_commit_intents').get()
+      ).toEqual({
+        memory_ids_json: JSON.stringify(['memory-first']),
+        status: 'promoted',
+      });
+
+      db.close();
+    });
+
+    it('does not let a stale save owner overwrite a promoted intent', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const saveMemory = vi.fn().mockImplementation(async (_memory, options) => {
+        const idempotencyKey = String(options.provenance.gateway_call_id).replace(
+          /:memory:\d+$/,
+          ''
+        );
+        db.prepare(
+          `UPDATE operator_memory_commit_intents
+           SET memory_ids_json = ?, status = 'promoted', claim_token = NULL, updated_at_ms = ?
+           WHERE idempotency_key = ?`
+        ).run(JSON.stringify(['memory-promoted-by-other-owner']), 1710000001001, idempotencyKey);
+        return { success: true, id: 'memory-stale-owner' };
+      });
+
+      const result = await commitConnectorIngressMemoryBatch(
+        makeInput(db, [first], { saveMemory })
+      );
+
+      expect(result).toMatchObject({
+        ok: false,
+        status: 'partial_failure',
+        processed: 0,
+        memoriesSaved: 0,
+        failedSeq: 1,
+      });
+      expect(
+        db.prepare('SELECT changed_refs_json FROM vnext_operator_commits').get()
+      ).toBeUndefined();
+      expect(
+        db.prepare('SELECT memory_ids_json, status FROM operator_memory_commit_intents').get()
+      ).toEqual({
+        memory_ids_json: JSON.stringify(['memory-promoted-by-other-owner']),
+        status: 'promoted',
+      });
+
+      db.close();
+    });
+
+    it('refreshes the saving intent lease while a memory save is in flight', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1710000000000);
+
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      let resolveSave: ((value: { success: boolean; id: string }) => void) | null = null;
+      const saveMemory = vi.fn((_memory: unknown, _options: TrustedMemoryWriteOptions) => {
+        return new Promise<{ success: boolean; id: string }>((resolve) => {
+          resolveSave = resolve;
+        });
+      });
+      const resultPromise = commitConnectorIngressMemoryBatch(
+        makeInput(db, [first], {
+          saveMemory,
+          nowMs: () => Date.now(),
+        })
+      );
+
+      try {
+        for (let i = 0; i < 5; i += 1) {
+          await Promise.resolve();
+        }
+
+        expect(saveMemory).toHaveBeenCalledTimes(1);
+        const beforeHeartbeat = db
+          .prepare(
+            `SELECT status, updated_at_ms
+             FROM operator_memory_commit_intents`
+          )
+          .get() as { status: string; updated_at_ms: number };
+        expect(beforeHeartbeat).toEqual({
+          status: 'saving',
+          updated_at_ms: 1710000000000,
+        });
+
+        await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+        const duringSave = db
+          .prepare(
+            `SELECT status, updated_at_ms
+             FROM operator_memory_commit_intents`
+          )
+          .get() as { status: string; updated_at_ms: number };
+        expect(duringSave).toEqual({
+          status: 'saving',
+          updated_at_ms: 1710000300000,
+        });
+
+        resolveSave?.({ success: true, id: 'memory-first' });
+        const result = await resultPromise;
+        expect(result).toMatchObject({
+          ok: true,
+          status: 'committed',
+          memoriesSaved: 1,
+        });
+      } finally {
+        resolveSave?.({ success: true, id: 'memory-first' });
+        await resultPromise.catch(() => undefined);
+        vi.useRealTimers();
+        db.close();
+      }
+    });
+
+    it('retries a partially saved multi-memory event without saving duplicate memories', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const eventMemories = [
+        {
+          eventIndexId: first,
+          memories: [
+            makeMemory({ topic: 'operator/manual-memory-first' }),
+            makeMemory({
+              topic: 'operator/manual-memory-second',
+              summary: 'Second reviewed memory should be committed on retry.',
+              details: 'The second memory failed after the first one was durably recorded.',
+            }),
+          ],
+        },
+      ];
+      const firstAttemptSave = vi
+        .fn()
+        .mockResolvedValueOnce({ success: true, id: 'memory-first' })
+        .mockRejectedValueOnce(new Error('second memory failed with synthetic marker'));
+      const firstAttemptSetMemoryStatus = vi.fn().mockResolvedValue(undefined);
+
+      const firstAttempt = await commitConnectorIngressMemoryBatch(
+        makeInput(db, [first], {
+          eventMemories,
+          saveMemory: firstAttemptSave,
+          setMemoryStatus: firstAttemptSetMemoryStatus,
+        })
+      );
+
+      expect(firstAttempt).toMatchObject({
+        ok: false,
+        status: 'partial_failure',
+        processed: 0,
+        advancedThroughSeq: 0,
+        failedSeq: 1,
+        error: 'Manual memory commit partially failed.',
+      });
+      expect(firstAttemptSave).toHaveBeenCalledTimes(2);
+      expect(firstAttemptSave.mock.calls[0]?.[0]).toMatchObject({ status: 'stale' });
+      expect(firstAttemptSetMemoryStatus).not.toHaveBeenCalled();
+      expect(
+        db.prepare('SELECT memory_ids_json, status FROM operator_memory_commit_intents').get()
+      ).toEqual({
+        memory_ids_json: JSON.stringify(['memory-first', null]),
+        status: 'pending',
+      });
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+
+      const retrySave = vi.fn().mockResolvedValue({ success: true, id: 'memory-second' });
+      const retrySetMemoryStatus = vi.fn().mockResolvedValue(undefined);
+      const retry = await commitConnectorIngressMemoryBatch(
+        makeInput(db, [first], {
+          eventMemories,
+          saveMemory: retrySave,
+          setMemoryStatus: retrySetMemoryStatus,
+        })
+      );
+
+      expect(retry).toMatchObject({
+        ok: true,
+        status: 'committed',
+        memoriesSaved: 1,
+        commits: [{ seq: 1, outcome: 'committed', cursorAdvanced: true }],
+      });
+      expect(retrySave).toHaveBeenCalledTimes(1);
+      expect(retrySave.mock.calls[0]?.[0]).toMatchObject({
+        topic: 'operator/manual-memory-second',
+      });
+      expect(retrySave.mock.calls[0]?.[1].provenance.gateway_call_id).toBe(
+        'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:1-1:memory:1'
+      );
+      expect(retrySetMemoryStatus).toHaveBeenCalledWith({
+        memoryId: 'memory-first',
+        status: 'active',
+      });
+      expect(retrySetMemoryStatus).toHaveBeenCalledWith({
+        memoryId: 'memory-second',
+        status: 'active',
+      });
+      expect(
+        db.prepare('SELECT memory_ids_json, status FROM operator_memory_commit_intents').get()
+      ).toEqual({
+        memory_ids_json: JSON.stringify(['memory-first', 'memory-second']),
+        status: 'promoted',
+      });
+      expect(db.prepare('SELECT changed_refs_json FROM vnext_operator_commits').get()).toEqual({
+        changed_refs_json: JSON.stringify(['memory:memory-first', 'memory:memory-second']),
+      });
+
+      db.close();
+    });
+  });
+
+  describe('AC: unsafe memory commit requests fail before durable writes', () => {
+    it.each([
+      [
+        'out-of-range confidence',
+        [{ eventIndexId: 'EVENT', memories: [makeMemory({ confidence: 2 })] }],
+      ],
+      [
+        'unsupported kind',
+        [{ eventIndexId: 'EVENT', memories: [makeMemory({ kind: 'unsupported' as never })] }],
+      ],
+      [
+        'unsupported status',
+        [{ eventIndexId: 'EVENT', memories: [makeMemory({ status: 'unsupported' as never })] }],
+      ],
+      ['empty scopes', [{ eventIndexId: 'EVENT', memories: [makeMemory({ scopes: [] })] }]],
+      [
+        'unsupported scope kind',
+        [
+          {
+            eventIndexId: 'EVENT',
+            memories: [
+              makeMemory({
+                scopes: [{ kind: 'workspace' as never, id: 'project_public_synthetic' }],
+              }),
+            ],
+          },
+        ],
+      ],
+      [
+        'negative eventDateTime',
+        [{ eventIndexId: 'EVENT', memories: [makeMemory({ eventDateTime: -1 })] }],
+      ],
+      [
+        'zero eventDateTime',
+        [{ eventIndexId: 'EVENT', memories: [makeMemory({ eventDateTime: 0 })] }],
+      ],
+      [
+        'invalid eventDate',
+        [{ eventIndexId: 'EVENT', memories: [makeMemory({ eventDate: 'not-a-date' })] }],
+      ],
+      [
+        'duplicate event ids',
+        [
+          { eventIndexId: 'EVENT', memories: [makeMemory()] },
+          { eventIndexId: 'EVENT', memories: [makeMemory()] },
+        ],
+      ],
+      ['empty memories', [{ eventIndexId: 'EVENT', memories: [] }]],
+    ])(
+      'rejects invalid manual memory input before durable writes: %s',
+      async (_name, eventMemories) => {
+        const db = makeOperatorVNextDb();
+        const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+        const saveMemory = vi.fn();
+        const normalizedEventMemories = eventMemories.map((eventMemory) => ({
+          ...eventMemory,
+          eventIndexId: eventMemory.eventIndexId === 'EVENT' ? first : eventMemory.eventIndexId,
+        }));
+
+        await expect(
+          commitConnectorIngressMemoryBatch(
+            makeInput(db, [first], {
+              saveMemory,
+              eventMemories: normalizedEventMemories,
+            })
+          )
+        ).rejects.toThrow();
+        expect(saveMemory).not.toHaveBeenCalled();
+        expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+        expect(countRows(db, 'operator_memory_commit_intents')).toBe(0);
+
+        db.close();
+      }
+    );
+
+    it('rejects caller-supplied source/provenance refs before saving memory', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const saveMemory = vi.fn();
+
+      await expect(
+        commitConnectorIngressMemoryBatch(
+          makeInput(db, [first], {
+            saveMemory,
+            eventMemories: [
+              {
+                eventIndexId: first,
+                memories: [
+                  {
+                    ...makeMemory(),
+                    source: { package: 'standalone', source_type: 'caller-spoofed' },
+                    source_refs: ['raw:slack:caller-spoofed'],
+                    changedRefs: ['memory:caller-spoofed'],
+                    provenance: { gateway_call_id: 'caller-spoofed' },
+                  } as never,
+                ],
+              },
+            ],
+          })
+        )
+      ).rejects.toThrow(/memory source and refs are derived from reviewed events/i);
+      expect(saveMemory).not.toHaveBeenCalled();
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(countRows(db, 'operator_memory_commit_intents')).toBe(0);
+
+      db.close();
+    });
+
+    it('rejects caller-supplied timeline and entity refs before saving memory', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      const saveMemory = vi.fn();
+
+      await expect(
+        commitConnectorIngressMemoryBatch(
+          makeInput(db, [first], {
+            saveMemory,
+            eventMemories: [
+              {
+                eventIndexId: first,
+                memories: [
+                  {
+                    ...makeMemory(),
+                    timelineEvent: {
+                      source_ref: 'raw:slack:caller-spoofed',
+                      event_type: 'decision',
+                      title: 'caller supplied timeline ref',
+                    },
+                    entityObservationIds: ['entity-observation:caller-spoofed'],
+                  } as never,
+                ],
+              },
+            ],
+          })
+        )
+      ).rejects.toThrow(/memory source and refs are derived from reviewed events/i);
+      expect(saveMemory).not.toHaveBeenCalled();
+      expect(countRows(db, 'vnext_operator_commits')).toBe(0);
+      expect(countRows(db, 'operator_memory_commit_intents')).toBe(0);
+
+      db.close();
+    });
+
+    it('rejects events already committed as no-update before saving memory', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      db.prepare(
+        `INSERT INTO vnext_operator_cursors (
+          cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+        ) VALUES (?, ?, ?, ?)`
+      ).run(
+        'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        1,
+        'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:1-1',
+        1710000000000
+      );
+      db.prepare(
+        `INSERT INTO vnext_operator_commits (
+          commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+          status, changed_refs_json, source_refs_json, created_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        'commit:no-update-existing',
+        'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:1-1',
+        1,
+        1,
+        'no_update',
+        JSON.stringify([]),
+        JSON.stringify([`raw:slack:${first}`]),
+        1710000000000
+      );
+      const saveMemory = vi.fn();
+
+      await expect(
+        commitConnectorIngressMemoryBatch(makeInput(db, [first], { saveMemory }))
+      ).rejects.toThrow(/non-changed operator commit/i);
+      expect(saveMemory).not.toHaveBeenCalled();
+      expect(countRows(db, 'operator_memory_commit_intents')).toBe(0);
+
+      db.close();
+    });
+
+    it('rejects events already committed as wiki changes before saving memory', async () => {
+      const db = makeOperatorVNextDb();
+      const first = insertRawEvent(db, { sourceId: 'msg-1', timestampMs: 1710000001000 });
+      db.prepare(
+        `INSERT INTO vnext_operator_cursors (
+          cursor_name, last_change_seq, last_idempotency_key, updated_at_ms
+        ) VALUES (?, ?, ?, ?)`
+      ).run(
+        'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        1,
+        'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:1-1',
+        1710000000000
+      );
+      db.prepare(
+        `INSERT INTO vnext_operator_commits (
+          commit_id, cursor_name, idempotency_key, first_change_seq, last_change_seq,
+          status, changed_refs_json, source_refs_json, created_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        'commit:wiki-existing',
+        'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:1-1',
+        1,
+        1,
+        'changed',
+        JSON.stringify(['wiki_page:projects/existing.md']),
+        JSON.stringify([`raw:slack:${first}`]),
+        1710000000000
+      );
+      const saveMemory = vi.fn();
+
+      await expect(
+        commitConnectorIngressMemoryBatch(makeInput(db, [first], { saveMemory }))
+      ).rejects.toThrow(/non-memory changed operator commit/i);
+      expect(saveMemory).not.toHaveBeenCalled();
+      expect(countRows(db, 'operator_memory_commit_intents')).toBe(0);
+
+      db.close();
+    });
+  });
+});

--- a/packages/standalone/tests/operator-vnext/fixtures.ts
+++ b/packages/standalone/tests/operator-vnext/fixtures.ts
@@ -6,7 +6,7 @@ export function makeOperatorVNextDb(): SQLiteDatabase {
   const db = new Database(':memory:');
   db.pragma('foreign_keys = ON');
   // The standalone SQLite wrapper exposes the migration helper's required better-sqlite3 surface.
-  applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 39);
+  applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 40);
   return db;
 }
 

--- a/packages/standalone/tests/operator-vnext/schema.test.ts
+++ b/packages/standalone/tests/operator-vnext/schema.test.ts
@@ -12,6 +12,13 @@ function tableExists(db: Database, tableName: string): boolean {
   return row !== undefined;
 }
 
+function tableSql(db: Database, tableName: string): string {
+  const row = db
+    .prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(tableName) as { sql?: string } | undefined;
+  return row?.sql ?? '';
+}
+
 describe('STORY-VNEXT-PR3-OPERATOR-BOOTSTRAP: operator schema bootstrap', () => {
   describe('AC: sessions DB gets the primary operator contract before runtime creation', () => {
     it('installs the vNext operator tables into an empty sessions database idempotently', () => {
@@ -157,6 +164,93 @@ describe('STORY-VNEXT-PR3-OPERATOR-BOOTSTRAP: operator schema bootstrap', () => 
       db.close();
     });
 
+    it('upgrades legacy operator memory intent tables before compatibility checks', () => {
+      const db = new Database(':memory:');
+      ensureVNextOperatorSchema(db);
+      db.exec(`
+        DROP TABLE operator_memory_commit_intents;
+        CREATE TABLE operator_memory_commit_intents (
+          intent_id TEXT PRIMARY KEY,
+          cursor_name TEXT NOT NULL,
+          idempotency_key TEXT NOT NULL UNIQUE,
+          expected_memory_count INTEGER NOT NULL CHECK (expected_memory_count > 0),
+          memory_payload_hash TEXT NOT NULL CHECK (memory_payload_hash LIKE 'sha256:%'),
+          memory_ids_json TEXT NOT NULL CHECK (json_valid(memory_ids_json)),
+          source_refs_json TEXT NOT NULL CHECK (json_valid(source_refs_json)),
+          status TEXT NOT NULL CHECK (status IN ('pending', 'saving', 'saved', 'promoted')),
+          claim_token TEXT,
+          created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+          updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms)
+        );
+        CREATE INDEX idx_operator_memory_commit_intents_cursor_created
+          ON operator_memory_commit_intents(cursor_name, created_at_ms DESC);
+        INSERT INTO operator_memory_commit_intents (
+          intent_id, cursor_name, idempotency_key, expected_memory_count,
+          memory_payload_hash, memory_ids_json, source_refs_json, status, claim_token,
+          created_at_ms, updated_at_ms
+        )
+        VALUES
+          (
+            'intent:legacy-saving-without-claim',
+            'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+            'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:6-6',
+            1,
+            'sha256:legacy-saving-without-claim',
+            '[null]',
+            '["raw:slack:synthetic-event-index-id"]',
+            'saving',
+            NULL,
+            1710000000000,
+            1710000000000
+          ),
+          (
+            'intent:legacy-pending-with-claim',
+            'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+            'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:7-7',
+            1,
+            'sha256:legacy-pending-with-claim',
+            '[null]',
+            '["raw:slack:synthetic-event-index-id"]',
+            'pending',
+            'claim:legacy',
+            1710000000000,
+            1710000000000
+          );
+      `);
+
+      expect(() =>
+        ensureVNextOperatorSchema(db, {
+          readMigrationSql: () => {
+            throw new Error('migration file should not be read');
+          },
+        })
+      ).not.toThrow();
+
+      const sql = tableSql(db, 'operator_memory_commit_intents');
+      expect(sql).toContain("(status = 'saving' AND claim_token IS NOT NULL)");
+      expect(sql).toContain("(status != 'saving' AND claim_token IS NULL)");
+      expect(
+        db
+          .prepare(
+            `SELECT status, claim_token
+             FROM operator_memory_commit_intents
+             WHERE intent_id = 'intent:legacy-saving-without-claim'`
+          )
+          .get()
+      ).toEqual({ status: 'pending', claim_token: null });
+      expect(
+        db
+          .prepare(
+            `SELECT status, claim_token
+             FROM operator_memory_commit_intents
+             WHERE intent_id = 'intent:legacy-pending-with-claim'`
+          )
+          .get()
+      ).toEqual({ status: 'pending', claim_token: null });
+
+      db.close();
+    });
+
     it('enforces operator memory commit intent constraints', () => {
       const db = new Database(':memory:');
       ensureVNextOperatorSchema(db);
@@ -166,6 +260,13 @@ describe('STORY-VNEXT-PR3-OPERATOR-BOOTSTRAP: operator schema bootstrap', () => 
           intent_id, cursor_name, idempotency_key, expected_memory_count,
           memory_payload_hash, memory_ids_json, source_refs_json, status, created_at_ms, updated_at_ms
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      );
+      const insertClaimedIntent = db.prepare(
+        `INSERT INTO operator_memory_commit_intents (
+          intent_id, cursor_name, idempotency_key, expected_memory_count,
+          memory_payload_hash, memory_ids_json, source_refs_json, status, claim_token,
+          created_at_ms, updated_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       );
       insertIntent.run(
         'intent:valid',
@@ -250,6 +351,48 @@ describe('STORY-VNEXT-PR3-OPERATOR-BOOTSTRAP: operator schema bootstrap', () => 
           1710000000000
         )
       ).toThrow();
+      expect(() =>
+        insertIntent.run(
+          'intent:saving-without-claim',
+          'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+          'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:6-6',
+          1,
+          'sha256:saving-without-claim',
+          JSON.stringify([null]),
+          JSON.stringify(['raw:slack:synthetic-event-index-id']),
+          'saving',
+          1710000000000,
+          1710000000000
+        )
+      ).toThrow();
+      expect(() =>
+        insertClaimedIntent.run(
+          'intent:pending-with-claim',
+          'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+          'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:7-7',
+          1,
+          'sha256:pending-with-claim',
+          JSON.stringify([null]),
+          JSON.stringify(['raw:slack:synthetic-event-index-id']),
+          'pending',
+          'claim-token',
+          1710000000000,
+          1710000000000
+        )
+      ).toThrow();
+      insertClaimedIntent.run(
+        'intent:claimed-saving',
+        'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:8-8',
+        1,
+        'sha256:claimed-saving',
+        JSON.stringify([null]),
+        JSON.stringify(['raw:slack:synthetic-event-index-id']),
+        'saving',
+        'claim-token',
+        1710000000000,
+        1710000000000
+      );
 
       db.close();
     });

--- a/packages/standalone/tests/operator-vnext/schema.test.ts
+++ b/packages/standalone/tests/operator-vnext/schema.test.ts
@@ -25,12 +25,16 @@ describe('STORY-VNEXT-PR3-OPERATOR-BOOTSTRAP: operator schema bootstrap', () => 
       expect(tableExists(db, 'vnext_operator_commits')).toBe(true);
       expect(tableExists(db, 'operator_no_updates')).toBe(true);
       expect(tableExists(db, 'worker_proposals')).toBe(true);
+      expect(tableExists(db, 'operator_memory_commit_intents')).toBe(true);
       expect(
         db.prepare('SELECT version, description FROM schema_version WHERE version = 38').get()
       ).toEqual({
         version: 38,
         description: 'Create vNext operator contracts',
       });
+      expect(
+        db.prepare('SELECT version, description FROM schema_version WHERE version = 40').get()
+      ).toBeUndefined();
 
       db.close();
     });
@@ -48,6 +52,7 @@ describe('STORY-VNEXT-PR3-OPERATOR-BOOTSTRAP: operator schema bootstrap', () => 
         description: 'Create vNext operator contracts',
       });
       expect(tableExists(db, 'vnext_operator_cursors')).toBe(true);
+      expect(tableExists(db, 'operator_memory_commit_intents')).toBe(true);
 
       db.close();
     });
@@ -122,6 +127,131 @@ describe('STORY-VNEXT-PR3-OPERATOR-BOOTSTRAP: operator schema bootstrap', () => 
       `);
 
       expect(() => ensureVNextOperatorSchema(db)).toThrow(/vnext_operator_cursors/i);
+
+      db.close();
+    });
+
+    it('rejects incompatible operator memory intent tables that claim migration 40', () => {
+      const db = new Database(':memory:');
+      ensureVNextOperatorSchema(db);
+      db.exec(`
+        DROP TABLE operator_memory_commit_intents;
+        CREATE TABLE operator_memory_commit_intents (
+          intent_id TEXT PRIMARY KEY,
+          cursor_name TEXT NOT NULL,
+          idempotency_key TEXT NOT NULL,
+          expected_memory_count INTEGER NOT NULL,
+          memory_payload_hash TEXT NOT NULL,
+          memory_ids_json TEXT NOT NULL,
+          source_refs_json TEXT NOT NULL,
+          status TEXT NOT NULL,
+          created_at_ms INTEGER NOT NULL,
+          updated_at_ms INTEGER NOT NULL
+        );
+        CREATE INDEX idx_operator_memory_commit_intents_cursor_created
+          ON operator_memory_commit_intents(cursor_name, created_at_ms DESC);
+        CREATE INDEX idx_operator_memory_commit_intents_idempotency_key
+          ON operator_memory_commit_intents(idempotency_key);
+      `);
+
+      expect(() => ensureVNextOperatorSchema(db)).toThrow(/operator_memory_commit_intents/i);
+
+      db.close();
+    });
+
+    it('enforces operator memory commit intent constraints', () => {
+      const db = new Database(':memory:');
+      ensureVNextOperatorSchema(db);
+
+      const insertIntent = db.prepare(
+        `INSERT INTO operator_memory_commit_intents (
+          intent_id, cursor_name, idempotency_key, expected_memory_count,
+          memory_payload_hash, memory_ids_json, source_refs_json, status, created_at_ms, updated_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      );
+      insertIntent.run(
+        'intent:valid',
+        'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:1-1',
+        1,
+        'sha256:valid',
+        JSON.stringify(['memory-1']),
+        JSON.stringify(['raw:slack:synthetic-event-index-id']),
+        'saved',
+        1710000000000,
+        1710000000000
+      );
+
+      expect(() =>
+        insertIntent.run(
+          'intent:bad-count',
+          'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+          'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:2-2',
+          0,
+          'sha256:bad-count',
+          JSON.stringify([]),
+          JSON.stringify(['raw:slack:synthetic-event-index-id']),
+          'pending',
+          1710000000000,
+          1710000000000
+        )
+      ).toThrow();
+      expect(() =>
+        insertIntent.run(
+          'intent:bad-json',
+          'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+          'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:3-3',
+          1,
+          'sha256:bad-json',
+          'not-json',
+          JSON.stringify(['raw:slack:synthetic-event-index-id']),
+          'pending',
+          1710000000000,
+          1710000000000
+        )
+      ).toThrow();
+      expect(() =>
+        insertIntent.run(
+          'intent:bad-status',
+          'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+          'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:4-4',
+          1,
+          'sha256:bad-status',
+          JSON.stringify([null]),
+          JSON.stringify(['raw:slack:synthetic-event-index-id']),
+          'done',
+          1710000000000,
+          1710000000000
+        )
+      ).toThrow();
+      expect(() =>
+        insertIntent.run(
+          'intent:bad-time',
+          'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+          'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:5-5',
+          1,
+          'sha256:bad-time',
+          JSON.stringify([null]),
+          JSON.stringify(['raw:slack:synthetic-event-index-id']),
+          'pending',
+          1710000000001,
+          1710000000000
+        )
+      ).toThrow();
+      expect(() =>
+        insertIntent.run(
+          'intent:duplicate-idempotency',
+          'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+          'cursor:connector:slack:channel:C_PUBLIC_SYNTHETIC:seq:1-1',
+          1,
+          'sha256:duplicate-idempotency',
+          JSON.stringify([null]),
+          JSON.stringify(['raw:slack:synthetic-event-index-id']),
+          'pending',
+          1710000000000,
+          1710000000000
+        )
+      ).toThrow();
 
       db.close();
     });

--- a/packages/standalone/tests/operator-vnext/schema.test.ts
+++ b/packages/standalone/tests/operator-vnext/schema.test.ts
@@ -150,8 +150,6 @@ describe('STORY-VNEXT-PR3-OPERATOR-BOOTSTRAP: operator schema bootstrap', () => 
         );
         CREATE INDEX idx_operator_memory_commit_intents_cursor_created
           ON operator_memory_commit_intents(cursor_name, created_at_ms DESC);
-        CREATE INDEX idx_operator_memory_commit_intents_idempotency_key
-          ON operator_memory_commit_intents(idempotency_key);
       `);
 
       expect(() => ensureVNextOperatorSchema(db)).toThrow(/operator_memory_commit_intents/i);

--- a/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
+++ b/packages/standalone/tests/runtime-vnext/bootstrap-api.test.ts
@@ -16,6 +16,10 @@ import {
   commitConnectorIngressNoUpdateBatch,
   createConnectorIngressManualNoUpdateCommitProvider,
 } from '../../src/operator-vnext/connector-ingress-manual-commit.js';
+import {
+  commitConnectorIngressMemoryBatch,
+  createConnectorIngressManualMemoryCommitProvider,
+} from '../../src/operator-vnext/connector-ingress-manual-memory-commit.js';
 import { commitConnectorIngressWikiBatch } from '../../src/operator-vnext/connector-ingress-manual-wiki-commit.js';
 import { createConnectorIngressMigrationDryRunProvider } from '../../src/operator-vnext/connector-ingress-migration-dry-run.js';
 import { ensureVNextOperatorSchema } from '../../src/operator-vnext/schema.js';
@@ -31,6 +35,7 @@ import {
   isVNextWikiPublishAdapter,
   MAX_WIKI_PAGE_CONTENT_CHARS,
 } from '../../src/wiki-artifacts/wiki-publish-adapter.js';
+import { resetSecurityMonitorForTests } from '../../src/security/security-monitor.js';
 
 const AUTH_TOKEN_ENV = 'MAMA_AUTH_TOKEN';
 const ADMIN_TOKEN_ENV = 'MAMA_ADMIN_TOKEN';
@@ -106,11 +111,42 @@ function makeManualWikiPages(count: number, prefix: string) {
   }));
 }
 
+function makeManualMemory(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    topic: 'operator/manual-memory',
+    kind: 'decision',
+    summary: 'Manual reviewed memory should be committed.',
+    details: 'The admin reviewed the connector event and approved this memory.',
+    confidence: 0.82,
+    scopes: [{ kind: 'project', id: 'project_public_synthetic' }],
+    ...overrides,
+  };
+}
+
+function makeManualMemoryCommitBody(
+  eventIndexId = 'synthetic-event-index-id',
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    connector: 'slack',
+    channel: 'C_PUBLIC_SYNTHETIC',
+    expected_advanced_through_seq: 0,
+    event_memories: [
+      {
+        event_index_id: eventIndexId,
+        memories: [makeManualMemory()],
+      },
+    ],
+    ...overrides,
+  };
+}
+
 describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
   const originalAuthToken = process.env[AUTH_TOKEN_ENV];
   const originalAdminToken = process.env[ADMIN_TOKEN_ENV];
 
   afterEach(() => {
+    resetSecurityMonitorForTests();
     if (originalAuthToken === undefined) {
       delete process.env[AUTH_TOKEN_ENV];
     } else {
@@ -823,6 +859,311 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
       db.close();
     });
 
+    it('serves admin-only manual memory ingress commits with an allowlisted payload', async () => {
+      process.env[AUTH_TOKEN_ENV] = 'vnext-status-token';
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      const db = new Database(':memory:');
+      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 40);
+      const eventIndexId = insertRawEvent(db, 'msg-1', { channel: 'C_PUBLIC_SYNTHETIC' });
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualMemoryCommitProvider: (input) =>
+          commitConnectorIngressMemoryBatch({
+            rawAdapter: db,
+            operatorDb: db,
+            ...input,
+            saveMemory: async (_memory, options) => ({
+              success: true,
+              id: `memory-${String(options.provenance.gateway_call_id).split(':').pop()}`,
+            }),
+            createTrustedProvenanceCapability: () =>
+              Object.freeze({
+                __trustedProvenanceCapability: 'mama-core',
+              }) as never,
+            listMemoriesByGatewayCallId: async () => [],
+            setMemoryStatus: async () => {},
+            nowMs: () => 1710000000000,
+          }),
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-memory-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send({
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_memories: [
+            {
+              event_index_id: eventIndexId,
+              memories: [
+                {
+                  topic: 'operator/manual-memory',
+                  kind: 'decision',
+                  summary: 'Manual reviewed memory should be committed.',
+                  details: 'The admin reviewed the connector event and approved this memory.',
+                  confidence: 0.82,
+                  scopes: [{ kind: 'project', id: 'project_public_synthetic' }],
+                },
+              ],
+            },
+          ],
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        ok: true,
+        mode: 'manual_memory_commit',
+        status: 'committed',
+        cursorName: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        connector: 'slack',
+        channel: 'C_PUBLIC_SYNTHETIC',
+        requestedCount: 1,
+        processed: 1,
+        advancedThroughSeq: 1,
+        firstSeq: 1,
+        lastSeq: 1,
+        memoriesSaved: 1,
+        commits: [{ seq: 1, status: 'changed', outcome: 'committed', cursorAdvanced: true }],
+      });
+      expect(JSON.stringify(response.body)).not.toContain('synthetic public rollout event');
+      expect(JSON.stringify(response.body)).not.toContain('synthetic-user');
+      expect(JSON.stringify(response.body)).not.toContain('metadata_json');
+      expect(JSON.stringify(response.body)).not.toContain('project_public_synthetic');
+      expect(JSON.stringify(response.body)).not.toContain(LOCAL_PATH_PREFIX);
+      expect(db.prepare('SELECT changed_refs_json FROM vnext_operator_commits').get()).toEqual({
+        changed_refs_json: JSON.stringify(['memory:memory-0']),
+      });
+
+      db.close();
+    });
+
+    it('requires admin auth for manual memory ingress commits', async () => {
+      process.env[AUTH_TOKEN_ENV] = 'vnext-status-token';
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      let providerCalls = 0;
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualMemoryCommitProvider: () => {
+          providerCalls += 1;
+          throw new Error('provider must not run without admin auth');
+        },
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-memory-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-status-token')
+        .send(makeManualMemoryCommitBody());
+
+      expect(response.status).toBe(401);
+      expect(response.body).toMatchObject({
+        error: true,
+        code: 'UNAUTHORIZED',
+      });
+      expect(providerCalls).toBe(0);
+    });
+
+    it('fails closed when admin auth is not configured for manual memory ingress commits', async () => {
+      delete process.env[ADMIN_TOKEN_ENV];
+      let providerCalls = 0;
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualMemoryCommitProvider: () => {
+          providerCalls += 1;
+          throw new Error('provider must not run without admin auth');
+        },
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-memory-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .send(makeManualMemoryCommitBody());
+
+      expect(response.status).toBe(503);
+      expect(response.body).toMatchObject({
+        error: true,
+        code: 'admin_token_required',
+      });
+      expect(providerCalls).toBe(0);
+    });
+
+    it('returns unavailable when manual memory ingress commits are not configured', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      const apiServer = createVNextBootstrapApiServer(makeStatus());
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-memory-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send(makeManualMemoryCommitBody());
+
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({
+        ok: false,
+        code: 'vnext_ingress_manual_memory_commit_unavailable',
+        error: 'vNext manual memory ingress commit is not configured.',
+      });
+    });
+
+    it('rejects manual memory ingress commits for the wrong configured channel', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      const db = new Database(':memory:');
+      applyMigrationsThrough(db as unknown as Parameters<typeof applyMigrationsThrough>[0], 40);
+      let saveCalls = 0;
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualMemoryCommitProvider: createConnectorIngressManualMemoryCommitProvider({
+          rawAdapter: db,
+          operatorDb: db,
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          saveMemory: async () => {
+            saveCalls += 1;
+            throw new Error('memory save must not run for wrong channel');
+          },
+          createTrustedProvenanceCapability: () =>
+            Object.freeze({
+              __trustedProvenanceCapability: 'mama-core',
+            }) as never,
+          listMemoriesByGatewayCallId: async () => [],
+          setMemoryStatus: async () => {},
+          nowMs: () => 1710000000000,
+        }),
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-memory-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send(makeManualMemoryCommitBody('synthetic-event-index-id', { channel: 'C_OTHER' }));
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'vnext_ingress_manual_memory_commit_invalid_request',
+      });
+      expect(JSON.stringify(response.body)).not.toContain('C_PUBLIC_SYNTHETIC');
+      expect(saveCalls).toBe(0);
+      expect(db.prepare('SELECT COUNT(*) AS count FROM vnext_operator_commits').get()).toEqual({
+        count: 0,
+      });
+
+      db.close();
+    });
+
+    it('rejects manual memory API requests above the aggregate memory limit before provider execution', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      let providerCalls = 0;
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualMemoryCommitProvider: () => {
+          providerCalls += 1;
+          throw new Error('provider must not run when aggregate memories exceed the request limit');
+        },
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-memory-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send(
+          makeManualMemoryCommitBody('synthetic-event-index-id', {
+            event_memories: [
+              {
+                event_index_id: 'synthetic-event-index-id',
+                memories: Array.from({ length: 101 }, (_, index) =>
+                  makeManualMemory({ topic: `operator/manual-memory-${index}` })
+                ),
+              },
+            ],
+          })
+        );
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'vnext_ingress_manual_memory_commit_invalid_request',
+      });
+      expect(response.body.error).toMatch(/at most 100 total memories/i);
+      expect(providerCalls).toBe(0);
+    });
+
+    it('sanitizes unexpected manual memory ingress commit failures', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualMemoryCommitProvider: () => {
+          throw new Error('memory backend failed with synthetic-error-marker');
+        },
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-memory-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send(makeManualMemoryCommitBody());
+
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({
+        ok: false,
+        code: 'vnext_ingress_manual_memory_commit_failed',
+        error: 'vNext manual memory ingress commit failed.',
+      });
+      expect(JSON.stringify(response.body)).not.toContain('memory backend');
+      expect(JSON.stringify(response.body)).not.toContain('synthetic-error-marker');
+    });
+
+    it('allowlists provider-returned manual memory partial failures', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualMemoryCommitProvider: () =>
+          ({
+            ok: false,
+            mode: 'manual_memory_commit',
+            status: 'partial_failure',
+            cursorName: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+            connector: 'slack',
+            channel: 'C_PUBLIC_SYNTHETIC',
+            requestedCount: 1,
+            processed: 0,
+            advancedThroughSeq: 0,
+            firstSeq: 1,
+            lastSeq: 1,
+            memoriesSaved: 0,
+            commits: [],
+            failedSeq: 1,
+            error: `${LOCAL_PATH_PREFIX}/private-memory.json raw synthetic public rollout event memory-private-id`,
+            rawConnectorEvent: 'synthetic public rollout event msg-1',
+            memoryIds: ['memory-private-id'],
+            localPath: `${LOCAL_PATH_PREFIX}/private-memory.json`,
+          }) as never,
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-memory-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send(makeManualMemoryCommitBody());
+
+      expect(response.status).toBe(409);
+      expect(response.body).toEqual({
+        ok: false,
+        mode: 'manual_memory_commit',
+        status: 'partial_failure',
+        cursorName: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        connector: 'slack',
+        channel: 'C_PUBLIC_SYNTHETIC',
+        requestedCount: 1,
+        processed: 0,
+        advancedThroughSeq: 0,
+        firstSeq: 1,
+        lastSeq: 1,
+        memoriesSaved: 0,
+        commits: [],
+        failedSeq: 1,
+        error: 'Manual memory commit partially failed.',
+      });
+      expect(JSON.stringify(response.body)).not.toContain('synthetic public rollout event');
+      expect(JSON.stringify(response.body)).not.toContain('memory-private-id');
+      expect(JSON.stringify(response.body)).not.toContain(LOCAL_PATH_PREFIX);
+    });
+
     it('accepts manual wiki content below the core wiki content limit through the API', async () => {
       process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
       const validLargeContent = 'x'.repeat(MAX_WIKI_PAGE_CONTENT_CHARS - 1);
@@ -1100,6 +1441,174 @@ describe('STORY-VNEXT-PR1-BOOTSTRAP-API: vNext bootstrap API security', () => {
       expect(response.body).toMatchObject({
         ok: false,
         code: 'vnext_ingress_manual_wiki_commit_invalid_request',
+      });
+      expect(providerCalls).toBe(0);
+    });
+
+    it('rejects manual memory ingress commit requests that try to supply source refs', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      let providerCalls = 0;
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualMemoryCommitProvider: () => {
+          providerCalls += 1;
+          throw new Error('provider must not run when memory source refs are supplied');
+        },
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-memory-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send({
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_memories: [
+            {
+              event_index_id: 'synthetic-event-index-id',
+              memories: [
+                {
+                  topic: 'operator/manual-memory',
+                  kind: 'decision',
+                  summary: 'Manual reviewed memory should be committed.',
+                  details: 'The admin reviewed the connector event and approved this memory.',
+                  scopes: [{ kind: 'project', id: 'project_public_synthetic' }],
+                  source_refs: ['raw:slack:synthetic-event-index-id'],
+                },
+              ],
+            },
+          ],
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'vnext_ingress_manual_memory_commit_invalid_request',
+      });
+      expect(providerCalls).toBe(0);
+    });
+
+    it('rejects manual memory ingress commit requests that try to supply root provenance', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      let providerCalls = 0;
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualMemoryCommitProvider: () => {
+          providerCalls += 1;
+          throw new Error('provider must not run when root provenance is supplied');
+        },
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-memory-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send(
+          makeManualMemoryCommitBody('synthetic-event-index-id', {
+            provenance: { gateway_call_id: 'caller-spoofed' },
+            gateway_call_id: 'caller-spoofed',
+            agent_id: 'caller-spoofed-agent',
+            model_run_id: 'caller-spoofed-model-run',
+          })
+        );
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'vnext_ingress_manual_memory_commit_invalid_request',
+      });
+      expect(providerCalls).toBe(0);
+    });
+
+    it('rejects manual memory ingress commit requests that try to supply source metadata', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      let providerCalls = 0;
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualMemoryCommitProvider: () => {
+          providerCalls += 1;
+          throw new Error('provider must not run when memory source metadata is supplied');
+        },
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-memory-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send({
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_memories: [
+            {
+              event_index_id: 'synthetic-event-index-id',
+              memories: [
+                {
+                  topic: 'operator/manual-memory',
+                  kind: 'decision',
+                  summary: 'Manual reviewed memory should be committed.',
+                  details: 'The admin reviewed the connector event and approved this memory.',
+                  scopes: [{ kind: 'project', id: 'project_public_synthetic' }],
+                  source: {
+                    package: 'standalone',
+                    source_type: 'caller-spoofed',
+                  },
+                },
+              ],
+            },
+          ],
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'vnext_ingress_manual_memory_commit_invalid_request',
+      });
+      expect(providerCalls).toBe(0);
+    });
+
+    it('rejects manual memory ingress commit requests that try to supply timeline or entity refs', async () => {
+      process.env[ADMIN_TOKEN_ENV] = 'vnext-admin-token';
+      let providerCalls = 0;
+      const apiServer = createVNextBootstrapApiServer(makeStatus(), {
+        ingressManualMemoryCommitProvider: () => {
+          providerCalls += 1;
+          throw new Error('provider must not run when memory timeline refs are supplied');
+        },
+      });
+
+      const response = await request(apiServer.app)
+        .post('/api/vnext/ingress/manual-memory-commit')
+        .set('cf-connecting-ip', '203.0.113.10')
+        .set('authorization', 'Bearer vnext-admin-token')
+        .send({
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 0,
+          event_memories: [
+            {
+              event_index_id: 'synthetic-event-index-id',
+              memories: [
+                {
+                  topic: 'operator/manual-memory',
+                  kind: 'decision',
+                  summary: 'Manual reviewed memory should be committed.',
+                  details: 'The admin reviewed the connector event and approved this memory.',
+                  scopes: [{ kind: 'project', id: 'project_public_synthetic' }],
+                  timeline_event: {
+                    source_ref: 'raw:slack:caller-spoofed',
+                    event_type: 'decision',
+                    title: 'caller supplied timeline ref',
+                  },
+                  entity_observation_ids: ['entity-observation:caller-spoofed'],
+                },
+              ],
+            },
+          ],
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'vnext_ingress_manual_memory_commit_invalid_request',
       });
       expect(providerCalls).toBe(0);
     });


### PR DESCRIPTION
## Summary
- Adds authenticated vNext manual memory commit endpoint for reviewed connector ingress events.
- Stores manual memory commit intents with idempotent replay, claim-token save ownership, stale saving lease recovery, and in-flight saving lease heartbeats.
- Promotes staged memories through core memory evolution after cursor commit, suppressing truth projection before promotion.
- Hardens connector/channel mismatch errors and manual-memory HTTP responses against raw/internal data leakage.

## Privacy / Internal Info Audit
- [x] ./scripts/check-pii.sh
- [x] added-line privacy/internal-info scan
- [x] gitleaks protect --source . --redact --verbose --no-banner
- [x] gitleaks protect --source . --staged --redact --verbose --no-banner

## Review
- [x] Security/privacy subagent: no blockers
- [x] Correctness subagent: P1/P2 findings fixed
- [x] Re-review: prior findings fixed
- [x] Codex review: staged truth projection P2 fixed
- [x] Codex review: promotion semantic fallback P2 addressed
- [x] Codex review: promotion retry supersedes P2 fixed
- [x] Codex review: invalid date intent wedge P1 fixed
- [x] Codex review: multi-event partial cursor P2 fixed
- [x] Codex review: root provenance spoofing P2 fixed
- [x] Codex review: saving-intent lease heartbeat P2 fixed
- [x] Final Codex review: no actionable correctness issues

## Test Plan
- [x] MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-core test
- [x] MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os test
- [x] pnpm --filter @jungjaehoon/mama-core build
- [x] pnpm --filter @jungjaehoon/mama-os typecheck
- [x] pnpm --filter @jungjaehoon/mama-os build
- [x] pnpm lint
- [x] git diff --check
- [x] pre-commit hook: lint-staged, gitleaks, doc version sync, typecheck, turbo changed-package tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new admin endpoint for manual memory commits, including validation, batch handling, and safer error responses.
  * Memories can now be promoted to a new status after being saved, with updated visibility in relevant queries.

* **Bug Fixes**
  * Improved replay safety so duplicate commits won’t create extra records or duplicate status changes.
  * Strengthened recovery for partial failures, stale locks, and interrupted migrations.
  * Tightened input checks to reject unsafe or conflicting request fields before any durable write.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->