### PR TITLE
feat: add vNext operator cockpit

### DIFF
--- a/packages/standalone/public/viewer/operator.html
+++ b/packages/standalone/public/viewer/operator.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; base-uri 'none'; frame-ancestors 'none'; form-action 'self'"
+    />
+    <title>MAMA Operator</title>
+    <meta name="theme-color" content="#F9F7F4" />
+    <link rel="icon" type="image/svg+xml" href="/viewer/icons/mama-icon.svg" />
+    <link rel="stylesheet" href="/viewer/viewer.css" />
+  </head>
+  <body class="operator-cockpit-page">
+    <main class="operator-cockpit-page-main">
+      <header class="operator-cockpit-page-header">
+        <a href="/viewer" rel="noopener" aria-label="Back to MAMA viewer">
+          <img src="/viewer/icons/mama-icon.svg" alt="" width="28" height="28" />
+          <span>MAMA</span>
+        </a>
+        <strong>Operator</strong>
+      </header>
+      <div id="operator-cockpit-content"></div>
+    </main>
+    <script type="module" src="/viewer/js/operator-entry.js"></script>
+  </body>
+</html>

--- a/packages/standalone/public/viewer/src/modules/operator-cockpit.ts
+++ b/packages/standalone/public/viewer/src/modules/operator-cockpit.ts
@@ -8,6 +8,9 @@
 /* eslint-env browser */
 
 import { API } from '../utils/api.js';
+import { DebugLogger } from '../utils/debug-logger.js';
+
+const logger = new DebugLogger('OperatorCockpit');
 
 export interface OperatorCockpitScope {
   connector: string;
@@ -354,6 +357,9 @@ export function renderOperatorCockpitShell(): string {
 }
 
 export function renderOperatorError(message: string, _error?: unknown): string {
+  if (_error !== undefined) {
+    logger.error(message, _error);
+  }
   return `<div class="operator-cockpit-error">${esc(message)}</div>`;
 }
 
@@ -370,7 +376,20 @@ function readNumberInput(root: ParentNode, selector: string, fallback: number): 
     return fallback;
   }
   const value = Number(input.value);
-  return Number.isInteger(value) && value > 0 ? value : fallback;
+  const max = Number(input.max);
+  const upperBound = Number.isFinite(max) && max > 0 ? max : Number.POSITIVE_INFINITY;
+  return Number.isInteger(value) && value > 0 ? Math.min(value, upperBound) : fallback;
+}
+
+function rowCommitButtons(row: Element | null, trigger?: HTMLElement): HTMLButtonElement[] {
+  const buttons = row
+    ? Array.from(row.querySelectorAll('button[data-action]'))
+    : trigger
+      ? [trigger]
+      : [];
+  return buttons.filter(
+    (button): button is HTMLButtonElement => button instanceof HTMLButtonElement
+  );
 }
 
 export class OperatorCockpitModule {
@@ -449,7 +468,12 @@ export class OperatorCockpitModule {
         if (!eventIndexId || !action) {
           return;
         }
-        void this.commitEvent(action, eventIndexId, button.closest('.operator-cockpit-row'));
+        void this.commitEvent(
+          action,
+          eventIndexId,
+          button.closest('.operator-cockpit-row'),
+          button
+        );
       });
     });
   }
