### PR TITLE
docs: record vNext release readiness gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,21 @@ All notable changes to this project will be documented in this file.
   and `memory_policy.implicit_legacy_context_search`, plus matching environment
   variable overrides, so startup-prompt memory recall and legacy context search
   remain explicit local choices instead of default gateway behavior.
+- **vNext release-readiness guide** — Added an opt-in rollout checklist that records
+  the remaining migration, real local smoke, privacy, dogfood, and review gates
+  before vNext can become the default runtime.
 
 ### Changed
 
 - **vNext rollout decision** — Kept vNext opt-in after the synthetic dogfood
   harness and operator cockpit landed; default rollout now waits on migration
   docs and real local smoke evidence.
+- **README release status** — Updated the top-level README to describe the PR #115
+  state: vNext remains opt-in, gateway memory recall is policy-gated, and release
+  readiness now depends on migration guidance plus public-safe smoke evidence.
+- **PII check branch-diff mode** — Added `scripts/check-pii.sh --base <ref>` so
+  release-readiness PRs can scan committed branch diffs, not only staged pre-commit
+  changes.
 
 ## [0.20.1] / mama-core [1.7.0] / mama-os [0.20.1] - 2026-05-04
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 Jung Jaehoon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,25 @@ Context Compile V0. `context_compile` turns those pieces into one selected/rejec
 evidence packet for a task, and `mama_save` can attach that packet through trusted
 `context_packet_id` provenance.
 
+## vNext Release Readiness
+
+The vNext primary-operator rebuild is in opt-in release hardening. PRs #98 through #115 rebuilt the
+runtime around one commit authority, source-linked writes, an operator review cockpit, synthetic
+end-to-end dogfood, and explicit gateway memory-policy opt-ins.
+
+vNext is **not the default runtime yet**. The reviewed path has synthetic coverage, but default
+rollout still waits on migration guidance and real local smoke evidence that can be shared without
+private connector payloads, local paths, channel IDs, or internal project details.
+
+Current release decision:
+
+- **Opt-in only:** legacy runtime remains available.
+- **Memory policy default:** ordinary gateway turns do not inject implicit recall or legacy context
+  search unless `memory_policy` or `MAMA_MEMORY_POLICY_*` explicitly enables it.
+- **Next release gate:** finish the [vNext Release Readiness Guide](docs/guides/vnext-release-readiness.md),
+  run the real local smoke checklist, and pass the public-project privacy scans before any default
+  rollout decision.
+
 ## Target Workflow
 
 MAMA is being built toward a local memory twin that agents can inspect, cite, and act on inside
@@ -308,7 +327,7 @@ that selects, rejects, and explains evidence before a worker writes memory or co
 | **Done** | v0.18   | Output layer: knowledge agents, viewer redesign, security hardening                                                                                                                                                                               |
 | **Done** | v0.19   | Agent-management foundation: viewer-aware frontdoor, validation UI, activity telemetry, conductor isolation                                                                                                                                       |
 | **Now**  | v0.20.1 | M1-M6 runtime foundation plus Context Compile V0: envelopes, model/tool trace ledger, raw/situation/graph worker APIs, strict search diagnostics, append-only `context_packets`, `context_compile`, and downstream `context_packet_id` provenance |
-| **Next** | v0.21   | Report composer, packet retention policy, search-quality feedback loops, browser onboarding for non-developers, and domain extraction templates                                                                                                   |
+| **Next** | v0.21   | vNext opt-in release readiness: migration guidance, real local smoke evidence, privacy gates, report composer hardening, packet retention policy, and search-quality feedback loops                                                               |
 |          | Later   | Domain extraction templates, cross-worker packet analytics, and team-scoped context review workflows                                                                                                                                              |
 |          | v1.0    | Team mode: shared scoped knowledge graph for organizations. General release                                                                                                                                                                       |
 
@@ -322,7 +341,7 @@ pnpm test     # 3000+ tests across all packages
 
 See [CLAUDE.md](CLAUDE.md) for development guidelines.
 
