### PR TITLE
feat: add vNext synthetic dogfood gate

### DIFF
--- a/docs/architecture/mama-vnext-primary-operator-rebuild.md
+++ b/docs/architecture/mama-vnext-primary-operator-rebuild.md
@@ -1,6 +1,6 @@
 # MAMA vNext Primary Operator Rebuild Plan
 
-Status: implementation through PR 13 merged; PR 14 aligns completion gates and privacy checks.
+Status: implementation through PR 15 merged; PR 16 adds the synthetic dogfood harness.
 Branch base: `origin/main`.
 Decision date: 2026-07-02.
 Last updated: 2026-07-03.
@@ -35,7 +35,7 @@ blockers for starting PR 0.
 
 ## Implementation Status
 
-PR 0 through PR 13 have landed on `main`.
+PR 0 through PR 15 have landed on `main`.
 
 | Slice | GitHub PR | State  | Result                                             |
 | ----- | --------- | ------ | -------------------------------------------------- |
@@ -53,10 +53,17 @@ PR 0 through PR 13 have landed on `main`.
 | PR 11 | #109      | merged | atomic changed commits through trusted writers     |
 | PR 12 | #110      | merged | manual reviewed wiki ingress commit                |
 | PR 13 | #111      | merged | manual reviewed memory ingress commit              |
+| PR 14 | #112      | merged | completion gates and staged privacy checks         |
+| PR 15 | #113      | merged | isolated vNext operator review cockpit             |
+| PR 16 | pending   | active | synthetic end-to-end dogfood harness               |
 
-PR 14 does not add runtime behavior. It closes the plan drift created by PR 9-13,
-centralizes staged privacy checks, defines completion gates, and prevents the
-next code slice from guessing what "done" means.
+PR 14 did not add runtime behavior. It closed the plan drift created by PR 9-13,
+centralized staged privacy checks, defined completion gates, and prevented later
+code slices from guessing what "done" means.
+
+PR 15 added the first-party operator review cockpit. PR 16 proves the cockpit's
+backend path with synthetic data only: preview, dry-run, no-update, wiki, memory,
+projection, replay, and explicit recall gating.
 
 ## Why
 
@@ -167,6 +174,7 @@ git diff --cached --check
 git diff --cached --name-only
 ./scripts/check-pii.sh
 gitleaks protect --source . --staged --redact --verbose --no-banner
+./scripts/check-pr-gitleaks.sh
 ```
 
 `scripts/check-pii.sh` is the authoritative staged-file privacy check. It loads
@@ -174,6 +182,12 @@ gitleaks protect --source . --staged --redact --verbose --no-banner
 checks built into the script, blocks high-confidence local path and credential
 prefix matches in staged added lines, and prints review-only warnings for
 privacy-sensitive connector or provider terms.
+
+`scripts/check-pr-gitleaks.sh` scans branch commits with `gitleaks git`,
+materializes staged blobs for direct gitleaks scans, and also scans files
+changed against the PR base from the working tree. This keeps the secret scan
+meaningful before and after commit creation without failing on unrelated
+historical examples in the base branch.
 
 The script is not a substitute for reading the diff.
 
@@ -1140,8 +1154,9 @@ Goal:
 - Add a repeatable synthetic connector scenario that exercises preview,
   migration dry-run, no-update commit, wiki commit, memory commit, projection,
   and replay.
-- Prove ordinary chat still does not inject memory by default, while explicit
-  trigger turns can recall committed memory once.
+- Prove ordinary message-router turns do not call `recallMemory` or legacy
+  decision-search context by default, while explicit `mama_recall` gateway turns
+  can recall committed memory through the reviewed memory path.
 
 Rules:
 
@@ -1149,12 +1164,43 @@ Rules:
 - The harness must run without network access or real connector credentials.
 - The harness must leave no local DB artifacts in the repo.
 
+Files:
+
+- Create: `packages/standalone/src/operator-vnext/synthetic-dogfood-harness.ts`
+- Create: `packages/standalone/tests/operator-vnext/synthetic-dogfood-harness.test.ts`
+- Create: `packages/standalone/tests/operator-vnext/synthetic-dogfood-agent-loop.test.ts`
+- Modify: `packages/standalone/src/agent/gateway-tool-executor.ts`
+- Modify: `packages/standalone/src/gateways/message-router.ts`
+- Modify: `packages/standalone/src/gateways/types.ts`
+- Modify: `packages/standalone/tests/agent/gateway-tool-executor.test.ts`
+- Modify: `packages/standalone/package.json`
+- Create: `scripts/check-pr-gitleaks.sh`
+- Modify: `docs/architecture/mama-vnext-primary-operator-rebuild.md`
+
+Verify:
+
+```bash
+MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os dogfood:vnext
+```
+
+The package script is the PR 16 gate: it builds mama-core and standalone, runs
+the synthetic dogfood harness plus the ingress/router/executor/cockpit
+regression suite, then runs staged PII/gitleaks checks plus
+`scripts/check-pr-gitleaks.sh`. The staged checks protect the pre-commit
+workflow; the helper's commit, staged-blob, and PR-changed-file scans keep the
+gate meaningful after commit and in CI-style runs without inheriting unrelated
+base-branch false positives.
+Prerequisite: `gitleaks` must be installed on `PATH` for the local security
+gate, matching the existing developer pre-commit scan workflow.
+
 ### PR 17: Default Rollout Decision
 
 Goal:
 
 - Decide whether vNext remains opt-in, becomes default for selected local modes,
   or needs another hardening pass.
+- Reconfirm the ordinary message-router memory policy before default rollout and
+  document explicit opt-ins for implicit recall and legacy context search.
 - Update user-facing docs and release notes only after PR 15 and PR 16 pass.
 
 Rules:
@@ -1173,8 +1219,8 @@ Rules:
 - vNext bootstrap does not start heartbeat/token/audit timers
 - vNext bootstrap does not start connector polling in PR 1
 - migration filenames are contiguous with no version gaps
-- ordinary turn does not recall memory
-- trigger turn recalls memory once
+- ordinary turn does not recall memory or legacy context search by default
+- explicit trigger turn recalls memory once
 - wiki publish rejects empty source refs
 - worker cannot commit durable state directly
 - cursor does not advance on model text alone

--- a/docs/architecture/mama-vnext-primary-operator-rebuild.md
+++ b/docs/architecture/mama-vnext-primary-operator-rebuild.md
@@ -1173,6 +1173,9 @@ Files:
 - Modify: `packages/standalone/src/gateways/message-router.ts`
 - Modify: `packages/standalone/src/gateways/types.ts`
 - Modify: `packages/standalone/tests/agent/gateway-tool-executor.test.ts`
+- Modify: `packages/standalone/tests/contract/envelope-callsite-matrix.test.ts`
+- Modify: `packages/standalone/tests/gateways/memory-v2.e2e.test.ts`
+- Modify: `packages/standalone/tests/gateways/message-router.test.ts`
 - Modify: `packages/standalone/package.json`
 - Create: `scripts/check-pr-gitleaks.sh`
 - Modify: `docs/architecture/mama-vnext-primary-operator-rebuild.md`

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -17,6 +17,7 @@
     "build:viewer:watch": "tsc -p public/viewer/tsconfig.viewer.json --watch",
     "test": "vitest run",
     "test:watch": "vitest watch",
+    "dogfood:vnext": "MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-core build && MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os build && MAMA_FORCE_TIER_3=true vitest run tests/operator-vnext/synthetic-dogfood-harness.test.ts tests/operator-vnext/synthetic-dogfood-agent-loop.test.ts tests/operator-vnext/connector-ingress-migration-dry-run.test.ts tests/operator-vnext/connector-ingress-manual-commit.test.ts tests/operator-vnext/connector-ingress-manual-wiki-commit.test.ts tests/operator-vnext/connector-ingress-manual-memory-commit.test.ts tests/gateways/message-router.test.ts tests/gateways/memory-v2.e2e.test.ts tests/agent/gateway-tool-executor.test.ts tests/viewer/operator-cockpit.test.ts && cd ../.. && ./scripts/check-pii.sh && gitleaks protect --source . --staged --redact --verbose --no-banner && ./scripts/check-pr-gitleaks.sh",
     "clean": "rm -rf dist node_modules",
     "typecheck": "tsc --noEmit",
     "start": "node dist/cli/index.js",

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -210,15 +210,16 @@ const RECALL_TEXT_REDACTION_PATTERNS = [
   /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
   /\b(?:Bearer|Token|Authorization)\s*[:=]?\s*[A-Za-z0-9._~+/=-]{8,}/gi,
   /\b(?:api[_-]?key|token|secret|password)\s*[:=]\s*[^\s"']{8,}/gi,
-  /\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{8,}\b/g,
-  /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g,
-  /\bsk-[A-Za-z0-9_-]{20,}\b/g,
+  /(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{8,}\b/g,
+  /xox[baprs]-[A-Za-z0-9-]{10,}\b/g,
+  /sk-[A-Za-z0-9_-]{20,}\b/g,
   /\b[CU][A-Z0-9]{8,}\b/g,
   /\b[0-9]{17,20}\b/g,
   /(?:\/Users|\/home|\/tmp)\/[^\s"']*/g,
   /[A-Za-z]:\\Users\\[^\s"']*/g,
 ] as const;
 const MAX_RECALL_TEXT_LENGTH = 280;
+const RECALL_TEXT_REDACTION_SCAN_LIMIT = MAX_RECALL_TEXT_LENGTH + 2048;
 
 type TrustedMemoryWriteBuildResult = {
   options: TrustedMemoryWriteOptions;
@@ -286,12 +287,19 @@ function sanitizeRecallText(value: string | undefined): string | undefined {
   if (!value) {
     return undefined;
   }
-  const needsTruncation = value.length > MAX_RECALL_TEXT_LENGTH;
-  let sanitized = needsTruncation ? value.slice(0, MAX_RECALL_TEXT_LENGTH) : value;
+  let sanitized =
+    value.length > RECALL_TEXT_REDACTION_SCAN_LIMIT
+      ? value.slice(0, RECALL_TEXT_REDACTION_SCAN_LIMIT)
+      : value;
   for (const pattern of RECALL_TEXT_REDACTION_PATTERNS) {
     sanitized = sanitized.replace(pattern, '[redacted]');
   }
-  if (needsTruncation) {
+  const wasTruncated =
+    value.length > MAX_RECALL_TEXT_LENGTH || sanitized.length > MAX_RECALL_TEXT_LENGTH;
+  if (sanitized.length > MAX_RECALL_TEXT_LENGTH) {
+    sanitized = sanitized.slice(0, MAX_RECALL_TEXT_LENGTH);
+  }
+  if (wasTruncated) {
     sanitized = `${sanitized} [truncated]`;
   }
   return sanitized;

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -286,12 +286,13 @@ function sanitizeRecallText(value: string | undefined): string | undefined {
   if (!value) {
     return undefined;
   }
-  let sanitized = value;
+  const needsTruncation = value.length > MAX_RECALL_TEXT_LENGTH;
+  let sanitized = needsTruncation ? value.slice(0, MAX_RECALL_TEXT_LENGTH) : value;
   for (const pattern of RECALL_TEXT_REDACTION_PATTERNS) {
     sanitized = sanitized.replace(pattern, '[redacted]');
   }
-  if (sanitized.length > MAX_RECALL_TEXT_LENGTH) {
-    sanitized = `${sanitized.slice(0, MAX_RECALL_TEXT_LENGTH)} [truncated]`;
+  if (needsTruncation) {
+    sanitized = `${sanitized} [truncated]`;
   }
   return sanitized;
 }

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -176,6 +176,50 @@ type ScopeAuditFields = {
   mismatch: 0 | 1;
 };
 
+type SafeRecallMemory = {
+  topic?: string;
+  kind?: string;
+  summary?: string;
+  confidence?: number;
+  status?: string;
+};
+
+type SafeRecallProfileEvidence = {
+  topic?: string;
+};
+
+type SafeRecallBundle = {
+  profile: {
+    static: SafeRecallMemory[];
+    dynamic: SafeRecallMemory[];
+    evidence: SafeRecallProfileEvidence[];
+  };
+  memories: SafeRecallMemory[];
+  graph_context: {
+    primary: SafeRecallMemory[];
+    expanded: SafeRecallMemory[];
+    edge_count: number;
+  };
+};
+
+const RECALL_TEXT_REDACTION_PATTERNS = [
+  /MAMA_SYNTHETIC_[A-Z0-9_]+_DO_NOT_LEAK/g,
+  /synthetic:\/\/raw[^\s"']*/g,
+  /raw:[^\s"']*/g,
+  /\bhttps?:\/\/[^\s"'<>()]+/gi,
+  /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
+  /\b(?:Bearer|Token|Authorization)\s*[:=]?\s*[A-Za-z0-9._~+/=-]{8,}/gi,
+  /\b(?:api[_-]?key|token|secret|password)\s*[:=]\s*[^\s"']{8,}/gi,
+  /\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{8,}\b/g,
+  /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g,
+  /\bsk-[A-Za-z0-9_-]{20,}\b/g,
+  /\b[CU][A-Z0-9]{8,}\b/g,
+  /\b[0-9]{17,20}\b/g,
+  /(?:\/Users|\/home|\/tmp)\/[^\s"']*/g,
+  /[A-Za-z]:\\Users\\[^\s"']*/g,
+] as const;
+const MAX_RECALL_TEXT_LENGTH = 280;
+
 type TrustedMemoryWriteBuildResult = {
   options: TrustedMemoryWriteOptions;
   contextPacketScopes?: MemoryScope[];
@@ -221,6 +265,118 @@ type CodeActSandboxRoleResolution = {
 };
 
 class ContextPacketProvenanceError extends Error {}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function stringField(record: Record<string, unknown>, field: string): string | undefined {
+  const value = record[field];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function numberField(record: Record<string, unknown>, field: string): number | undefined {
+  const value = record[field];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function sanitizeRecallText(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  let sanitized = value;
+  for (const pattern of RECALL_TEXT_REDACTION_PATTERNS) {
+    sanitized = sanitized.replace(pattern, '[redacted]');
+  }
+  if (sanitized.length > MAX_RECALL_TEXT_LENGTH) {
+    sanitized = `${sanitized.slice(0, MAX_RECALL_TEXT_LENGTH)} [truncated]`;
+  }
+  return sanitized;
+}
+
+function sanitizeRecallMemory(value: unknown): SafeRecallMemory | null {
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+
+  const safe: SafeRecallMemory = {};
+  const topic = sanitizeRecallText(stringField(record, 'topic'));
+  const kind = sanitizeRecallText(stringField(record, 'kind'));
+  const summary = sanitizeRecallText(stringField(record, 'summary'));
+  const status = sanitizeRecallText(stringField(record, 'status'));
+  const confidence = numberField(record, 'confidence');
+
+  if (topic) {
+    safe.topic = topic;
+  }
+  if (kind) {
+    safe.kind = kind;
+  }
+  if (summary) {
+    safe.summary = summary;
+  }
+  if (status) {
+    safe.status = status;
+  }
+  if (confidence !== undefined) {
+    safe.confidence = confidence;
+  }
+
+  return Object.keys(safe).length > 0 ? safe : null;
+}
+
+function sanitizeRecallMemories(value: unknown): SafeRecallMemory[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((memory) => sanitizeRecallMemory(memory))
+    .filter((memory): memory is SafeRecallMemory => memory !== null);
+}
+
+function sanitizeProfileEvidence(value: unknown): SafeRecallProfileEvidence[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((item) => {
+      const record = asRecord(item);
+      if (!record) {
+        return null;
+      }
+      const evidence: SafeRecallProfileEvidence = {};
+      const topic = sanitizeRecallText(stringField(record, 'topic'));
+      if (topic) {
+        evidence.topic = topic;
+      }
+      return Object.keys(evidence).length > 0 ? evidence : null;
+    })
+    .filter((evidence): evidence is SafeRecallProfileEvidence => evidence !== null);
+}
+
+function sanitizeMamaRecallBundle(bundle: unknown): SafeRecallBundle {
+  const record = asRecord(bundle) ?? {};
+  const profile = asRecord(record.profile) ?? {};
+  const graphContext = asRecord(record.graph_context) ?? {};
+  const edges = Array.isArray(graphContext.edges) ? graphContext.edges : [];
+
+  return {
+    profile: {
+      static: sanitizeRecallMemories(profile.static),
+      dynamic: sanitizeRecallMemories(profile.dynamic),
+      evidence: sanitizeProfileEvidence(profile.evidence),
+    },
+    memories: sanitizeRecallMemories(record.memories),
+    graph_context: {
+      primary: sanitizeRecallMemories(graphContext.primary),
+      expanded: sanitizeRecallMemories(graphContext.expanded),
+      edge_count: edges.length,
+    },
+  };
+}
 
 async function withManagedAgentMutationLock<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
   const previous = managedAgentMutationTails.get(agentId) ?? Promise.resolve();
@@ -1333,6 +1489,64 @@ export class GatewayToolExecutor {
       userId: context.session.userId,
       projectId: process.env.MAMA_WORKSPACE || process.cwd(),
     });
+  }
+
+  private resolveMamaRecallScopes(input: RecallInput): {
+    scopes: MemoryScope[];
+    denial?: GatewayToolResult;
+  } {
+    const ctx = this.getExecutionState();
+    const requestedScopes = normalizeMemoryScopes(input.scopes);
+    const callerProvidedScopes = input.scopes !== undefined;
+    const allowedScopes =
+      ctx.envelope?.scope.memory_scopes ?? this.deriveMemoryScopesFromActiveContext(ctx) ?? [];
+    const hasActiveScopeBoundary = Boolean(ctx.envelope || ctx.agentContext);
+
+    if (callerProvidedScopes && !requestedScopes) {
+      return {
+        scopes: [],
+        denial: {
+          success: false,
+          code: 'memory_scope_invalid',
+          error: 'mama_recall scopes must be valid memory scope objects.',
+        } as GatewayToolResult,
+      };
+    }
+
+    if (!hasActiveScopeBoundary) {
+      if (callerProvidedScopes) {
+        return {
+          scopes: [],
+          denial: {
+            success: false,
+            code: 'memory_scope_denied',
+            error: 'mama_recall requires an active session or envelope for caller-supplied scopes.',
+          } as GatewayToolResult,
+        };
+      }
+      return { scopes: [] };
+    }
+
+    if (!requestedScopes || requestedScopes.length === 0) {
+      return { scopes: allowedScopes };
+    }
+
+    const allowedScopeKeys = new Set(allowedScopes.map(memoryScopeKey));
+    const hasUnauthorizedScope = requestedScopes.some(
+      (scope) => !allowedScopeKeys.has(memoryScopeKey(scope))
+    );
+    if (hasUnauthorizedScope) {
+      return {
+        scopes: [],
+        denial: {
+          success: false,
+          code: 'memory_scope_denied',
+          error: 'mama_recall requested scopes outside the active session or envelope.',
+        } as GatewayToolResult,
+      };
+    }
+
+    return { scopes: requestedScopes };
   }
 
   private applyEnvelopeScopedReadDefaults(
@@ -3817,17 +4031,11 @@ export class GatewayToolExecutor {
       } as GatewayToolResult;
     }
 
-    const context = this.getActiveContext();
-    const fallbackScopes = context
-      ? deriveMemoryScopes({
-          source: context.source,
-          channelId: context.session.channelId,
-          userId: context.session.userId,
-          projectId: process.env.MAMA_WORKSPACE || process.cwd(),
-        })
-      : [];
-    const inputScopes = Array.isArray(input.scopes) ? input.scopes : [];
-    const scopes = inputScopes.length > 0 ? inputScopes : fallbackScopes;
+    const scopeResolution = this.resolveMamaRecallScopes(input);
+    if (scopeResolution.denial) {
+      return scopeResolution.denial;
+    }
+    const scopes = scopeResolution.scopes;
 
     if (scopes.length === 0) {
       return {
@@ -3841,7 +4049,7 @@ export class GatewayToolExecutor {
         scopes,
         includeProfile: true,
       });
-      return { success: true, bundle } as GatewayToolResult;
+      return { success: true, bundle: sanitizeMamaRecallBundle(bundle) } as GatewayToolResult;
     } catch (err) {
       return {
         success: false,

--- a/packages/standalone/src/gateways/message-router.ts
+++ b/packages/standalone/src/gateways/message-router.ts
@@ -456,6 +456,8 @@ export class MessageRouter {
         'Korean'
       ),
       backend: config.backend ?? 'claude',
+      implicitMemoryRecall: config.implicitMemoryRecall ?? false,
+      implicitLegacyContextSearch: config.implicitLegacyContextSearch ?? false,
     };
     this.roleManager = getRoleManager();
     this.promptEnhancer = new PromptEnhancer();
@@ -650,9 +652,10 @@ This protects your credentials from being exposed in chat logs.`;
     const enhanced = await this.promptEnhancer.enhance(message.text, workspacePath, ruleContext);
 
     // CONTINUE: skip expensive embedding search — Codex retains full conversation via threadId
