### PR TITLE
feat: add vNext rollout memory policy opt-ins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Message-router memory policy opt-ins** — Added `memory_policy.implicit_recall`
+  and `memory_policy.implicit_legacy_context_search`, plus matching environment
+  variable overrides, so startup-prompt memory recall and legacy context search
+  remain explicit local choices instead of default gateway behavior.
+
+### Changed
+
+- **vNext rollout decision** — Kept vNext opt-in after the synthetic dogfood
+  harness and operator cockpit landed; default rollout now waits on migration
+  docs and real local smoke evidence.
+
 ## [0.20.1] / mama-core [1.7.0] / mama-os [0.20.1] - 2026-05-04
 
 ### Added

--- a/docs/architecture/mama-vnext-primary-operator-rebuild.md
+++ b/docs/architecture/mama-vnext-primary-operator-rebuild.md
@@ -1,9 +1,9 @@
 # MAMA vNext Primary Operator Rebuild Plan
 
-Status: implementation through PR 15 merged; PR 16 adds the synthetic dogfood harness.
+Status: implementation through PR 16 merged; PR 17 records the rollout decision and explicit memory-policy opt-ins.
 Branch base: `origin/main`.
 Decision date: 2026-07-02.
-Last updated: 2026-07-03.
+Last updated: 2026-07-04.
 
 ## Decision
 
@@ -35,7 +35,7 @@ blockers for starting PR 0.
 
 ## Implementation Status
 
-PR 0 through PR 15 have landed on `main`.
+PR 0 through PR 16 have landed on `main`.
 
 | Slice | GitHub PR | State  | Result                                             |
 | ----- | --------- | ------ | -------------------------------------------------- |
@@ -55,13 +55,14 @@ PR 0 through PR 15 have landed on `main`.
 | PR 13 | #111      | merged | manual reviewed memory ingress commit              |
 | PR 14 | #112      | merged | completion gates and staged privacy checks         |
 | PR 15 | #113      | merged | isolated vNext operator review cockpit             |
-| PR 16 | pending   | active | synthetic end-to-end dogfood harness               |
+| PR 16 | #114      | merged | synthetic end-to-end dogfood harness               |
+| PR 17 | pending   | active | default rollout decision and memory-policy opt-ins |
 
 PR 14 did not add runtime behavior. It closed the plan drift created by PR 9-13,
 centralized staged privacy checks, defined completion gates, and prevented later
 code slices from guessing what "done" means.
 
-PR 15 added the first-party operator review cockpit. PR 16 proves the cockpit's
+PR 15 added the first-party operator review cockpit. PR 16 proved the cockpit's
 backend path with synthetic data only: preview, dry-run, no-update, wiki, memory,
 projection, replay, and explicit recall gating.
 
@@ -1206,10 +1207,27 @@ Goal:
   document explicit opt-ins for implicit recall and legacy context search.
 - Update user-facing docs and release notes only after PR 15 and PR 16 pass.
 
+Decision:
+
+- vNext remains opt-in after PR 17. The synthetic dogfood harness and cockpit
+  prove the reviewed local path, but default rollout still needs migration
+  guidance and real local smoke evidence.
+- Ordinary gateway turns keep `implicit_recall` and
+  `implicit_legacy_context_search` disabled by default.
+- Explicit recall remains available through the reviewed tool path. Users who
+  deliberately want startup-prompt implicit context for new CLI sessions must
+  opt in through `memory_policy` in `config.yaml` or the matching
+  `MAMA_MEMORY_POLICY_*` environment variables.
+- PR 17 does not redefine the older session-start context path for channel
+  summaries, checkpoints, or recent decision snippets. That legacy startup
+  behavior remains one reason default rollout waits on migration docs and real
+  local smoke evidence.
+
 Rules:
 
-- Do not make vNext default until the synthetic dogfood harness passes and the
-  operator cockpit has been reviewed for private-data leakage.
+- Do not make vNext default until migration docs and real local smoke evidence
+  exist, even though the synthetic dogfood harness has passed.
+- Continue reviewing every rollout change for private-data leakage before PR.
 - Legacy runtime must remain available until migration docs exist.
 
 ## Global Regression Checklist

--- a/docs/guides/gateway-config.md
+++ b/docs/guides/gateway-config.md
@@ -50,8 +50,8 @@ gateways:
 
   slack:
     enabled: false