-_Last updated: 2026-05-01_
+_Last updated: 2026-07-04_
 
 ## License
 

--- a/docs/architecture/mama-vnext-primary-operator-rebuild.md
+++ b/docs/architecture/mama-vnext-primary-operator-rebuild.md
@@ -1,6 +1,6 @@
 # MAMA vNext Primary Operator Rebuild Plan
 
-Status: implementation through PR 16 merged; PR 17 records the rollout decision and explicit memory-policy opt-ins.
+Status: implementation through PR 17 merged; PR 18 is release-readiness documentation and smoke-gate alignment.
 Branch base: `origin/main`.
 Decision date: 2026-07-02.
 Last updated: 2026-07-04.
@@ -35,28 +35,29 @@ blockers for starting PR 0.
 
 ## Implementation Status
 
-PR 0 through PR 16 have landed on `main`.
+PR 0 through PR 17 have landed on `main`.
 
-| Slice | GitHub PR | State  | Result                                             |
-| ----- | --------- | ------ | -------------------------------------------------- |
-| PR 0  | #98       | merged | SourceRef contract and vNext operator DB contracts |
-| PR 1  | #99       | merged | vNext bootstrap mode with legacy fanout disabled   |
-| PR 2  | #100      | merged | primary operator commit shell and cursor semantics |
-| PR 3  | #101      | merged | primary operator runtime bootstrap/status API      |
-| PR 4  | #102      | merged | source-linked wiki artifact adapter and store      |
-| PR 5  | #103      | merged | dashboard projection and commit authority          |
-| PR 6  | #104      | merged | connector ingress preview dry-run                  |
-| PR 7  | #105      | merged | connector ingress migration dry-run report         |
-| PR 8  | #106      | merged | legacy dashboard/wiki agents opt-in by default     |
-| PR 9  | #107      | merged | global vNext architecture invariant coverage       |
-| PR 10 | #108      | merged | manual reviewed no-update ingress commit           |
-| PR 11 | #109      | merged | atomic changed commits through trusted writers     |
-| PR 12 | #110      | merged | manual reviewed wiki ingress commit                |
-| PR 13 | #111      | merged | manual reviewed memory ingress commit              |
-| PR 14 | #112      | merged | completion gates and staged privacy checks         |
-| PR 15 | #113      | merged | isolated vNext operator review cockpit             |
-| PR 16 | #114      | merged | synthetic end-to-end dogfood harness               |
-| PR 17 | pending   | active | default rollout decision and memory-policy opt-ins |
+| Slice | GitHub PR | State  | Result                                                   |
+| ----- | --------- | ------ | -------------------------------------------------------- |
+| PR 0  | #98       | merged | SourceRef contract and vNext operator DB contracts       |
+| PR 1  | #99       | merged | vNext bootstrap mode with legacy fanout disabled         |
+| PR 2  | #100      | merged | primary operator commit shell and cursor semantics       |
+| PR 3  | #101      | merged | primary operator runtime bootstrap/status API            |
+| PR 4  | #102      | merged | source-linked wiki artifact adapter and store            |
+| PR 5  | #103      | merged | dashboard projection and commit authority                |
+| PR 6  | #104      | merged | connector ingress preview dry-run                        |
+| PR 7  | #105      | merged | connector ingress migration dry-run report               |
+| PR 8  | #106      | merged | legacy dashboard/wiki agents opt-in by default           |
+| PR 9  | #107      | merged | global vNext architecture invariant coverage             |
+| PR 10 | #108      | merged | manual reviewed no-update ingress commit                 |
+| PR 11 | #109      | merged | atomic changed commits through trusted writers           |
+| PR 12 | #110      | merged | manual reviewed wiki ingress commit                      |
+| PR 13 | #111      | merged | manual reviewed memory ingress commit                    |
+| PR 14 | #112      | merged | completion gates and staged privacy checks               |
+| PR 15 | #113      | merged | isolated vNext operator review cockpit                   |
+| PR 16 | #114      | merged | synthetic end-to-end dogfood harness                     |
+| PR 17 | #115      | merged | default rollout decision and memory-policy opt-ins       |
+| PR 18 | pending   | active | release-readiness docs, migration checklist, smoke gates |
 
 PR 14 did not add runtime behavior. It closed the plan drift created by PR 9-13,
 centralized staged privacy checks, defined completion gates, and prevented later