@@ -457,13 +481,21 @@ export class OperatorCockpitModule {
   private async commitEvent(
     action: string,
     eventIndexId: string,
-    row: Element | null
+    row: Element | null,
+    trigger?: HTMLElement
   ): Promise<void> {
     const state = this.currentState;
     const resultSlot = this.container?.querySelector('#operator-cockpit-result');
     if (!state || !(resultSlot instanceof HTMLElement)) {
       return;
     }
+    const commitButtons = rowCommitButtons(row, trigger);
+    if (commitButtons.some((button) => button.disabled)) {
+      return;
+    }
+    commitButtons.forEach((button) => {
+      button.disabled = true;
+    });
     resultSlot.innerHTML = '<div class="operator-cockpit-empty">Committing...</div>';
     const base = {
       connector: state.cursor.connector,
@@ -539,6 +571,10 @@ export class OperatorCockpitModule {
       resultSlot.innerHTML = renderCommitResultState(resultState);
     } catch (error) {
       resultSlot.innerHTML = renderOperatorError('Operator commit failed.', error);
+    } finally {
+      commitButtons.forEach((button) => {
+        button.disabled = false;
+      });
     }
   }
 }

--- a/packages/standalone/public/viewer/src/modules/operator-cockpit.ts
+++ b/packages/standalone/public/viewer/src/modules/operator-cockpit.ts
@@ -33,7 +33,7 @@ export interface OperatorPreviewEvent {
   sourceTimestampMs: number;
   sourceId: string;
   channel: string | null;
-  sourceRef: OperatorSourceRef;
+  sourceRef?: OperatorSourceRef;
   [key: string]: unknown;
 }
 
@@ -54,7 +54,7 @@ export interface OperatorPreviewResponse {
 export interface OperatorDryRunCandidate {
   seq: number;
   eventIndexId: string;
-  sourceRef: OperatorSourceRef;
+  sourceRef?: OperatorSourceRef;
   readiness: 'requires_decision';
 }
 
@@ -201,7 +201,10 @@ function queryForScope(scope: OperatorCockpitScope): Record<string, string | num
   return query;
 }
 
-function sourceRefText(ref: OperatorSourceRef): string {
+function sourceRefText(ref?: OperatorSourceRef | null): string {
+  if (!ref) {
+    return 'raw:unknown:unknown';
+  }
   const kind = ref.kind ?? 'raw';
   const connector = ref.connector ?? 'unknown';
   const id = ref.id ?? 'unknown';
@@ -217,6 +220,14 @@ function numberOrNull(value: unknown): number | null {
 
 function numberOrZero(value: unknown): number {
   return numberOrNull(value) ?? 0;
+}
+
+function requiredFiniteNumber(value: unknown, fieldName: string): number {
+  const parsed = numberOrNull(value);
+  if (parsed === null) {
+    throw new Error(`${fieldName} is required for operator review events.`);
+  }
+  return parsed;
 }
 
 function stringOrEmpty(value: unknown): string {
@@ -472,6 +483,9 @@ export class OperatorCockpitModule {
           auth
         );
       } else if (action === 'wiki') {
+        if (!row) {
+          throw new Error('Event row element not found for wiki commit.');
+        }
         result = await this.controller.commitWiki(
           {
             ...base,
@@ -480,10 +494,10 @@ export class OperatorCockpitModule {
                 event_index_id: eventIndexId,
                 pages: [
                   {
-                    path: readTextInput(row ?? document, '[data-field="wiki-path"]'),
-                    title: readTextInput(row ?? document, '[data-field="wiki-title"]'),
+                    path: readTextInput(row, '[data-field="wiki-path"]'),
+                    title: readTextInput(row, '[data-field="wiki-title"]'),
                     type: 'entity',
-                    content: readTextInput(row ?? document, '[data-field="wiki-content"]'),
+                    content: readTextInput(row, '[data-field="wiki-content"]'),
                   },
                 ],
               },
@@ -492,6 +506,9 @@ export class OperatorCockpitModule {
           auth
         );
       } else if (action === 'memory') {
+        if (!row) {
+          throw new Error('Event row element not found for memory commit.');
+        }
         result = await this.controller.commitMemory(
           {
             ...base,
@@ -500,10 +517,10 @@ export class OperatorCockpitModule {
                 event_index_id: eventIndexId,
                 memories: [
                   {
-                    topic: readTextInput(row ?? document, '[data-field="memory-topic"]'),
+                    topic: readTextInput(row, '[data-field="memory-topic"]'),
                     kind: 'decision',
-                    summary: readTextInput(row ?? document, '[data-field="memory-summary"]'),
-                    details: readTextInput(row ?? document, '[data-field="memory-details"]'),
+                    summary: readTextInput(row, '[data-field="memory-summary"]'),
+                    details: readTextInput(row, '[data-field="memory-details"]'),
                     confidence: 0.8,
                     scopes: buildOperatorMemoryScopes(state.cursor.connector, state.cursor.channel),
                   },
@@ -527,30 +544,33 @@ export class OperatorCockpitModule {
 }
 
 export function buildOperatorReviewState(batch: OperatorReviewBatch): OperatorReviewState {
+  const preview = batch.preview?.preview;
+  if (!preview) {
+    throw new Error('Operator preview payload is required.');
+  }
+  const dryRun = batch.dryRun?.dry_run;
+  const candidates = Array.isArray(dryRun?.candidates) ? dryRun.candidates : [];
   const readinessByEventIndexId = new Map(
-    batch.dryRun.dry_run.candidates.map((candidate) => [
-      candidate.eventIndexId,
-      candidate.readiness,
-    ])
+    candidates.map((candidate) => [candidate.eventIndexId, candidate.readiness])
   );
-  const preview = batch.preview.preview;
+  const events = Array.isArray(preview.events) ? preview.events : [];
 
   return {
     cursor: {
-      cursorName: preview.cursorName,
-      connector: preview.connector,
-      channel: preview.channel,
-      advancedThroughSeq: preview.advancedThroughSeq,
-      status: batch.dryRun.dry_run.status,
-      candidateCount: batch.dryRun.dry_run.candidateCount,
+      cursorName: stringOrEmpty(preview.cursorName),
+      connector: stringOrEmpty(preview.connector),
+      channel: stringOrEmpty(preview.channel),
+      advancedThroughSeq: numberOrZero(preview.advancedThroughSeq),
+      status: dryRun?.status === 'ready' ? 'ready' : 'idle',
+      candidateCount: numberOrZero(dryRun?.candidateCount),
     },
-    events: preview.events.map((event) => ({
-      seq: event.seq,
-      eventIndexId: event.eventIndexId,
+    events: events.map((event) => ({
+      seq: numberOrZero(event.seq),
+      eventIndexId: stringOrEmpty(event.eventIndexId),
       sourceRefText: sourceRefText(event.sourceRef),
-      sourceId: event.sourceId,
-      channel: event.channel,
-      sourceTimestampMs: event.sourceTimestampMs,
+      sourceId: stringOrEmpty(event.sourceId),
+      channel: typeof event.channel === 'string' ? event.channel : null,
+      sourceTimestampMs: requiredFiniteNumber(event.sourceTimestampMs, 'sourceTimestampMs'),
       readiness: readinessByEventIndexId.get(event.eventIndexId) ?? 'requires_decision',
     })),
   };

--- a/packages/standalone/public/viewer/src/modules/operator-cockpit.ts
+++ b/packages/standalone/public/viewer/src/modules/operator-cockpit.ts
@@ -1,0 +1,678 @@
+/**
+ * vNext Operator Cockpit
+ *
+ * Thin viewer/client layer over primary-operator ingress endpoints.
+ * Keep this module projection-only: no canonical state, no raw connector payloads.
+ */
+
+/* eslint-env browser */
+
+import { API } from '../utils/api.js';
+
+export interface OperatorCockpitScope {
+  connector: string;
+  channel: string;
+  limit?: number;
+}
+
+export interface OperatorAdminAuth {
+  adminToken: string;
+}
+
+export interface OperatorSourceRef {
+  kind?: string;
+  connector?: string;
+  id?: string;
+  source_id?: string;
+  channel_id?: string | null;
+}
+
+export interface OperatorPreviewEvent {
+  seq: number;
+  eventIndexId: string;
+  sourceTimestampMs: number;
+  sourceId: string;
+  channel: string | null;
+  sourceRef: OperatorSourceRef;
+  [key: string]: unknown;
+}
+
+export interface OperatorPreviewPayload {
+  cursorName: string;
+  connector: string;
+  channel: string;
+  advancedThroughSeq: number;
+  events: OperatorPreviewEvent[];
+}
+
+export interface OperatorPreviewResponse {
+  ok: boolean;
+  mode: 'dry_run';
+  preview: OperatorPreviewPayload;
+}
+
+export interface OperatorDryRunCandidate {
+  seq: number;
+  eventIndexId: string;
+  sourceRef: OperatorSourceRef;
+  readiness: 'requires_decision';
+}
+
+export interface OperatorDryRunPayload {
+  mode?: 'dry_run';
+  status: 'idle' | 'ready';
+  cursorName?: string;
+  connector?: string;
+  channel?: string;
+  advancedThroughSeq: number;
+  candidateCount: number;
+  highestCandidateSeq?: number | null;
+  requiresOperatorDecision?: boolean;
+  durableWrites?: {
+    commits: 0;
+    cursors: 0;
+    noUpdates: 0;
+  };
+  candidates: OperatorDryRunCandidate[];
+}
+
+export interface OperatorDryRunResponse {
+  ok: boolean;
+  mode: 'dry_run';
+  dry_run: OperatorDryRunPayload;
+}
+
+export interface OperatorReviewBatch {
+  preview: OperatorPreviewResponse;
+  dryRun: OperatorDryRunResponse;
+}
+
+export interface OperatorReviewState {
+  cursor: {
+    cursorName: string;
+    connector: string;
+    channel: string;
+    advancedThroughSeq: number;
+    status: OperatorDryRunPayload['status'];
+    candidateCount: number;
+  };
+  events: Array<{
+    seq: number;
+    eventIndexId: string;
+    sourceRefText: string;
+    sourceId: string;
+    channel: string | null;
+    sourceTimestampMs: number;
+    readiness: OperatorDryRunCandidate['readiness'];
+  }>;
+}
+
+export interface NoUpdateCommitRequest {
+  connector: string;
+  channel: string;
+  expected_advanced_through_seq: number;
+  event_index_ids: string[];
+}
+
+export interface WikiCommitRequest {
+  connector: string;
+  channel: string;
+  expected_advanced_through_seq: number;
+  event_pages: Array<{
+    event_index_id: string;
+    pages: Array<{
+      path: string;
+      title: string;
+      type: string;
+      content: string;
+    }>;
+  }>;
+}
+
+export interface MemoryCommitRequest {
+  connector: string;
+  channel: string;
+  expected_advanced_through_seq: number;
+  event_memories: Array<{
+    event_index_id: string;
+    memories: Array<Record<string, unknown>>;
+  }>;
+}
+
+export interface CommitResultCommit {
+  seq: number;
+  status: string;
+  outcome: string;
+  cursorAdvanced: boolean;
+}
+
+export interface CommitResultInput {
+  ok?: boolean;
+  mode?: string;
+  status?: string;
+  cursorName?: string;
+  connector?: string;
+  channel?: string;
+  requestedCount?: number;
+  processed?: number;
+  advancedThroughSeq?: number;
+  firstSeq?: number;
+  lastSeq?: number;
+  pagesStored?: number;
+  memoriesSaved?: number;
+  commits?: CommitResultCommit[];
+  [key: string]: unknown;
+}
+
+export interface OperatorMemoryScope {
+  kind: 'channel';
+  id: string;
+}
+
+export interface CommitResultState {
+  ok: boolean;
+  mode: string;
+  status: string;
+  cursorName: string;
+  connector: string;
+  channel: string;
+  requestedCount: number;
+  processed: number;
+  advancedThroughSeq: number;
+  firstSeq: number | null;
+  lastSeq: number | null;
+  pagesStored: number | null;
+  memoriesSaved: number | null;
+  commits: CommitResultCommit[];
+}
+
+const DEFAULT_CONNECTOR = 'slack';
+const DEFAULT_CHANNEL = 'C_PUBLIC_SYNTHETIC';
+const DEFAULT_LIMIT = 25;
+
+function queryForScope(scope: OperatorCockpitScope): Record<string, string | number> {
+  const query: Record<string, string | number> = {
+    connector: scope.connector,
+    channel: scope.channel,
+  };
+  if (typeof scope.limit === 'number') {
+    query.limit = scope.limit;
+  }
+  return query;
+}
+
+function sourceRefText(ref: OperatorSourceRef): string {
+  const kind = ref.kind ?? 'raw';
+  const connector = ref.connector ?? 'unknown';
+  const id = ref.id ?? 'unknown';
+  if (kind === 'raw') {
+    return `raw:${connector}:${id}`;
+  }
+  return `${kind}:${id}`;
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function numberOrZero(value: unknown): number {
+  return numberOrNull(value) ?? 0;
+}
+
+function stringOrEmpty(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function boolOrFalse(value: unknown): boolean {
+  return typeof value === 'boolean' ? value : false;
+}
+
+function esc(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function sanitizeCommits(value: unknown): CommitResultCommit[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((commit) => {
+    const row = commit && typeof commit === 'object' ? (commit as Record<string, unknown>) : {};
+    return {
+      seq: numberOrZero(row.seq),
+      status: stringOrEmpty(row.status),
+      outcome: stringOrEmpty(row.outcome),
+      cursorAdvanced: boolOrFalse(row.cursorAdvanced),
+    };
+  });
+}
+
+function adminRequestOptions(auth: OperatorAdminAuth): { headers: Record<string, string> } {
+  const token = auth.adminToken.trim();
+  if (token.length === 0) {
+    throw new Error('Admin token is required for operator commits.');
+  }
+  return { headers: { Authorization: `Bearer ${token}` } };
+}
+
+export function buildOperatorMemoryScopes(
+  connector: string,
+  channel: string
+): OperatorMemoryScope[] {
+  const connectorPart = connector.trim() || DEFAULT_CONNECTOR;
+  const channelPart = channel.trim() || DEFAULT_CHANNEL;
+  return [{ kind: 'channel', id: `${connectorPart}:${channelPart}` }];
+}
+
+export class OperatorCockpitController {
+  async fetchReviewBatch(scope: OperatorCockpitScope): Promise<OperatorReviewBatch> {
+    const query = queryForScope(scope);
+    const [preview, dryRun] = await Promise.all([
+      API.get<OperatorPreviewResponse>('/api/vnext/ingress/preview', query),
+      API.get<OperatorDryRunResponse>('/api/vnext/ingress/migration-dry-run', query),
+    ]);
+    return { preview, dryRun };
+  }
+
+  async commitNoUpdate(
+    body: NoUpdateCommitRequest,
+    auth: OperatorAdminAuth
+  ): Promise<CommitResultInput> {
+    return API.post<CommitResultInput>(
+      '/api/vnext/ingress/manual-no-update-commit',
+      body,
+      adminRequestOptions(auth)
+    );
+  }
+
+  async commitWiki(body: WikiCommitRequest, auth: OperatorAdminAuth): Promise<CommitResultInput> {
+    return API.post<CommitResultInput>(
+      '/api/vnext/ingress/manual-wiki-commit',
+      body,
+      adminRequestOptions(auth)
+    );
+  }
+
+  async commitMemory(
+    body: MemoryCommitRequest,
+    auth: OperatorAdminAuth
+  ): Promise<CommitResultInput> {
+    return API.post<CommitResultInput>(
+      '/api/vnext/ingress/manual-memory-commit',
+      body,
+      adminRequestOptions(auth)
+    );
+  }
+}
+
+export function renderOperatorCockpitShell(): string {
+  return `
+    <div class="operator-cockpit-shell">
+      <form id="operator-cockpit-form" class="operator-cockpit-form">
+        <label>
+          <span>Connector</span>
+          <input name="connector" value="${DEFAULT_CONNECTOR}" autocomplete="off" />
+        </label>
+        <label>
+          <span>Channel</span>
+          <input name="channel" value="${DEFAULT_CHANNEL}" autocomplete="off" />
+        </label>
+        <label>
+          <span>Limit</span>
+          <input name="limit" type="number" min="1" max="100" value="${DEFAULT_LIMIT}" />
+        </label>
+        <label>
+          <span>Admin token</span>
+          <input
+            name="admin-token"
+            type="password"
+            autocomplete="off"
+            spellcheck="false"
+            placeholder="MAMA_ADMIN_TOKEN"
+          />
+        </label>
+        <button type="submit" class="operator-cockpit-refresh">Refresh</button>
+      </form>
+      <div id="operator-cockpit-batch" class="operator-cockpit-batch"></div>
+      <div id="operator-cockpit-result" class="operator-cockpit-result-slot"></div>
+    </div>
+  `;
+}
+
+export function renderOperatorError(message: string, _error?: unknown): string {
+  return `<div class="operator-cockpit-error">${esc(message)}</div>`;
+}
+
+function readTextInput(root: ParentNode, selector: string): string {
+  const input = root.querySelector(selector);
+  return input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement
+    ? input.value.trim()
+    : '';
+}
+
+function readNumberInput(root: ParentNode, selector: string, fallback: number): number {
+  const input = root.querySelector(selector);
+  if (!(input instanceof HTMLInputElement)) {
+    return fallback;
+  }
+  const value = Number(input.value);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+export class OperatorCockpitModule {
+  private readonly controller: OperatorCockpitController;
+  private container: HTMLElement | null = null;
+  private currentState: OperatorReviewState | null = null;
+
+  constructor(controller = new OperatorCockpitController()) {
+    this.controller = controller;
+  }
+
+  init(): void {
+    this.container = document.getElementById('operator-cockpit-content');
+    if (!this.container) {
+      return;
+    }
+    this.container.innerHTML = renderOperatorCockpitShell();
+    this.bindForm();
+  }
+
+  private bindForm(): void {
+    const form = this.container?.querySelector('#operator-cockpit-form');
+    if (!(form instanceof HTMLFormElement)) {
+      return;
+    }
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      void this.loadBatch();
+    });
+  }
+
+  private readScope(): OperatorCockpitScope {
+    const root = this.container ?? document;
+    return {
+      connector: readTextInput(root, 'input[name="connector"]') || DEFAULT_CONNECTOR,
+      channel: readTextInput(root, 'input[name="channel"]') || DEFAULT_CHANNEL,
+      limit: readNumberInput(root, 'input[name="limit"]', DEFAULT_LIMIT),
+    };
+  }
+
+  private readAdminAuth(): OperatorAdminAuth {
+    const root = this.container ?? document;
+    return { adminToken: readTextInput(root, 'input[name="admin-token"]') };
+  }
+
+  private async loadBatch(options: { clearResult?: boolean } = {}): Promise<void> {
+    const clearResult = options.clearResult ?? true;
+    const batchSlot = this.container?.querySelector('#operator-cockpit-batch');
+    const resultSlot = this.container?.querySelector('#operator-cockpit-result');
+    if (!(batchSlot instanceof HTMLElement)) {
+      return;
+    }
+    if (clearResult && resultSlot instanceof HTMLElement) {
+      resultSlot.innerHTML = '';
+    }
+    batchSlot.innerHTML = '<div class="operator-cockpit-empty">Loading...</div>';
+
+    try {
+      const batch = await this.controller.fetchReviewBatch(this.readScope());
+      this.currentState = buildOperatorReviewState(batch);
+      batchSlot.innerHTML = renderOperatorReviewState(this.currentState);
+      this.bindCommitActions();
+    } catch (error) {
+      batchSlot.innerHTML = renderOperatorError('Operator review failed.', error);
+    }
+  }
+
+  private bindCommitActions(): void {
+    this.container?.querySelectorAll('[data-action][data-event-index-id]').forEach((button) => {
+      button.addEventListener('click', () => {
+        if (!(button instanceof HTMLElement)) {
+          return;
+        }
+        const eventIndexId = button.dataset.eventIndexId;
+        const action = button.dataset.action;
+        if (!eventIndexId || !action) {
+          return;
+        }
+        void this.commitEvent(action, eventIndexId, button.closest('.operator-cockpit-row'));
+      });
+    });
+  }
+
+  private async commitEvent(
+    action: string,
+    eventIndexId: string,
+    row: Element | null
+  ): Promise<void> {
+    const state = this.currentState;
+    const resultSlot = this.container?.querySelector('#operator-cockpit-result');
+    if (!state || !(resultSlot instanceof HTMLElement)) {
+      return;
+    }
+    resultSlot.innerHTML = '<div class="operator-cockpit-empty">Committing...</div>';
+    const base = {
+      connector: state.cursor.connector,
+      channel: state.cursor.channel,
+      expected_advanced_through_seq: state.cursor.advancedThroughSeq,
+    };
+
+    try {
+      let result: CommitResultInput;
+      const auth = this.readAdminAuth();
+      if (action === 'no_update') {
+        result = await this.controller.commitNoUpdate(
+          {
+            ...base,
+            event_index_ids: [eventIndexId],
+          },
+          auth
+        );
+      } else if (action === 'wiki') {
+        result = await this.controller.commitWiki(
+          {
+            ...base,
+            event_pages: [
+              {
+                event_index_id: eventIndexId,
+                pages: [
+                  {
+                    path: readTextInput(row ?? document, '[data-field="wiki-path"]'),
+                    title: readTextInput(row ?? document, '[data-field="wiki-title"]'),
+                    type: 'entity',
+                    content: readTextInput(row ?? document, '[data-field="wiki-content"]'),
+                  },
+                ],
+              },
+            ],
+          },
+          auth
+        );
+      } else if (action === 'memory') {
+        result = await this.controller.commitMemory(
+          {
+            ...base,
+            event_memories: [
+              {
+                event_index_id: eventIndexId,
+                memories: [
+                  {
+                    topic: readTextInput(row ?? document, '[data-field="memory-topic"]'),
+                    kind: 'decision',
+                    summary: readTextInput(row ?? document, '[data-field="memory-summary"]'),
+                    details: readTextInput(row ?? document, '[data-field="memory-details"]'),
+                    confidence: 0.8,
+                    scopes: buildOperatorMemoryScopes(state.cursor.connector, state.cursor.channel),
+                  },
+                ],
+              },
+            ],
+          },
+          auth
+        );
+      } else {
+        throw new Error(`Unknown operator action: ${action}`);
+      }
+
+      const resultState = buildCommitResultState(result);
+      await this.loadBatch({ clearResult: false });
+      resultSlot.innerHTML = renderCommitResultState(resultState);
+    } catch (error) {
+      resultSlot.innerHTML = renderOperatorError('Operator commit failed.', error);
+    }
+  }
+}
+
+export function buildOperatorReviewState(batch: OperatorReviewBatch): OperatorReviewState {
+  const readinessByEventIndexId = new Map(
+    batch.dryRun.dry_run.candidates.map((candidate) => [
+      candidate.eventIndexId,
+      candidate.readiness,
+    ])
+  );
+  const preview = batch.preview.preview;
+
+  return {
+    cursor: {
+      cursorName: preview.cursorName,
+      connector: preview.connector,
+      channel: preview.channel,
+      advancedThroughSeq: preview.advancedThroughSeq,
+      status: batch.dryRun.dry_run.status,
+      candidateCount: batch.dryRun.dry_run.candidateCount,
+    },
+    events: preview.events.map((event) => ({
+      seq: event.seq,
+      eventIndexId: event.eventIndexId,
+      sourceRefText: sourceRefText(event.sourceRef),
+      sourceId: event.sourceId,
+      channel: event.channel,
+      sourceTimestampMs: event.sourceTimestampMs,
+      readiness: readinessByEventIndexId.get(event.eventIndexId) ?? 'requires_decision',
+    })),
+  };
+}
+
+export function buildCommitResultState(input: CommitResultInput): CommitResultState {
+  return {
+    ok: boolOrFalse(input.ok),
+    mode: stringOrEmpty(input.mode),
+    status: stringOrEmpty(input.status),
+    cursorName: stringOrEmpty(input.cursorName),
+    connector: stringOrEmpty(input.connector),
+    channel: stringOrEmpty(input.channel),
+    requestedCount: numberOrZero(input.requestedCount),
+    processed: numberOrZero(input.processed),
+    advancedThroughSeq: numberOrZero(input.advancedThroughSeq),
+    firstSeq: numberOrNull(input.firstSeq),
+    lastSeq: numberOrNull(input.lastSeq),
+    pagesStored: numberOrNull(input.pagesStored),
+    memoriesSaved: numberOrNull(input.memoriesSaved),
+    commits: sanitizeCommits(input.commits),
+  };
+}
+
+export function renderOperatorReviewState(state: OperatorReviewState): string {
+  const eventRows =
+    state.events.length === 0
+      ? '<div class="operator-cockpit-empty">No reviewed events.</div>'
+      : state.events
+          .map(
+            (event) => `
+              <article class="operator-cockpit-row" data-event-index-id="${esc(event.eventIndexId)}">
+                <div class="operator-cockpit-row-main">
+                  <div class="operator-cockpit-seq">Seq ${esc(event.seq)}</div>
+                  <div class="operator-cockpit-source">${esc(event.sourceRefText)}</div>
+                  <div class="operator-cockpit-meta">
+                    <span>${esc(event.readiness)}</span>
+                    <span>${esc(event.channel ?? 'no-channel')}</span>
+                    <span>${esc(event.sourceId)}</span>
+                  </div>
+                </div>
+                <div class="operator-cockpit-actions">
+                  <button type="button" data-action="no_update" data-event-index-id="${esc(
+                    event.eventIndexId
+                  )}">No update</button>
+                  <button type="button" data-action="wiki" data-event-index-id="${esc(
+                    event.eventIndexId
+                  )}">Wiki</button>
+                  <button type="button" data-action="memory" data-event-index-id="${esc(
+                    event.eventIndexId
+                  )}">Memory</button>
+                </div>
+                <div class="operator-cockpit-editors">
+                  <div>
+                    <input data-field="wiki-path" value="projects/operator-${esc(event.seq)}.md" />
+                    <input data-field="wiki-title" value="Operator ${esc(event.seq)}" />
+                    <textarea data-field="wiki-content">Reviewed event ${esc(event.seq)}</textarea>
+                  </div>
+                  <div>
+                    <input data-field="memory-topic" value="operator/event-${esc(event.seq)}" />
+                    <input data-field="memory-summary" value="Reviewed event ${esc(event.seq)}" />
+                    <textarea data-field="memory-details">Operator reviewed ${esc(
+                      event.sourceRefText
+                    )}</textarea>
+                  </div>
+                </div>
+              </article>
+            `
+          )
+          .join('');
+
+  return `
+    <section class="operator-cockpit-panel">
+      <header class="operator-cockpit-header">
+        <div>
+          <h2>Operator</h2>
+          <p>${esc(state.cursor.connector)} / ${esc(state.cursor.channel)}</p>
+        </div>
+        <div class="operator-cockpit-cursor">
+          <span>${esc(state.cursor.cursorName)}</span>
+          <strong>${esc(state.cursor.advancedThroughSeq)}</strong>
+        </div>
+      </header>
+      <div class="operator-cockpit-summary">
+        <span>${esc(state.cursor.status)}</span>
+        <span>${esc(state.cursor.candidateCount)} candidates</span>
+      </div>
+      <div class="operator-cockpit-list">${eventRows}</div>
+    </section>
+  `;
+}
+
+export function renderCommitResultState(state: CommitResultState): string {
+  const commits = state.commits
+    .map(
+      (commit) => `
+        <li>
+          <span>Seq ${esc(commit.seq)}</span>
+          <span>${esc(commit.status)}</span>
+          <span>${esc(commit.outcome)}</span>
+          <span>${commit.cursorAdvanced ? 'advanced' : 'held'}</span>
+        </li>
+      `
+    )
+    .join('');
+
+  return `
+    <section class="operator-cockpit-result" data-ok="${state.ok ? 'true' : 'false'}">
+      <header>
+        <strong>${esc(state.mode)}</strong>
+        <span>${esc(state.status)}</span>
+      </header>
+      <dl>
+        <dt>Cursor</dt><dd>${esc(state.cursorName)}</dd>
+        <dt>Connector</dt><dd>${esc(state.connector)}</dd>
+        <dt>Channel</dt><dd>${esc(state.channel)}</dd>
+        <dt>Processed</dt><dd>${esc(state.processed)} / ${esc(state.requestedCount)}</dd>
+        <dt>Advanced</dt><dd>${esc(state.advancedThroughSeq)}</dd>
+        <dt>Pages</dt><dd>${esc(state.pagesStored ?? 'n/a')}</dd>
+        <dt>Memories</dt><dd>${esc(state.memoriesSaved ?? 'n/a')}</dd>
+      </dl>
+      <ul>${commits}</ul>
+    </section>
+  `;
+}

--- a/packages/standalone/public/viewer/src/modules/operator-cockpit.ts
+++ b/packages/standalone/public/viewer/src/modules/operator-cockpit.ts
@@ -249,6 +249,20 @@ function esc(value: unknown): string {
     .replace(/"/g, '&quot;');
 }
 
+function errorDiagnostic(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name}: ${redactDiagnosticText(error.message)}`;
+  }
+  return `NonError:${typeof error}`;
+}
+
+function redactDiagnosticText(value: string): string {
+  return value
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+\b/gi, 'Bearer ***')
+    .replace(/\/Users\/[^\s"'<>]+/g, '/Users/***')
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '***@***');
+}
+
 function sanitizeCommits(value: unknown): CommitResultCommit[] {
   if (!Array.isArray(value)) {
     return [];
@@ -358,7 +372,7 @@ export function renderOperatorCockpitShell(): string {
 
 export function renderOperatorError(message: string, _error?: unknown): string {
   if (_error !== undefined) {
-    logger.error(message, _error);
+    logger.error(message, errorDiagnostic(_error));
   }
   return `<div class="operator-cockpit-error">${esc(message)}</div>`;
 }

--- a/packages/standalone/public/viewer/src/operator-entry.ts
+++ b/packages/standalone/public/viewer/src/operator-entry.ts
@@ -1,0 +1,14 @@
+/* eslint-env browser */
+
+import { OperatorCockpitModule } from './modules/operator-cockpit.js';
+
+const operatorCockpit = new OperatorCockpitModule();
+operatorCockpit.init();
+
+declare global {
+  interface Window {
+    operatorCockpitModule?: OperatorCockpitModule;
+  }
+}
+
+window.operatorCockpitModule = operatorCockpit;

--- a/packages/standalone/public/viewer/src/utils/api.ts
+++ b/packages/standalone/public/viewer/src/utils/api.ts
@@ -608,11 +608,11 @@ export class API {
   static async post<T = unknown, B = unknown>(
     endpoint: string,
     body: B,
-    options: ApiRequestOptions = {}
+    options: ApiRequestOptions | null = {}
   ): Promise<T> {
     const response = await fetch(endpoint, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...(options.headers ?? {}) },
+      headers: { 'Content-Type': 'application/json', ...(options?.headers ?? {}) },
       body: JSON.stringify(body),
     });
 

--- a/packages/standalone/public/viewer/src/utils/api.ts
+++ b/packages/standalone/public/viewer/src/utils/api.ts
@@ -13,6 +13,9 @@ export type QueryValue = string | number | boolean | null | undefined;
 export type QueryParams = Record<string, QueryValue>;
 export type ApiErrorPayload = { message?: string; error?: string };
 export type JsonRecord = Record<string, unknown>;
+export interface ApiRequestOptions {
+  headers?: Record<string, string>;
+}
 
 export interface GraphNode {
   id: string | number;
@@ -602,10 +605,14 @@ export class API {
    * @param {Object} body - Request body
    * @returns {Promise<Object>} Response data
    */
-  static async post<T = unknown, B = unknown>(endpoint: string, body: B): Promise<T> {
+  static async post<T = unknown, B = unknown>(
+    endpoint: string,
+    body: B,
+    options: ApiRequestOptions = {}
+  ): Promise<T> {
     const response = await fetch(endpoint, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...(options.headers ?? {}) },
       body: JSON.stringify(body),
     });
 

--- a/packages/standalone/public/viewer/sw.js
+++ b/packages/standalone/public/viewer/sw.js
@@ -10,6 +10,7 @@
 const CACHE_NAME = 'mama-mobile-v1.6.1';
 const STATIC_ASSETS = [
   '/viewer',
+  '/viewer/operator.html',
   '/viewer/viewer.css',
   '/viewer/manifest.json',
   '/viewer/js/modules/graph.js',
@@ -17,6 +18,7 @@ const STATIC_ASSETS = [
   '/viewer/js/modules/memory.js',
   '/viewer/js/modules/dashboard.js',
   '/viewer/js/modules/operator-cockpit.js',
+  '/viewer/js/operator-entry.js',
   '/viewer/js/modules/settings.js',
   '/viewer/js/utils/dom.js',
   '/viewer/js/utils/format.js',

--- a/packages/standalone/public/viewer/sw.js
+++ b/packages/standalone/public/viewer/sw.js
@@ -7,7 +7,7 @@
 
 /* eslint-env serviceworker */
 
-const CACHE_NAME = 'mama-mobile-v1.6.0';
+const CACHE_NAME = 'mama-mobile-v1.6.1';
 const STATIC_ASSETS = [
   '/viewer',
   '/viewer/viewer.css',
@@ -16,6 +16,7 @@ const STATIC_ASSETS = [
   '/viewer/js/modules/chat.js',
   '/viewer/js/modules/memory.js',
   '/viewer/js/modules/dashboard.js',
+  '/viewer/js/modules/operator-cockpit.js',
   '/viewer/js/modules/settings.js',
   '/viewer/js/utils/dom.js',
   '/viewer/js/utils/format.js',

--- a/packages/standalone/public/viewer/viewer.css
+++ b/packages/standalone/public/viewer/viewer.css
@@ -994,6 +994,43 @@ body,
   max-width: 1120px;
 }
 
+.operator-cockpit-page {
+  min-height: 100vh;
+  margin: 0;
+  background: #f9f7f4;
+  color: #131313;
+  font-family: Inter, 'Noto Sans KR', 'Noto Sans JP', sans-serif;
+}
+
+.operator-cockpit-page-main {
+  width: min(1180px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 24px 0 40px;
+}
+
+.operator-cockpit-page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.operator-cockpit-page-header a {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: #131313;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.operator-cockpit-page-header strong {
+  font-size: 13px;
+  letter-spacing: 0;
+  color: #625b52;
+}
+
 .operator-cockpit-form {
   display: grid;
   grid-template-columns: minmax(140px, 0.9fr) minmax(160px, 1fr) 88px minmax(160px, 1fr) auto;

--- a/packages/standalone/public/viewer/viewer.css
+++ b/packages/standalone/public/viewer/viewer.css
@@ -987,6 +987,241 @@ body,
   box-shadow: none;
 }
 
+.operator-cockpit-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 1120px;
+}
+
+.operator-cockpit-form {
+  display: grid;
+  grid-template-columns: minmax(140px, 0.9fr) minmax(160px, 1fr) 88px minmax(160px, 1fr) auto;
+  gap: 8px;
+  align-items: end;
+  padding: 12px;
+  border: 1px solid #ede9e1;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.operator-cockpit-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #6b6560;
+}
+
+.operator-cockpit-form input,
+.operator-cockpit-editors input,
+.operator-cockpit-editors textarea {
+  width: 100%;
+  border: 1px solid #ded8cf;
+  border-radius: 6px;
+  background: #fff;
+  color: #1a1a1a;
+  font-size: 12px;
+  line-height: 1.4;
+  padding: 7px 8px;
+}
+
+.operator-cockpit-form input:focus,
+.operator-cockpit-editors input:focus,
+.operator-cockpit-editors textarea:focus {
+  outline: 2px solid rgba(255, 206, 0, 0.35);
+  border-color: #c5aa21;
+}
+
+.operator-cockpit-refresh,
+.operator-cockpit-actions button {
+  border: 1px solid #1a1a1a;
+  border-radius: 6px;
+  background: #1a1a1a;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 7px 10px;
+}
+
+.operator-cockpit-actions button[data-action='wiki'] {
+  background: #fef9e7;
+  color: #1a1a1a;
+  border-color: #e0c33a;
+}
+
+.operator-cockpit-actions button[data-action='memory'] {
+  background: #edf7f2;
+  color: #183b2b;
+  border-color: #8fc7a8;
+}
+
+.operator-cockpit-panel,
+.operator-cockpit-result {
+  border: 1px solid #ede9e1;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.operator-cockpit-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px;
+  border-bottom: 1px solid #ede9e1;
+}
+
+.operator-cockpit-header h2 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.operator-cockpit-header p,
+.operator-cockpit-meta,
+.operator-cockpit-summary,
+.operator-cockpit-cursor span {
+  color: #6b6560;
+  font-size: 12px;
+}
+
+.operator-cockpit-cursor {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+}
+
+.operator-cockpit-cursor strong {
+  font-size: 20px;
+}
+
+.operator-cockpit-summary {
+  display: flex;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid #ede9e1;
+}
+
+.operator-cockpit-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.operator-cockpit-row {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) auto;
+  gap: 12px;
+  padding: 12px 14px;
+  border-bottom: 1px solid #f2eee7;
+}
+
+.operator-cockpit-row:last-child {
+  border-bottom: none;
+}
+
+.operator-cockpit-seq {
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.operator-cockpit-source {
+  margin-top: 3px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: #1a1a1a;
+  overflow-wrap: anywhere;
+}
+
+.operator-cockpit-meta,
+.operator-cockpit-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.operator-cockpit-editors {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(240px, 1fr));
+  gap: 10px;
+}
+
+.operator-cockpit-editors > div {
+  display: grid;
+  gap: 6px;
+}
+
+.operator-cockpit-editors textarea {
+  min-height: 68px;
+  resize: vertical;
+}
+
+.operator-cockpit-result {
+  padding: 12px 14px;
+}
+
+.operator-cockpit-result header {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.operator-cockpit-result dl {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 4px 10px;
+  font-size: 12px;
+}
+
+.operator-cockpit-result dt {
+  color: #6b6560;
+}
+
+.operator-cockpit-result ul {
+  margin: 10px 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 4px;
+}
+
+.operator-cockpit-result li {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.operator-cockpit-empty,
+.operator-cockpit-error {
+  padding: 24px;
+  text-align: center;
+  color: #6b6560;
+  font-size: 13px;
+}
+
+.operator-cockpit-error {
+  color: #b42318;
+}
+
+@media (max-width: 768px) {
+  .operator-cockpit-form,
+  .operator-cockpit-row,
+  .operator-cockpit-editors {
+    grid-template-columns: 1fr;
+  }
+
+  .operator-cockpit-header {
+    flex-direction: column;
+  }
+
+  .operator-cockpit-cursor {
+    align-items: flex-start;
+  }
+}
+
 /* ============================================================================
    FLOATING BLOB DECORATIONS (Optional - for special sections)
    ============================================================================ */

--- a/packages/standalone/public/viewer/viewer.html
+++ b/packages/standalone/public/viewer/viewer.html
@@ -214,6 +214,7 @@
         font-family: 'Inter', 'Noto Sans KR', sans-serif;
         font-size: 13px;
         font-weight: 600;
+        text-decoration: none;
         cursor: pointer;
         transition:
           background 0.15s ease,
@@ -280,6 +281,7 @@
         color: #6b6560;
         font-size: 10px;
         font-weight: 600;
+        text-decoration: none;
         font-family: 'Inter', 'Noto Sans KR', sans-serif;
         cursor: pointer;
         transition: color 0.15s ease;
@@ -444,14 +446,10 @@
             <i data-lucide="rss"></i>
             <span>Feed</span>
           </button>
-          <button
-            class="mama-nav-item"
-            data-tab="operator"
-            onclick="window.switchTab && window.switchTab('operator')"
-          >
+          <a class="mama-nav-item" href="/viewer/operator.html" target="_blank" rel="noopener">
             <i data-lucide="clipboard-check"></i>
             <span>Operator</span>
-          </button>
+          </a>
           <button
             class="mama-nav-item"
             data-tab="wiki"
@@ -521,13 +519,6 @@
                   Loading connectors...
                 </div>
               </div>
-            </div>
-          </div>
-
-          <!-- Operator Tab -->
-          <div class="tab-content" id="tab-operator">
-            <div class="flex-1 flex flex-col min-h-0 overflow-y-auto p-4 md:p-6">
-              <div id="operator-cockpit-content"></div>
             </div>
           </div>
 
@@ -1550,13 +1541,9 @@
           >
             <i data-lucide="rss"></i><span>Feed</span>
           </button>
-          <button
-            class="mama-mobile-tab"
-            data-tab="operator"
-            onclick="window.switchTab && window.switchTab('operator')"
-          >
+          <a class="mama-mobile-tab" href="/viewer/operator.html" target="_blank" rel="noopener">
             <i data-lucide="clipboard-check"></i><span>Operator</span>
-          </button>
+          </a>
           <button
             class="mama-mobile-tab"
             data-tab="wiki"
@@ -1952,7 +1939,6 @@ export MAMA_AUTH_TOKEN="your-secure-token-here"</pre
       import { DashboardModule } from '/viewer/js/modules/dashboard.js';
       import { SettingsModule } from '/viewer/js/modules/settings.js';
       import { ConnectorFeedModule } from '/viewer/js/modules/connector-feed.js';
-      import { OperatorCockpitModule } from '/viewer/js/modules/operator-cockpit.js';
       import { WikiModule } from '/viewer/js/modules/wiki.js';
       import { AgentsModule } from '/viewer/js/modules/agents.js';
       import { API } from '/viewer/js/utils/api.js';
@@ -1964,7 +1950,6 @@ export MAMA_AUTH_TOKEN="your-secure-token-here"</pre
       const dashboard = new DashboardModule();
       const settings = new SettingsModule();
       const connectorFeed = new ConnectorFeedModule();
-      const operatorCockpit = new OperatorCockpitModule();
       const wiki = new WikiModule();
       const agentsModule = new AgentsModule();
 
@@ -2047,7 +2032,6 @@ export MAMA_AUTH_TOKEN="your-secure-token-here"</pre
       window.memoryModule = memory;
       window.dashboardModule = dashboard;
       window.settingsModule = settings;
-      window.operatorCockpitModule = operatorCockpit;
 
       // Quiz choice button handler
       window.sendQuizChoice = (choice) => {
@@ -2067,7 +2051,7 @@ export MAMA_AUTH_TOKEN="your-secure-token-here"</pre
         const moreMenu = document.getElementById('mama-mobile-more');
         if (moreMenu) moreMenu.style.display = 'none';
         const moreBtn = document.querySelector('#mama-mobile-tabs [data-tab="more"]');
-        const overflowTabs = ['feed', 'operator', 'wiki', 'logs', 'settings'];
+        const overflowTabs = ['feed', 'wiki', 'logs', 'settings'];
         if (moreBtn) {
           moreBtn.classList.toggle('mama-nav-active', overflowTabs.includes(tabName));
         }
@@ -2161,9 +2145,6 @@ export MAMA_AUTH_TOKEN="your-secure-token-here"</pre
           publishBasicTabContext();
         } else if (tabName === 'feed') {
           connectorFeed.init();
-          publishBasicTabContext();
-        } else if (tabName === 'operator') {
-          operatorCockpit.init();
           publishBasicTabContext();
         } else if (tabName === 'agents') {
           agentsModule.init();

--- a/packages/standalone/public/viewer/viewer.html
+++ b/packages/standalone/public/viewer/viewer.html
@@ -446,6 +446,14 @@
           </button>
           <button
             class="mama-nav-item"
+            data-tab="operator"
+            onclick="window.switchTab && window.switchTab('operator')"
+          >
+            <i data-lucide="clipboard-check"></i>
+            <span>Operator</span>
+          </button>
+          <button
+            class="mama-nav-item"
             data-tab="wiki"
             onclick="window.switchTab && window.switchTab('wiki')"
           >
@@ -513,6 +521,13 @@
                   Loading connectors...
                 </div>
               </div>
+            </div>
+          </div>
+
+          <!-- Operator Tab -->
+          <div class="tab-content" id="tab-operator">
+            <div class="flex-1 flex flex-col min-h-0 overflow-y-auto p-4 md:p-6">
+              <div id="operator-cockpit-content"></div>
             </div>
           </div>
 
@@ -1537,6 +1552,13 @@
           </button>
           <button
             class="mama-mobile-tab"
+            data-tab="operator"
+            onclick="window.switchTab && window.switchTab('operator')"
+          >
+            <i data-lucide="clipboard-check"></i><span>Operator</span>
+          </button>
+          <button
+            class="mama-mobile-tab"
             data-tab="wiki"
             onclick="window.switchTab && window.switchTab('wiki')"
           >
@@ -1930,6 +1952,7 @@ export MAMA_AUTH_TOKEN="your-secure-token-here"</pre
       import { DashboardModule } from '/viewer/js/modules/dashboard.js';
       import { SettingsModule } from '/viewer/js/modules/settings.js';
       import { ConnectorFeedModule } from '/viewer/js/modules/connector-feed.js';
+      import { OperatorCockpitModule } from '/viewer/js/modules/operator-cockpit.js';
       import { WikiModule } from '/viewer/js/modules/wiki.js';
       import { AgentsModule } from '/viewer/js/modules/agents.js';
       import { API } from '/viewer/js/utils/api.js';
@@ -1941,6 +1964,7 @@ export MAMA_AUTH_TOKEN="your-secure-token-here"</pre
       const dashboard = new DashboardModule();
       const settings = new SettingsModule();
       const connectorFeed = new ConnectorFeedModule();
+      const operatorCockpit = new OperatorCockpitModule();
       const wiki = new WikiModule();
       const agentsModule = new AgentsModule();
 
@@ -2023,6 +2047,7 @@ export MAMA_AUTH_TOKEN="your-secure-token-here"</pre
       window.memoryModule = memory;
       window.dashboardModule = dashboard;
       window.settingsModule = settings;
+      window.operatorCockpitModule = operatorCockpit;
 
       // Quiz choice button handler
       window.sendQuizChoice = (choice) => {
@@ -2042,7 +2067,7 @@ export MAMA_AUTH_TOKEN="your-secure-token-here"</pre
         const moreMenu = document.getElementById('mama-mobile-more');
         if (moreMenu) moreMenu.style.display = 'none';
         const moreBtn = document.querySelector('#mama-mobile-tabs [data-tab="more"]');
-        const overflowTabs = ['feed', 'wiki', 'logs', 'settings'];
+        const overflowTabs = ['feed', 'operator', 'wiki', 'logs', 'settings'];
         if (moreBtn) {
           moreBtn.classList.toggle('mama-nav-active', overflowTabs.includes(tabName));
         }
@@ -2136,6 +2161,9 @@ export MAMA_AUTH_TOKEN="your-secure-token-here"</pre
           publishBasicTabContext();
         } else if (tabName === 'feed') {
           connectorFeed.init();
+          publishBasicTabContext();
+        } else if (tabName === 'operator') {
+          operatorCockpit.init();
           publishBasicTabContext();
         } else if (tabName === 'agents') {
           agentsModule.init();

--- a/packages/standalone/src/api/graph-api.ts
+++ b/packages/standalone/src/api/graph-api.ts
@@ -96,6 +96,7 @@ function getViewerDirectory(): string {
 
 const VIEWER_DIR = getViewerDirectory();
 const VIEWER_HTML_PATH = path.join(VIEWER_DIR, 'viewer.html');
+const OPERATOR_HTML_PATH = path.join(VIEWER_DIR, 'operator.html');
 const VIEWER_CSS_PATH = path.join(VIEWER_DIR, 'viewer.css');
 const SW_JS_PATH = path.join(VIEWER_DIR, 'sw.js');
 const MANIFEST_JSON_PATH = path.join(VIEWER_DIR, 'manifest.json');
@@ -106,6 +107,8 @@ const MAX_GRAPH_LIMIT = 2000;
 const GRAPH_PREVIEW_CHARS = 220;
 const SIMILAR_QUERY_DECISION_CHARS = 400;
 const CODE_ACT_RATE_LIMIT_WINDOW_MS = 60_000;
+const OPERATOR_HTML_CSP =
+  "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; base-uri 'none'; frame-ancestors 'none'; form-action 'self'";
 const CODE_ACT_RATE_LIMIT_TTL_MS = CODE_ACT_RATE_LIMIT_WINDOW_MS * 5;
 const CODE_ACT_RATE_LIMIT_DEFAULT_MAX = 30;
 const codeActRateBuckets = new Map<
@@ -533,7 +536,12 @@ function filterEdgesByNodes(edges: GraphEdge[], nodes: GraphNode[]): GraphEdge[]
   return edges.filter((e) => nodeIds.has(e.from) || nodeIds.has(e.to));
 }
 
-function serveStaticFile(res: ServerResponse, filePath: string, contentType: string): void {
+function serveStaticFile(
+  res: ServerResponse,
+  filePath: string,
+  contentType: string,
+  extraHeaders: Record<string, string> = {}
+): void {
   try {
     const stats = fs.statSync(filePath);
     if (!stats.isFile()) {
@@ -551,6 +559,7 @@ function serveStaticFile(res: ServerResponse, filePath: string, contentType: str
       Pragma: 'no-cache',
       Expires: '0',
       ETag: etag,
+      ...extraHeaders,
     });
     res.end(content);
   } catch (error: unknown) {
@@ -569,6 +578,12 @@ function serveStaticFile(res: ServerResponse, filePath: string, contentType: str
 
 function handleViewerRequest(_req: IncomingMessage, res: ServerResponse): void {
   serveStaticFile(res, VIEWER_HTML_PATH, 'text/html');
+}
+
+function handleOperatorRequest(_req: IncomingMessage, res: ServerResponse): void {
+  serveStaticFile(res, OPERATOR_HTML_PATH, 'text/html', {
+    'Content-Security-Policy': OPERATOR_HTML_CSP,
+  });
 }
 
 function handleCssRequest(_req: IncomingMessage, res: ServerResponse): void {
@@ -1303,6 +1318,13 @@ function createGraphHandler(options: GraphHandlerOptions = {}): GraphHandlerFn {
       return true;
     }
 
+    // Route: GET/HEAD /viewer/operator.html - serve isolated operator console
+    if (pathname === '/viewer/operator.html' && (req.method === 'GET' || req.method === 'HEAD')) {
+      console.log('[GraphHandler] Serving operator.html');
+      handleOperatorRequest(req, res);
+      return true;
+    }
+
     // Route: GET/HEAD /viewer/viewer.css - serve stylesheet
     if (pathname === '/viewer/viewer.css' && (req.method === 'GET' || req.method === 'HEAD')) {
       handleCssRequest(req, res);
@@ -1365,6 +1387,20 @@ function createGraphHandler(options: GraphHandlerOptions = {}): GraphHandlerFn {
     ) {
       const fileName = pathname.split('/').pop()!;
       const filePath = path.join(VIEWER_DIR, 'js', 'utils', fileName);
+      serveStaticFile(res, filePath, 'application/javascript');
+      return true;
+    }
+
+    // Route: GET/HEAD /viewer/js/*.js - serve first-party viewer entry modules
+    if (
+      pathname.startsWith('/viewer/js/') &&
+      !pathname.includes('/modules/') &&
+      !pathname.includes('/utils/') &&
+      pathname.endsWith('.js') &&
+      (req.method === 'GET' || req.method === 'HEAD')
+    ) {
+      const fileName = pathname.split('/').pop()!;
+      const filePath = path.join(VIEWER_DIR, 'js', fileName);
       serveStaticFile(res, filePath, 'application/javascript');
       return true;
     }
@@ -4172,6 +4208,8 @@ export {
   filterNodesByTopic,
   filterEdgesByNodes,
   VIEWER_HTML_PATH,
+  OPERATOR_HTML_PATH,
+  OPERATOR_HTML_CSP,
   VIEWER_CSS_PATH,
 };
 

--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -1432,10 +1432,16 @@ Keep the report under 2000 characters as it will be sent to Discord.`;
 
   apiServer.app.use(
     express.static(publicDir, {
-      setHeaders: (res) => {
+      setHeaders: (res, filePath) => {
         res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
         res.setHeader('Pragma', 'no-cache');
         res.setHeader('Expires', '0');
+        if (filePath.endsWith(path.join('viewer', 'operator.html'))) {
+          res.setHeader(
+            'Content-Security-Policy',
+            "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; base-uri 'none'; frame-ancestors 'none'; form-action 'self'"
+          );
+        }
       },
     })
   );

--- a/packages/standalone/tests/api/graph-api.test.ts
+++ b/packages/standalone/tests/api/graph-api.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import type { IncomingMessage, ServerResponse } from 'http';
+import { dirname } from 'path';
+import { existsSync, mkdirSync, rmSync, rmdirSync, writeFileSync } from 'fs';
+import { fileURLToPath } from 'url';
 import Database from '../../src/sqlite.js';
 import { initValidationTables, createValidationSession } from '../../src/validation/store.js';
 import * as validationStore from '../../src/validation/store.js';
@@ -15,6 +18,37 @@ import {
   validateConfigUpdate,
   createGraphHandler,
 } from '../../src/api/graph-api.js';
+
+const OPERATOR_ENTRY_JS_PATH = fileURLToPath(
+  new URL('../../public/viewer/js/operator-entry.js', import.meta.url)
+);
+
+function ensureOperatorEntryFixture(): () => void {
+  if (existsSync(OPERATOR_ENTRY_JS_PATH)) {
+    return () => {};
+  }
+
+  const operatorEntryDir = dirname(OPERATOR_ENTRY_JS_PATH);
+  const hadOperatorEntryDir = existsSync(operatorEntryDir);
+
+  mkdirSync(operatorEntryDir, { recursive: true });
+  writeFileSync(
+    OPERATOR_ENTRY_JS_PATH,
+    "import { OperatorCockpitModule } from './modules/operator-cockpit.js';\n",
+    'utf8'
+  );
+
+  return () => {
+    rmSync(OPERATOR_ENTRY_JS_PATH, { force: true });
+    if (!hadOperatorEntryDir) {
+      try {
+        rmdirSync(operatorEntryDir);
+      } catch {
+        // Another test may have reused the generated asset directory.
+      }
+    }
+  };
+}
 
 describe('graph api helpers', () => {
   let db: Database;
@@ -105,6 +139,7 @@ describe('graph api helpers', () => {
       });
 
       it('serves the first-party operator entry module without falling through to auth', async () => {
+        const cleanupOperatorEntryFixture = ensureOperatorEntryFixture();
         const handler = createGraphHandler({ sessionsDb: db });
         const req = {
           method: 'GET',
@@ -114,11 +149,15 @@ describe('graph api helpers', () => {
         } as IncomingMessage;
         const res = createMockRes();
 
-        const handled = await handler(req, res as unknown as ServerResponse);
+        try {
+          const handled = await handler(req, res as unknown as ServerResponse);
 
-        expect(handled).toBe(true);
-        expect(res._status).toBe(200);
-        expect(res._body).toContain('OperatorCockpitModule');
+          expect(handled).toBe(true);
+          expect(res._status).toBe(200);
+          expect(res._body).toContain('OperatorCockpitModule');
+        } finally {
+          cleanupOperatorEntryFixture();
+        }
       });
     });
   });

--- a/packages/standalone/tests/api/graph-api.test.ts
+++ b/packages/standalone/tests/api/graph-api.test.ts
@@ -83,6 +83,46 @@ describe('graph api helpers', () => {
     expect(filtered).toEqual([{ from: 'a', to: 'b', relationship: 'builds_on', reason: null }]);
   });
 
+  describe('Story V19.15: isolated operator viewer assets', () => {
+    describe('AC #1: operator admin surface is served before the auth gate', () => {
+      it('serves operator.html with a strict CSP header', async () => {
+        const handler = createGraphHandler({ sessionsDb: db });
+        const req = {
+          method: 'GET',
+          url: '/viewer/operator.html',
+          headers: { host: 'localhost' },
+          socket: { remoteAddress: '127.0.0.1' },
+        } as IncomingMessage;
+        const res = createMockRes();
+
+        const handled = await handler(req, res as unknown as ServerResponse);
+
+        expect(handled).toBe(true);
+        expect(res._status).toBe(200);
+        expect(res._headers['Content-Security-Policy']).toContain("script-src 'self'");
+        expect(res._body).toContain('/viewer/js/operator-entry.js');
+        expect(res._body).not.toContain('https://');
+      });
+
+      it('serves the first-party operator entry module without falling through to auth', async () => {
+        const handler = createGraphHandler({ sessionsDb: db });
+        const req = {
+          method: 'GET',
+          url: '/viewer/js/operator-entry.js',
+          headers: { host: 'localhost' },
+          socket: { remoteAddress: '127.0.0.1' },
+        } as IncomingMessage;
+        const res = createMockRes();
+
+        const handled = await handler(req, res as unknown as ServerResponse);
+
+        expect(handled).toBe(true);
+        expect(res._status).toBe(200);
+        expect(res._body).toContain('OperatorCockpitModule');
+      });
+    });
+  });
+
   it('rejects validation approval when the session belongs to another agent', async () => {
     createValidationSession(db, {
       id: 'vs-foreign',
@@ -636,8 +676,9 @@ function createMockRes() {
     setHeader(name: string, value: string) {
       this._headers[name] = value;
     },
-    writeHead(status: number) {
+    writeHead(status: number, headers?: Record<string, string>) {
       this._status = status;
+      this._headers = { ...this._headers, ...(headers ?? {}) };
     },
     end(body: string) {
       this._body = body;

--- a/packages/standalone/tests/viewer/api.test.ts
+++ b/packages/standalone/tests/viewer/api.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { API } from '../../public/viewer/src/utils/api.js';
+
+describe('viewer API utility', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('allows null request options for POST calls', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await API.post('/api/test', { ok: true }, null);
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledWith('/api/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ok: true }),
+    });
+  });
+});

--- a/packages/standalone/tests/viewer/api.test.ts
+++ b/packages/standalone/tests/viewer/api.test.ts
@@ -2,27 +2,29 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { API } from '../../public/viewer/src/utils/api.js';
 
-describe('viewer API utility', () => {
+describe('Story V19.15: Viewer API request options', () => {
   beforeEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it('allows null request options for POST calls', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ ok: true }), {
-        status: 200,
+  describe('AC #1: POST request options are optional at runtime', () => {
+    it('allows null request options for POST calls', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await API.post('/api/test', { ok: true }, null);
+
+      expect(result).toEqual({ ok: true });
+      expect(fetchMock).toHaveBeenCalledWith('/api/test', {
+        method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-      })
-    );
-    vi.stubGlobal('fetch', fetchMock);
-
-    const result = await API.post('/api/test', { ok: true }, null);
-
-    expect(result).toEqual({ ok: true });
-    expect(fetchMock).toHaveBeenCalledWith('/api/test', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ok: true }),
+        body: JSON.stringify({ ok: true }),
+      });
     });
   });
 });

--- a/packages/standalone/tests/viewer/operator-cockpit.test.ts
+++ b/packages/standalone/tests/viewer/operator-cockpit.test.ts
@@ -1,0 +1,407 @@
+import { readFileSync } from 'node:fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const get = vi.fn();
+const post = vi.fn();
+
+vi.mock('../../public/viewer/src/utils/api.js', () => ({
+  API: { get, post },
+}));
+
+describe('viewer operator cockpit module', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('OperatorCockpitController.fetchReviewBatch', () => {
+    it('reads preview and migration dry-run data from existing vNext ingress endpoints', async () => {
+      get
+        .mockResolvedValueOnce({
+          ok: true,
+          mode: 'dry_run',
+          preview: {
+            cursorName: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+            connector: 'slack',
+            channel: 'C_PUBLIC_SYNTHETIC',
+            advancedThroughSeq: 0,
+            events: [],
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          mode: 'dry_run',
+          dry_run: {
+            status: 'idle',
+            candidates: [],
+            candidateCount: 0,
+            advancedThroughSeq: 0,
+          },
+        });
+
+      const { OperatorCockpitController } =
+        await import('../../public/viewer/src/modules/operator-cockpit.js');
+      const controller = new OperatorCockpitController();
+      const result = await controller.fetchReviewBatch({
+        connector: 'slack',
+        channel: 'C_PUBLIC_SYNTHETIC',
+        limit: 10,
+      });
+
+      expect(get).toHaveBeenNthCalledWith(1, '/api/vnext/ingress/preview', {
+        connector: 'slack',
+        channel: 'C_PUBLIC_SYNTHETIC',
+        limit: 10,
+      });
+      expect(get).toHaveBeenNthCalledWith(2, '/api/vnext/ingress/migration-dry-run', {
+        connector: 'slack',
+        channel: 'C_PUBLIC_SYNTHETIC',
+        limit: 10,
+      });
+      expect(result.preview.preview.cursorName).toBe('connector:slack:channel:C_PUBLIC_SYNTHETIC');
+      expect(result.dryRun.dry_run.status).toBe('idle');
+    });
+  });
+
+  describe('buildOperatorReviewState', () => {
+    it('renders only review-safe event fields', async () => {
+      const { buildOperatorReviewState } =
+        await import('../../public/viewer/src/modules/operator-cockpit.js');
+
+      const state = buildOperatorReviewState({
+        preview: {
+          ok: true,
+          mode: 'dry_run',
+          preview: {
+            cursorName: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+            connector: 'slack',
+            channel: 'C_PUBLIC_SYNTHETIC',
+            advancedThroughSeq: 7,
+            events: [
+              {
+                seq: 8,
+                eventIndexId: 'raw_synthetic_8',
+                sourceTimestampMs: 1710000001000,
+                sourceId: 'msg-8',
+                channel: 'C_PUBLIC_SYNTHETIC',
+                sourceRef: {
+                  kind: 'raw',
+                  connector: 'slack',
+                  id: 'raw_synthetic_8',
+                  source_id: 'msg-8',
+                  channel_id: 'C_PUBLIC_SYNTHETIC',
+                },
+                content: 'RAW_BODY_SHOULD_NOT_RENDER',
+                author: 'synthetic-user',
+                source_locator: 'LOCAL_PATH_SHOULD_NOT_RENDER',
+                provider_internal: { request_id: 'PROVIDER_REQUEST_SHOULD_NOT_RENDER' },
+              },
+            ],
+          },
+        },
+        dryRun: {
+          ok: true,
+          mode: 'dry_run',
+          dry_run: {
+            mode: 'dry_run',
+            status: 'ready',
+            cursorName: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+            connector: 'slack',
+            channel: 'C_PUBLIC_SYNTHETIC',
+            advancedThroughSeq: 7,
+            candidateCount: 1,
+            highestCandidateSeq: 8,
+            requiresOperatorDecision: true,
+            durableWrites: { commits: 0, cursors: 0, noUpdates: 0 },
+            candidates: [
+              {
+                seq: 8,
+                eventIndexId: 'raw_synthetic_8',
+                sourceRef: {
+                  kind: 'raw',
+                  connector: 'slack',
+                  id: 'raw_synthetic_8',
+                  source_id: 'msg-8',
+                  channel_id: 'C_PUBLIC_SYNTHETIC',
+                },
+                readiness: 'requires_decision',
+              },
+            ],
+          },
+        },
+      });
+
+      expect(state.cursor.cursorName).toBe('connector:slack:channel:C_PUBLIC_SYNTHETIC');
+      expect(state.cursor.advancedThroughSeq).toBe(7);
+      expect(state.events).toEqual([
+        {
+          seq: 8,
+          eventIndexId: 'raw_synthetic_8',
+          sourceRefText: 'raw:slack:raw_synthetic_8',
+          sourceId: 'msg-8',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          sourceTimestampMs: 1710000001000,
+          readiness: 'requires_decision',
+        },
+      ]);
+      const serialized = JSON.stringify(state);
+      expect(serialized).not.toContain('RAW_BODY_SHOULD_NOT_RENDER');
+      expect(serialized).not.toContain('LOCAL_PATH_SHOULD_NOT_RENDER');
+      expect(serialized).not.toContain('PROVIDER_REQUEST_SHOULD_NOT_RENDER');
+    });
+  });
+
+  describe('buildCommitResultState', () => {
+    it('allowlists commit response fields before rendering', async () => {
+      const { buildCommitResultState } =
+        await import('../../public/viewer/src/modules/operator-cockpit.js');
+
+      const state = buildCommitResultState({
+        ok: true,
+        mode: 'manual_memory_commit',
+        status: 'committed',
+        cursorName: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        connector: 'slack',
+        channel: 'C_PUBLIC_SYNTHETIC',
+        requestedCount: 1,
+        processed: 1,
+        advancedThroughSeq: 8,
+        firstSeq: 8,
+        lastSeq: 8,
+        memoriesSaved: 1,
+        commits: [{ seq: 8, status: 'changed', outcome: 'committed', cursorAdvanced: true }],
+        memoryIds: ['MEMORY_ID_SHOULD_NOT_RENDER'],
+        localPath: 'LOCAL_PATH_SHOULD_NOT_RENDER',
+        providerResponse: { request_id: 'PROVIDER_REQUEST_SHOULD_NOT_RENDER' },
+      });
+
+      expect(state).toEqual({
+        ok: true,
+        mode: 'manual_memory_commit',
+        status: 'committed',
+        cursorName: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        connector: 'slack',
+        channel: 'C_PUBLIC_SYNTHETIC',
+        requestedCount: 1,
+        processed: 1,
+        advancedThroughSeq: 8,
+        firstSeq: 8,
+        lastSeq: 8,
+        pagesStored: null,
+        memoriesSaved: 1,
+        commits: [{ seq: 8, status: 'changed', outcome: 'committed', cursorAdvanced: true }],
+      });
+      const serialized = JSON.stringify(state);
+      expect(serialized).not.toContain('MEMORY_ID_SHOULD_NOT_RENDER');
+      expect(serialized).not.toContain('LOCAL_PATH_SHOULD_NOT_RENDER');
+      expect(serialized).not.toContain('PROVIDER_REQUEST_SHOULD_NOT_RENDER');
+    });
+  });
+
+  describe('rendering', () => {
+    it('renders generic request errors without backend internals', async () => {
+      const { renderOperatorError } =
+        await import('../../public/viewer/src/modules/operator-cockpit.js');
+
+      const html = renderOperatorError('Operator request failed.', {
+        message: 'LOCAL_PATH_SHOULD_NOT_RENDER',
+      });
+
+      expect(html).toContain('Operator request failed.');
+      expect(html).not.toContain('LOCAL_PATH_SHOULD_NOT_RENDER');
+    });
+
+    it('renders the cockpit shell with synthetic defaults', async () => {
+      const { renderOperatorCockpitShell } =
+        await import('../../public/viewer/src/modules/operator-cockpit.js');
+
+      const html = renderOperatorCockpitShell();
+
+      expect(html).toContain('id="operator-cockpit-form"');
+      expect(html).toContain('value="slack"');
+      expect(html).toContain('value="C_PUBLIC_SYNTHETIC"');
+      expect(html).toContain('name="admin-token"');
+      expect(html).toContain('type="password"');
+      expect(html).toContain('id="operator-cockpit-batch"');
+      expect(html).toContain('id="operator-cockpit-result"');
+    });
+
+    it('renders cockpit review rows without raw connector payloads', async () => {
+      const { renderOperatorReviewState } =
+        await import('../../public/viewer/src/modules/operator-cockpit.js');
+
+      const html = renderOperatorReviewState({
+        cursor: {
+          cursorName: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          advancedThroughSeq: 7,
+          status: 'ready',
+          candidateCount: 1,
+        },
+        events: [
+          {
+            seq: 8,
+            eventIndexId: 'raw_synthetic_8',
+            sourceRefText: 'raw:slack:raw_synthetic_8',
+            sourceId: 'msg-8',
+            channel: 'C_PUBLIC_SYNTHETIC',
+            sourceTimestampMs: 1710000001000,
+            readiness: 'requires_decision',
+          },
+        ],
+      });
+
+      expect(html).toContain('connector:slack:channel:C_PUBLIC_SYNTHETIC');
+      expect(html).toContain('raw:slack:raw_synthetic_8');
+      expect(html).toContain('requires_decision');
+      expect(html).toContain('data-action="no_update"');
+      expect(html).toContain('data-action="wiki"');
+      expect(html).toContain('data-action="memory"');
+      expect(html).not.toContain('RAW_BODY_SHOULD_NOT_RENDER');
+      expect(html).not.toContain('LOCAL_PATH_SHOULD_NOT_RENDER');
+      expect(html).not.toContain('PROVIDER_REQUEST_SHOULD_NOT_RENDER');
+    });
+
+    it('renders commit results from the allowlisted state only', async () => {
+      const { renderCommitResultState } =
+        await import('../../public/viewer/src/modules/operator-cockpit.js');
+
+      const html = renderCommitResultState({
+        ok: true,
+        mode: 'manual_memory_commit',
+        status: 'committed',
+        cursorName: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+        connector: 'slack',
+        channel: 'C_PUBLIC_SYNTHETIC',
+        requestedCount: 1,
+        processed: 1,
+        advancedThroughSeq: 8,
+        firstSeq: 8,
+        lastSeq: 8,
+        pagesStored: null,
+        memoriesSaved: 1,
+        commits: [{ seq: 8, status: 'changed', outcome: 'committed', cursorAdvanced: true }],
+      });
+
+      expect(html).toContain('manual_memory_commit');
+      expect(html).toContain('committed');
+      expect(html).toContain('8');
+      expect(html).not.toContain('MEMORY_ID_SHOULD_NOT_RENDER');
+      expect(html).not.toContain('LOCAL_PATH_SHOULD_NOT_RENDER');
+      expect(html).not.toContain('PROVIDER_REQUEST_SHOULD_NOT_RENDER');
+    });
+  });
+
+  describe('manual commit actions', () => {
+    it('posts decisions to the existing primary-operator endpoints with admin auth', async () => {
+      post.mockResolvedValue({ ok: true, status: 'committed' });
+      const { OperatorCockpitController } =
+        await import('../../public/viewer/src/modules/operator-cockpit.js');
+      const controller = new OperatorCockpitController();
+      const adminAuth = { adminToken: 'ADMIN_BEARER_VALUE' };
+
+      await controller.commitNoUpdate(
+        {
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 7,
+          event_index_ids: ['raw_synthetic_8'],
+        },
+        adminAuth
+      );
+      await controller.commitWiki(
+        {
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 8,
+          event_pages: [],
+        },
+        adminAuth
+      );
+      await controller.commitMemory(
+        {
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 9,
+          event_memories: [],
+        },
+        adminAuth
+      );
+
+      const expectedOptions = { headers: { Authorization: 'Bearer ADMIN_BEARER_VALUE' } };
+      expect(post).toHaveBeenNthCalledWith(
+        1,
+        '/api/vnext/ingress/manual-no-update-commit',
+        {
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 7,
+          event_index_ids: ['raw_synthetic_8'],
+        },
+        expectedOptions
+      );
+      expect(post).toHaveBeenNthCalledWith(
+        2,
+        '/api/vnext/ingress/manual-wiki-commit',
+        {
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 8,
+          event_pages: [],
+        },
+        expectedOptions
+      );
+      expect(post).toHaveBeenNthCalledWith(
+        3,
+        '/api/vnext/ingress/manual-memory-commit',
+        {
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          expected_advanced_through_seq: 9,
+          event_memories: [],
+        },
+        expectedOptions
+      );
+    });
+
+    it('rejects manual commit calls without an explicit admin token', async () => {
+      const { OperatorCockpitController } =
+        await import('../../public/viewer/src/modules/operator-cockpit.js');
+      const controller = new OperatorCockpitController();
+
+      await expect(
+        controller.commitNoUpdate(
+          {
+            connector: 'slack',
+            channel: 'C_PUBLIC_SYNTHETIC',
+            expected_advanced_through_seq: 7,
+            event_index_ids: ['raw_synthetic_8'],
+          },
+          { adminToken: '   ' }
+        )
+      ).rejects.toThrow('Admin token is required');
+      expect(post).not.toHaveBeenCalled();
+    });
+
+    it('derives memory scopes from the active connector channel', async () => {
+      const { buildOperatorMemoryScopes } =
+        await import('../../public/viewer/src/modules/operator-cockpit.js');
+
+      expect(buildOperatorMemoryScopes('discord', 'G_PUBLIC')).toEqual([
+        { kind: 'channel', id: 'discord:G_PUBLIC' },
+      ]);
+      expect(JSON.stringify(buildOperatorMemoryScopes('discord', 'G_PUBLIC'))).not.toContain(
+        'project_public_synthetic'
+      );
+    });
+  });
+
+  describe('service worker cache', () => {
+    it('caches the operator cockpit module behind a bumped cache version', () => {
+      const sw = readFileSync(new URL('../../public/viewer/sw.js', import.meta.url), 'utf8');
+
+      expect(sw).toContain("const CACHE_NAME = 'mama-mobile-v1.6.1'");
+      expect(sw).toContain("'/viewer/js/modules/operator-cockpit.js'");
+    });
+  });
+});

--- a/packages/standalone/tests/viewer/operator-cockpit.test.ts
+++ b/packages/standalone/tests/viewer/operator-cockpit.test.ts
@@ -1,8 +1,10 @@
 import { readFileSync } from 'node:fs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const get = vi.fn();
-const post = vi.fn();
+const { get, post } = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}));
 
 vi.mock('../../public/viewer/src/utils/api.js', () => ({
   API: { get, post },
@@ -284,6 +286,7 @@ describe('viewer operator cockpit module', () => {
     it('renders generic request errors without backend internals', async () => {
       const { renderOperatorError } =
         await import('../../public/viewer/src/modules/operator-cockpit.js');
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
       const html = renderOperatorError('Operator request failed.', {
         message: 'LOCAL_PATH_SHOULD_NOT_RENDER',
@@ -291,6 +294,8 @@ describe('viewer operator cockpit module', () => {
 
       expect(html).toContain('Operator request failed.');
       expect(html).not.toContain('LOCAL_PATH_SHOULD_NOT_RENDER');
+      expect(consoleError).toHaveBeenCalled();
+      consoleError.mockRestore();
     });
 
     it('renders the cockpit shell with synthetic defaults', async () => {
@@ -478,6 +483,137 @@ describe('viewer operator cockpit module', () => {
       );
     });
 
+    it('clamps review limit input to its visible max bound', async () => {
+      const { OperatorCockpitModule } =
+        await import('../../public/viewer/src/modules/operator-cockpit.js');
+
+      class FakeInput {
+        constructor(
+          readonly value: string,
+          readonly max = ''
+        ) {}
+      }
+      vi.stubGlobal('HTMLInputElement', FakeInput);
+      vi.stubGlobal('HTMLTextAreaElement', FakeInput);
+
+      const container = {
+        querySelector: vi.fn((selector: string) => {
+          if (selector === 'input[name="connector"]') {
+            return new FakeInput('discord');
+          }
+          if (selector === 'input[name="channel"]') {
+            return new FakeInput('G_PUBLIC');
+          }
+          if (selector === 'input[name="limit"]') {
+            return new FakeInput('10000', '100');
+          }
+          return null;
+        }),
+      };
+      const module = new OperatorCockpitModule();
+      Reflect.set(module, 'container', container);
+      const readScope = Reflect.get(module, 'readScope') as () => {
+        connector: string;
+        channel: string;
+        limit?: number;
+      };
+
+      expect(readScope.call(module)).toEqual({
+        connector: 'discord',
+        channel: 'G_PUBLIC',
+        limit: 100,
+      });
+    });
+
+    it('blocks duplicate commits while the same row is already committing', async () => {
+      const { OperatorCockpitModule } =
+        await import('../../public/viewer/src/modules/operator-cockpit.js');
+
+      class FakeHTMLElement {
+        innerHTML = '';
+      }
+      class FakeInput {
+        constructor(readonly value: string) {}
+      }
+      class FakeButton extends FakeHTMLElement {
+        disabled = false;
+      }
+      const firstButton = new FakeButton();
+      const secondButton = new FakeButton();
+      const row = {
+        querySelectorAll: vi.fn(() => [firstButton, secondButton]),
+      };
+      const resultSlot = new FakeHTMLElement();
+      const container = {
+        querySelector: vi.fn((selector: string) => {
+          if (selector === '#operator-cockpit-result') {
+            return resultSlot;
+          }
+          if (selector === 'input[name="admin-token"]') {
+            return new FakeInput('ADMIN_BEARER_VALUE');
+          }
+          return null;
+        }),
+      };
+      let resolveCommit: (value: { ok: boolean; status: string }) => void = () => {};
+      const pendingCommit = new Promise<{ ok: boolean; status: string }>((resolve) => {
+        resolveCommit = resolve;
+      });
+      const controller = {
+        commitNoUpdate: vi.fn(() => pendingCommit),
+      };
+
+      vi.stubGlobal('HTMLElement', FakeHTMLElement);
+      vi.stubGlobal('HTMLButtonElement', FakeButton);
+      vi.stubGlobal('HTMLInputElement', FakeInput);
+      vi.stubGlobal('HTMLTextAreaElement', FakeInput);
+
+      const module = new OperatorCockpitModule(
+        controller as unknown as ConstructorParameters<typeof OperatorCockpitModule>[0]
+      );
+      Reflect.set(module, 'container', container);
+      Reflect.set(module, 'currentState', {
+        cursor: {
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          advancedThroughSeq: 7,
+        },
+        events: [],
+      });
+      Reflect.set(module, 'loadBatch', vi.fn().mockResolvedValue(undefined));
+      const commitEvent = Reflect.get(module, 'commitEvent') as (
+        action: string,
+        eventIndexId: string,
+        row: Element | null,
+        trigger?: HTMLElement
+      ) => Promise<void>;
+
+      const firstCommit = commitEvent.call(
+        module,
+        'no_update',
+        'raw_synthetic_8',
+        row as unknown as Element,
+        firstButton as unknown as HTMLElement
+      );
+      await commitEvent.call(
+        module,
+        'no_update',
+        'raw_synthetic_8',
+        row as unknown as Element,
+        secondButton as unknown as HTMLElement
+      );
+
+      expect(controller.commitNoUpdate).toHaveBeenCalledTimes(1);
+      expect(firstButton.disabled).toBe(true);
+      expect(secondButton.disabled).toBe(true);
+
+      resolveCommit({ ok: true, status: 'committed' });
+      await firstCommit;
+
+      expect(firstButton.disabled).toBe(false);
+      expect(secondButton.disabled).toBe(false);
+    });
+
     it('does not fall back to document inputs when the event row is missing', async () => {
       const { OperatorCockpitModule } =
         await import('../../public/viewer/src/modules/operator-cockpit.js');
@@ -513,6 +649,7 @@ describe('viewer operator cockpit module', () => {
       const controller = {
         commitWiki: vi.fn().mockResolvedValue({ ok: true, status: 'committed' }),
       };
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
       vi.stubGlobal('document', documentRoot);
       vi.stubGlobal('HTMLElement', FakeHTMLElement);
       vi.stubGlobal('HTMLInputElement', FakeInput);
@@ -533,7 +670,8 @@ describe('viewer operator cockpit module', () => {
       const commitEvent = Reflect.get(module, 'commitEvent') as (
         action: string,
         eventIndexId: string,
-        row: Element | null
+        row: Element | null,
+        trigger?: HTMLElement
       ) => Promise<void>;
 
       await commitEvent.call(module, 'wiki', 'raw_synthetic_8', null);
@@ -541,6 +679,8 @@ describe('viewer operator cockpit module', () => {
       expect(controller.commitWiki).not.toHaveBeenCalled();
       expect(documentRoot.querySelector).not.toHaveBeenCalled();
       expect(resultSlot.innerHTML).toContain('Operator commit failed.');
+      expect(consoleError).toHaveBeenCalled();
+      consoleError.mockRestore();
     });
   });
 

--- a/packages/standalone/tests/viewer/operator-cockpit.test.ts
+++ b/packages/standalone/tests/viewer/operator-cockpit.test.ts
@@ -10,8 +10,9 @@ vi.mock('../../public/viewer/src/utils/api.js', () => ({
   API: { get, post },
 }));
 
-describe('viewer operator cockpit module', () => {
+describe('Story V19.15: Viewer operator cockpit', () => {
   beforeEach(() => {
+    process.env.MAMA_FORCE_TIER_3 = 'true';
     vi.clearAllMocks();
     vi.unstubAllGlobals();
   });
@@ -295,6 +296,7 @@ describe('viewer operator cockpit module', () => {
       expect(html).toContain('Operator request failed.');
       expect(html).not.toContain('LOCAL_PATH_SHOULD_NOT_RENDER');
       expect(consoleError).toHaveBeenCalled();
+      expect(JSON.stringify(consoleError.mock.calls)).not.toContain('LOCAL_PATH_SHOULD_NOT_RENDER');
       consoleError.mockRestore();
     });
 
@@ -311,6 +313,27 @@ describe('viewer operator cockpit module', () => {
       expect(html).toContain('type="password"');
       expect(html).toContain('id="operator-cockpit-batch"');
       expect(html).toContain('id="operator-cockpit-result"');
+    });
+
+    it('keeps admin token entry off the CDN-loaded main viewer page', () => {
+      const viewer = readFileSync(
+        new URL('../../public/viewer/viewer.html', import.meta.url),
+        'utf8'
+      );
+      const operator = readFileSync(
+        new URL('../../public/viewer/operator.html', import.meta.url),
+        'utf8'
+      );
+
+      expect(viewer).not.toContain('/viewer/js/modules/operator-cockpit.js');
+      expect(viewer).not.toContain('operator-cockpit-content');
+      expect(viewer).not.toContain('name="admin-token"');
+      expect(viewer).toContain('href="/viewer/operator.html"');
+      expect(operator).toContain('Content-Security-Policy');
+      expect(operator).toContain("script-src 'self'");
+      expect(operator).not.toContain('https://');
+      expect(operator).toContain('/viewer/js/operator-entry.js');
+      expect(operator).toContain('operator-cockpit-content');
     });
 
     it('renders cockpit review rows without raw connector payloads', async () => {
@@ -689,7 +712,9 @@ describe('viewer operator cockpit module', () => {
       const sw = readFileSync(new URL('../../public/viewer/sw.js', import.meta.url), 'utf8');
 
       expect(sw).toContain("const CACHE_NAME = 'mama-mobile-v1.6.1'");
+      expect(sw).toContain("'/viewer/operator.html'");
       expect(sw).toContain("'/viewer/js/modules/operator-cockpit.js'");
+      expect(sw).toContain("'/viewer/js/operator-entry.js'");
     });
   });
 });

--- a/packages/standalone/tests/viewer/operator-cockpit.test.ts
+++ b/packages/standalone/tests/viewer/operator-cockpit.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../public/viewer/src/utils/api.js', () => ({
 describe('viewer operator cockpit module', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
 
   describe('OperatorCockpitController.fetchReviewBatch', () => {
@@ -147,6 +148,88 @@ describe('viewer operator cockpit module', () => {
       expect(serialized).not.toContain('RAW_BODY_SHOULD_NOT_RENDER');
       expect(serialized).not.toContain('LOCAL_PATH_SHOULD_NOT_RENDER');
       expect(serialized).not.toContain('PROVIDER_REQUEST_SHOULD_NOT_RENDER');
+    });
+
+    it('uses safe defaults for missing optional review fields', async () => {
+      const { buildOperatorReviewState } =
+        await import('../../public/viewer/src/modules/operator-cockpit.js');
+
+      const malformedBatch = {
+        preview: {
+          ok: true,
+          mode: 'dry_run',
+          preview: {
+            cursorName: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+            connector: 'slack',
+            channel: 'C_PUBLIC_SYNTHETIC',
+            advancedThroughSeq: 7,
+            events: [
+              {
+                seq: 8,
+                eventIndexId: 'raw_synthetic_8',
+                sourceTimestampMs: 1710000001000,
+                sourceId: 'msg-8',
+                channel: 'C_PUBLIC_SYNTHETIC',
+              },
+            ],
+          },
+        },
+        dryRun: {
+          ok: true,
+          mode: 'dry_run',
+          dry_run: {
+            status: 'ready',
+            candidateCount: 1,
+          },
+        },
+      } as unknown as Parameters<typeof buildOperatorReviewState>[0];
+
+      const state = buildOperatorReviewState(malformedBatch);
+
+      expect(state.cursor.status).toBe('ready');
+      expect(state.cursor.candidateCount).toBe(1);
+      expect(state.events[0].sourceRefText).toBe('raw:unknown:unknown');
+      expect(state.events[0].readiness).toBe('requires_decision');
+    });
+
+    it('throws an explicit error when an event timestamp is missing', async () => {
+      const { buildOperatorReviewState } =
+        await import('../../public/viewer/src/modules/operator-cockpit.js');
+
+      const malformedBatch = {
+        preview: {
+          ok: true,
+          mode: 'dry_run',
+          preview: {
+            cursorName: 'connector:slack:channel:C_PUBLIC_SYNTHETIC',
+            connector: 'slack',
+            channel: 'C_PUBLIC_SYNTHETIC',
+            advancedThroughSeq: 7,
+            events: [
+              {
+                seq: 8,
+                eventIndexId: 'raw_synthetic_8',
+                sourceId: 'msg-8',
+                channel: 'C_PUBLIC_SYNTHETIC',
+                sourceRef: { kind: 'raw', connector: 'slack', id: 'raw_synthetic_8' },
+              },
+            ],
+          },
+        },
+        dryRun: {
+          ok: true,
+          mode: 'dry_run',
+          dry_run: {
+            status: 'ready',
+            candidateCount: 1,
+            candidates: [],
+          },
+        },
+      } as unknown as Parameters<typeof buildOperatorReviewState>[0];
+
+      expect(() => buildOperatorReviewState(malformedBatch)).toThrow(
+        'sourceTimestampMs is required'
+      );
     });
   });
 
@@ -393,6 +476,71 @@ describe('viewer operator cockpit module', () => {
       expect(JSON.stringify(buildOperatorMemoryScopes('discord', 'G_PUBLIC'))).not.toContain(
         'project_public_synthetic'
       );
+    });
+
+    it('does not fall back to document inputs when the event row is missing', async () => {
+      const { OperatorCockpitModule } =
+        await import('../../public/viewer/src/modules/operator-cockpit.js');
+
+      class FakeHTMLElement {
+        innerHTML = '';
+      }
+      class FakeInput {
+        constructor(readonly value: string) {}
+      }
+      class FakeTextArea extends FakeInput {}
+
+      const documentRoot = {
+        querySelector: vi.fn((selector: string) => {
+          if (selector === '[data-field="wiki-path"]') {
+            return new FakeInput('WRONG_FIRST_ROW_PATH');
+          }
+          if (selector === '[data-field="wiki-title"]') {
+            return new FakeInput('WRONG_FIRST_ROW_TITLE');
+          }
+          if (selector === '[data-field="wiki-content"]') {
+            return new FakeTextArea('WRONG_FIRST_ROW_CONTENT');
+          }
+          return null;
+        }),
+      };
+      const resultSlot = new FakeHTMLElement();
+      const container = {
+        querySelector: vi.fn((selector: string) =>
+          selector === '#operator-cockpit-result' ? resultSlot : null
+        ),
+      };
+      const controller = {
+        commitWiki: vi.fn().mockResolvedValue({ ok: true, status: 'committed' }),
+      };
+      vi.stubGlobal('document', documentRoot);
+      vi.stubGlobal('HTMLElement', FakeHTMLElement);
+      vi.stubGlobal('HTMLInputElement', FakeInput);
+      vi.stubGlobal('HTMLTextAreaElement', FakeTextArea);
+
+      const module = new OperatorCockpitModule(
+        controller as unknown as ConstructorParameters<typeof OperatorCockpitModule>[0]
+      );
+      Reflect.set(module, 'container', container);
+      Reflect.set(module, 'currentState', {
+        cursor: {
+          connector: 'slack',
+          channel: 'C_PUBLIC_SYNTHETIC',
+          advancedThroughSeq: 7,
+        },
+        events: [],
+      });
+      const commitEvent = Reflect.get(module, 'commitEvent') as (
+        action: string,
+        eventIndexId: string,
+        row: Element | null
+      ) => Promise<void>;
+
+      await commitEvent.call(module, 'wiki', 'raw_synthetic_8', null);
+
+      expect(controller.commitWiki).not.toHaveBeenCalled();
+      expect(documentRoot.querySelector).not.toHaveBeenCalled();
+      expect(resultSlot.innerHTML).toContain('Operator commit failed.');
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a vNext Operator Cockpit as an isolated first-party viewer page so an operator can inspect ingress preview/dry-run state and manually commit selected items to no-update, wiki, or memory lanes.

- Adds `/viewer/operator.html` as a dedicated operator surface with a strict first-party CSP.
- Links the existing desktop nav and mobile More menu to the isolated operator page instead of embedding admin controls in the main viewer shell.
- Adds a client-only cockpit module that uses the existing vNext ingress preview, dry-run, and manual commit endpoints.
- Adds admin-token entry for commit operations without storing the token in browser storage.
- Adds allowlisted rendering for review state and commit results, with generic UI errors and redacted diagnostics to avoid leaking backend internals.
- Bumps the viewer service worker cache and includes the operator page/entry asset.
- Adds static-route coverage so `/viewer/operator.html` receives the CSP header and `/viewer/js/operator-entry.js` is served before viewer auth gates.
- Makes the operator-entry static route test hermetic for clean CI checkouts where viewer JS build artifacts are gitignored and absent.
- Adds viewer/API tests for preview/dry-run rendering, manual commit calls, auth header handling, memory scope derivation, cache coverage, redaction guarantees, malformed review payload handling, null-safe API request options, limit clamping, in-flight commit dedupe, isolated operator asset serving, and clean-checkout static route behavior.
- Addresses Gemini Code Assist review feedback in `8711901b`, CodeRabbit review follow-ups in `c24270cb`, the final pre-merge Codex hardening review in `d8d1b694`, and the CI clean-checkout test failure in `23ee5d05`.

## Test Coverage

All new Operator Cockpit code paths have targeted test coverage.

- Preview and dry-run happy paths
- Empty/failed review states
- Commit flow for no-update, wiki, and memory
- Blank admin-token rejection before network calls
- `Authorization: Bearer <token>` propagation for manual commits
- Memory commit scope derived from connector/channel instead of a synthetic project scope
- Service worker cache version/page/module coverage
- Redaction checks for raw connector body, local paths, provider internals, memory IDs, and error diagnostics
- Generic UI error rendering for operator review/commit failures with safe DebugLogger diagnostics
- Missing optional review fields and missing event timestamp behavior
- No document-level input fallback when wiki/memory commit rows are missing
- Null request options for `API.post`
- Review limit input clamped to the visible max bound
- Same-row duplicate commit submissions blocked while a commit is in flight
- Main viewer no longer contains operator admin token DOM or cockpit module boot code
- Dedicated operator page contains first-party CSP and avoids third-party scripts
- Graph API and Express static serving apply the operator-page CSP
- Operator entry route test creates and removes an ignored fixture when build output is absent

## Pre-Landing Review

- Bohr subagent re-review: no blocking issues remain after initial fixes.
- Gemini Code Assist: 4 comments received and addressed in commit `8711901b`.
- CodeRabbit: 4 actionable comments received and addressed in commit `c24270cb`.
- Codex final pre-merge review found an admin-surface isolation issue after earlier review comments were fixed. The cockpit is now isolated on `/viewer/operator.html` with first-party-only loading and CSP in `d8d1b694`.
- Codex staged re-review after `d8d1b694`: gate passed; remaining notes were non-blocking drift/build-order risks.
- GitHub `test-standalone` then failed because the new graph API test assumed gitignored viewer JS output existed in a clean checkout. Root cause reproduced locally with build output removed, fixed in `23ee5d05`, and Codex read-only review returned `GATE PASS`.

## Privacy / Public Repo Safety

- `scripts/check-pii.sh`: passed. Review-only warnings were limited to generic UI/test strings such as `admin-token` before the latest test-only fix.
- `gitleaks protect --source . --staged --redact --verbose --no-banner`: passed for the latest staged fix.
- `gitleaks git --log-opts origin/main..HEAD --redact --verbose --no-banner`: passed after `23ee5d05`; no leaks found across 5 commits.
- Sensitive-string review found only synthetic redaction fixtures and public connector labels.
- PR body intentionally omits local machine paths, account identifiers, real tokens, raw connector bodies, and provider internals.

## Scope Drift

Scope Check: CLEAN

Intent: expose a Kagemusha-style operator review surface for vNext ingress commits.

Delivered: a first-party-only Operator Cockpit wired to existing vNext ingress endpoints, with tests, CSP hardening, hermetic CI coverage, and public-safety redaction.

## Verification Results

- `pnpm --filter @jungjaehoon/mama-os build:viewer`: passed.
- `pnpm --filter @jungjaehoon/mama-os typecheck`: passed.
- `MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run tests/api/graph-api.test.ts -t "first-party operator entry"` with viewer JS output removed: 1 targeted test passed and left no generated directory behind.
- `MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run tests/api/graph-api.test.ts tests/viewer/operator-cockpit.test.ts tests/viewer/api.test.ts` with viewer JS output removed: 41 tests passed across 3 files.
- `MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os test` with viewer JS output removed: 242 files passed; 3451 tests passed, 1 skipped.
- `MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os exec vitest run tests/api/graph-api.test.ts tests/viewer/operator-cockpit.test.ts tests/viewer/api.test.ts`: 41 tests passed across 3 files after the final lint fix.
- Commit hook for `23ee5d05` reran lint-staged, PII check, gitleaks, sync-versions, typecheck, standalone build, and standalone tests successfully: 241 files passed, 1 skipped; 3449 tests passed, 3 skipped.
- Browser smoke with mocked APIs verified operator auth header propagation, memory scope payload, and no raw/local path rendering before review follow-ups; review follow-up regressions are now covered by unit tests.

## Eval Results

No prompt-related files changed, evals skipped.

## Test plan

- [x] Unit tests for Operator Cockpit behavior and redaction
- [x] API utility null-options regression test
- [x] Graph API static serving and CSP regression tests
- [x] Clean-checkout graph API static route regression test
- [x] Viewer command/entity/runtime regression subset
- [x] Viewer build
- [x] Standalone typecheck
- [x] PII and secret scans
- [x] Mocked browser smoke for operator auth/scope/rendering
- [x] Gemini Code Assist comments addressed
- [x] CodeRabbit comments addressed
- [x] Final Codex hardening review addressed and re-reviewed
- [x] CI clean-checkout failure reproduced, fixed, and re-reviewed