-    bot_token: 'xoxb-...'
-    app_token: 'xapp-...'
+    bot_token: 'SLACK_BOT_TOKEN_VALUE'
+    app_token: 'SLACK_APP_TOKEN_VALUE'
     # ... Slack-specific options
 
   telegram:
@@ -66,6 +66,32 @@ gateways:
 ```
 
 You can enable multiple gateways at once. MAMA will handle messages from all enabled platforms simultaneously.
+
+### Gateway Memory Policy
+
+New gateway CLI sessions do not add `recallMemory` or legacy decision-search
+bundles to the startup prompt by default. This keeps chat responses from pulling
+broad local context unless the user asks for it through explicit memory tools.
+
+To opt into startup-prompt recall for a trusted local deployment, set:
+
+```yaml
+memory_policy:
+  implicit_recall: true
+  implicit_legacy_context_search: true
+```
+
+These options are intentionally off by default. Leave them disabled for public,
+shared, or unreviewed gateway deployments.
+
+Use YAML booleans (`true`/`false`) rather than quoted strings.
+
+Continuing resumed CLI turns keep using the existing CLI context instead of
+rebuilding the full startup prompt.
+
+This policy does not disable the older session-start context path for channel
+summaries, checkpoints, or recent decision snippets when those startup APIs are
+configured.
 
 ---
 
@@ -260,7 +286,7 @@ Slack requires **two tokens**: bot token and app token.
 2. Toggle **Enable Socket Mode** → **On**
 3. Enter token name (e.g., "MAMA App Token")
 4. Click **Generate**
-5. Copy the **app token** (starts with `xapp-`)
+5. Copy the **app token** from Slack
 6. Click **Done**
 
 **Step 3: Add Bot Token Scopes**
@@ -282,7 +308,7 @@ Slack requires **two tokens**: bot token and app token.
 1. Scroll up to **OAuth Tokens for Your Workspace**
 2. Click **Install to Workspace**
 3. Review permissions → **Allow**
-4. Copy the **Bot User OAuth Token** (starts with `xoxb-`)
+4. Copy the **Bot User OAuth Token** from Slack
 
 **Step 5: Subscribe to Events**
 
@@ -296,12 +322,12 @@ Slack requires **two tokens**: bot token and app token.
 
 ### Configuration Options
 
-| Option      | Type    | Required | Description                                |
-| ----------- | ------- | -------- | ------------------------------------------ |
-| `enabled`   | boolean | Yes      | Enable Slack gateway                       |
-| `bot_token` | string  | Yes      | Bot User OAuth Token (xoxb-...)            |
-| `app_token` | string  | Yes      | App-Level Token for Socket Mode (xapp-...) |
-| `channels`  | object  | No       | Channel-specific settings (see below)      |
+| Option      | Type    | Required | Description                           |
+| ----------- | ------- | -------- | ------------------------------------- |
+| `enabled`   | boolean | Yes      | Enable Slack gateway                  |
+| `bot_token` | string  | Yes      | Bot User OAuth Token                  |
+| `app_token` | string  | Yes      | App-Level Token for Socket Mode       |
+| `channels`  | object  | No       | Channel-specific settings (see below) |
 
 ### Channel Configuration
 
@@ -342,8 +368,8 @@ gateways:
 gateways:
   slack:
     enabled: true
-    bot_token: 'xoxb-...'
-    app_token: 'xapp-...'
+    bot_token: 'SLACK_BOT_TOKEN_VALUE'
+    app_token: 'SLACK_APP_TOKEN_VALUE'
 ```
 
 **Respond to all messages in specific channel:**
@@ -352,8 +378,8 @@ gateways:
 gateways:
   slack:
     enabled: true
-    bot_token: 'xoxb-...'
-    app_token: 'xapp-...'
+    bot_token: 'SLACK_BOT_TOKEN_VALUE'
+    app_token: 'SLACK_APP_TOKEN_VALUE'
     channels:
       'C01234567': # #bot-testing channel
         requireMention: false
@@ -574,8 +600,8 @@ gateways:
 gateways:
   slack:
     enabled: true