@@ -65,6 +66,11 @@ code slices from guessing what "done" means.
 PR 15 added the first-party operator review cockpit. PR 16 proved the cockpit's
 backend path with synthetic data only: preview, dry-run, no-update, wiki, memory,
 projection, replay, and explicit recall gating.
+
+PR 17 kept vNext opt-in and made gateway startup-prompt memory recall and legacy
+context search explicit local opt-ins. PR 18 records the release checkpoint:
+README alignment, migration guidance, real local smoke evidence, and privacy
+scans before any default rollout decision.
 
 ## Why
 
@@ -152,11 +158,11 @@ Deterministic Projections
 
 ## Public Release Privacy Gate
 
-MAMA is a public project. Every stage must prove it does not publish private,
+MAMA is a public project. Every stage must show it does not publish private,
 customer, channel, local-machine, or internal project information.
 
-Run this gate before opening every PR, after responding to PR review comments, and
-before starting the next branch.
+Run this gate before committing staged changes, before opening every PR, after
+responding to PR review comments, and before starting the next branch.
 
 What to check:
 
@@ -168,21 +174,28 @@ What to check:
 - tests and fixtures: real connector payloads, real timestamps tied to private work,
   real message IDs unless synthetic and clearly marked
 
-Required commands for every PR:
+Required commands before committing staged changes:
 
 ```bash
 git diff --cached --check
-git diff --cached --name-only
 ./scripts/check-pii.sh
 gitleaks protect --source . --staged --redact --verbose --no-banner
+```
+
+Required commands before opening every PR, after responding to PR review
+comments, and before starting the next branch:
+
+```bash
+git diff origin/main...HEAD --check
+./scripts/check-pii.sh --base origin/main
 ./scripts/check-pr-gitleaks.sh
 ```
 
-`scripts/check-pii.sh` is the authoritative staged-file privacy check. It loads
-`.pii-patterns` when that gitignored file exists, always runs the generic ID
-checks built into the script, blocks high-confidence local path and credential
-prefix matches in staged added lines, and prints review-only warnings for
-privacy-sensitive connector or provider terms.
+`scripts/check-pii.sh` is the authoritative staged-file and branch-diff privacy
+check. It loads `.pii-patterns` when that gitignored file exists, always runs
+the generic ID checks built into the script, blocks high-confidence local path
+and credential prefix matches in added lines, and prints review-only warnings
+for privacy-sensitive connector or provider terms.
 
 `scripts/check-pr-gitleaks.sh` scans branch commits with `gitleaks git`,
 materializes staged blobs for direct gitleaks scans, and also scans files
@@ -1210,7 +1223,7 @@ Goal:
 Decision:
 
 - vNext remains opt-in after PR 17. The synthetic dogfood harness and cockpit
-  prove the reviewed local path, but default rollout still needs migration
+  exercise the reviewed path, but default rollout still needs migration
   guidance and real local smoke evidence.
 - Ordinary gateway turns keep `implicit_recall` and
   `implicit_legacy_context_search` disabled by default.
@@ -1229,6 +1242,39 @@ Rules:
   exist, even though the synthetic dogfood harness has passed.
 - Continue reviewing every rollout change for private-data leakage before PR.
 - Legacy runtime must remain available until migration docs exist.