-    const context = isNewCliSession
-      ? await this.contextInjector.getRelevantContext(message.text)
-      : { prompt: '', decisions: [], hasContext: false };
+    const context =
+      isNewCliSession && this.config.implicitLegacyContextSearch
+        ? await this.contextInjector.getRelevantContext(message.text)
+        : { prompt: '', decisions: [], hasContext: false };
 
     if (!isNewCliSession) {
       systemPrompt = '';
@@ -1304,6 +1307,12 @@ ${historyContext}
         this.config.translationTargetLanguage
       );
     }
+    if (config.implicitMemoryRecall !== undefined) {
+      this.config.implicitMemoryRecall = config.implicitMemoryRecall;
+    }
+    if (config.implicitLegacyContextSearch !== undefined) {
+      this.config.implicitLegacyContextSearch = config.implicitLegacyContextSearch;
+    }
 
     // Update context injector config
     this.contextInjector.setConfig({
@@ -1494,7 +1503,7 @@ INSTRUCTION:
   }
 
   private async getPerTurnMemoryPrefix(message: NormalizedMessage): Promise<string> {
-    if (this.mamaApi.recallMemory) {
+    if (this.config.implicitMemoryRecall && this.mamaApi.recallMemory) {
       try {
         const scopes = deriveMemoryScopes({
           source: message.source,
@@ -1513,6 +1522,10 @@ INSTRUCTION:
           `[memory-prefix] recallMemory failed: ${error instanceof Error ? error.message : String(error)}`
         );
       }
+    }
+
+    if (!this.config.implicitLegacyContextSearch) {
+      return '';
     }
 
     const context = await this.contextInjector.getRelevantContext(message.text);

--- a/packages/standalone/src/gateways/types.ts
+++ b/packages/standalone/src/gateways/types.ts
@@ -158,6 +158,10 @@ export interface MessageRouterConfig {
   translationTargetLanguage?: string;
   /** Backend type for backend-specific AGENTS.md injection */
   backend?: 'claude' | 'codex' | 'codex-mcp';
+  /** Opt into implicit per-turn recallMemory injection. Default: false. */
+  implicitMemoryRecall?: boolean;
+  /** Opt into legacy decision-search context injection. Default: false. */
+  implicitLegacyContextSearch?: boolean;
 }
 
 /**

--- a/packages/standalone/src/operator-vnext/synthetic-dogfood-harness.ts
+++ b/packages/standalone/src/operator-vnext/synthetic-dogfood-harness.ts
@@ -1,0 +1,991 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, readdirSync, statSync, type Dirent } from 'node:fs';
+import { relative, resolve } from 'node:path';
+
+import {
+  createTrustedProvenanceCapability,
+  type MemoryProvenanceRecord,
+  type RecallBundle,
+  type MemoryScopeRef,
+  type MemoryStatus,
+  type PublicSaveMemoryInput,
+  type TrustedMemoryWriteOptions,
+} from '@jungjaehoon/mama-core';
+import { connectorEventIndexId } from '@jungjaehoon/mama-core/connectors/event-index';
+import type { SourceRef } from '@jungjaehoon/mama-core/provenance/source-ref';
+
+import { GatewayToolExecutor } from '../agent/gateway-tool-executor.js';
+import type {
+  AgentContext,
+  GatewayToolExecutionContext,
+  GatewayToolResult,
+  MAMAApiInterface,
+} from '../agent/types.js';
+import { DEFAULT_ROLES } from '../cli/config/types.js';
+import type { MamaApiClient } from '../gateways/context-injector.js';
+import { createMockAgentLoop, MessageRouter } from '../gateways/message-router.js';
+import { SessionStore } from '../gateways/session-store.js';
+import type { SQLiteDatabase } from '../sqlite.js';
+import { WikiArtifactStore } from '../wiki-artifacts/wiki-artifact-store.js';
+import { createWikiPublishAdapter } from '../wiki-artifacts/wiki-publish-adapter.js';
+import {
+  buildConnectorEventIngressPreview,
+  type ConnectorEventIngressPreview,
+} from './connector-event-ingress.js';
+import {
+  commitConnectorIngressMemoryBatch,
+  type ConnectorIngressManualMemoryCommitInput,
+  type ConnectorIngressManualMemoryCommitResult,
+} from './connector-ingress-manual-memory-commit.js';
+import {
+  commitConnectorIngressNoUpdateBatch,
+  type ConnectorIngressManualCommitResult,
+} from './connector-ingress-manual-commit.js';
+import {
+  commitConnectorIngressWikiBatch,
+  type ConnectorIngressManualWikiCommitResult,
+} from './connector-ingress-manual-wiki-commit.js';
+import {
+  buildConnectorIngressMigrationDryRun,
+  type ConnectorIngressMigrationDryRun,
+} from './connector-ingress-migration-dry-run.js';
+import { buildSituationProjection } from './situation-projection.js';
+import type { VNextSituationProjection } from './situation-projection-types.js';
+
+export const SYNTHETIC_DOGFOOD_CONNECTOR = 'synthetic';
+export const SYNTHETIC_DOGFOOD_CHANNEL = 'C_MAMA_VNEXT_SYNTHETIC';
+
+const SYNTHETIC_INDEXED_AT = '2026-07-03T00:00:00.000Z';
+const SYNTHETIC_MEMORY_TOPIC = 'operator/manual-memory';
+const SYNTHETIC_MEMORY_SUMMARY = 'Synthetic reviewed memory is available after explicit recall.';
+const SYNTHETIC_MEMORY_DETAILS =
+  'Synthetic operator-approved detail derived from a reviewed fixture.';
+const SYNTHETIC_PROJECT_SCOPE: MemoryScopeRef = {
+  kind: 'project',
+  id: 'project_public_synthetic',
+};
+const SYNTHETIC_CHANNEL_SCOPE: MemoryScopeRef = {
+  kind: 'channel',
+  id: `discord:${SYNTHETIC_DOGFOOD_CHANNEL}`,
+};
+const REPO_DB_ARTIFACT_SUFFIXES = [
+  '.db',
+  '.sqlite',
+  '.sqlite3',
+  '.db-wal',
+  '.db-shm',
+  '.db-journal',
+  '.sqlite-wal',
+  '.sqlite-shm',
+  '.sqlite-journal',
+  '.sqlite3-wal',
+  '.sqlite3-shm',
+  '.sqlite3-journal',
+] as const;
+const REPO_DB_ARTIFACT_EXCLUDED_DIRS = new Set(['.git', '.pnpm-store', 'node_modules']);
+const RAW_CONTENT_CANARY = 'MAMA_SYNTHETIC_RAW_CONTENT_CANARY_DO_NOT_LEAK';
+const RAW_AUTHOR_CANARY = 'MAMA_SYNTHETIC_AUTHOR_CANARY_DO_NOT_LEAK';
+const RAW_LOCATOR_CANARY = 'synthetic://raw-locator-canary/do-not-leak';
+const RAW_METADATA_CANARY = 'MAMA_SYNTHETIC_METADATA_CANARY_DO_NOT_LEAK';
+const RAW_PATH_CANARY = '/tmp/mama-synthetic-private-path-canary';
+export const SYNTHETIC_DOGFOOD_RAW_CANARIES = Object.freeze([
+  RAW_CONTENT_CANARY,
+  RAW_AUTHOR_CANARY,
+  RAW_LOCATOR_CANARY,
+  RAW_METADATA_CANARY,
+  RAW_PATH_CANARY,
+]);
+
+type SyntheticDogfoodEventRole = 'no_update' | 'wiki' | 'memory';
+
+interface SyntheticDogfoodEventSpec {
+  role: SyntheticDogfoodEventRole;
+  sourceId: string;
+  timestampMs: number;
+  title: string;
+  rawBody: string;
+}
+
+export interface SyntheticDogfoodSeededEvent {
+  role: SyntheticDogfoodEventRole;
+  eventIndexId: string;
+  sourceId: string;
+}
+
+interface SyntheticDogfoodWriteCounts {
+  commits: number;
+  cursors: number;
+  noUpdates: number;
+  wikiArtifacts: number;
+  memoryIntents: number;
+}
+
+interface RepoDbArtifactSnapshot {
+  size: number;
+  sha256: string;
+}
+
+export interface SyntheticDogfoodRecallMemory {
+  topic: string;
+  summary: string;
+}
+
+interface SyntheticDogfoodExplicitRecall {
+  recallInvoked: true;
+  memories: SyntheticDogfoodRecallMemory[];
+}
+
+interface SyntheticDogfoodOrdinaryRecall {
+  recallInvoked: false;
+  memories: [];
+}
+
+export interface SyntheticDogfoodHarnessInput {
+  db: SQLiteDatabase;
+  nowMs?: () => number;
+  artifactRoot?: string;
+  memoryStore?: SyntheticDogfoodMemoryBackend;
+}
+
+export interface SyntheticDogfoodHarnessResult {
+  scenario: {
+    synthetic: true;
+    connector: typeof SYNTHETIC_DOGFOOD_CONNECTOR;
+    channel: typeof SYNTHETIC_DOGFOOD_CHANNEL;
+  };
+  events: SyntheticDogfoodSeededEvent[];
+  preview: ConnectorEventIngressPreview;
+  dryRun: ConnectorIngressMigrationDryRun;
+  dryRunWriteCounts: SyntheticDogfoodWriteCounts;
+  commits: {
+    noUpdate: ConnectorIngressManualCommitResult;
+    wiki: ConnectorIngressManualWikiCommitResult;
+    memory: ConnectorIngressManualMemoryCommitResult;
+  };
+  replay: {
+    memory: ConnectorIngressManualMemoryCommitResult;
+  };
+  projection: VNextSituationProjection;
+  recall: {
+    ordinary: SyntheticDogfoodOrdinaryRecall;
+    negativeExplicit: SyntheticDogfoodExplicitRecall;
+    explicit: SyntheticDogfoodExplicitRecall;
+    totalRecallCalls: number;
+  };
+  artifacts: {
+    repoDbFilesCreated: string[];
+  };
+}
+
+interface StoredSyntheticMemory {
+  id: string;
+  topic: string;
+  summary: string;
+  details: string;
+  status: MemoryStatus;
+  scopes: MemoryScopeRef[];
+  gatewayCallId: string;
+  sourceRefs: string[];
+}
+
+export interface SyntheticDogfoodMemoryBackend {
+  saveMemory: (
+    input: PublicSaveMemoryInput,
+    options: TrustedMemoryWriteOptions
+  ) => Promise<{ success: boolean; id: string }>;
+  listMemoriesByGatewayCallId: (gatewayCallId: string) => Promise<MemoryProvenanceRecord[]>;
+  setMemoryStatus: (input: { memoryId: string; status: MemoryStatus }) => Promise<void> | void;
+  recallMemory: (
+    query: string,
+    options?: { scopes?: Array<{ kind: string; id: string }>; includeProfile?: boolean }
+  ) => Promise<RecallBundle> | RecallBundle;
+  getTotalRecallCalls: () => number;
+  hasActiveMemory: (topic: string) => boolean | Promise<boolean>;
+}
+
+function syntheticMemoryMatchesScopes(
+  memory: StoredSyntheticMemory,
+  requestedScopes: ReadonlyArray<{ kind: string; id: string }>
+): boolean {
+  if (requestedScopes.length === 0) {
+    return false;
+  }
+  return memory.scopes.some((scope) =>
+    requestedScopes.some((requested) => requested.kind === scope.kind && requested.id === scope.id)
+  );
+}
+
+const SYNTHETIC_DOGFOOD_EVENTS: SyntheticDogfoodEventSpec[] = [
+  {
+    role: 'no_update',
+    sourceId: 'synthetic-no-update-001',
+    timestampMs: 1_710_000_001_000,
+    title: 'Synthetic no-update event',
+    rawBody: `SYNTHETIC RAW REDACTED BODY: no-update fixture must never appear in harness output. ${RAW_CONTENT_CANARY}`,
+  },
+  {
+    role: 'wiki',
+    sourceId: 'synthetic-wiki-001',
+    timestampMs: 1_710_000_002_000,
+    title: 'Synthetic wiki event',
+    rawBody: `SYNTHETIC RAW REDACTED BODY: wiki fixture must never appear in harness output. ${RAW_CONTENT_CANARY}`,
+  },
+  {
+    role: 'memory',
+    sourceId: 'synthetic-memory-001',
+    timestampMs: 1_710_000_003_000,
+    title: 'Synthetic memory event',
+    rawBody: `SYNTHETIC RAW REDACTED BODY: memory fixture must never appear in harness output. ${RAW_CONTENT_CANARY}`,
+  },
+];
+
+function createSyntheticTrustedCapability(): TrustedMemoryWriteOptions['capability'] {
+  return createTrustedProvenanceCapability();
+}
+
+function countRowsBySql(db: SQLiteDatabase, sql: string): number {
+  const row = db.prepare(sql).get() as { count: number } | undefined;
+  return row?.count ?? 0;
+}
+
+function readWriteCounts(db: SQLiteDatabase): SyntheticDogfoodWriteCounts {
+  return {
+    commits: countRowsBySql(db, 'SELECT COUNT(*) AS count FROM vnext_operator_commits'),
+    cursors: countRowsBySql(db, 'SELECT COUNT(*) AS count FROM vnext_operator_cursors'),
+    noUpdates: countRowsBySql(db, 'SELECT COUNT(*) AS count FROM operator_no_updates'),
+    wikiArtifacts: countRowsBySql(db, 'SELECT COUNT(*) AS count FROM wiki_artifacts'),
+    memoryIntents: countRowsBySql(
+      db,
+      'SELECT COUNT(*) AS count FROM operator_memory_commit_intents'
+    ),
+  };
+}
+
+function readSyntheticEventSeq(db: SQLiteDatabase, event: SyntheticDogfoodSeededEvent): number {
+  const row = db
+    .prepare(
+      `SELECT operator_ingest_seq
+       FROM connector_event_index
+       WHERE event_index_id = ?
+       LIMIT 1`
+    )
+    .get(event.eventIndexId) as { operator_ingest_seq: number } | undefined;
+  if (!row) {
+    throw new Error(`Synthetic dogfood event seq not found: ${event.eventIndexId}`);
+  }
+  return row.operator_ingest_seq;
+}
+
+function isRepoDbArtifact(filename: string): boolean {
+  return REPO_DB_ARTIFACT_SUFFIXES.some((suffix) => filename.endsWith(suffix));
+}
+
+function snapshotRepoDbArtifacts(root: string): Map<string, RepoDbArtifactSnapshot> {
+  const artifactRoot = resolve(root);
+  const artifacts = new Map<string, RepoDbArtifactSnapshot>();
+
+  function walk(directory: string): void {
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(directory, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) {
+        continue;
+      }
+      const entryPath = resolve(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (!REPO_DB_ARTIFACT_EXCLUDED_DIRS.has(entry.name)) {
+          walk(entryPath);
+        }
+        continue;
+      }
+      if (entry.isFile() && isRepoDbArtifact(entry.name)) {
+        const stats = statSync(entryPath);
+        artifacts.set(relative(artifactRoot, entryPath), {
+          size: stats.size,
+          sha256: createHash('sha256').update(readFileSync(entryPath)).digest('hex'),
+        });
+      }
+    }
+  }
+
+  walk(artifactRoot);
+  return artifacts;
+}
+
+function listChangedRepoDbArtifacts(
+  before: Map<string, RepoDbArtifactSnapshot>,
+  after: Map<string, RepoDbArtifactSnapshot>
+): string[] {
+  const changed: string[] = [];
+  const artifactPaths = new Set([...before.keys(), ...after.keys()]);
+  for (const artifact of artifactPaths) {
+    const afterSnapshot = after.get(artifact);
+    const beforeSnapshot = before.get(artifact);
+    if (
+      !beforeSnapshot ||
+      !afterSnapshot ||
+      beforeSnapshot.size !== afterSnapshot.size ||
+      beforeSnapshot.sha256 !== afterSnapshot.sha256
+    ) {
+      changed.push(artifact);
+    }
+  }
+  return changed.sort();
+}
+
+function findGitRoot(start: string): string {
+  let current = resolve(start);
+  let parent = resolve(current, '..');
+  while (parent !== current) {
+    if (existsSync(resolve(current, '.git'))) {
+      return current;
+    }
+    current = parent;
+    parent = resolve(current, '..');
+  }
+  if (existsSync(resolve(current, '.git'))) {
+    return current;
+  }
+  return resolve(start);
+}
+
+function resolveArtifactRoot(artifactRoot: string | undefined): string {
+  return artifactRoot ? resolve(artifactRoot) : findGitRoot(process.cwd());
+}
+
+function sourceRefFor(event: SyntheticDogfoodSeededEvent): SourceRef {
+  return {
+    kind: 'raw',
+    connector: SYNTHETIC_DOGFOOD_CONNECTOR,
+    id: event.eventIndexId,
+    source_id: event.sourceId,
+    channel_id: SYNTHETIC_DOGFOOD_CHANNEL,
+  };
+}
+
+function seedSyntheticDogfoodEvent(
+  db: SQLiteDatabase,
+  spec: SyntheticDogfoodEventSpec,
+  index: number
+): SyntheticDogfoodSeededEvent {
+  const eventIndexId = connectorEventIndexId(SYNTHETIC_DOGFOOD_CONNECTOR, spec.sourceId);
+  const existing = db
+    .prepare(
+      `SELECT event_index_id
+       FROM connector_event_index
+       WHERE source_connector = ?
+         AND source_id = ?
+       LIMIT 1`
+    )
+    .get(SYNTHETIC_DOGFOOD_CONNECTOR, spec.sourceId) as { event_index_id: string } | undefined;
+
+  if (!existing) {
+    db.prepare(
+      `INSERT INTO connector_event_index (
+        event_index_id, source_connector, source_type, source_id, source_locator,
+        channel, author, title, content, event_datetime, event_date, source_timestamp_ms,
+        metadata_json, content_hash, indexed_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      eventIndexId,
+      SYNTHETIC_DOGFOOD_CONNECTOR,
+      'synthetic_message',
+      spec.sourceId,
+      `${RAW_LOCATOR_CANARY}/${spec.sourceId}`,
+      SYNTHETIC_DOGFOOD_CHANNEL,
+      RAW_AUTHOR_CANARY,
+      spec.title,
+      spec.rawBody,
+      spec.timestampMs,
+      new Date(spec.timestampMs).toISOString().slice(0, 10),
+      spec.timestampMs,
+      JSON.stringify({
+        synthetic: true,
+        fixture: 'vnext-dogfood',
+        raw_locator: `synthetic://redacted/raw/${spec.sourceId}`,
+        raw_metadata_canary: RAW_METADATA_CANARY,
+        raw_path_canary: RAW_PATH_CANARY,
+      }),
+      Buffer.alloc(32, index + 1),
+      SYNTHETIC_INDEXED_AT,
+      SYNTHETIC_INDEXED_AT
+    );
+  }
+
+  return {
+    role: spec.role,
+    eventIndexId,
+    sourceId: spec.sourceId,
+  };
+}
+
+function seedSyntheticDogfoodEvents(db: SQLiteDatabase): SyntheticDogfoodSeededEvent[] {
+  return SYNTHETIC_DOGFOOD_EVENTS.map((spec, index) => seedSyntheticDogfoodEvent(db, spec, index));
+}
+
+export class SyntheticDogfoodMemoryStore {
+  private readonly memories = new Map<string, StoredSyntheticMemory>();
+  private readonly memoryIdByGatewayCallId = new Map<string, string>();
+  private saveSequence = 0;
+  private recallCalls = 0;
+
+  saveMemory = async (
+    input: PublicSaveMemoryInput,
+    options: TrustedMemoryWriteOptions
+  ): Promise<{ success: boolean; id: string }> => {
+    const gatewayCallId = options.provenance.gateway_call_id;
+    if (!gatewayCallId) {
+      throw new Error('Synthetic dogfood memory save requires gateway_call_id');
+    }
+
+    const existingId = this.memoryIdByGatewayCallId.get(gatewayCallId);
+    if (existingId) {
+      return { success: true, id: existingId };
+    }
+
+    this.saveSequence += 1;
+    const id = `memory_synthetic_${this.saveSequence}`;
+    const sourceRefs = options.provenance.source_refs ?? [];
+    this.memories.set(id, {
+      id,
+      topic: input.topic,
+      summary: input.summary,
+      details: input.details,
+      status: input.status ?? 'stale',
+      scopes: input.scopes,
+      gatewayCallId,
+      sourceRefs,
+    });
+    this.memoryIdByGatewayCallId.set(gatewayCallId, id);
+
+    return { success: true, id };
+  };
+
+  listMemoriesByGatewayCallId = async (
+    gatewayCallId: string
+  ): Promise<MemoryProvenanceRecord[]> => {
+    const memoryId = this.memoryIdByGatewayCallId.get(gatewayCallId);
+    if (!memoryId) {
+      return [];
+    }
+    const memory = this.memories.get(memoryId);
+    if (!memory) {
+      return [];
+    }
+    return [
+      {
+        memory_id: memory.id,
+        agent_id: 'operator:manual-admin',
+        model_run_id: null,
+        envelope_hash: null,
+        gateway_call_id: memory.gatewayCallId,
+        source_refs: memory.sourceRefs,
+        provenance: { synthetic: true },
+      },
+    ];
+  };
+
+  setMemoryStatus = async (input: { memoryId: string; status: MemoryStatus }): Promise<void> => {
+    const memory = this.memories.get(input.memoryId);
+    if (!memory) {
+      throw new Error('Synthetic dogfood memory status target not found');
+    }
+    this.memories.set(input.memoryId, {
+      ...memory,
+      status: input.status,
+    });
+  };
+
+  recallMemory(
+    query: string,
+    options?: { scopes?: Array<{ kind: string; id: string }>; includeProfile?: boolean }
+  ): RecallBundle {
+    this.recallCalls += 1;
+    const requestedScopes = options?.scopes ?? [];
+    const normalizedQuery = query.trim().toLowerCase();
+    const scopeOrder = requestedScopes
+      .map((scope) => scope.kind)
+      .filter((kind): kind is MemoryScopeRef['kind'] =>
+        ['global', 'user', 'channel', 'project'].includes(kind)
+      );
+    const activeMemories = [...this.memories.values()]
+      .filter((memory) => memory.status === 'active')
+      .filter((memory) => syntheticMemoryMatchesScopes(memory, requestedScopes))
+      .filter(
+        (memory) =>
+          normalizedQuery.length === 0 ||
+          memory.topic.toLowerCase().includes(normalizedQuery) ||
+          memory.summary.toLowerCase().includes(normalizedQuery) ||
+          memory.details.toLowerCase().includes(normalizedQuery)
+      )
+      .map((memory) => ({
+        id: memory.id,
+        topic: memory.topic,
+        kind: 'decision' as const,
+        summary: memory.summary,
+        details: memory.details,
+        confidence: 0.88,
+        status: memory.status,
+        scopes: memory.scopes,
+        source: {
+          package: 'standalone' as const,
+          source_type: 'synthetic-dogfood',
+          channel_id: SYNTHETIC_DOGFOOD_CHANNEL,
+          project_id: SYNTHETIC_PROJECT_SCOPE.id,
+        },
+        created_at: SYNTHETIC_INDEXED_AT,
+        updated_at: SYNTHETIC_INDEXED_AT,
+      }));
+    return {
+      profile: {
+        static: [],
+        dynamic: [],
+        evidence: activeMemories.map((memory, index) => ({
+          memory_id: `synthetic_recall_${index + 1}`,
+          topic: memory.topic,
+          why_included: 'Synthetic explicit recall matched the requested project scope.',
+        })),
+      },
+      memories: activeMemories,
+      graph_context: {
+        primary: activeMemories,
+        expanded: [],
+        edges: [],
+      },
+      search_meta: {
+        query,
+        scope_order: scopeOrder,
+        retrieval_sources: ['synthetic'],
+      },
+    };
+  }
+
+  getTotalRecallCalls(): number {
+    return this.recallCalls;
+  }
+
+  hasActiveMemory(topic: string): boolean {
+    return [...this.memories.values()].some(
+      (memory) => memory.topic === topic && memory.status === 'active'
+    );
+  }
+}
+
+export function createSyntheticDogfoodMemoryStore(): SyntheticDogfoodMemoryStore {
+  return new SyntheticDogfoodMemoryStore();
+}
+
+function createSyntheticMamaApi(memoryStore: SyntheticDogfoodMemoryBackend): MAMAApiInterface {
+  return {
+    save: async () => ({
+      success: false,
+      code: 'synthetic_unused',
+      message: 'Synthetic dogfood harness only enables explicit recall.',
+    }),
+    saveCheckpoint: async () => ({
+      success: false,
+      message: 'Synthetic dogfood harness does not save checkpoints.',
+    }),
+    listDecisions: async () => [],
+    suggest: async () => ({
+      success: true,
+      results: [],
+      count: 0,
+    }),
+    recallMemory: async (query, options) => memoryStore.recallMemory(query, options),
+    ingestMemory: async () => ({
+      success: false,
+      code: 'synthetic_unused',
+    }),
+    updateOutcome: async () => ({
+      success: false,
+      message: 'Synthetic dogfood harness does not update outcomes.',
+    }),
+    loadCheckpoint: async () => ({
+      success: false,
+      message: 'Synthetic dogfood harness does not load checkpoints.',
+    }),
+    appendToolTrace: async (trace) => ({
+      trace_id: trace.trace_id ?? 'trace_synthetic_dogfood_recall',
+      model_run_id: trace.model_run_id,
+      gateway_call_id: trace.gateway_call_id ?? null,
+      tool_name: trace.tool_name,
+      input_summary: trace.input_summary ?? null,
+      output_summary: trace.output_summary ?? null,
+      execution_status: trace.execution_status ?? null,
+      duration_ms: trace.duration_ms ?? 0,
+      envelope_hash: trace.envelope_hash ?? null,
+      created_at: trace.created_at ?? Date.parse(SYNTHETIC_INDEXED_AT),
+    }),
+  };
+}
+
+function createSyntheticRouterApi(memoryStore: SyntheticDogfoodMemoryBackend): MamaApiClient {
+  return {
+    search: async () => [],
+    listDecisions: async () => [],
+    save: async () => ({
+      success: false,
+      code: 'synthetic_unused',
+    }),
+    recallMemory: async (query, options) => memoryStore.recallMemory(query, options),
+    ingestMemory: async () => ({
+      success: false,
+      code: 'synthetic_unused',
+    }),
+  };
+}
+
+async function executeSyntheticOrdinaryRouterTurn(input: {
+  db: SQLiteDatabase;
+  memoryStore: SyntheticDogfoodMemoryBackend;
+}): Promise<SyntheticDogfoodOrdinaryRecall> {
+  const callsBefore = input.memoryStore.getTotalRecallCalls();
+  let prompt = '';
+  const router = new MessageRouter(
+    new SessionStore(input.db),
+    createMockAgentLoop((nextPrompt) => {
+      prompt = nextPrompt;
+      return 'Synthetic ordinary response';
+    }),
+    createSyntheticRouterApi(input.memoryStore)
+  );
+
+  await router.process({
+    source: 'discord',
+    channelId: SYNTHETIC_DOGFOOD_CHANNEL,
+    userId: 'synthetic-ordinary-user',
+    text: 'Synthetic ordinary turn should not recall memory without the explicit tool.',
+  });
+
+  if (input.memoryStore.getTotalRecallCalls() !== callsBefore) {
+    throw new Error('Synthetic ordinary router turn unexpectedly invoked recallMemory');
+  }
+  if (prompt.includes('[MAMA Profile]') || prompt.includes('[MAMA Memories]')) {
+    throw new Error('Synthetic ordinary router turn injected recalled memory');
+  }
+
+  return {
+    recallInvoked: false,
+    memories: [],
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function parseRecallMemory(value: unknown): SyntheticDogfoodRecallMemory {
+  if (!isRecord(value) || typeof value.topic !== 'string' || typeof value.summary !== 'string') {
+    throw new Error('Synthetic recall result did not contain a valid memory');
+  }
+  return {
+    topic: value.topic,
+    summary: value.summary,
+  };
+}
+
+function recallMemoriesFromGatewayResult(
+  result: GatewayToolResult
+): SyntheticDogfoodRecallMemory[] {
+  if (!result.success) {
+    const error =
+      isRecord(result) && typeof result.error === 'string' ? result.error : 'unknown error';
+    throw new Error(`Synthetic explicit recall failed: ${error}`);
+  }
+  const bundle = isRecord(result) ? result.bundle : undefined;
+  if (!isRecord(bundle)) {
+    throw new Error('Synthetic explicit recall did not return a recall bundle');
+  }
+  if (!Array.isArray(bundle.memories)) {
+    return [];
+  }
+  return bundle.memories.map(parseRecallMemory);
+}
+
+async function executeSyntheticExplicitRecall(input: {
+  executor: GatewayToolExecutor;
+  query: string;
+  scopes: MemoryScopeRef[];
+  executionContext: GatewayToolExecutionContext;
+}): Promise<SyntheticDogfoodExplicitRecall> {
+  const result = await input.executor.execute(
+    'mama_recall',
+    {
+      query: input.query,
+      scopes: input.scopes,
+    },
+    input.executionContext
+  );
+  return {
+    recallInvoked: true,
+    memories: recallMemoriesFromGatewayResult(result),
+  };
+}
+
+function createSyntheticRecallAgentContext(): AgentContext {
+  const role = DEFAULT_ROLES.definitions.chat_bot;
+  return {
+    source: 'discord',
+    platform: 'discord',
+    roleName: 'chat_bot',
+    role,
+    session: {
+      sessionId: 'synthetic-dogfood-explicit-recall',
+      channelId: SYNTHETIC_DOGFOOD_CHANNEL,
+      userId: 'synthetic-dogfood-user',
+      startedAt: new Date(SYNTHETIC_INDEXED_AT),
+    },
+    capabilities: role.allowedTools,
+    limitations: ['Synthetic dogfood execution context'],
+    tier: 1,
+  };
+}
+
+function createSyntheticRecallExecutionContext(): GatewayToolExecutionContext {
+  const agentContext = createSyntheticRecallAgentContext();
+  return {
+    agentContext,
+    agentId: 'chat_bot',
+    source: 'discord',
+    channelId: SYNTHETIC_DOGFOOD_CHANNEL,
+    executionSurface: 'model_tool',
+    sourceTurnId: 'synthetic-dogfood-explicit-recall',
+    sourceMessageRef: 'synthetic-dogfood-explicit-recall',
+    modelRunId: 'mr_synthetic_dogfood_recall',
+  };
+}
+
+function buildMemoryCommitInput(
+  db: SQLiteDatabase,
+  event: SyntheticDogfoodSeededEvent,
+  expectedAdvancedThroughSeq: number,
+  memoryStore: SyntheticDogfoodMemoryBackend,
+  nowMs: () => number
+): ConnectorIngressManualMemoryCommitInput {
+  return {
+    rawAdapter: db,
+    operatorDb: db,
+    connector: SYNTHETIC_DOGFOOD_CONNECTOR,
+    channel: SYNTHETIC_DOGFOOD_CHANNEL,
+    expectedAdvancedThroughSeq,
+    eventMemories: [
+      {
+        eventIndexId: event.eventIndexId,
+        memories: [
+          {
+            topic: SYNTHETIC_MEMORY_TOPIC,
+            kind: 'decision',
+            summary: SYNTHETIC_MEMORY_SUMMARY,
+            details: SYNTHETIC_MEMORY_DETAILS,
+            confidence: 0.88,
+            scopes: [SYNTHETIC_PROJECT_SCOPE, SYNTHETIC_CHANNEL_SCOPE],
+          },
+        ],
+      },
+    ],
+    saveMemory: memoryStore.saveMemory,
+    createTrustedProvenanceCapability: createSyntheticTrustedCapability,
+    listMemoriesByGatewayCallId: memoryStore.listMemoriesByGatewayCallId,
+    setMemoryStatus: memoryStore.setMemoryStatus,
+    nowMs,
+  };
+}
+
+function requireEvent(
+  events: readonly SyntheticDogfoodSeededEvent[],
+  role: SyntheticDogfoodEventRole
+): SyntheticDogfoodSeededEvent {
+  const event = events.find((candidate) => candidate.role === role);
+  if (!event) {
+    throw new Error(`Synthetic dogfood fixture missing ${role} event`);
+  }
+  return event;
+}
+
+async function ensureReplayHasRetrievableMemory(input: {
+  memoryStore: SyntheticDogfoodMemoryBackend;
+}): Promise<void> {
+  if (await input.memoryStore.hasActiveMemory(SYNTHETIC_MEMORY_TOPIC)) {
+    return;
+  }
+  throw new Error(
+    'Synthetic dogfood replay found committed memory intent without retrievable memory state'
+  );
+}
+
+export async function runSyntheticDogfoodHarness(
+  input: SyntheticDogfoodHarnessInput
+): Promise<SyntheticDogfoodHarnessResult> {
+  const nowMs = input.nowMs ?? Date.now;
+  const artifactRoot = resolveArtifactRoot(input.artifactRoot);
+  const repoDbArtifactsBefore = snapshotRepoDbArtifacts(artifactRoot);
+  const events = seedSyntheticDogfoodEvents(input.db);
+  const noUpdateEvent = requireEvent(events, 'no_update');
+  const wikiEvent = requireEvent(events, 'wiki');
+  const memoryEvent = requireEvent(events, 'memory');
+  const noUpdateSeq = readSyntheticEventSeq(input.db, noUpdateEvent);
+  const wikiSeq = readSyntheticEventSeq(input.db, wikiEvent);
+  const wikiStore = new WikiArtifactStore(input.db);
+  wikiStore.ensureSchema();
+
+  const preview = buildConnectorEventIngressPreview({
+    rawAdapter: input.db,
+    operatorDb: input.db,
+    connector: SYNTHETIC_DOGFOOD_CONNECTOR,
+    channel: SYNTHETIC_DOGFOOD_CHANNEL,
+    limit: 10,
+  });
+  const dryRun = buildConnectorIngressMigrationDryRun({
+    rawAdapter: input.db,
+    operatorDb: input.db,
+    connector: SYNTHETIC_DOGFOOD_CONNECTOR,
+    channel: SYNTHETIC_DOGFOOD_CHANNEL,
+    limit: 10,
+  });
+  const dryRunWriteCounts = readWriteCounts(input.db);
+
+  const noUpdate = await commitConnectorIngressNoUpdateBatch({
+    rawAdapter: input.db,
+    operatorDb: input.db,
+    connector: SYNTHETIC_DOGFOOD_CONNECTOR,
+    channel: SYNTHETIC_DOGFOOD_CHANNEL,
+    expectedAdvancedThroughSeq: 0,
+    eventIndexIds: [noUpdateEvent.eventIndexId],
+    nowMs,
+  });
+
+  const wikiPublishAdapter = createWikiPublishAdapter({
+    mode: 'vnext',
+    store: wikiStore,
+    now: () => new Date(nowMs()),
+    nowMs,
+  });
+  const wiki = await commitConnectorIngressWikiBatch({
+    rawAdapter: input.db,
+    operatorDb: input.db,
+    wikiPublishAdapter,
+    connector: SYNTHETIC_DOGFOOD_CONNECTOR,
+    channel: SYNTHETIC_DOGFOOD_CHANNEL,
+    expectedAdvancedThroughSeq: noUpdateSeq,
+    eventPages: [
+      {
+        eventIndexId: wikiEvent.eventIndexId,
+        pages: [
+          {
+            path: 'synthetic/vnext-dogfood.md',
+            title: 'Synthetic vNext Dogfood',
+            type: 'entity',
+            content: 'Operator-authored synthetic wiki projection summary.',
+            confidence: 'high',
+          },
+        ],
+      },
+    ],
+    nowMs,
+  });
+
+  const memoryStore = input.memoryStore ?? createSyntheticDogfoodMemoryStore();
+  const memoryInput = buildMemoryCommitInput(input.db, memoryEvent, wikiSeq, memoryStore, nowMs);
+  const memory = await commitConnectorIngressMemoryBatch(memoryInput);
+  const memoryReplay = await commitConnectorIngressMemoryBatch(memoryInput);
+  const memoryWasReplayOnly =
+    memory.memoriesSaved === 0 &&
+    memory.commits.some((commit) => commit.outcome === 'already_committed');
+  if (memoryWasReplayOnly) {
+    await ensureReplayHasRetrievableMemory({
+      memoryStore,
+    });
+  }
+
+  const projection = buildSituationProjection(
+    [
+      {
+        situationId: 'synthetic_dogfood_memory_follow_up',
+        situationVersion: 1,
+        awarenessRunId: 'synthetic_dogfood_run',
+        title: 'Synthetic memory follow-up is committed',
+        status: 'done',
+        summary: 'The synthetic reviewed memory event reached an operator-approved projection.',
+        nextAction: 'Use explicit recall when the next synthetic turn asks for this memory.',
+        freshness: 'live',
+        verificationState: 'verified',
+        confidence: 0.92,
+        evidenceRefs: [sourceRefFor(memoryEvent)],
+        updatedAtMs: nowMs(),
+        viewModelHash: `synthetic-dogfood-${memoryEvent.eventIndexId}`,
+        priority: 1,
+        tags: ['synthetic', 'dogfood'],
+        ownerHint: 'operator',
+      },
+    ],
+    nowMs()
+  );
+
+  const recallExecutor = new GatewayToolExecutor({
+    mamaApi: createSyntheticMamaApi(memoryStore),
+    envelopeIssuanceMode: 'off',
+  });
+  const recallExecutionContext = createSyntheticRecallExecutionContext();
+  const ordinary = await executeSyntheticOrdinaryRouterTurn({
+    db: input.db,
+    memoryStore,
+  });
+  const negativeExplicit = await executeSyntheticExplicitRecall({
+    executor: recallExecutor,
+    query: 'unrelated synthetic topic',
+    scopes: [SYNTHETIC_CHANNEL_SCOPE],
+    executionContext: recallExecutionContext,
+  });
+  const explicit = await executeSyntheticExplicitRecall({
+    executor: recallExecutor,
+    query: SYNTHETIC_MEMORY_TOPIC,
+    scopes: [SYNTHETIC_CHANNEL_SCOPE],
+    executionContext: recallExecutionContext,
+  });
+  const repoDbArtifactsAfter = snapshotRepoDbArtifacts(artifactRoot);
+  const repoDbArtifactsChanged = listChangedRepoDbArtifacts(
+    repoDbArtifactsBefore,
+    repoDbArtifactsAfter
+  );
+  if (repoDbArtifactsChanged.length > 0) {
+    throw new Error(
+      `Synthetic dogfood created or modified repository DB artifacts: ${repoDbArtifactsChanged.join(', ')}`
+    );
+  }
+
+  return {
+    scenario: {
+      synthetic: true,
+      connector: SYNTHETIC_DOGFOOD_CONNECTOR,
+      channel: SYNTHETIC_DOGFOOD_CHANNEL,
+    },
+    events,
+    preview,
+    dryRun,
+    dryRunWriteCounts,
+    commits: {
+      noUpdate,
+      wiki,
+      memory,
+    },
+    replay: {
+      memory: memoryReplay,
+    },
+    projection,
+    recall: {
+      ordinary,
+      negativeExplicit,
+      explicit,
+      totalRecallCalls: memoryStore.getTotalRecallCalls(),
+    },
+    artifacts: {
+      repoDbFilesCreated: repoDbArtifactsChanged,
+    },
+  };
+}

--- a/packages/standalone/tests/agent/gateway-tool-executor.test.ts
+++ b/packages/standalone/tests/agent/gateway-tool-executor.test.ts
@@ -370,6 +370,56 @@ describe('STORY-V019 - GatewayToolExecutor', () => {
         });
         expect(mockApi.recallMemory).not.toHaveBeenCalled();
       });
+
+      it('should redact recall secrets that cross the truncation boundary', async () => {
+        const mockApi = createMockApi();
+        const boundaryCrossingSecret = `sk-${'a'.repeat(120)}`;
+        vi.mocked(mockApi.recallMemory).mockResolvedValue({
+          profile: { static: [], dynamic: [], evidence: [] },
+          memories: [
+            {
+              topic: 'operator/manual-memory',
+              summary: `${'x'.repeat(260)}${boundaryCrossingSecret} should not leak`,
+            },
+          ],
+          graph_context: { primary: [], expanded: [], edges: [] },
+          search_meta: { query: boundaryCrossingSecret },
+        });
+        const executor = new GatewayToolExecutor({
+          mamaApi: mockApi,
+          envelopeIssuanceMode: 'off',
+        });
+        const discordContext = createDiscordContext();
+
+        const result = await executor.execute(
+          'mama_recall',
+          {
+            query: 'operator/manual-memory',
+          },
+          {
+            agentContext: {
+              ...discordContext,
+              session: {
+                ...discordContext.session,
+                channelId: 'channel-allowed',
+                userId: 'user-allowed',
+              },
+            },
+            agentId: 'chat_bot',
+            source: 'discord',
+            channelId: 'channel-allowed',
+            executionSurface: 'model_tool',
+          } as Parameters<GatewayToolExecutor['execute']>[2]
+        );
+
+        expect(result).toMatchObject({ success: true });
+        const bundle = (result as { bundle: { memories: Array<{ summary?: string }> } }).bundle;
+        const summary = bundle.memories[0]?.summary ?? '';
+        expect(summary).toContain('[redacted]');
+        expect(summary).toContain('[truncated]');
+        expect(summary).not.toContain('sk-');
+        expect(JSON.stringify(result)).not.toContain(boundaryCrossingSecret);
+      });
     });
 
     describe('update tool', () => {

--- a/packages/standalone/tests/agent/gateway-tool-executor.test.ts
+++ b/packages/standalone/tests/agent/gateway-tool-executor.test.ts
@@ -314,6 +314,64 @@ describe('STORY-V019 - GatewayToolExecutor', () => {
       });
     });
 
+    describe('recall tool', () => {
+      it('should deny model-supplied scopes outside the active Discord session', async () => {
+        const mockApi = createMockApi();
+        const executor = new GatewayToolExecutor({
+          mamaApi: mockApi,
+          envelopeIssuanceMode: 'off',
+        });
+        const discordContext = createDiscordContext();
+
+        const result = await executor.execute(
+          'mama_recall',
+          {
+            query: 'operator/manual-memory',
+            scopes: [{ kind: 'project', id: 'project_other_synthetic' }],
+          },
+          {
+            agentContext: {
+              ...discordContext,
+              session: {
+                ...discordContext.session,
+                channelId: 'channel-allowed',
+                userId: 'user-allowed',
+              },
+            },
+            agentId: 'chat_bot',
+            source: 'discord',
+            channelId: 'channel-allowed',
+            executionSurface: 'model_tool',
+          } as Parameters<GatewayToolExecutor['execute']>[2]
+        );
+
+        expect(result).toMatchObject({
+          success: false,
+          code: 'memory_scope_denied',
+        });
+        expect(mockApi.recallMemory).not.toHaveBeenCalled();
+      });
+
+      it('should deny caller-supplied recall scopes without an active session boundary', async () => {
+        const mockApi = createMockApi();
+        const executor = new GatewayToolExecutor({
+          mamaApi: mockApi,
+          envelopeIssuanceMode: 'off',
+        });
+
+        const result = await executor.execute('mama_recall', {
+          query: 'operator/manual-memory',
+          scopes: [{ kind: 'global', id: '*' }],
+        });
+
+        expect(result).toMatchObject({
+          success: false,
+          code: 'memory_scope_denied',
+        });
+        expect(mockApi.recallMemory).not.toHaveBeenCalled();
+      });
+    });
+
     describe('update tool', () => {
       it('should update outcome', async () => {
         const mockApi = createMockApi();

--- a/packages/standalone/tests/contract/envelope-callsite-matrix.test.ts
+++ b/packages/standalone/tests/contract/envelope-callsite-matrix.test.ts
@@ -51,6 +51,10 @@ const CLASSIFIED = new Map<string, string>([
     'agent/code-act/host-bridge.ts',
     'M1R Reactive Main: HostBridge gateway calls carry the active envelope context',
   ],
+  [
+    'operator-vnext/synthetic-dogfood-harness.ts',
+    'PR16 dogfood-only: explicit synthetic recall carries GatewayToolExecutionContext',
+  ],
   ['multi-agent/', 'M7-owned: spawn_subordinate delegated memory worker envelopes are outside M1R'],
   ['scheduler/', 'M8-owned: schedule_worker/Autonomous Standing envelope issuance is outside M1R'],
 ]);

--- a/packages/standalone/tests/gateways/memory-v2.e2e.test.ts
+++ b/packages/standalone/tests/gateways/memory-v2.e2e.test.ts
@@ -62,12 +62,13 @@ describe('Story: Memory V2 Standalone Integration', () => {
         return 'Agent response';
       });
 
+      const recallMemory = vi.fn(mamaApi.recallMemory.bind(mamaApi));
       const mamaApiClient = {
         search: async (query: string, limit?: number) => {
           const result = await mamaApi.suggest(query, limit !== undefined ? { limit } : undefined);
           return result?.results || [];
         },
-        recallMemory: mamaApi.recallMemory.bind(mamaApi),
+        recallMemory,
         ingestMemory: mamaApi.ingestMemory.bind(mamaApi),
         save: mamaApi.save.bind(mamaApi),
       };
@@ -111,6 +112,7 @@ describe('Story: Memory V2 Standalone Integration', () => {
 
       expect(lastPrompt).not.toContain('[MAMA Profile]');
       expect(lastPrompt).not.toContain('[MAMA Memories]');
+      expect(recallMemory).not.toHaveBeenCalled();
 
       sessionStore.close();
     });

--- a/packages/standalone/tests/gateways/message-router.test.ts
+++ b/packages/standalone/tests/gateways/message-router.test.ts
@@ -147,14 +147,16 @@ describe('MessageRouter', () => {
       expect(generatedTurnId).not.toBe('msg-1');
     });
 
-    it('should inject profile-aware recall bundle into the prompt', async () => {
+    it('should inject profile-aware recall bundle into the prompt when implicit recall is enabled', async () => {
       let receivedPrompt = '';
       const agentLoop = createMockAgentLoop((prompt) => {
         receivedPrompt = prompt;
         return 'Agent response';
       });
       const mamaApi = createMockMamaApi(mockDecisions);
-      const customRouter = new MessageRouter(sessionStore, agentLoop, mamaApi);
+      const customRouter = new MessageRouter(sessionStore, agentLoop, mamaApi, {
+        implicitMemoryRecall: true,
+      });
 
       await customRouter.process({
         source: 'discord',
@@ -166,6 +168,32 @@ describe('MessageRouter', () => {
       expect(receivedPrompt).toContain('[MAMA Profile]');
       expect(receivedPrompt).toContain('[MAMA Memories]');
       expect(receivedPrompt).toContain('Current repo uses pnpm');
+    });
+
+    it('should not inject legacy MAMA Memory context by default', async () => {
+      let receivedPrompt = '';
+      const agentLoop = createMockAgentLoop((prompt) => {
+        receivedPrompt = prompt;
+        return 'Agent response';
+      });
+      const mamaApi = createMockMamaApi(mockDecisions);
+      const search = vi.fn(mamaApi.search.bind(mamaApi));
+      const customRouter = new MessageRouter(sessionStore, agentLoop, {
+        ...mamaApi,
+        search,
+      });
+
+      await customRouter.process({
+        source: 'discord',
+        channelId: 'channel-legacy-memory',
+        userId: 'user-456',
+        text: 'Tell me about test_topic',
+      });
+
+      expect(search).not.toHaveBeenCalled();
+      expect(receivedPrompt).not.toContain('[MAMA Memory]');
+      expect(receivedPrompt).not.toContain('Prior Decisions');
+      expect(receivedPrompt).not.toContain('Test decision');
     });
 
     it('should pass system prompt to agent loop for new sessions', async () => {

--- a/packages/standalone/tests/operator-vnext/synthetic-dogfood-agent-loop.test.ts
+++ b/packages/standalone/tests/operator-vnext/synthetic-dogfood-agent-loop.test.ts
@@ -270,7 +270,6 @@ describe('STORY-VNEXT-PR16-SYNTHETIC-DOGFOOD: production gateway tool-call path'
       scopes: [SYNTHETIC_ALLOWED_CHANNEL_SCOPE],
     });
 
-    expect(persistentAdapterOptionsMock.mock.calls[0]?.[0]?.systemPrompt).toContain('mama_recall');
     expect(mamaApi.recallMemory).toHaveBeenCalledWith('operator/manual-memory', {
       scopes: [SYNTHETIC_ALLOWED_CHANNEL_SCOPE],
       includeProfile: true,

--- a/packages/standalone/tests/operator-vnext/synthetic-dogfood-agent-loop.test.ts
+++ b/packages/standalone/tests/operator-vnext/synthetic-dogfood-agent-loop.test.ts
@@ -264,140 +264,144 @@ describe('STORY-VNEXT-PR16-SYNTHETIC-DOGFOOD: production gateway tool-call path'
     persistentAdapterOptionsMock.mockClear();
   });
 
-  it('exposes, authorizes, and executes mama_recall through AgentLoop tool_use routing', async () => {
-    const { mamaApi, gatewayResult, result } = await runSyntheticRecallTool({
-      query: 'operator/manual-memory',
-      scopes: [SYNTHETIC_ALLOWED_CHANNEL_SCOPE],
-    });
-
-    expect(mamaApi.recallMemory).toHaveBeenCalledWith('operator/manual-memory', {
-      scopes: [SYNTHETIC_ALLOWED_CHANNEL_SCOPE],
-      includeProfile: true,
-    });
-    expect(gatewayResult).toMatchObject({
-      success: true,
-      bundle: {
-        memories: [
-          {
-            topic: 'operator/manual-memory',
-            summary: 'Synthetic reviewed memory is available after explicit recall.',
-          },
-        ],
-      },
-    });
-    const toolResultContent = extractToolResultContent(result.history);
-    expect(toolResultContent).toContain(
-      'Synthetic reviewed memory is available after explicit recall.'
-    );
-    for (const canary of SYNTHETIC_DOGFOOD_RAW_CANARIES) {
-      expect(toolResultContent).not.toContain(canary);
-    }
-    const serializedGatewayResult = JSON.stringify(gatewayResult);
-    for (const internal of [
-      'memory_real_agent_loop_synthetic',
-      'memory_id',
-      'source_type',
-      'synthetic-agent-loop',
-      'channel_id',
-      'project_id',
-      'source_refs',
-      'raw:synthetic:private-source-ref',
-      '/tmp/mama-synthetic-private-source.txt',
-      'created_at',
-      'updated_at',
-      'search_meta',
-      'scope_order',
-      'retrieval_sources',
-    ]) {
-      expect(serializedGatewayResult).not.toContain(internal);
-      expect(toolResultContent).not.toContain(internal);
-    }
-  });
-
-  it('does not echo raw recall query canaries into model-visible tool output', async () => {
-    const queryCanary =
-      'MAMA_SYNTHETIC_RECALL_QUERY_CANARY_DO_NOT_LEAK /tmp/mama-synthetic-query-canary';
-    const { gatewayResult, result } = await runSyntheticRecallTool({
-      query: queryCanary,
-      scopes: [SYNTHETIC_ALLOWED_CHANNEL_SCOPE],
-    });
-
-    const serializedGatewayResult = JSON.stringify(gatewayResult);
-    const toolResultContent = extractToolResultContent(result.history);
-    expect(serializedGatewayResult).not.toContain(queryCanary);
-    expect(toolResultContent).not.toContain(queryCanary);
-    expect(serializedGatewayResult).not.toContain('MAMA_SYNTHETIC_RECALL_QUERY_CANARY_DO_NOT_LEAK');
-    expect(toolResultContent).not.toContain('MAMA_SYNTHETIC_RECALL_QUERY_CANARY_DO_NOT_LEAK');
-  });
-
-  it('redacts raw canaries from returned recall topic and summary fields', async () => {
-    const { gatewayResult, result } = await runSyntheticRecallTool({
-      query: `operator/manual-memory ${SYNTHETIC_RETURNED_FIELD_CANARY}`,
-      scopes: [SYNTHETIC_ALLOWED_CHANNEL_SCOPE],
-    });
-
-    const serializedGatewayResult = JSON.stringify(gatewayResult);
-    const toolResultContent = extractToolResultContent(result.history);
-    expect(serializedGatewayResult).not.toContain(SYNTHETIC_RETURNED_FIELD_CANARY);
-    expect(toolResultContent).not.toContain(SYNTHETIC_RETURNED_FIELD_CANARY);
-    expect(serializedGatewayResult).not.toContain('/tmp/mama-synthetic-returned-field');
-    expect(toolResultContent).not.toContain('/tmp/mama-synthetic-returned-field');
-    expect(serializedGatewayResult).toContain('[redacted]');
-    expect(toolResultContent).toContain('[redacted]');
-  });
-
-  it('redacts production-shaped private strings from returned recall fields', async () => {
-    const { gatewayResult, result } = await runSyntheticRecallTool({
-      query: PRODUCTION_REDACTION_QUERY,
-      scopes: [SYNTHETIC_ALLOWED_CHANNEL_SCOPE],
-    });
-
-    const serializedGatewayResult = JSON.stringify(gatewayResult);
-    const toolResultContent = extractToolResultContent(result.history);
-    for (const leak of PRODUCTION_REDACTION_LEAKS) {
-      expect(serializedGatewayResult).not.toContain(leak);
-      expect(toolResultContent).not.toContain(leak);
-    }
-    expect(serializedGatewayResult).toContain('[redacted]');
-    expect(toolResultContent).toContain('[redacted]');
-  });
-
-  it('does not return memory for wrong project, wrong channel, or broad scopes', async () => {
-    const cases: Array<{ label: string; input: Record<string, unknown> }> = [
-      {
-        label: 'wrong project scope',
-        input: {
-          query: 'operator/manual-memory',
-          scopes: [{ kind: 'project', id: 'project_other_synthetic' }],
-        },
-      },
-      {
-        label: 'wrong channel scope',
-        input: {
-          query: 'operator/manual-memory',
-          scopes: [{ kind: 'channel', id: 'discord:C_OTHER_SYNTHETIC' }],
-        },
-      },
-      {
-        label: 'broad global scope',
-        input: {
-          query: 'operator/manual-memory',
-          scopes: [{ kind: 'global', id: '*' }],
-        },
-      },
-    ];
-
-    for (const testCase of cases) {
-      const { mamaApi, gatewayResult, result } = await runSyntheticRecallTool(testCase.input);
-
-      expect(gatewayResult, testCase.label).toMatchObject({
-        success: false,
-        code: 'memory_scope_denied',
+  describe('AC: scoped production recall is explicit and redacted', () => {
+    it('exposes, authorizes, and executes mama_recall through AgentLoop tool_use routing', async () => {
+      const { mamaApi, gatewayResult, result } = await runSyntheticRecallTool({
+        query: 'operator/manual-memory',
+        scopes: [SYNTHETIC_ALLOWED_CHANNEL_SCOPE],
       });
-      expect(mamaApi.recallMemory, testCase.label).not.toHaveBeenCalled();
-      expect(extractToolResultContent(result.history), testCase.label).toContain(
-        'memory_scope_denied'
+
+      expect(mamaApi.recallMemory).toHaveBeenCalledWith('operator/manual-memory', {
+        scopes: [SYNTHETIC_ALLOWED_CHANNEL_SCOPE],
+        includeProfile: true,
+      });
+      expect(gatewayResult).toMatchObject({
+        success: true,
+        bundle: {
+          memories: [
+            {
+              topic: 'operator/manual-memory',
+              summary: 'Synthetic reviewed memory is available after explicit recall.',
+            },
+          ],
+        },
+      });
+      const toolResultContent = extractToolResultContent(result.history);
+      expect(toolResultContent).toContain(
+        'Synthetic reviewed memory is available after explicit recall.'
       );
-    }
+      for (const canary of SYNTHETIC_DOGFOOD_RAW_CANARIES) {
+        expect(toolResultContent).not.toContain(canary);
+      }
+      const serializedGatewayResult = JSON.stringify(gatewayResult);
+      for (const internal of [
+        'memory_real_agent_loop_synthetic',
+        'memory_id',
+        'source_type',
+        'synthetic-agent-loop',
+        'channel_id',
+        'project_id',
+        'source_refs',
+        'raw:synthetic:private-source-ref',
+        '/tmp/mama-synthetic-private-source.txt',
+        'created_at',
+        'updated_at',
+        'search_meta',
+        'scope_order',
+        'retrieval_sources',
+      ]) {
+        expect(serializedGatewayResult).not.toContain(internal);
+        expect(toolResultContent).not.toContain(internal);
+      }
+    });
+
+    it('does not echo raw recall query canaries into model-visible tool output', async () => {
+      const queryCanary =
+        'MAMA_SYNTHETIC_RECALL_QUERY_CANARY_DO_NOT_LEAK /tmp/mama-synthetic-query-canary';
+      const { gatewayResult, result } = await runSyntheticRecallTool({
+        query: queryCanary,
+        scopes: [SYNTHETIC_ALLOWED_CHANNEL_SCOPE],
+      });
+
+      const serializedGatewayResult = JSON.stringify(gatewayResult);
+      const toolResultContent = extractToolResultContent(result.history);
+      expect(serializedGatewayResult).not.toContain(queryCanary);
+      expect(toolResultContent).not.toContain(queryCanary);
+      expect(serializedGatewayResult).not.toContain(
+        'MAMA_SYNTHETIC_RECALL_QUERY_CANARY_DO_NOT_LEAK'
+      );
+      expect(toolResultContent).not.toContain('MAMA_SYNTHETIC_RECALL_QUERY_CANARY_DO_NOT_LEAK');
+    });
+
+    it('redacts raw canaries from returned recall topic and summary fields', async () => {
+      const { gatewayResult, result } = await runSyntheticRecallTool({
+        query: `operator/manual-memory ${SYNTHETIC_RETURNED_FIELD_CANARY}`,
+        scopes: [SYNTHETIC_ALLOWED_CHANNEL_SCOPE],
+      });
+
+      const serializedGatewayResult = JSON.stringify(gatewayResult);
+      const toolResultContent = extractToolResultContent(result.history);
+      expect(serializedGatewayResult).not.toContain(SYNTHETIC_RETURNED_FIELD_CANARY);
+      expect(toolResultContent).not.toContain(SYNTHETIC_RETURNED_FIELD_CANARY);
+      expect(serializedGatewayResult).not.toContain('/tmp/mama-synthetic-returned-field');
+      expect(toolResultContent).not.toContain('/tmp/mama-synthetic-returned-field');
+      expect(serializedGatewayResult).toContain('[redacted]');
+      expect(toolResultContent).toContain('[redacted]');
+    });
+
+    it('redacts production-shaped private strings from returned recall fields', async () => {
+      const { gatewayResult, result } = await runSyntheticRecallTool({
+        query: PRODUCTION_REDACTION_QUERY,
+        scopes: [SYNTHETIC_ALLOWED_CHANNEL_SCOPE],
+      });
+
+      const serializedGatewayResult = JSON.stringify(gatewayResult);
+      const toolResultContent = extractToolResultContent(result.history);
+      for (const leak of PRODUCTION_REDACTION_LEAKS) {
+        expect(serializedGatewayResult).not.toContain(leak);
+        expect(toolResultContent).not.toContain(leak);
+      }
+      expect(serializedGatewayResult).toContain('[redacted]');
+      expect(toolResultContent).toContain('[redacted]');
+    });
+
+    it('does not return memory for wrong project, wrong channel, or broad scopes', async () => {
+      const cases: Array<{ label: string; input: Record<string, unknown> }> = [
+        {
+          label: 'wrong project scope',
+          input: {
+            query: 'operator/manual-memory',
+            scopes: [{ kind: 'project', id: 'project_other_synthetic' }],
+          },
+        },
+        {
+          label: 'wrong channel scope',
+          input: {
+            query: 'operator/manual-memory',
+            scopes: [{ kind: 'channel', id: 'discord:C_OTHER_SYNTHETIC' }],
+          },
+        },
+        {
+          label: 'broad global scope',
+          input: {
+            query: 'operator/manual-memory',
+            scopes: [{ kind: 'global', id: '*' }],
+          },
+        },
+      ];
+
+      for (const testCase of cases) {
+        const { mamaApi, gatewayResult, result } = await runSyntheticRecallTool(testCase.input);
+
+        expect(gatewayResult, testCase.label).toMatchObject({
+          success: false,
+          code: 'memory_scope_denied',
+        });
+        expect(mamaApi.recallMemory, testCase.label).not.toHaveBeenCalled();
+        expect(extractToolResultContent(result.history), testCase.label).toContain(
+          'memory_scope_denied'
+        );
+      }
+    });
   });
 });

--- a/packages/standalone/tests/operator-vnext/synthetic-dogfood-agent-loop.test.ts
+++ b/packages/standalone/tests/operator-vnext/synthetic-dogfood-agent-loop.test.ts
@@ -1,0 +1,404 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RecallBundle } from '@jungjaehoon/mama-core';
+import { DEFAULT_ROLES } from '../../src/cli/config/types.js';
+import { AgentLoop } from '../../src/agent/agent-loop.js';
+import { createAgentContext } from '../../src/agent/context-prompt-builder.js';
+import type { MAMAApiInterface } from '../../src/agent/types.js';
+import type { OAuthManager } from '../../src/auth/index.js';
+import {
+  SYNTHETIC_DOGFOOD_RAW_CANARIES,
+  SYNTHETIC_DOGFOOD_CHANNEL,
+} from '../../src/operator-vnext/synthetic-dogfood-harness.js';
+
+process.env.MAMA_FORCE_TIER_3 = 'true';
+
+const { persistentPromptMock, persistentAdapterOptionsMock } = vi.hoisted(() => ({
+  persistentPromptMock: vi.fn(),
+  persistentAdapterOptionsMock: vi.fn(),
+}));
+
+vi.mock('../../src/agent/persistent-cli-adapter.js', () => ({
+  PersistentCLIAdapter: vi.fn().mockImplementation((options) => {
+    persistentAdapterOptionsMock(options);
+    return {
+      prompt: persistentPromptMock,
+      setSystemPrompt: vi.fn(),
+      setSessionId: vi.fn(),
+      stop: vi.fn(),
+      isHealthy: vi.fn(() => true),
+      getMetrics: vi.fn(() => ({
+        requestCount: 0,
+        failureCount: 0,
+        avgLatencyMs: 0,
+        lastRequestAt: null,
+      })),
+    };
+  }),
+}));
+
+function createMockOAuthManager(): OAuthManager {
+  return {
+    getToken: vi.fn().mockResolvedValue('synthetic-oauth-token'),
+  } as unknown as OAuthManager;
+}
+
+interface SyntheticRecallOptions {
+  scopes?: Array<{ kind: string; id: string }>;
+  includeProfile?: boolean;
+}
+
+const SYNTHETIC_ALLOWED_CHANNEL_SCOPE = {
+  kind: 'channel' as const,
+  id: `discord:${SYNTHETIC_DOGFOOD_CHANNEL}`,
+};
+const SYNTHETIC_RETURNED_FIELD_CANARY = 'MAMA_SYNTHETIC_RETURNED_FIELD_CANARY_DO_NOT_LEAK';
+const PRODUCTION_REDACTION_QUERY = 'operator/production-redaction';
+const PRODUCTION_REDACTION_LEAKS = [
+  'alice@example.com',
+  ['https://hooks.slack.com/services', 'T00000000', 'B00000000', 'abcdef'].join('/'),
+  ['ghp_', 'abcdefghijklmnopqrstuvwx'].join(''),
+  ['/', 'home', 'alice', 'private.txt'].join('/'),
+  '123456789012345678',
+] as const;
+
+function hasAuthorizedSyntheticScope(options?: SyntheticRecallOptions): boolean {
+  return (
+    options?.scopes?.some(
+      (scope) =>
+        scope.kind === SYNTHETIC_ALLOWED_CHANNEL_SCOPE.kind &&
+        scope.id === SYNTHETIC_ALLOWED_CHANNEL_SCOPE.id
+    ) ?? false
+  );
+}
+
+function createSyntheticRecallBundle(query: string): RecallBundle {
+  const includeReturnedFieldCanary = query.includes(SYNTHETIC_RETURNED_FIELD_CANARY);
+  const includeProductionRedaction = query.includes(PRODUCTION_REDACTION_QUERY);
+  const memory = {
+    id: 'memory_real_agent_loop_synthetic',
+    topic: includeProductionRedaction
+      ? `operator/private ${PRODUCTION_REDACTION_LEAKS[0]} ${PRODUCTION_REDACTION_LEAKS[1]}`
+      : includeReturnedFieldCanary
+        ? `operator/${SYNTHETIC_RETURNED_FIELD_CANARY}`
+        : 'operator/manual-memory',
+    kind: 'decision' as const,
+    summary: includeProductionRedaction
+      ? `Synthetic private token ${PRODUCTION_REDACTION_LEAKS[2]} at ${PRODUCTION_REDACTION_LEAKS[3]} for ${PRODUCTION_REDACTION_LEAKS[4]}`
+      : includeReturnedFieldCanary
+        ? `Synthetic ${SYNTHETIC_RETURNED_FIELD_CANARY} /tmp/mama-synthetic-returned-field`
+        : 'Synthetic reviewed memory is available after explicit recall.',
+    details:
+      'Synthetic operator-approved detail derived from a reviewed fixture at /tmp/mama-synthetic-private-source.txt.',
+    confidence: 0.88,
+    status: 'active' as const,
+    scopes: [SYNTHETIC_ALLOWED_CHANNEL_SCOPE],
+    source: {
+      package: 'standalone' as const,
+      source_type: 'synthetic-agent-loop',
+      channel_id: SYNTHETIC_DOGFOOD_CHANNEL,
+      project_id: 'project_public_synthetic',
+    },
+    created_at: '2026-07-03T00:00:00.000Z',
+    updated_at: '2026-07-03T00:00:00.000Z',
+    source_refs: ['raw:synthetic:private-source-ref'],
+    local_path: '/tmp/mama-synthetic-private-source.txt',
+  };
+  return {
+    profile: {
+      static: [],
+      dynamic: [],
+      evidence: [
+        {
+          memory_id: memory.id,
+          topic: memory.topic,
+          why_included:
+            'Synthetic gateway tool call matched the requested project scope from /tmp/mama-synthetic-private-source.txt.',
+        },
+      ],
+    },
+    memories: [memory],
+    graph_context: {
+      primary: [memory],
+      expanded: [],
+      edges: [],
+    },
+    search_meta: {
+      query,
+      scope_order: ['project'],
+      retrieval_sources: ['synthetic'],
+    },
+  };
+}
+
+function createEmptyRecallBundle(query: string): RecallBundle {
+  return {
+    profile: {
+      static: [],
+      dynamic: [],
+      evidence: [],
+    },
+    memories: [],
+    graph_context: {
+      primary: [],
+      expanded: [],
+      edges: [],
+    },
+    search_meta: {
+      query,
+      scope_order: [],
+      retrieval_sources: [],
+    },
+  };
+}
+
+function createToolRecallApi(): MAMAApiInterface {
+  return {
+    save: vi.fn().mockResolvedValue({ success: true, id: 'unused' }),
+    saveCheckpoint: vi.fn().mockResolvedValue({ success: true }),
+    listDecisions: vi.fn().mockResolvedValue([]),
+    suggest: vi.fn().mockResolvedValue({ success: true, results: [], count: 0 }),
+    recallMemory: vi.fn(async (query: string, options?: SyntheticRecallOptions) =>
+      hasAuthorizedSyntheticScope(options)
+        ? createSyntheticRecallBundle(query)
+        : createEmptyRecallBundle(query)
+    ),
+    ingestMemory: vi.fn().mockResolvedValue({ success: false }),
+    updateOutcome: vi.fn().mockResolvedValue({ success: false }),
+    loadCheckpoint: vi.fn().mockResolvedValue({ success: false }),
+    appendToolTrace: vi.fn().mockResolvedValue({
+      trace_id: 'trace_synthetic_recall',
+      model_run_id: 'mr_synthetic_tool_call',
+    }),
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function extractToolResultContent(history: unknown): string {
+  if (!Array.isArray(history)) {
+    throw new Error('AgentLoop history must be an array');
+  }
+
+  for (const message of history) {
+    const messageRecord = asRecord(message);
+    const content = messageRecord?.content;
+    if (!Array.isArray(content)) {
+      continue;
+    }
+    for (const block of content) {
+      const blockRecord = asRecord(block);
+      if (blockRecord?.type === 'tool_result' && typeof blockRecord.content === 'string') {
+        return blockRecord.content;
+      }
+    }
+  }
+
+  throw new Error('AgentLoop history did not include a tool_result block');
+}
+
+async function runSyntheticRecallTool(input: Record<string, unknown>) {
+  const mamaApi = createToolRecallApi();
+  const toolCall = {
+    name: 'mama_recall',
+    input,
+  };
+  persistentPromptMock.mockResolvedValueOnce({
+    response: `\`\`\`tool_call\n${JSON.stringify(toolCall)}\n\`\`\``,
+    usage: { input_tokens: 12, output_tokens: 4 },
+    session_id: 'synthetic-agent-loop-session',
+  });
+  persistentPromptMock.mockResolvedValueOnce({
+    response: 'Synthetic final response after tool denial.',
+    usage: { input_tokens: 4, output_tokens: 4 },
+    session_id: 'synthetic-agent-loop-session',
+  });
+
+  let gatewayResult: unknown;
+  const agentLoop = new AgentLoop(
+    createMockOAuthManager(),
+    {
+      model: 'claude-sonnet-4-6',
+      maxTurns: 3,
+      toolsConfig: { gateway: ['*'], mcp: [], mcp_config: '~/.mama/mama-mcp-config.json' },
+      onToolUse: (toolName, _input, result) => {
+        if (toolName === 'mama_recall') {
+          gatewayResult = result;
+        }
+      },
+    },
+    {},
+    { mamaApi, envelopeIssuanceMode: 'off' }
+  );
+
+  const role = DEFAULT_ROLES.definitions.chat_bot;
+  const agentContext = createAgentContext(
+    'discord',
+    'chat_bot',
+    role,
+    {
+      sessionId: 'synthetic-router-session',
+      channelId: SYNTHETIC_DOGFOOD_CHANNEL,
+      userId: 'synthetic-agent-loop-user',
+    },
+    [],
+    []
+  );
+  const result = await agentLoop.run('Recall the reviewed synthetic memory.', {
+    source: 'discord',
+    channelId: SYNTHETIC_DOGFOOD_CHANNEL,
+    agentContext,
+    modelRunId: 'mr_synthetic_tool_call',
+    stopAfterSuccessfulTools: ['mama_recall'],
+  });
+
+  return { mamaApi, gatewayResult, result };
+}
+
+describe('STORY-VNEXT-PR16-SYNTHETIC-DOGFOOD: production gateway tool-call path', () => {
+  beforeEach(() => {
+    persistentPromptMock.mockReset();
+    persistentAdapterOptionsMock.mockClear();
+  });
+
+  it('exposes, authorizes, and executes mama_recall through AgentLoop tool_use routing', async () => {
+    const { mamaApi, gatewayResult, result } = await runSyntheticRecallTool({
+      query: 'operator/manual-memory',
+      scopes: [SYNTHETIC_ALLOWED_CHANNEL_SCOPE],
+    });
+
+    expect(persistentAdapterOptionsMock.mock.calls[0]?.[0]?.systemPrompt).toContain('mama_recall');
+    expect(mamaApi.recallMemory).toHaveBeenCalledWith('operator/manual-memory', {
+      scopes: [SYNTHETIC_ALLOWED_CHANNEL_SCOPE],
+      includeProfile: true,
+    });
+    expect(gatewayResult).toMatchObject({
+      success: true,
+      bundle: {
+        memories: [
+          {
+            topic: 'operator/manual-memory',
+            summary: 'Synthetic reviewed memory is available after explicit recall.',
+          },
+        ],
+      },
+    });
+    const toolResultContent = extractToolResultContent(result.history);
+    expect(toolResultContent).toContain(
+      'Synthetic reviewed memory is available after explicit recall.'
+    );
+    for (const canary of SYNTHETIC_DOGFOOD_RAW_CANARIES) {
+      expect(toolResultContent).not.toContain(canary);
+    }
+    const serializedGatewayResult = JSON.stringify(gatewayResult);
+    for (const internal of [
+      'memory_real_agent_loop_synthetic',
+      'memory_id',
+      'source_type',
+      'synthetic-agent-loop',
+      'channel_id',
+      'project_id',
+      'source_refs',
+      'raw:synthetic:private-source-ref',
+      '/tmp/mama-synthetic-private-source.txt',
+      'created_at',
+      'updated_at',
+      'search_meta',
+      'scope_order',
+      'retrieval_sources',
+    ]) {
+      expect(serializedGatewayResult).not.toContain(internal);
+      expect(toolResultContent).not.toContain(internal);
+    }
+  });
+
+  it('does not echo raw recall query canaries into model-visible tool output', async () => {
+    const queryCanary =
+      'MAMA_SYNTHETIC_RECALL_QUERY_CANARY_DO_NOT_LEAK /tmp/mama-synthetic-query-canary';
+    const { gatewayResult, result } = await runSyntheticRecallTool({
+      query: queryCanary,
+      scopes: [SYNTHETIC_ALLOWED_CHANNEL_SCOPE],
+    });
+
+    const serializedGatewayResult = JSON.stringify(gatewayResult);
+    const toolResultContent = extractToolResultContent(result.history);
+    expect(serializedGatewayResult).not.toContain(queryCanary);
+    expect(toolResultContent).not.toContain(queryCanary);
+    expect(serializedGatewayResult).not.toContain('MAMA_SYNTHETIC_RECALL_QUERY_CANARY_DO_NOT_LEAK');
+    expect(toolResultContent).not.toContain('MAMA_SYNTHETIC_RECALL_QUERY_CANARY_DO_NOT_LEAK');
+  });
+
+  it('redacts raw canaries from returned recall topic and summary fields', async () => {
+    const { gatewayResult, result } = await runSyntheticRecallTool({
+      query: `operator/manual-memory ${SYNTHETIC_RETURNED_FIELD_CANARY}`,
+      scopes: [SYNTHETIC_ALLOWED_CHANNEL_SCOPE],
+    });
+
+    const serializedGatewayResult = JSON.stringify(gatewayResult);
+    const toolResultContent = extractToolResultContent(result.history);
+    expect(serializedGatewayResult).not.toContain(SYNTHETIC_RETURNED_FIELD_CANARY);
+    expect(toolResultContent).not.toContain(SYNTHETIC_RETURNED_FIELD_CANARY);
+    expect(serializedGatewayResult).not.toContain('/tmp/mama-synthetic-returned-field');
+    expect(toolResultContent).not.toContain('/tmp/mama-synthetic-returned-field');
+    expect(serializedGatewayResult).toContain('[redacted]');
+    expect(toolResultContent).toContain('[redacted]');
+  });
+
+  it('redacts production-shaped private strings from returned recall fields', async () => {
+    const { gatewayResult, result } = await runSyntheticRecallTool({
+      query: PRODUCTION_REDACTION_QUERY,
+      scopes: [SYNTHETIC_ALLOWED_CHANNEL_SCOPE],
+    });
+
+    const serializedGatewayResult = JSON.stringify(gatewayResult);
+    const toolResultContent = extractToolResultContent(result.history);
+    for (const leak of PRODUCTION_REDACTION_LEAKS) {
+      expect(serializedGatewayResult).not.toContain(leak);
+      expect(toolResultContent).not.toContain(leak);
+    }
+    expect(serializedGatewayResult).toContain('[redacted]');
+    expect(toolResultContent).toContain('[redacted]');
+  });
+
+  it('does not return memory for wrong project, wrong channel, or broad scopes', async () => {
+    const cases: Array<{ label: string; input: Record<string, unknown> }> = [
+      {
+        label: 'wrong project scope',
+        input: {
+          query: 'operator/manual-memory',
+          scopes: [{ kind: 'project', id: 'project_other_synthetic' }],
+        },
+      },
+      {
+        label: 'wrong channel scope',
+        input: {
+          query: 'operator/manual-memory',
+          scopes: [{ kind: 'channel', id: 'discord:C_OTHER_SYNTHETIC' }],
+        },
+      },
+      {
+        label: 'broad global scope',
+        input: {
+          query: 'operator/manual-memory',
+          scopes: [{ kind: 'global', id: '*' }],
+        },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const { mamaApi, gatewayResult, result } = await runSyntheticRecallTool(testCase.input);
+
+      expect(gatewayResult, testCase.label).toMatchObject({
+        success: false,
+        code: 'memory_scope_denied',
+      });
+      expect(mamaApi.recallMemory, testCase.label).not.toHaveBeenCalled();
+      expect(extractToolResultContent(result.history), testCase.label).toContain(
+        'memory_scope_denied'
+      );
+    }
+  });
+});

--- a/packages/standalone/tests/operator-vnext/synthetic-dogfood-harness.test.ts
+++ b/packages/standalone/tests/operator-vnext/synthetic-dogfood-harness.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { appendFileSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
@@ -12,8 +12,6 @@ import type {
 } from '@jungjaehoon/mama-core';
 import type { SyntheticDogfoodMemoryBackend } from '../../src/operator-vnext/synthetic-dogfood-harness.js';
 import type { SQLiteDatabase } from '../../src/sqlite.js';
-
-process.env.MAMA_FORCE_TIER_3 = 'true';
 
 const require = createRequire(import.meta.url);
 
@@ -53,8 +51,12 @@ let SYNTHETIC_DOGFOOD_CONNECTOR: HarnessModule['SYNTHETIC_DOGFOOD_CONNECTOR'];
 let SYNTHETIC_DOGFOOD_RAW_CANARIES: HarnessModule['SYNTHETIC_DOGFOOD_RAW_CANARIES'];
 let countRows: FixturesModule['countRows'];
 let makeOperatorVNextDb: FixturesModule['makeOperatorVNextDb'];
+let previousForceTier3: string | undefined;
 
 beforeAll(async () => {
+  previousForceTier3 = process.env.MAMA_FORCE_TIER_3;
+  process.env.MAMA_FORCE_TIER_3 = 'true';
+
   const harness = await import('../../src/operator-vnext/synthetic-dogfood-harness.js');
   const fixtures = await import('./fixtures.js');
 
@@ -65,6 +67,14 @@ beforeAll(async () => {
   SYNTHETIC_DOGFOOD_RAW_CANARIES = harness.SYNTHETIC_DOGFOOD_RAW_CANARIES;
   countRows = fixtures.countRows;
   makeOperatorVNextDb = fixtures.makeOperatorVNextDb;
+});
+
+afterAll(() => {
+  if (previousForceTier3 === undefined) {
+    delete process.env.MAMA_FORCE_TIER_3;
+    return;
+  }
+  process.env.MAMA_FORCE_TIER_3 = previousForceTier3;
 });
 
 function readNonRawLedgerRows(db: SQLiteDatabase): Record<string, unknown[]> {

--- a/packages/standalone/tests/operator-vnext/synthetic-dogfood-harness.test.ts
+++ b/packages/standalone/tests/operator-vnext/synthetic-dogfood-harness.test.ts
@@ -1,0 +1,533 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { appendFileSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type {
+  MemoryProvenanceRecord,
+  MemoryStatus,
+  PublicSaveMemoryInput,
+  RecallBundle,
+  TrustedMemoryWriteOptions,
+} from '@jungjaehoon/mama-core';
+import type { SyntheticDogfoodMemoryBackend } from '../../src/operator-vnext/synthetic-dogfood-harness.js';
+import type { SQLiteDatabase } from '../../src/sqlite.js';
+
+process.env.MAMA_FORCE_TIER_3 = 'true';
+
+const require = createRequire(import.meta.url);
+
+type HarnessModule = typeof import('../../src/operator-vnext/synthetic-dogfood-harness.js');
+type FixturesModule = typeof import('./fixtures.js');
+
+interface MamaApiModule {
+  saveMemoryWithTrustedProvenance: (
+    input: PublicSaveMemoryInput,
+    options: TrustedMemoryWriteOptions
+  ) => Promise<{ success: boolean; id: string }>;
+  recallMemory: (
+    query: string,
+    options?: { scopes?: Array<{ kind: string; id: string }>; includeProfile?: boolean }
+  ) => Promise<RecallBundle>;
+  listMemoriesByGatewayCallId: (gatewayCallId: string) => Promise<MemoryProvenanceRecord[]>;
+}
+
+interface MamaCoreModule {
+  promoteMemoryStatus: (input: { memoryId: string; status: MemoryStatus }) => Promise<void>;
+}
+
+interface DbManagerModule {
+  initDB: () => Promise<unknown>;
+  closeDB: () => Promise<void>;
+  getAdapter: () => {
+    prepare: (sql: string) => {
+      get: (...params: unknown[]) => unknown;
+    };
+  };
+}
+
+let runSyntheticDogfoodHarness: HarnessModule['runSyntheticDogfoodHarness'];
+let createSyntheticDogfoodMemoryStore: HarnessModule['createSyntheticDogfoodMemoryStore'];
+let SYNTHETIC_DOGFOOD_CHANNEL: HarnessModule['SYNTHETIC_DOGFOOD_CHANNEL'];
+let SYNTHETIC_DOGFOOD_CONNECTOR: HarnessModule['SYNTHETIC_DOGFOOD_CONNECTOR'];
+let SYNTHETIC_DOGFOOD_RAW_CANARIES: HarnessModule['SYNTHETIC_DOGFOOD_RAW_CANARIES'];
+let countRows: FixturesModule['countRows'];
+let makeOperatorVNextDb: FixturesModule['makeOperatorVNextDb'];
+
+beforeAll(async () => {
+  const harness = await import('../../src/operator-vnext/synthetic-dogfood-harness.js');
+  const fixtures = await import('./fixtures.js');
+
+  runSyntheticDogfoodHarness = harness.runSyntheticDogfoodHarness;
+  createSyntheticDogfoodMemoryStore = harness.createSyntheticDogfoodMemoryStore;
+  SYNTHETIC_DOGFOOD_CHANNEL = harness.SYNTHETIC_DOGFOOD_CHANNEL;
+  SYNTHETIC_DOGFOOD_CONNECTOR = harness.SYNTHETIC_DOGFOOD_CONNECTOR;
+  SYNTHETIC_DOGFOOD_RAW_CANARIES = harness.SYNTHETIC_DOGFOOD_RAW_CANARIES;
+  countRows = fixtures.countRows;
+  makeOperatorVNextDb = fixtures.makeOperatorVNextDb;
+});
+
+function readNonRawLedgerRows(db: SQLiteDatabase): Record<string, unknown[]> {
+  return {
+    commits: db
+      .prepare(
+        `SELECT cursor_name, first_change_seq, last_change_seq, status, idempotency_key,
+                source_refs_json, changed_refs_json
+         FROM vnext_operator_commits
+         ORDER BY last_change_seq`
+      )
+      .all() as unknown[],
+    noUpdates: db
+      .prepare(
+        `SELECT scope_key, reason, source_refs_json
+         FROM operator_no_updates
+         ORDER BY created_at_ms`
+      )
+      .all() as unknown[],
+    wikiArtifacts: db
+      .prepare(
+        `SELECT path, title, content, source_refs_json
+         FROM wiki_artifacts
+         ORDER BY path`
+      )
+      .all() as unknown[],
+    memoryIntents: db
+      .prepare(
+        `SELECT cursor_name, memory_payload_hash, source_refs_json, status
+         FROM operator_memory_commit_intents
+         ORDER BY created_at_ms`
+      )
+      .all() as unknown[],
+  };
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+async function withIsolatedMamaCoreDb<T>(
+  fn: (modules: {
+    mamaApi: MamaApiModule;
+    mamaCore: MamaCoreModule;
+    dbManager: DbManagerModule;
+  }) => Promise<T>
+): Promise<T> {
+  const tempDir = mkdtempSync(join(tmpdir(), 'mama-dogfood-real-core-'));
+  const dbPath = join(tempDir, 'mama-memory.db');
+  const previousDbPath = process.env.MAMA_DB_PATH;
+  const previousTier3 = process.env.MAMA_FORCE_TIER_3;
+  process.env.MAMA_DB_PATH = dbPath;
+  process.env.MAMA_FORCE_TIER_3 = 'true';
+
+  const dbManager = require('@jungjaehoon/mama-core/db-manager') as DbManagerModule;
+  await dbManager.closeDB();
+
+  try {
+    const mamaApi = require('@jungjaehoon/mama-core/mama-api') as MamaApiModule;
+    const mamaCore = require('@jungjaehoon/mama-core') as MamaCoreModule;
+    return await fn({ mamaApi, mamaCore, dbManager });
+  } finally {
+    await dbManager.closeDB();
+    restoreEnv('MAMA_DB_PATH', previousDbPath);
+    restoreEnv('MAMA_FORCE_TIER_3', previousTier3);
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function createRealMamaCoreMemoryBackend(input: {
+  mamaApi: MamaApiModule;
+  mamaCore: MamaCoreModule;
+  dbManager: DbManagerModule;
+}): SyntheticDogfoodMemoryBackend {
+  let recallCalls = 0;
+  return {
+    saveMemory: input.mamaApi.saveMemoryWithTrustedProvenance,
+    listMemoriesByGatewayCallId: input.mamaApi.listMemoriesByGatewayCallId,
+    setMemoryStatus: ({ memoryId, status }) =>
+      input.mamaCore.promoteMemoryStatus({ memoryId, status }),
+    recallMemory: async (query, options) => {
+      recallCalls += 1;
+      return input.mamaApi.recallMemory(query, options);
+    },
+    getTotalRecallCalls: () => recallCalls,
+    hasActiveMemory: async (topic) => {
+      await input.dbManager.initDB();
+      const row = input.dbManager
+        .getAdapter()
+        .prepare(
+          `SELECT id
+           FROM decisions
+           WHERE topic = ?
+             AND status = 'active'
+           LIMIT 1`
+        )
+        .get(topic) as { id: string } | undefined;
+      return row !== undefined;
+    },
+  };
+}
+
+function withMutatingSaveMemory(
+  memoryStore: SyntheticDogfoodMemoryBackend,
+  mutate: () => void
+): SyntheticDogfoodMemoryBackend {
+  return {
+    saveMemory: async (...args: Parameters<SyntheticDogfoodMemoryBackend['saveMemory']>) => {
+      mutate();
+      return memoryStore.saveMemory(...args);
+    },
+    listMemoriesByGatewayCallId: memoryStore.listMemoriesByGatewayCallId,
+    setMemoryStatus: memoryStore.setMemoryStatus,
+    recallMemory: memoryStore.recallMemory.bind(memoryStore),
+    getTotalRecallCalls: () => memoryStore.getTotalRecallCalls(),
+    hasActiveMemory: (topic) => memoryStore.hasActiveMemory(topic),
+  };
+}
+
+describe('STORY-VNEXT-PR16-SYNTHETIC-DOGFOOD: synthetic end-to-end dogfood harness', () => {
+  describe('AC: repeatable synthetic connector review proves preview, commit, projection, and recall gates', () => {
+    it('runs one synthetic batch without real connector data, local artifacts, or raw-data leakage', async () => {
+      const db = makeOperatorVNextDb();
+      const memoryStore = createSyntheticDogfoodMemoryStore();
+      const artifactRoot = mkdtempSync(join(tmpdir(), 'mama-dogfood-artifacts-'));
+      writeFileSync(join(artifactRoot, 'preexisting.db'), 'synthetic pre-existing artifact');
+
+      try {
+        const result = await runSyntheticDogfoodHarness({
+          db,
+          memoryStore,
+          artifactRoot,
+          nowMs: () => 1_710_000_000_000,
+        });
+
+        expect(result.scenario).toMatchObject({
+          synthetic: true,
+          connector: SYNTHETIC_DOGFOOD_CONNECTOR,
+          channel: SYNTHETIC_DOGFOOD_CHANNEL,
+        });
+        expect(result.events.map((event) => event.sourceId)).toEqual([
+          'synthetic-no-update-001',
+          'synthetic-wiki-001',
+          'synthetic-memory-001',
+        ]);
+
+        expect(result.preview).toMatchObject({
+          advancedThroughSeq: 0,
+          events: [
+            { seq: 1, sourceId: 'synthetic-no-update-001' },
+            { seq: 2, sourceId: 'synthetic-wiki-001' },
+            { seq: 3, sourceId: 'synthetic-memory-001' },
+          ],
+        });
+        expect(result.dryRun).toMatchObject({
+          mode: 'dry_run',
+          status: 'ready',
+          candidateCount: 3,
+          durableWrites: { commits: 0, cursors: 0, noUpdates: 0 },
+        });
+        expect(result.dryRunWriteCounts).toEqual({
+          commits: 0,
+          cursors: 0,
+          noUpdates: 0,
+          wikiArtifacts: 0,
+          memoryIntents: 0,
+        });
+
+        expect(result.commits.noUpdate).toMatchObject({
+          ok: true,
+          status: 'committed',
+          processed: 1,
+          advancedThroughSeq: 1,
+          commits: [{ seq: 1, status: 'no_update', outcome: 'committed' }],
+        });
+        expect(result.commits.wiki).toMatchObject({
+          ok: true,
+          status: 'committed',
+          processed: 1,
+          advancedThroughSeq: 2,
+          pagesStored: 1,
+          commits: [{ seq: 2, status: 'changed', outcome: 'committed' }],
+        });
+        expect(result.commits.memory).toMatchObject({
+          ok: true,
+          status: 'committed',
+          processed: 1,
+          advancedThroughSeq: 3,
+          memoriesSaved: 1,
+          commits: [{ seq: 3, status: 'changed', outcome: 'committed' }],
+        });
+        expect(result.replay.memory).toMatchObject({
+          ok: true,
+          status: 'committed',
+          processed: 1,
+          memoriesSaved: 0,
+          commits: [{ seq: 3, outcome: 'already_committed', cursorAdvanced: false }],
+        });
+
+        expect(result.projection).toMatchObject({
+          projectionVersion: 1,
+          status: { total: 1, live: 1, pendingVerification: 0, verified: 1 },
+        });
+        expect(result.projection.today[0]).toMatchObject({
+          situation_id: 'synthetic_dogfood_memory_follow_up',
+          title: 'Synthetic memory follow-up is committed',
+          evidence_refs: [`raw:${SYNTHETIC_DOGFOOD_CONNECTOR}:${result.events[2].eventIndexId}`],
+        });
+
+        expect(result.recall.ordinary).toEqual({
+          recallInvoked: false,
+          memories: [],
+        });
+        expect(result.recall.negativeExplicit).toEqual({
+          recallInvoked: true,
+          memories: [],
+        });
+        expect(result.recall.explicit).toMatchObject({
+          recallInvoked: true,
+          memories: [
+            {
+              topic: 'operator/manual-memory',
+              summary: 'Synthetic reviewed memory is available after explicit recall.',
+            },
+          ],
+        });
+        expect(result.recall.totalRecallCalls).toBe(2);
+
+        const countsAfterFirstRun = {
+          commits: countRows(db, 'vnext_operator_commits'),
+          cursors: countRows(db, 'vnext_operator_cursors'),
+          noUpdates: countRows(db, 'operator_no_updates'),
+          wikiArtifacts: countRows(db, 'wiki_artifacts'),
+          memoryIntents: countRows(db, 'operator_memory_commit_intents'),
+        };
+        expect(countsAfterFirstRun).toEqual({
+          commits: 3,
+          cursors: 1,
+          noUpdates: 1,
+          wikiArtifacts: 1,
+          memoryIntents: 1,
+        });
+        expect(countRows(db, 'vnext_operator_commits')).toBe(3);
+        expect(countRows(db, 'operator_no_updates')).toBe(1);
+        expect(countRows(db, 'wiki_artifacts')).toBe(1);
+        expect(countRows(db, 'operator_memory_commit_intents')).toBe(1);
+        expect(result.artifacts.repoDbFilesCreated).toEqual([]);
+
+        const durableLedgers = JSON.stringify(readNonRawLedgerRows(db));
+        expect(durableLedgers).not.toContain('SYNTHETIC RAW REDACTED BODY');
+        expect(durableLedgers).not.toContain('synthetic-redacted-author');
+        expect(durableLedgers).not.toContain('metadata_json');
+        expect(durableLedgers).not.toContain('/Users/');
+        for (const canary of SYNTHETIC_DOGFOOD_RAW_CANARIES) {
+          expect(durableLedgers).not.toContain(canary);
+        }
+
+        const serialized = JSON.stringify(result);
+        expect(serialized).not.toContain('SYNTHETIC RAW REDACTED BODY');
+        expect(serialized).not.toContain('synthetic-redacted-author');
+        expect(serialized).not.toContain('metadata_json');
+        expect(serialized).not.toContain('/Users/');
+        expect(serialized).not.toContain('memory_synthetic_');
+        for (const canary of SYNTHETIC_DOGFOOD_RAW_CANARIES) {
+          expect(serialized).not.toContain(canary);
+        }
+
+        const repeat = await runSyntheticDogfoodHarness({
+          db,
+          memoryStore,
+          artifactRoot,
+          nowMs: () => 1_710_000_000_000,
+        });
+
+        expect(repeat.preview).toMatchObject({
+          advancedThroughSeq: 3,
+          events: [],
+        });
+        expect(repeat.commits.noUpdate.commits).toEqual([
+          { seq: 1, status: 'no_update', outcome: 'already_committed', cursorAdvanced: false },
+        ]);
+        expect(repeat.commits.wiki).toMatchObject({
+          pagesStored: 0,
+          commits: [{ seq: 2, status: 'changed', outcome: 'already_committed' }],
+        });
+        expect(repeat.commits.memory).toMatchObject({
+          memoriesSaved: 0,
+          commits: [{ seq: 3, status: 'changed', outcome: 'already_committed' }],
+        });
+        expect(repeat.recall.totalRecallCalls).toBe(4);
+        expect(repeat.recall.explicit.memories).toEqual(result.recall.explicit.memories);
+        expect(repeat.artifacts.repoDbFilesCreated).toEqual([]);
+        expect({
+          commits: countRows(db, 'vnext_operator_commits'),
+          cursors: countRows(db, 'vnext_operator_cursors'),
+          noUpdates: countRows(db, 'operator_no_updates'),
+          wikiArtifacts: countRows(db, 'wiki_artifacts'),
+          memoryIntents: countRows(db, 'operator_memory_commit_intents'),
+        }).toEqual(countsAfterFirstRun);
+
+        await expect(
+          runSyntheticDogfoodHarness({
+            db,
+            memoryStore: createSyntheticDogfoodMemoryStore(),
+            artifactRoot,
+            nowMs: () => 1_710_000_000_000,
+          })
+        ).rejects.toThrow(/committed memory intent without retrievable memory state/);
+        expect({
+          commits: countRows(db, 'vnext_operator_commits'),
+          cursors: countRows(db, 'vnext_operator_cursors'),
+          noUpdates: countRows(db, 'operator_no_updates'),
+          wikiArtifacts: countRows(db, 'wiki_artifacts'),
+          memoryIntents: countRows(db, 'operator_memory_commit_intents'),
+        }).toEqual(countsAfterFirstRun);
+      } finally {
+        db.close();
+        rmSync(artifactRoot, { recursive: true, force: true });
+      }
+    });
+
+    it('uses the repository root for database artifact checks by default', async () => {
+      const db = makeOperatorVNextDb();
+      const memoryStore = createSyntheticDogfoodMemoryStore();
+
+      try {
+        const result = await runSyntheticDogfoodHarness({
+          db,
+          memoryStore,
+          nowMs: () => 1_710_000_000_000,
+        });
+
+        expect(result.artifacts.repoDbFilesCreated).toEqual([]);
+      } finally {
+        db.close();
+      }
+    });
+
+    it('fails if a synthetic run mutates an existing repository database artifact', async () => {
+      const db = makeOperatorVNextDb();
+      const memoryStore = createSyntheticDogfoodMemoryStore();
+      const artifactRoot = mkdtempSync(join(tmpdir(), 'mama-dogfood-artifact-mutation-'));
+      const preexistingDb = join(artifactRoot, 'preexisting.db');
+      writeFileSync(preexistingDb, 'synthetic pre-existing artifact');
+      const mutatingMemoryStore = withMutatingSaveMemory(memoryStore, () => {
+        appendFileSync(preexistingDb, '\nmodified during synthetic run');
+      });
+
+      try {
+        await expect(
+          runSyntheticDogfoodHarness({
+            db,
+            memoryStore: mutatingMemoryStore,
+            artifactRoot,
+            nowMs: () => 1_710_000_000_000,
+          })
+        ).rejects.toThrow(/created or modified repository DB artifacts: preexisting\.db/);
+      } finally {
+        db.close();
+        rmSync(artifactRoot, { recursive: true, force: true });
+      }
+    });
+
+    it('fails if a synthetic run deletes an existing repository database artifact', async () => {
+      const db = makeOperatorVNextDb();
+      const memoryStore = createSyntheticDogfoodMemoryStore();
+      const artifactRoot = mkdtempSync(join(tmpdir(), 'mama-dogfood-artifact-delete-'));
+      const preexistingDb = join(artifactRoot, 'preexisting.db');
+      writeFileSync(preexistingDb, 'synthetic pre-existing artifact');
+      const mutatingMemoryStore = withMutatingSaveMemory(memoryStore, () => {
+        unlinkSync(preexistingDb);
+      });
+
+      try {
+        await expect(
+          runSyntheticDogfoodHarness({
+            db,
+            memoryStore: mutatingMemoryStore,
+            artifactRoot,
+            nowMs: () => 1_710_000_000_000,
+          })
+        ).rejects.toThrow(/created or modified repository DB artifacts: preexisting\.db/);
+      } finally {
+        db.close();
+        rmSync(artifactRoot, { recursive: true, force: true });
+      }
+    });
+
+    it('fails if a synthetic run rewrites an existing repository database artifact at the same size', async () => {
+      const db = makeOperatorVNextDb();
+      const memoryStore = createSyntheticDogfoodMemoryStore();
+      const artifactRoot = mkdtempSync(join(tmpdir(), 'mama-dogfood-artifact-same-size-'));
+      const preexistingDb = join(artifactRoot, 'preexisting.db');
+      writeFileSync(preexistingDb, 'AAAA');
+      const mutatingMemoryStore = withMutatingSaveMemory(memoryStore, () => {
+        writeFileSync(preexistingDb, 'BBBB');
+      });
+
+      try {
+        await expect(
+          runSyntheticDogfoodHarness({
+            db,
+            memoryStore: mutatingMemoryStore,
+            artifactRoot,
+            nowMs: () => 1_710_000_000_000,
+          })
+        ).rejects.toThrow(/created or modified repository DB artifacts: preexisting\.db/);
+      } finally {
+        db.close();
+        rmSync(artifactRoot, { recursive: true, force: true });
+      }
+    });
+
+    it('uses real isolated mama-core save, provenance, and recall across replay restart', async () => {
+      await withIsolatedMamaCoreDb(async ({ mamaApi, mamaCore, dbManager }) => {
+        const db = makeOperatorVNextDb();
+        const artifactRoot = mkdtempSync(join(tmpdir(), 'mama-dogfood-real-artifacts-'));
+
+        try {
+          const result = await runSyntheticDogfoodHarness({
+            db,
+            memoryStore: createRealMamaCoreMemoryBackend({ mamaApi, mamaCore, dbManager }),
+            artifactRoot,
+            nowMs: () => 1_710_000_000_000,
+          });
+
+          expect(result.commits.memory).toMatchObject({
+            memoriesSaved: 1,
+            commits: [{ seq: 3, status: 'changed', outcome: 'committed' }],
+          });
+          expect(result.recall.explicit).toMatchObject({
+            recallInvoked: true,
+            memories: [
+              {
+                topic: 'operator/manual-memory',
+                summary: 'Synthetic reviewed memory is available after explicit recall.',
+              },
+            ],
+          });
+
+          await dbManager.closeDB();
+          const replay = await runSyntheticDogfoodHarness({
+            db,
+            memoryStore: createRealMamaCoreMemoryBackend({ mamaApi, mamaCore, dbManager }),
+            artifactRoot,
+            nowMs: () => 1_710_000_000_000,
+          });
+
+          expect(replay.commits.memory).toMatchObject({
+            memoriesSaved: 0,
+            commits: [{ seq: 3, status: 'changed', outcome: 'already_committed' }],
+          });
+          expect(replay.recall.totalRecallCalls).toBe(2);
+          expect(replay.recall.explicit.memories).toEqual(result.recall.explicit.memories);
+        } finally {
+          db.close();
+          rmSync(artifactRoot, { recursive: true, force: true });
+        }
+      });
+    });
+  });
+});

--- a/scripts/check-pr-gitleaks.sh
+++ b/scripts/check-pr-gitleaks.sh
@@ -42,6 +42,7 @@ trap 'rm -f "$TMP_ALL_PATHS" "$TMP_STAGED_PATHS"; rm -rf "$TMP_STAGED_ROOT"' EXI
 
 FOUND=0
 COMMIT_COUNT="$(git rev-list --count "${BASE_REF}..HEAD")"
+MERGE_BASE="$(git merge-base "$BASE_REF" HEAD)"
 
 HIGH_RISK_PRIVATE_PATTERN=$(
   printf '%s\n' \
@@ -80,10 +81,10 @@ if [ "$COMMIT_COUNT" -gt 0 ]; then
   fi
 fi
 
-git diff -z --name-only --diff-filter=ACMRT "${BASE_REF}...HEAD" -- >> "$TMP_ALL_PATHS"
-git diff -z --cached --name-only --diff-filter=ACMRT "$BASE_REF" -- \
+git diff -z --name-only --diff-filter=ACMRT "$MERGE_BASE" HEAD -- >> "$TMP_ALL_PATHS"
+git diff -z --cached --name-only --diff-filter=ACMRT "$MERGE_BASE" -- \
   | tee -a "$TMP_ALL_PATHS" >> "$TMP_STAGED_PATHS"
-git diff -z --name-only --diff-filter=ACMRT "$BASE_REF" -- >> "$TMP_ALL_PATHS"
+git diff -z --name-only --diff-filter=ACMRT "$MERGE_BASE" -- >> "$TMP_ALL_PATHS"
 
 CHANGED_FILES=()
 while IFS= read -r -d '' path; do
@@ -100,7 +101,7 @@ if [ "${#CHANGED_FILES[@]}" -eq 0 ]; then
   exit "$FOUND"
 fi
 
-echo "Scanning ${#CHANGED_FILES[@]} PR-changed files with gitleaks against ${BASE_REF}"
+echo "Scanning ${#CHANGED_FILES[@]} PR-changed files with gitleaks against merge-base ${MERGE_BASE} (${BASE_REF})"
 
 if [ "${#STAGED_FILES[@]}" -gt 0 ]; then
   for path in "${STAGED_FILES[@]}"; do

--- a/scripts/check-pr-gitleaks.sh
+++ b/scripts/check-pr-gitleaks.sh
@@ -16,6 +16,20 @@ if ! command -v gitleaks >/dev/null 2>&1; then
   exit 1
 fi
 
+GITLEAKS_VERSION="$(gitleaks version 2>/dev/null | head -n 1)"
+GITLEAKS_VERSION="${GITLEAKS_VERSION#v}"
+GITLEAKS_MAJOR="${GITLEAKS_VERSION%%.*}"
+case "$GITLEAKS_MAJOR" in
+  '' | *[!0-9]*)
+    echo "Cannot parse gitleaks version: ${GITLEAKS_VERSION:-unknown}" >&2
+    exit 1
+    ;;
+esac
+if [ "$GITLEAKS_MAJOR" -lt 8 ]; then
+  echo "gitleaks v8.0.0 or newer is required (found: ${GITLEAKS_VERSION})" >&2
+  exit 1
+fi
+
 if ! git rev-parse --verify "${BASE_REF}^{commit}" >/dev/null 2>&1; then
   echo "Cannot resolve gitleaks base ref: ${BASE_REF}" >&2
   exit 1
@@ -88,21 +102,23 @@ fi
 
 echo "Scanning ${#CHANGED_FILES[@]} PR-changed files with gitleaks against ${BASE_REF}"
 
-for path in "${STAGED_FILES[@]}"; do
-  if [ -z "$path" ]; then
-    continue
-  fi
+if [ "${#STAGED_FILES[@]}" -gt 0 ]; then
+  for path in "${STAGED_FILES[@]}"; do
+    if [ -z "$path" ]; then
+      continue
+    fi
 
-  staged_scan_path="$TMP_STAGED_ROOT/$path"
-  mkdir -p "$(dirname -- "$staged_scan_path")"
-  if ! git show ":$path" > "$staged_scan_path"; then
-    echo "Failed to materialize staged blob for gitleaks scan: $path" >&2
-    FOUND=1
-    continue
-  fi
+    staged_scan_path="$TMP_STAGED_ROOT/$path"
+    mkdir -p "$(dirname -- "$staged_scan_path")"
+    if ! git show ":$path" > "$staged_scan_path"; then
+      echo "Failed to materialize staged blob for gitleaks scan: $path" >&2
+      FOUND=1
+      continue
+    fi
 
-  scan_materialized_file "$staged_scan_path" "$path"
-done
+    scan_materialized_file "$staged_scan_path" "$path"
+  done
+fi
 
 for path in "${CHANGED_FILES[@]}"; do
   if [ -z "$path" ]; then

--- a/scripts/check-pr-gitleaks.sh
+++ b/scripts/check-pr-gitleaks.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Scan PR-changed files for secrets before or after commit creation.
+#
+# gitleaks protect --staged is useful before committing, but it becomes a no-op
+# after the index is clean. This script scans PR commits, staged blob contents,
+# and working-tree files changed against the PR base.
+
+set -euo pipefail
+
+BASE_REF="${MAMA_GITLEAKS_BASE_REF:-origin/main}"
+REPO_ROOT="$(cd "$(git rev-parse --show-toplevel)" && pwd -P)"
+cd "$REPO_ROOT"
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "gitleaks is required for PR secret scanning" >&2
+  exit 1
+fi
+
+if ! git rev-parse --verify "${BASE_REF}^{commit}" >/dev/null 2>&1; then
+  echo "Cannot resolve gitleaks base ref: ${BASE_REF}" >&2
+  exit 1
+fi
+
+TMP_ALL_PATHS="$(mktemp)"
+TMP_STAGED_PATHS="$(mktemp)"
+TMP_STAGED_ROOT="$(mktemp -d)"
+trap 'rm -f "$TMP_ALL_PATHS" "$TMP_STAGED_PATHS"; rm -rf "$TMP_STAGED_ROOT"' EXIT
+
+FOUND=0
+COMMIT_COUNT="$(git rev-list --count "${BASE_REF}..HEAD")"
+
+HIGH_RISK_PRIVATE_PATTERN=$(
+  printf '%s\n' \
+    '/Users/[[:alnum:]_.-]+/[[:alnum:]_.-]+' \
+    '/home/[[:alnum:]_.-]+/[[:alnum:]_.-]+' \
+    '[A-Za-z]:\\Users\\[[:alnum:]_.-]+\\[[:alnum:]_.-]+' \
+    'ghp_[[:alnum:]_]{20,}' \
+    'github_pat_[[:alnum:]_]{20,}' \
+    'xox[baprs]-[[:alnum:]-]{10,}' \
+    'sk-[[:alnum:]_-]{20,}' \
+    'hooks\.slack\.com/services/[A-Za-z0-9/_-]+' |
+    paste -sd '|' -
+)
+
+scan_materialized_file() {
+  local scan_path="$1"
+  local display_path="$2"
+  local high_risk_matches
+
+  if ! gitleaks dir "$scan_path" --redact --verbose --no-banner; then
+    FOUND=1
+  fi
+
+  high_risk_matches="$(grep -IEn "$HIGH_RISK_PRIVATE_PATTERN" "$scan_path" || true)"
+  if [ -n "$high_risk_matches" ]; then
+    echo "High-risk private data pattern found in PR-changed file: $display_path" >&2
+    echo "$high_risk_matches" >&2
+    FOUND=1
+  fi
+}
+
+if [ "$COMMIT_COUNT" -gt 0 ]; then
+  echo "Scanning ${COMMIT_COUNT} PR commits with gitleaks against ${BASE_REF}"
+  if ! gitleaks git --log-opts "${BASE_REF}..HEAD" --redact --verbose --no-banner; then
+    FOUND=1
+  fi
+fi
+
+git diff -z --name-only --diff-filter=ACMRT "${BASE_REF}...HEAD" -- >> "$TMP_ALL_PATHS"
+git diff -z --cached --name-only --diff-filter=ACMRT "$BASE_REF" -- \
+  | tee -a "$TMP_ALL_PATHS" >> "$TMP_STAGED_PATHS"
+git diff -z --name-only --diff-filter=ACMRT "$BASE_REF" -- >> "$TMP_ALL_PATHS"
+
+readarray -d '' CHANGED_FILES < <(sort -zu "$TMP_ALL_PATHS")
+readarray -d '' STAGED_FILES < <(sort -zu "$TMP_STAGED_PATHS")
+
+if [ "${#CHANGED_FILES[@]}" -eq 0 ]; then
+  echo "No PR-changed files to scan with gitleaks."
+  exit "$FOUND"
+fi
+
+echo "Scanning ${#CHANGED_FILES[@]} PR-changed files with gitleaks against ${BASE_REF}"
+
+for path in "${STAGED_FILES[@]}"; do
+  if [ -z "$path" ]; then
+    continue
+  fi
+
+  staged_scan_path="$TMP_STAGED_ROOT/$path"
+  mkdir -p "$(dirname -- "$staged_scan_path")"
+  if ! git show ":$path" > "$staged_scan_path"; then
+    echo "Failed to materialize staged blob for gitleaks scan: $path" >&2
+    FOUND=1
+    continue
+  fi
+
+  scan_materialized_file "$staged_scan_path" "$path"
+done
+
+for path in "${CHANGED_FILES[@]}"; do
+  if [ -z "$path" ]; then
+    continue
+  fi
+
+  if [ -L "$path" ]; then
+    symlink_scan_path="$TMP_STAGED_ROOT/worktree-symlinks/$path"
+    mkdir -p "$(dirname -- "$symlink_scan_path")"
+    if ! readlink -- "$path" > "$symlink_scan_path"; then
+      echo "Failed to materialize symlink target for gitleaks scan: $path" >&2
+      FOUND=1
+      continue
+    fi
+
+    scan_materialized_file "$symlink_scan_path" "$path (symlink target)"
+    continue
+  fi
+
+  if [ ! -f "$path" ]; then
+    continue
+  fi
+
+  path_dir="$(dirname -- "$path")"
+  path_base="$(basename -- "$path")"
+  if [ ! -d "$path_dir" ]; then
+    continue
+  fi
+
+  real_dir="$(cd "$path_dir" && pwd -P)"
+  scan_path="$real_dir/$path_base"
+  case "$scan_path" in
+    "$REPO_ROOT"/* | "$REPO_ROOT") ;;
+    *)
+      echo "Skipping changed path outside repository root: $path" >&2
+      continue
+      ;;
+  esac
+
+  scan_materialized_file "$scan_path" "$path"
+done
+
+exit "$FOUND"

--- a/scripts/check-pr-gitleaks.sh
+++ b/scripts/check-pr-gitleaks.sh
@@ -71,8 +71,15 @@ git diff -z --cached --name-only --diff-filter=ACMRT "$BASE_REF" -- \
   | tee -a "$TMP_ALL_PATHS" >> "$TMP_STAGED_PATHS"
 git diff -z --name-only --diff-filter=ACMRT "$BASE_REF" -- >> "$TMP_ALL_PATHS"
 
-readarray -d '' CHANGED_FILES < <(sort -zu "$TMP_ALL_PATHS")
-readarray -d '' STAGED_FILES < <(sort -zu "$TMP_STAGED_PATHS")
+CHANGED_FILES=()
+while IFS= read -r -d '' path; do
+  CHANGED_FILES+=("$path")
+done < <(sort -zu "$TMP_ALL_PATHS")
+
+STAGED_FILES=()
+while IFS= read -r -d '' path; do
+  STAGED_FILES+=("$path")
+done < <(sort -zu "$TMP_STAGED_PATHS")
 
 if [ "${#CHANGED_FILES[@]}" -eq 0 ]; then
   echo "No PR-changed files to scan with gitleaks."


### PR DESCRIPTION
## Summary
- Add a synthetic vNext dogfood harness that runs preview, migration dry-run, reviewed no-update/wiki/memory commits, projection, replay, and explicit recall using synthetic-only connector data.
- Lock down `mama_recall` so model-visible recall output only exposes sanitized topic/kind/summary/confidence/status fields, removes raw search metadata, and denies scopes outside the active session/envelope.
- Make implicit memory recall and legacy context search opt-in for ordinary message-router turns.
- Add `scripts/check-pr-gitleaks.sh` so PR secret scanning still works before and after commit creation, including commit range, staged blobs, changed files, and symlink target strings without following symlinks.

## Privacy / Internal Data Gate
- Fixtures use synthetic connector/channel/project IDs only. No real connector payloads or credentials are included.
- `./scripts/check-pii.sh` passed.
- `gitleaks protect --source . --staged --redact --verbose --no-banner` passed.
- `gitleaks git --log-opts origin/main..HEAD --redact --verbose --no-banner` passed with no leaks.
- `./scripts/check-pr-gitleaks.sh` passed against the PR diff.
- Symlink privacy regression checks verified that staged and committed symlink targets containing `/Users/...` are blocked.

## Verification
- `MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os dogfood:vnext` passed: 10 test files, 184 tests.
- Pre-commit hook reran standalone typecheck and changed-package tests; standalone test replay reported 243 passed, 1 skipped test file, 3463 passed and 3 skipped tests.
- `bash -n scripts/check-pr-gitleaks.sh` passed.
- Post-fix Codex adversarial review: `GATE PASS`.

## Review Notes
- A pre-PR adversarial review initially found one Important issue: symlink blobs were skipped by the PR gitleaks helper.
- Fixed by materializing staged blobs via `git show ":$path"`, scanning worktree symlink target strings via `readlink`, and adding high-risk private path/token pattern checks to the materialized scan path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a synthetic dogfood workflow to validate end-to-end operator behavior with safe, repeatable checks.
  * Introduced optional settings to control whether memory recall and legacy context are included automatically.
  * Added a PR secret-scan step to help catch sensitive data before merge.

* **Bug Fixes**
  * Tightened memory access rules so only valid, in-scope requests can retrieve recalled content.
  * Reduced unintended context injection during normal message handling.
  * Improved redaction so sensitive details are removed from returned recall results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->