-    bot_token: 'xoxb-...'
-    app_token: 'xapp-...'
+    bot_token: 'SLACK_BOT_TOKEN_VALUE'
+    app_token: 'SLACK_APP_TOKEN_VALUE'
     channels:
       'C01234567': # #bot-testing
         requireMention: false
@@ -776,7 +802,7 @@ Error: Incorrect login details were provided.
 Error: invalid_auth
 ```
 
-→ Check both `bot_token` (xoxb-) and `app_token` (xapp-) are correct.
+→ Check both `bot_token` and `app_token` are correct.
 
 **Telegram:**
 

--- a/docs/guides/standalone-setup.md
+++ b/docs/guides/standalone-setup.md
@@ -287,6 +287,11 @@ agent:
 database:
   path: ~/.claude/mama-memory.db # SQLite database location
 
+# Message-router memory policy
+memory_policy:
+  implicit_recall: false # Opt into startup-prompt recallMemory injection
+  implicit_legacy_context_search: false # Opt into startup-prompt legacy decision search
+
 # Logging settings
 logging:
   level: info # Log level: debug, info, warn, error
@@ -304,8 +309,8 @@ discord:
 # Slack gateway (optional)
 slack:
   enabled: false
-  bot_token: xoxb-YOUR-BOT-TOKEN
-  app_token: xapp-YOUR-APP-TOKEN
+  bot_token: SLACK_BOT_TOKEN_VALUE
+  app_token: SLACK_APP_TOKEN_VALUE
 
 # Telegram gateway (optional)
 telegram:
@@ -404,6 +409,27 @@ Notes:
 | `path` | string | ~/.claude/mama-memory.db | SQLite database location |
 
 **Note:** Database is shared with Claude Code plugin and MCP server if using the same path.
+
+#### Memory Policy Settings
+
+| Option                           | Type | Default | Description                                   |
+| -------------------------------- | ---- | ------- | --------------------------------------------- |
+| `implicit_recall`                | bool | false   | Add `recallMemory` results to startup prompts |
+| `implicit_legacy_context_search` | bool | false   | Add legacy decision-search to startup prompts |
+
+By default, new gateway CLI sessions do not add `recallMemory` or legacy
+decision-search bundles to the startup prompt. Use explicit memory tools such as
+`mama_recall` when you want evidence for a turn. Enable these options only when
+broad startup recall is an intentional local policy.
+
+Use YAML booleans (`true`/`false`) rather than quoted strings.
+
+Continuing resumed CLI turns keep using the existing CLI context instead of
+rebuilding the full startup prompt.
+
+This policy does not disable the older session-start context path for channel
+summaries, checkpoints, or recent decision snippets when those startup APIs are
+configured.
 
 #### Logging Settings
 
@@ -801,6 +827,12 @@ export MAMA_DB_PATH=/custom/path/mama.db
 
 # Set log level
 export MAMA_LOG_LEVEL=debug
+
+# Opt into implicit startup-prompt memory recall
+export MAMA_MEMORY_POLICY_IMPLICIT_RECALL=true
+
+# Opt into startup-prompt legacy decision-search context injection
+export MAMA_MEMORY_POLICY_IMPLICIT_LEGACY_CONTEXT_SEARCH=true
 
 # Start with environment overrides
 mama start

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -65,6 +65,7 @@ import { initVNextWikiPublishAdapter } from '../runtime/wiki-publish-adapter-ini
 import { startServer } from '../runtime/server-start.js';
 import { installShutdownHandlers } from '../runtime/shutdown.js';
 import { buildRuntimeEnvelopeBootstrap } from '../runtime/envelope-bootstrap.js';
+import { resolveMessageRouterConfig } from '../runtime/message-router-config.js';
 import { requireAdminAuth, requireAuth } from '../../api/auth-middleware.js';
 import { buildPublicVNextProjectionPayload } from '../../api/report-handler.js';
 import {
@@ -1758,9 +1759,7 @@ export async function runAgentLoop(
     sessionStore,
     agentLoopClient,
     mamaApiClient,
-    {
-      backend: runtimeBackend,
-    },
+    resolveMessageRouterConfig(config, runtimeBackend),
     envelopeBootstrap.envelopeConfig,
     envelopeBootstrap.envelopeAuthority
   );

--- a/packages/standalone/src/cli/config/config-manager.ts
+++ b/packages/standalone/src/cli/config/config-manager.ts
@@ -58,6 +58,9 @@ export function overrideConfig(overrides: Partial<MAMAConfig>): MAMAConfig {
     token_budget: overrides.token_budget
       ? { ...base.token_budget!, ...overrides.token_budget }
       : base.token_budget,
+    memory_policy: overrides.memory_policy
+      ? { ...base.memory_policy!, ...overrides.memory_policy }
+      : base.memory_policy,
     agent: overrides.agent ? { ...base.agent, ...overrides.agent } : base.agent,
     database: overrides.database ? { ...base.database, ...overrides.database } : base.database,
     logging: overrides.logging ? { ...base.logging, ...overrides.logging } : base.logging,
@@ -151,6 +154,17 @@ const envMap: Array<{
     path: ['token_budget', 'alert_threshold'],
     type: 'number',
   },
+  // Message-router memory policy
+  {
+    env: 'MAMA_MEMORY_POLICY_IMPLICIT_RECALL',
+    path: ['memory_policy', 'implicit_recall'],
+    type: 'boolean',
+  },
+  {
+    env: 'MAMA_MEMORY_POLICY_IMPLICIT_LEGACY_CONTEXT_SEARCH',
+    path: ['memory_policy', 'implicit_legacy_context_search'],
+    type: 'boolean',
+  },
 ];
 
 /**
@@ -240,8 +254,24 @@ function validateRequiredFields(config: MAMAConfig, configPath: string): void {
     }
   }
 
+  appendMemoryPolicyValidationErrors(config, errors);
+
   if (errors.length > 0) {
     throw new ConfigValidationError(errors, configPath);
+  }
+}
+
+function appendMemoryPolicyValidationErrors(config: MAMAConfig, errors: string[]): void {
+  if (!config.memory_policy) {
+    return;
+  }
+
+  if (typeof config.memory_policy.implicit_recall !== 'boolean') {
+    errors.push('memory_policy.implicit_recall must be boolean');
+  }
+
+  if (typeof config.memory_policy.implicit_legacy_context_search !== 'boolean') {
+    errors.push('memory_policy.implicit_legacy_context_search must be boolean');
   }
 }
 
@@ -423,6 +453,9 @@ function mergeWithDefaults(config: Partial<MAMAConfig>): MAMAConfig {
     token_budget: config.token_budget
       ? { ...DEFAULT_CONFIG.token_budget!, ...config.token_budget }
       : DEFAULT_CONFIG.token_budget,
+    memory_policy: config.memory_policy
+      ? { ...DEFAULT_CONFIG.memory_policy!, ...config.memory_policy }
+      : DEFAULT_CONFIG.memory_policy,
   };
 }
 
@@ -668,6 +701,8 @@ export function validateConfig(config: MAMAConfig): string[] {
   if (!validLogLevels.includes(config.logging.level)) {
     errors.push(`logging.level must be one of: ${validLogLevels.join(', ')}`);
   }
+
+  appendMemoryPolicyValidationErrors(config, errors);
 
   return errors;
 }

--- a/packages/standalone/src/cli/config/config-manager.ts
+++ b/packages/standalone/src/cli/config/config-manager.ts
@@ -183,7 +183,9 @@ function applyEnvOverrides(config: MAMAConfig): MAMAConfig {
     const [section, field] = path;
     const sectionObj = result[section];
     if (sectionObj && typeof sectionObj === 'object') {
-      const parsed = type === 'boolean' ? value === 'true' || value === '1' : Number(value);
+      const normalizedValue = value.trim().toLowerCase();
+      const parsed =
+        type === 'boolean' ? normalizedValue === 'true' || normalizedValue === '1' : Number(value);
       if (type === 'number' && isNaN(parsed as number)) {
         continue;
       }

--- a/packages/standalone/src/cli/config/types.ts
+++ b/packages/standalone/src/cli/config/types.ts
@@ -340,12 +340,12 @@ export interface AgentPersonaConfig {
    */
   bot_token?: string;
   /**
-   * Optional dedicated Slack bot token (xoxb-...) for this agent
+   * Optional dedicated Slack bot token for this agent
    * If provided, this agent will use its own Slack bot
    */
   slack_bot_token?: string;
   /**
-   * Optional dedicated Slack app token (xapp-...) for Socket Mode
+   * Optional dedicated Slack app token for Socket Mode
    * Required alongside slack_bot_token for Slack multi-bot support
    */
   slack_app_token?: string;
@@ -597,6 +597,20 @@ export interface TokenBudgetConfig {
 }
 
 /**
+ * Message-router memory policy.
+ *
+ * These controls are intentionally opt-in. By default, ordinary gateway turns do
+ * not silently add recall memory or legacy context-search bundles to startup
+ * prompts; users can call explicit memory tools when they want evidence in a turn.
+ */
+export interface MemoryPolicyConfig {
+  /** Opt into implicit recallMemory injection for new CLI session startup prompts @default false */
+  implicit_recall: boolean;
+  /** Opt into legacy decision-search context injection for new CLI session startup prompts @default false */
+  implicit_legacy_context_search: boolean;
+}
+
+/**
  * Full MAMA configuration
  */
 export interface MAMAConfig {
@@ -642,6 +656,8 @@ export interface MAMAConfig {
   metrics?: MetricsConfig;
   /** Token budget settings */
   token_budget?: TokenBudgetConfig;
+  /** Message-router memory policy */
+  memory_policy?: MemoryPolicyConfig;
   /** Preserve user-defined sections (scheduling, custom integrations, etc.) */
   [key: string]: unknown;
 }
@@ -731,6 +747,10 @@ export const DEFAULT_CONFIG: MAMAConfig = {
   token_budget: {
     daily_limit: 0,
     alert_threshold: 0.9,
+  },
+  memory_policy: {
+    implicit_recall: false,
+    implicit_legacy_context_search: false,
   },
 };
 

--- a/packages/standalone/src/cli/runtime/message-router-config.ts
+++ b/packages/standalone/src/cli/runtime/message-router-config.ts
@@ -1,0 +1,13 @@
+import type { MAMAConfig } from '../config/types.js';
+import type { MessageRouterConfig } from '../../gateways/types.js';
+
+export function resolveMessageRouterConfig(
+  config: Pick<MAMAConfig, 'memory_policy'>,
+  backend: NonNullable<MessageRouterConfig['backend']>
+): MessageRouterConfig {
+  return {
+    backend,
+    implicitMemoryRecall: config.memory_policy?.implicit_recall ?? false,
+    implicitLegacyContextSearch: config.memory_policy?.implicit_legacy_context_search ?? false,
+  };
+}

--- a/packages/standalone/src/gateways/message-router.ts
+++ b/packages/standalone/src/gateways/message-router.ts
@@ -745,7 +745,8 @@ This protects your credentials from being exposed in chat logs.`;
       );
     }
 