+
+### PR 18: Release Readiness Docs And Smoke Checkpoint
+
+Goal:
+
+- Update README and release-facing docs so the public status matches PR #115:
+  vNext is opt-in, memory-policy injection is off by default, and default rollout
+  waits on migration docs plus real local smoke evidence.
+- Add a release-readiness guide that turns the remaining release work into
+  decision and checkpoint gates.
+- Keep all evidence public-safe: no real connector payloads, local absolute
+  paths, channel IDs, memory ids, screenshots, or internal project names.
+
+Files:
+
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+- Modify: `docs/index.md`
+- Modify: `docs/architecture/mama-vnext-primary-operator-rebuild.md`
+- Modify: `docs/development/release-process.md`
+- Modify: `docs/guides/gateway-config.md`
+- Modify: `docs/guides/standalone-setup.md`
+- Modify: `scripts/check-pii.sh`
+- Create: `docs/guides/vnext-release-readiness.md`
+
+Verify:
+
+```bash
+git diff origin/main...HEAD --check
+rg "PR 17|#115|vNext|memory_policy|release readiness" README.md CHANGELOG.md docs
+./scripts/check-pii.sh --base origin/main
+./scripts/check-pr-gitleaks.sh
+```
 
 ## Global Regression Checklist
 
@@ -1332,7 +1378,10 @@ Conflict flags:
     remaining work.
 16. Land PR 15 and dogfood the operator review cockpit on synthetic connector data.
 17. Land PR 16 and run the synthetic end-to-end dogfood harness.
-18. Land PR 17 only if the default rollout decision remains safe after PR 15-16.
+18. Land PR 17 after confirming the default rollout decision remains safe after
+    PR 15-16.
+19. Land PR 18 after README, release-readiness docs, smoke gates, and privacy
+    checks agree on the same opt-in release status.
 
 ## Review Notes
 

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -17,6 +17,7 @@ Run this checklist in order for every release candidate.
 2. Align release-facing docs
    - Update [README](../../README.md)
    - Update [CHANGELOG](../../CHANGELOG.md)
+   - Update [vNext Release Readiness](../guides/vnext-release-readiness.md) when rollout gates change
    - Update operator/install docs when auth detection, setup flow, or CLI UX changed
    - Update roadmap/design docs for the affected release train
    - Remove or archive stale docs for deleted surfaces
@@ -64,6 +65,7 @@ A release is not ready until these are true:
 - README describes the shipped architecture and current frontdoor roles
 - CHANGELOG contains an unreleased/release entry for the exact changes being shipped
 - Roadmap docs distinguish shipped foundation work from next-branch architecture
+- vNext default-rollout claims are backed by migration guidance and real local smoke evidence
 - Deleted surfaces are no longer described as active features
 - Local-only superpower planning/review docs are ignored unless intentionally promoted into public docs
 
@@ -108,4 +110,4 @@ to land through review first.
 
 ---
 
-**Last Updated:** 2026-05-03
+**Last Updated:** 2026-07-04

--- a/docs/guides/gateway-config.md
+++ b/docs/guides/gateway-config.md
@@ -93,6 +93,9 @@ This policy does not disable the older session-start context path for channel
 summaries, checkpoints, or recent decision snippets when those startup APIs are
 configured.
 
+For rollout status and smoke evidence requirements, see the
+[vNext Release Readiness Guide](vnext-release-readiness.md).
+
 ---
 
 ## Discord Gateway
@@ -869,5 +872,5 @@ missing_scope
 
 ---
 
-**Last Updated:** 2026-02-01  
+**Last Updated:** 2026-07-04
 **MAMA OS Version:** 0.1.0

--- a/docs/guides/standalone-setup.md
+++ b/docs/guides/standalone-setup.md
@@ -807,6 +807,7 @@ After successful setup:
 **Recommended reading:**
 
 - [Gateway Configuration Guide](gateway-config.md) - Detailed gateway setup
+- [vNext Release Readiness Guide](vnext-release-readiness.md) - Opt-in rollout and smoke gates
 - [Skills API Reference](../reference/skills-api.md) - Build custom skills
 - [Security Guide](security.md) - Secure your MAMA instance
 
@@ -886,4 +887,4 @@ sudo systemctl status mama
 ---
 
 **Author**: SpineLift Team
-**Last Updated**: 2026-04-20
+**Last Updated**: 2026-07-04

--- a/docs/guides/vnext-release-readiness.md
+++ b/docs/guides/vnext-release-readiness.md
@@ -1,0 +1,95 @@
+# vNext Release Readiness Guide
+
+MAMA vNext is the primary-operator rebuild. It keeps durable writes behind one reviewed commit
+authority instead of letting dashboard, wiki, memory, connector, and gateway agents write state from
+separate loops.
+
+This guide records the release decision and the remaining checkpoint before vNext can move from
+opt-in to default.
+
+## Current Decision
+
+vNext remains opt-in after PR #115.
+
+The synthetic dogfood harness and operator cockpit exercise the reviewed path with synthetic
+connector data. They do not prove that existing users can migrate safely, or that a real local smoke
+run can be documented without leaking private connector content.
+
+Default rollout waits on:
+
+- migration guidance for enabling, verifying, and rolling back vNext
+- real local smoke evidence using redacted or synthetic-visible outputs only
+- public-project privacy checks before every release-readiness PR
+- documentation consistency across README, setup, gateway, release, and architecture docs
+
+## Release Checkpoint
+
+Release readiness is achieved only when the vNext-specific gates below and the standard release
+verification in [Release Process](../development/release-process.md) are true.
+
+| Gate                      | Status      | Evidence required                                                                |
+| ------------------------- | ----------- | -------------------------------------------------------------------------------- |
+| PR #115 merged            | Done        | GitHub PR #115 merged into `main`                                                |
+| vNext opt-in documented   | In progress | README, setup guide, gateway guide, architecture plan, changelog                 |
+| Migration path documented | Pending     | Steps to enable vNext, run smoke checks, and return to legacy mode               |
+| Real local smoke evidence | Pending     | Redacted command output or synthetic-equivalent transcript with no private data  |
+| Privacy scans             | Per PR      | `./scripts/check-pii.sh --base origin/main`, `./scripts/check-pr-gitleaks.sh`    |
+| Dogfood gate              | Pending     | `MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os dogfood:vnext`        |
+| Release verification      | Pending     | `pnpm test`, `pnpm build`, plus any scoped smoke checks from the release process |
+| Review gate               | Pending     | Code review before PR, after PR comments, and before the next branch             |
+
+## Smoke Checklist
+
+Run the smoke checklist on an opt-in local config. Do not use real connector payloads in committed
+fixtures, screenshots, logs, or docs.
+
+1. Start from a clean branch based on `origin/main`.
+2. Confirm legacy mode still starts without enabling vNext.
+3. Enable vNext only in the local config under review.
+4. Run the synthetic dogfood gate:
+
+   ```bash
+   MAMA_FORCE_TIER_3=true pnpm --filter @jungjaehoon/mama-os dogfood:vnext
+   ```
+
+5. Run one local operator cockpit smoke pass using synthetic or redacted connector data.
+6. Verify ordinary gateway turns do not inject implicit recall or legacy context search by default.
+7. Verify explicit `mama_recall` can recall reviewed memory.
+8. Capture only safe evidence:
+   - command names and pass/fail summaries
+   - synthetic connector/channel names
+   - redacted timestamps if needed
+   - no message bodies from private sources
+   - no local absolute paths
+   - no memory ids from a real user database
+
+## Rollback Rule
+
+Until vNext becomes default, rollback is simple: leave vNext disabled and keep using the legacy
+runtime. Release docs must preserve that path.
+
+Do not delete or hide legacy runtime setup steps before migration docs and real smoke evidence are
+merged.
+
+## Public-Project Privacy Rule
+
+Before committing release-readiness changes, scan the staged diff:
+
+```bash
+git diff --cached --check
+./scripts/check-pii.sh
+gitleaks protect --source . --staged --redact --verbose --no-banner
+```
+
+Before opening a release-readiness PR, after responding to review comments, and before starting the
+next branch, scan the full branch diff against `main`:
+
+```bash
+git diff origin/main...HEAD --check
+./scripts/check-pii.sh --base origin/main
+./scripts/check-pr-gitleaks.sh
+```
+
+These scans are gates, not a substitute for reading the diff. Review added docs and fixtures for
+tokens, local paths, channel IDs, customer names, raw connector payloads, and internal project
+details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ _Step-by-step instructions for specific tasks_
 - [Installation Guide](guides/installation.md) - Complete installation process
 - [Standalone Setup](guides/standalone-setup.md) - Set up always-on AI agent
 - [Gateway Configuration](guides/gateway-config.md) - Configure Discord, Slack, Telegram bots