-    // Per-turn memory injection (works for both NEW and CONTINUE sessions)
+    // NEW sessions may receive implicit memory/context prefixes. CONTINUE turns
+    // keep using CLI conversation state and only prepend queued audit notices.
     let memoryPrefix = '';
     let pendingNotices = false;
     let pendingNoticeCount = 0;

--- a/packages/standalone/src/gateways/types.ts
+++ b/packages/standalone/src/gateways/types.ts
@@ -158,9 +158,9 @@ export interface MessageRouterConfig {
   translationTargetLanguage?: string;
   /** Backend type for backend-specific AGENTS.md injection */
   backend?: 'claude' | 'codex' | 'codex-mcp';
-  /** Opt into implicit per-turn recallMemory injection. Default: false. */
+  /** Opt into implicit recallMemory injection for new CLI session startup prompts. Default: false. */
   implicitMemoryRecall?: boolean;
-  /** Opt into legacy decision-search context injection. Default: false. */
+  /** Opt into legacy decision-search context injection for new CLI session startup prompts. Default: false. */
   implicitLegacyContextSearch?: boolean;
 }
 

--- a/packages/standalone/tests/cli/config-manager.test.ts
+++ b/packages/standalone/tests/cli/config-manager.test.ts
@@ -11,6 +11,7 @@ import * as yaml from 'js-yaml';
 
 import {
   expandPath,
+  initConfig,
   loadConfig,
   saveConfig,
   createDefaultConfig,
@@ -117,6 +118,77 @@ describe('ConfigManager', () => {
       // Default values filled in
       expect(loaded.agent.max_turns).toBe(DEFAULT_CONFIG.agent.max_turns);
       expect(loaded.logging.level).toBe(DEFAULT_CONFIG.logging.level);
+      expect(loaded.memory_policy).toEqual(DEFAULT_CONFIG.memory_policy);
+    });
+
+    it('should keep implicit memory policy disabled unless explicitly configured', async () => {
+      const mamaDir = join(testDir, '.mama');
+      await mkdir(mamaDir, { recursive: true });
+      const configPath = join(mamaDir, 'config.yaml');
+
+      const minimalConfig = {
+        version: 1,
+        agent: { model: 'custom-model' },
+        database: { path: '~/.test/db.sqlite' },
+      };
+
+      await writeFile(configPath, yaml.dump(minimalConfig));
+
+      const loaded = await loadConfig();
+
+      expect(loaded.memory_policy).toEqual({
+        implicit_recall: false,
+        implicit_legacy_context_search: false,
+      });
+    });
+
+    it('should allow env overrides for explicit message-router memory policy opt-ins', async () => {
+      const mamaDir = join(testDir, '.mama');
+      await mkdir(mamaDir, { recursive: true });
+      const configPath = join(mamaDir, 'config.yaml');
+
+      const minimalConfig = {
+        version: 1,
+        agent: { model: 'custom-model' },
+        database: { path: '~/.test/db.sqlite' },
+      };
+
+      await writeFile(configPath, yaml.dump(minimalConfig));
+
+      process.env.MAMA_MEMORY_POLICY_IMPLICIT_RECALL = 'true';
+      process.env.MAMA_MEMORY_POLICY_IMPLICIT_LEGACY_CONTEXT_SEARCH = '1';
+
+      try {
+        const loaded = await initConfig();
+
+        expect(loaded.memory_policy).toEqual({
+          implicit_recall: true,
+          implicit_legacy_context_search: true,
+        });
+      } finally {
+        delete process.env.MAMA_MEMORY_POLICY_IMPLICIT_RECALL;
+        delete process.env.MAMA_MEMORY_POLICY_IMPLICIT_LEGACY_CONTEXT_SEARCH;
+      }
+    });
+
+    it('should reject string values for message-router memory policy toggles', async () => {
+      const mamaDir = join(testDir, '.mama');
+      await mkdir(mamaDir, { recursive: true });
+      const configPath = join(mamaDir, 'config.yaml');
+
+      const config = {
+        version: 1,
+        agent: { model: 'custom-model' },
+        database: { path: '~/.test/db.sqlite' },
+        memory_policy: {
+          implicit_recall: 'false',
+          implicit_legacy_context_search: 'true',
+        },
+      };
+
+      await writeFile(configPath, yaml.dump(config));
+
+      await expect(loadConfig()).rejects.toThrow(/memory_policy\.implicit_recall must be boolean/);
     });
 
     it('should normalize legacy developer agent permissions on load', async () => {
@@ -476,6 +548,21 @@ describe('ConfigManager', () => {
       };
       const errors = validateConfig(config);
       expect(errors.some((e) => e.includes('logging.level'))).toBe(true);
+    });
+
+    it('should detect invalid memory policy toggle types', () => {
+      const config = {
+        ...DEFAULT_CONFIG,
+        memory_policy: {
+          implicit_recall: 'false',
+          implicit_legacy_context_search: 'true',
+        },
+      } as unknown as MAMAConfig;
+
+      const errors = validateConfig(config);
+
+      expect(errors).toContain('memory_policy.implicit_recall must be boolean');
+      expect(errors).toContain('memory_policy.implicit_legacy_context_search must be boolean');
     });
   });
 });

--- a/packages/standalone/tests/cli/config-manager.test.ts
+++ b/packages/standalone/tests/cli/config-manager.test.ts
@@ -155,8 +155,8 @@ describe('ConfigManager', () => {
 
       await writeFile(configPath, yaml.dump(minimalConfig));
 
-      process.env.MAMA_MEMORY_POLICY_IMPLICIT_RECALL = 'true';
-      process.env.MAMA_MEMORY_POLICY_IMPLICIT_LEGACY_CONTEXT_SEARCH = '1';
+      process.env.MAMA_MEMORY_POLICY_IMPLICIT_RECALL = ' TRUE ';
+      process.env.MAMA_MEMORY_POLICY_IMPLICIT_LEGACY_CONTEXT_SEARCH = ' 1 ';
 
       try {
         const loaded = await initConfig();
@@ -554,10 +554,13 @@ describe('ConfigManager', () => {
       const config = {
         ...DEFAULT_CONFIG,
         memory_policy: {
-          implicit_recall: 'false',
-          implicit_legacy_context_search: 'true',
+          ...DEFAULT_CONFIG.memory_policy!,
         },
-      } as unknown as MAMAConfig;
+      };
+      Object.assign(config.memory_policy, {
+        implicit_recall: 'false',
+        implicit_legacy_context_search: 'true',
+      });
 
       const errors = validateConfig(config);
 

--- a/packages/standalone/tests/cli/runtime/message-router-config.test.ts
+++ b/packages/standalone/tests/cli/runtime/message-router-config.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MAMAConfig } from '../../../src/cli/config/types.js';
+import { resolveMessageRouterConfig } from '../../../src/cli/runtime/message-router-config.js';
+
+describe('Story PR17: message-router memory policy config', () => {
+  describe('AC: default rollout remains explicit opt-in', () => {
+    it('keeps implicit memory recall and legacy context search disabled by default', () => {
+      const routerConfig = resolveMessageRouterConfig(
+        {} as Pick<MAMAConfig, 'memory_policy'>,
+        'claude'
+      );
+
+      expect(routerConfig).toMatchObject({
+        backend: 'claude',
+        implicitMemoryRecall: false,
+        implicitLegacyContextSearch: false,
+      });
+    });
+
+    it('passes explicit opt-ins through to MessageRouter config', () => {
+      const routerConfig = resolveMessageRouterConfig(
+        {
+          memory_policy: {
+            implicit_recall: true,
+            implicit_legacy_context_search: true,
+          },
+        },
+        'codex-mcp'
+      );
+
+      expect(routerConfig).toMatchObject({
+        backend: 'codex-mcp',
+        implicitMemoryRecall: true,
+        implicitLegacyContextSearch: true,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Keep vNext rollout opt-in after PR16 and document the PR17 default rollout decision.
- Add `memory_policy.implicit_recall` and `memory_policy.implicit_legacy_context_search` with env overrides so message-router startup-prompt memory injection stays explicitly opt-in.
- Validate memory policy toggles as real YAML booleans and remove token-shaped Slack examples from changed public docs.

## Review and privacy gates

- CodeRabbit review: 0 issues.
- Codex review: no correctness issues after the final diff; standalone suite and typecheck passed during review.
- Subagent review: fixed docs/comments that overstated the policy as per-turn instead of startup-prompt/new-session scope.
- Public-project privacy check: added lines scanned for token/private patterns; Slack matches are synthetic placeholders only.

## Verification

- `pnpm --filter @jungjaehoon/mama-os exec vitest run tests/cli/config-manager.test.ts tests/cli/runtime/message-router-config.test.ts tests/gateways/message-router.test.ts tests/gateways/memory-v2.e2e.test.ts`
- `pnpm --filter @jungjaehoon/mama-os typecheck`
- `pnpm exec eslint packages/standalone/src/cli/commands/start.ts packages/standalone/src/cli/config/config-manager.ts packages/standalone/src/cli/config/types.ts packages/standalone/src/cli/runtime/message-router-config.ts packages/standalone/src/gateways/types.ts packages/standalone/src/gateways/message-router.ts packages/standalone/tests/cli/config-manager.test.ts packages/standalone/tests/cli/runtime/message-router-config.test.ts`
- `MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os dogfood:vnext`
- `git diff --cached --check`
- `./scripts/check-pii.sh`
- `gitleaks protect --source . --staged --redact --verbose --no-banner`
- `./scripts/check-pr-gitleaks.sh`
- commit hook: lint-staged, gitleaks, doc version sync, typecheck, changed package tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional memory policy settings for gateway and standalone setups, with environment-variable overrides to control implicit recall and legacy context search.
  * Updated startup behavior so message routing now respects these explicit memory policy choices.

* **Bug Fixes**
  * Clarified default behavior so memory-related context is off by default unless explicitly enabled.
  * Improved configuration validation and error handling for memory policy values.

* **Documentation**
  * Updated setup, gateway, architecture, and changelog guidance to reflect the new memory policy options and rollout status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->