+- [vNext Release Readiness](guides/vnext-release-readiness.md) - Opt-in rollout, smoke evidence, and privacy gates
 - [Mobile Access](guides/mobile-access.md) - Access MAMA from any device with mobile chat
 - [Webchat Media](guides/webchat-media.md) - Image upload, TTS/STT voice features
 - [Troubleshooting](guides/troubleshooting.md) - Common issues and solutions
@@ -152,4 +153,4 @@ _Contributing, testing, and development guidelines_
 ---
 
 **Status:** MAMA OS v0.20.1 — Runtime Envelopes, Context Compile V0, Worker Context APIs
-**Last Updated:** 2026-05-03
+**Last Updated:** 2026-07-04

--- a/packages/memorybench/package.json
+++ b/packages/memorybench/package.json
@@ -2,6 +2,7 @@
   "name": "memorybench",
   "version": "1.0.0",
   "type": "module",
+  "license": "MIT",
   "scripts": {
     "start": "bun run src/index.ts",
     "test": "bun test",

--- a/scripts/check-pii.sh
+++ b/scripts/check-pii.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Pre-commit PII check: scan staged files for personal/project information.
+# PII check: scan staged files, or a branch diff, for personal/project information.
 #
 # Patterns are loaded from .pii-patterns (gitignored).
 # If .pii-patterns doesn't exist, only generic checks run.
@@ -13,9 +13,45 @@ YELLOW='\033[0;33m'
 NC='\033[0m'
 
 PATTERNS_FILE=".pii-patterns"
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(ts|js|md|json)$' || true)
+MODE="staged"
+DIFF_RANGE=("--cached")
 
-if [ -z "$STAGED_FILES" ]; then
+if [ "${1:-}" = "--base" ]; then
+  MODE="diff"
+  BASE_REF="${2:-origin/main}"
+  if ! git rev-parse --verify -q "${BASE_REF}^{commit}" >/dev/null 2>&1; then
+    echo -e "${RED}✗ Base ref does not resolve to a commit: ${BASE_REF}${NC}" >&2
+    exit 2
+  fi
+  DIFF_RANGE=("${BASE_REF}...HEAD")
+  if [ -n "$(git status --porcelain)" ]; then
+    echo -e "${YELLOW}⚠ Working tree has uncommitted changes; --base scans committed branch diff only.${NC}" >&2
+  fi
+elif [ -n "${1:-}" ]; then
+  echo "Usage: $0 [--base <ref>]" >&2
+  exit 2
+fi
+
+if ! DIFF_FILE_LIST=$(git diff "${DIFF_RANGE[@]}" --name-only --diff-filter=ACM); then
+  echo -e "${RED}✗ git diff failed. Ensure the base ref is valid and fetched.${NC}" >&2
+  exit 1
+fi
+
+set +e
+FILTERED_FILE_LIST=$(printf '%s\n' "$DIFF_FILE_LIST" | grep -E '\.(ts|js|md|json)$')
+FILTERED_FILE_STATUS=$?
+set -e
+if [ "$FILTERED_FILE_STATUS" -ne 0 ] && [ "$FILTERED_FILE_STATUS" -ne 1 ]; then
+  echo -e "${RED}✗ file filter failed while selecting files to scan.${NC}" >&2
+  exit 1
+fi
+
+SCAN_FILES=()
+while IFS= read -r file; do
+  [ -n "$file" ] && SCAN_FILES+=("$file")
+done < <(printf '%s\n' "$FILTERED_FILE_LIST")
+
+if [ "${#SCAN_FILES[@]}" -eq 0 ]; then
   exit 0
 fi
 
@@ -28,8 +64,21 @@ if [ -f "$PATTERNS_FILE" ]; then
     # Skip comments and empty lines
     [[ "$pattern" =~ ^#.*$ || -z "$pattern" ]] && continue
 
-    # Search staged file contents (not filenames)
-    MATCHES=$(echo "$STAGED_FILES" | xargs grep -ln "$pattern" 2>/dev/null || true)
+    # Search changed file contents (not filenames).
+    MATCHES=$(
+      for f in "${SCAN_FILES[@]}"; do
+        if grep -l "$pattern" "$f" 2>/dev/null; then
+          continue
+        fi
+        status=$?
+        if [ "$status" -ne 1 ]; then
+          exit "$status"
+        fi
+      done
+    ) || {
+      echo -e "${RED}✗ PII pattern search failed: ${pattern}${NC}" >&2
+      exit 1
+    }
     if [ -n "$MATCHES" ]; then
       echo -e "${RED}✗ PII pattern found: ${pattern}${NC}"
       echo "$MATCHES" | while read -r f; do
@@ -42,7 +91,7 @@ fi
 
 # 2. Generic checks (always run, no project-specific data needed)
 # Check for Discord snowflake IDs (17-20 digit numbers in non-test source)
-for f in $STAGED_FILES; do
+for f in "${SCAN_FILES[@]}"; do
   # Skip test files and config files
   [[ "$f" == *.test.* || "$f" == *.spec.* || "$f" == */tests/* ]] && continue
   [[ "$f" == *.json ]] && continue
@@ -56,7 +105,7 @@ for f in $STAGED_FILES; do
   fi
 done
 
-# 3. Staged added-line checks for local paths and credential-like prefixes.
+# 3. Added-line checks for local paths and credential-like prefixes.
 BLOCKING_ADDED_LINE_PATTERN=$(
   printf '%s\n' \
     '/'"Users/[[:alnum:]_.-]+/[[:alnum:]_.-]+" \
@@ -81,24 +130,43 @@ REVIEW_ADDED_LINE_PATTERN=$(
     paste -sd '|' -
 )
 
+if ! ADDED_LINE_DIFF=$(git diff "${DIFF_RANGE[@]}" --unified=0 -- "${SCAN_FILES[@]}"); then
+  echo -e "${RED}✗ git diff failed while scanning added lines.${NC}" >&2
+  exit 1
+fi
+
+set +e
 BLOCKING_ADDED_LINE_MATCHES=$(
-  git diff --cached --unified=0 -- $STAGED_FILES |
-    grep -Ein "^[+]([^+]|$).*(${BLOCKING_ADDED_LINE_PATTERN})" || true
+  printf '%s\n' "$ADDED_LINE_DIFF" |
+    grep -Ein "^[+]([^+]|$).*(${BLOCKING_ADDED_LINE_PATTERN})"
 )
+BLOCKING_ADDED_LINE_STATUS=$?
+set -e
+if [ "$BLOCKING_ADDED_LINE_STATUS" -ne 0 ] && [ "$BLOCKING_ADDED_LINE_STATUS" -ne 1 ]; then
+  echo -e "${RED}✗ blocking added-line scan failed.${NC}" >&2
+  exit 1
+fi
 
 if [ -n "$BLOCKING_ADDED_LINE_MATCHES" ]; then
-  echo -e "${RED}✗ High-risk private data pattern found in staged added lines${NC}"
+  echo -e "${RED}✗ High-risk private data pattern found in ${MODE} added lines${NC}"
   echo "$BLOCKING_ADDED_LINE_MATCHES"
   FOUND=1
 fi
 
+set +e
 REVIEW_ADDED_LINE_MATCHES=$(
-  git diff --cached --unified=0 -- $STAGED_FILES |
-    grep -Ein "^[+]([^+]|$).*(${REVIEW_ADDED_LINE_PATTERN})" || true
+  printf '%s\n' "$ADDED_LINE_DIFF" |
+    grep -Ein "^[+]([^+]|$).*(${REVIEW_ADDED_LINE_PATTERN})"
 )
+REVIEW_ADDED_LINE_STATUS=$?
+set -e
+if [ "$REVIEW_ADDED_LINE_STATUS" -ne 0 ] && [ "$REVIEW_ADDED_LINE_STATUS" -ne 1 ]; then
+  echo -e "${RED}✗ review added-line scan failed.${NC}" >&2
+  exit 1
+fi
 
 if [ -n "$REVIEW_ADDED_LINE_MATCHES" ]; then
-  echo -e "${YELLOW}⚠ Review staged added lines for possible private data:${NC}"
+  echo -e "${YELLOW}⚠ Review ${MODE} added lines for possible private data:${NC}"
   echo "$REVIEW_ADDED_LINE_MATCHES"
   echo -e "  ${YELLOW}Review-only warning: confirm matches are synthetic, generic, or public-safe.${NC}"
 fi
@@ -106,7 +174,7 @@ fi
 if [ "$FOUND" -eq 1 ]; then
   echo ""
   echo -e "${RED}╔══════════════════════════════════════════════════════╗${NC}"
-  echo -e "${RED}║  COMMIT BLOCKED: PII detected in staged files       ║${NC}"
+  echo -e "${RED}║  COMMIT BLOCKED: PII detected in changed files      ║${NC}"
   echo -e "${RED}║  Remove personal/project info before committing.    ║${NC}"
   echo -e "${RED}╚══════════════════════════════════════════════════════╝${NC}"
   echo ""


### PR DESCRIPTION
## Summary

- Record the post-#115 vNext release decision: vNext remains opt-in until migration guidance and public-safe real local smoke evidence exist.
- Add the vNext Release Readiness guide and link it from README, docs index, setup, gateway, and release-process docs.
- Add `scripts/check-pii.sh --base <ref>` so pre-PR privacy checks scan committed branch diffs instead of only staged files.

## Review Notes

- PR #115 was merged into `main` before this branch was cut.
- Release goal was saved locally as MAMA decision `decision_mama_vnext_release_readiness_1783134753809_8755c316` and checkpoint `481`.
- Subagent review found a staged-only privacy gate mismatch; fixed by adding `check-pii.sh --base origin/main` and splitting staged vs branch-diff gates.
- Follow-up subagent review confirmed the prior P1 was resolved; remaining stale PR18 file list was fixed before push.

## Verification

- `git diff origin/main...HEAD --check`
- `bash -n scripts/check-pii.sh`
- `./scripts/check-pii.sh --base origin/main`
- `./scripts/check-pr-gitleaks.sh`
- `pnpm sync-versions --check`
- pre-commit hook: prettier, staged gitleaks, doc version sync, standalone typecheck

## Privacy / Public-Project Check

- No private connector payloads, real local paths, channel IDs, raw screenshots, memory IDs, tokens, or internal project details were added.
- `./scripts/check-pr-gitleaks.sh` scanned 1 PR commit and 9 PR-changed files with no leaks found.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “vNext Release Readiness” guide with explicit opt-in and default-rollout checkpoint gates (migration, local smoke evidence, privacy checks).
  * Enhanced privacy scanning to support branch-diff checks via `check-pii` base reference mode.

* **Documentation**
  * Updated README, changelog, and multiple gateway/release-process guides to align rollout wording and readiness evidence requirements.
  * Refreshed “Last updated” timestamps and added new readiness links across the docs.

* **Chores**
  * Added MIT license text and set MIT license metadata for the memorybench package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->