### PR TITLE
feat(mama-core): e5 query/passage prefix scheme with version-guarded re-embed (M5)

### DIFF
--- a/packages/claude-code-plugin/scripts/precompact-hook.js
+++ b/packages/claude-code-plugin/scripts/precompact-hook.js
@@ -91,7 +91,7 @@ async function getSavedTopicsFromDB() {
 
     // Get recent decisions (no embedding needed, just list recent)
     const { generateEmbedding } = require('@jungjaehoon/mama-core/embeddings');
-    const embedding = await generateEmbedding('recent decisions architecture');
+    const embedding = await generateEmbedding('recent decisions architecture', 'query');
     if (embedding) {
       const results = await vectorSearch(embedding, 20, 0.3);
       if (results && Array.isArray(results)) {

--- a/packages/claude-code-plugin/scripts/pretooluse-hook.js
+++ b/packages/claude-code-plugin/scripts/pretooluse-hook.js
@@ -125,7 +125,7 @@ async function main() {
 
     // Build search query from file path
     const searchQuery = buildSearchQuery(filePath);
-    const embedding = await generateEmbedding(searchQuery);
+    const embedding = await generateEmbedding(searchQuery, 'query');
 
     if (!embedding) {
       markFileEdited(filePath);

--- a/packages/mama-core/db/migrations/042-embedding-prefix-scheme.sql
+++ b/packages/mama-core/db/migrations/042-embedding-prefix-scheme.sql
@@ -1,0 +1,21 @@
+-- Migration 042: track the embedding instruction-prefix scheme (e5 query/passage).
+-- Fresh DB (no stored vectors) starts current; an upgraded DB with pre-existing
+-- unprefixed vectors is marked legacy so the runtime guard forces a re-embed.
+
+CREATE TABLE IF NOT EXISTS embedding_meta (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
+);
+
+INSERT OR IGNORE INTO embedding_meta (key, value)
+SELECT 'embedding_prefix_scheme',
+  CASE
+    WHEN EXISTS (SELECT 1 FROM embeddings)
+      OR EXISTS (SELECT 1 FROM wiki_page_embeddings)
+    THEN 'legacy-unprefixed'
+    ELSE 'e5-prefixed-v1'
+  END;
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES (42, 'Track embedding prefix scheme (e5 query/passage)');

--- a/packages/mama-core/db/migrations/042-embedding-prefix-scheme.sql
+++ b/packages/mama-core/db/migrations/042-embedding-prefix-scheme.sql
@@ -1,6 +1,16 @@
 -- Migration 042: track the embedding instruction-prefix scheme (e5 query/passage).
 -- Fresh DB (no stored vectors) starts current; an upgraded DB with pre-existing
 -- unprefixed vectors is marked legacy so the runtime guard forces a re-embed.
+--
+-- Robustness: a SQLite statement that references a missing table fails at prepare
+-- time. Some legacy-recovery paths reach 042 with a partial schema (e.g. a DB whose
+-- schema_version was fast-forwarded past migration 030, so wiki_page_embeddings does
+-- not exist yet). We therefore key the marker off the decisions vector store
+-- (embeddings, created in migration 013) only, and gate the whole INSERT behind a
+-- sqlite_master existence check so it never references a table that is absent. The
+-- runtime guard in db-manager (assertEmbeddingSchemeCurrent) still counts BOTH
+-- embeddings and wiki_page_embeddings (each wrapped in try/catch), so any legacy wiki
+-- vector under a legacy marker still fails loud at initDB.
 
 CREATE TABLE IF NOT EXISTS embedding_meta (
   key TEXT PRIMARY KEY,
@@ -12,10 +22,10 @@ INSERT OR IGNORE INTO embedding_meta (key, value)
 SELECT 'embedding_prefix_scheme',
   CASE
     WHEN EXISTS (SELECT 1 FROM embeddings)
-      OR EXISTS (SELECT 1 FROM wiki_page_embeddings)
     THEN 'legacy-unprefixed'
     ELSE 'e5-prefixed-v1'
-  END;
+  END
+WHERE EXISTS (SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'embeddings');
 
 INSERT OR IGNORE INTO schema_version (version, description)
 VALUES (42, 'Track embedding prefix scheme (e5 query/passage)');

--- a/packages/mama-core/db/migrations/042-embedding-prefix-scheme.sql
+++ b/packages/mama-core/db/migrations/042-embedding-prefix-scheme.sql
@@ -1,16 +1,17 @@
 -- Migration 042: track the embedding instruction-prefix scheme (e5 query/passage).
 -- Fresh DB (no stored vectors) starts current; an upgraded DB with pre-existing
--- unprefixed vectors is marked legacy so the runtime guard forces a re-embed.
+-- unprefixed vectors (in EITHER vector store) is marked legacy so the runtime guard
+-- forces a re-embed.
 --
 -- Robustness: a SQLite statement that references a missing table fails at prepare
--- time. Some legacy-recovery paths reach 042 with a partial schema (e.g. a DB whose
--- schema_version was fast-forwarded past migration 030, so wiki_page_embeddings does
--- not exist yet). We therefore key the marker off the decisions vector store
--- (embeddings, created in migration 013) only, and gate the whole INSERT behind a
--- sqlite_master existence check so it never references a table that is absent. The
--- runtime guard in db-manager (assertEmbeddingSchemeCurrent) still counts BOTH
--- embeddings and wiki_page_embeddings (each wrapped in try/catch), so any legacy wiki
--- vector under a legacy marker still fails loud at initDB.
+-- time, so a sqlite_master-gated WHERE clause alone cannot protect a reference to an
+-- absent table. Some legacy-recovery paths reach 042 with a partial schema (e.g. a DB
+-- whose schema_version was fast-forwarded past migration 030, so wiki_page_embeddings
+-- does not exist yet). We therefore CREATE IF NOT EXISTS both vector-store tables with
+-- the exact shapes of migrations 013/030 (no-op on any normally-migrated DB, empty
+-- shells on partial ones) before the marker statement references them. The runtime
+-- guard in db-manager (assertEmbeddingSchemeCurrent) independently counts both tables
+-- (try/catch-wrapped), so the two layers agree.
 
 CREATE TABLE IF NOT EXISTS embedding_meta (
   key TEXT PRIMARY KEY,
@@ -18,14 +19,28 @@ CREATE TABLE IF NOT EXISTS embedding_meta (
   updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
 );
 
+-- Shape of migration 013 (embeddings) - no-op unless the schema is partial.
+CREATE TABLE IF NOT EXISTS embeddings (
+  rowid INTEGER PRIMARY KEY,
+  embedding BLOB NOT NULL
+);
+
+-- Shape of migration 030 (wiki_page_embeddings) - no-op unless the schema is partial.
+-- The FK to wiki_page_index resolves lazily in SQLite, so this is safe even when
+-- wiki_page_index itself is absent.
+CREATE TABLE IF NOT EXISTS wiki_page_embeddings (
+  page_id TEXT PRIMARY KEY REFERENCES wiki_page_index(page_id) ON DELETE CASCADE,
+  embedding BLOB NOT NULL
+);
+
 INSERT OR IGNORE INTO embedding_meta (key, value)
 SELECT 'embedding_prefix_scheme',
   CASE
     WHEN EXISTS (SELECT 1 FROM embeddings)
+      OR EXISTS (SELECT 1 FROM wiki_page_embeddings)
     THEN 'legacy-unprefixed'
     ELSE 'e5-prefixed-v1'
-  END
-WHERE EXISTS (SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'embeddings');
+  END;
 
 INSERT OR IGNORE INTO schema_version (version, description)
 VALUES (42, 'Track embedding prefix scheme (e5 query/passage)');

--- a/packages/mama-core/scripts/re-embed-migration.mjs
+++ b/packages/mama-core/scripts/re-embed-migration.mjs
@@ -60,6 +60,12 @@ export async function reEmbedDatabase({ db, embedDecision, embedWiki, log = () =
   const wikiVecs = [];
   for (const row of wikiRows) {
     const text = `${row.title || ''}\n${row.content || ''}`.trim();
+    if (!text) {
+      throw new Error(
+        `wiki page "${row.key}" has empty title+content and cannot be re-embedded. ` +
+          `Remove its wiki_page_embeddings row and re-run (the scheme marker stays legacy until this succeeds).`
+      );
+    }
     const vec = await embedWiki(text);
     wikiVecs.push({ key: row.key, buf: Buffer.from(vec.buffer, vec.byteOffset, vec.byteLength) });
   }
@@ -107,7 +113,7 @@ async function main() {
         },
         'passage'
       ),
-    embedWiki: (text) => generateEmbedding(text || ' ', 'passage'),
+    embedWiki: (text) => generateEmbedding(text, 'passage'),
     log,
   });
   db.close();

--- a/packages/mama-core/scripts/re-embed-migration.mjs
+++ b/packages/mama-core/scripts/re-embed-migration.mjs
@@ -41,7 +41,9 @@ export async function reEmbedDatabase({ db, embedDecision, embedWiki, log = () =
   for (const row of decisions) {
     const vec = await embedDecision(row);
     decVecs.push({ rid: row.rid, buf: Buffer.from(vec.buffer, vec.byteOffset, vec.byteLength) });
-    if (++i % 50 === 0) log(`  decisions embedded: ${i}/${decisions.length}`);
+    if (++i % 50 === 0) {
+      log(`  decisions embedded: ${i}/${decisions.length}`);
+    }
   }
 
   // 2) Wiki pages -> wiki_page_embeddings (schema-aware; skip if table empty/absent).
@@ -73,12 +75,16 @@ export async function reEmbedDatabase({ db, embedDecision, embedWiki, log = () =
   // 3) One sync transaction: overwrite vectors + flip marker last.
   const writeAll = db.transaction(() => {
     const putDec = db.prepare('INSERT OR REPLACE INTO embeddings (rowid, embedding) VALUES (?, ?)');
-    for (const d of decVecs) putDec.run(d.rid, d.buf);
+    for (const d of decVecs) {
+      putDec.run(d.rid, d.buf);
+    }
     if (wikiVecs.length) {
       const putWiki = wikiSchemaVector
         ? db.prepare('UPDATE wiki_page_embeddings SET vector = ? WHERE wiki_page_id = ?')
         : db.prepare('UPDATE wiki_page_embeddings SET embedding = ? WHERE page_id = ?');
-      for (const w of wikiVecs) putWiki.run(w.buf, w.key);
+      for (const w of wikiVecs) {
+        putWiki.run(w.buf, w.key);
+      }
     }
     db.prepare("INSERT OR REPLACE INTO embedding_meta (key, value) VALUES ('embedding_prefix_scheme', ?)")
       .run(EMBEDDING_PREFIX_SCHEME);

--- a/packages/mama-core/scripts/re-embed-migration.mjs
+++ b/packages/mama-core/scripts/re-embed-migration.mjs
@@ -1,0 +1,122 @@
+// packages/mama-core/scripts/re-embed-migration.mjs
+// Local-only. Re-embeds all stored vectors with the e5 'passage' prefix and sets the
+// scheme marker. NEVER call initDB here (its guard would block legacy DBs).
+import { fileURLToPath } from 'node:url';
+
+export const EMBEDDING_PREFIX_SCHEME = 'e5-prefixed-v1';
+
+function ensureMarkerTable(db) {
+  db.exec(`CREATE TABLE IF NOT EXISTS embedding_meta (
+    key TEXT PRIMARY KEY, value TEXT NOT NULL,
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch() * 1000)
+  )`);
+}
+
+function tableColumns(db, table) {
+  return new Set(db.prepare(`PRAGMA table_info(${table})`).all().map((r) => r.name));
+}
+
+function tableExists(db, table) {
+  return Boolean(db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(table));
+}
+
+/**
+ * @param {object} o
+ * @param {import('better-sqlite3').Database} o.db  writable DB
+ * @param {(row:{topic:string,decision:string,reasoning:?string,outcome:?string,confidence:?number})=>Promise<Float32Array>} o.embedDecision  role='passage'
+ * @param {(text:string)=>Promise<Float32Array>} o.embedWiki  role='passage'
+ * @param {(msg:string)=>void} [o.log]
+ * @returns {Promise<{decisions:number, wikiPages:number}>}
+ */
+export async function reEmbedDatabase({ db, embedDecision, embedWiki, log = () => {} }) {
+  ensureMarkerTable(db);
+
+  // 1) Decisions -> embeddings(rowid, embedding). Embed async first, write sync after.
+  const decisions = db
+    .prepare('SELECT rowid AS rid, topic, decision, reasoning, outcome, confidence FROM decisions')
+    .all();
+  log(`decisions to re-embed: ${decisions.length}`);
+  const decVecs = [];
+  let i = 0;
+  for (const row of decisions) {
+    const vec = await embedDecision(row);
+    decVecs.push({ rid: row.rid, buf: Buffer.from(vec.buffer, vec.byteOffset, vec.byteLength) });
+    if (++i % 50 === 0) log(`  decisions embedded: ${i}/${decisions.length}`);
+  }
+
+  // 2) Wiki pages -> wiki_page_embeddings (schema-aware; skip if table empty/absent).
+  let wikiRows = [];
+  let wikiSchemaVector = false;
+  if (tableExists(db, 'wiki_page_embeddings') && tableExists(db, 'wiki_page_index')) {
+    const embCols = tableColumns(db, 'wiki_page_embeddings');
+    wikiSchemaVector = embCols.has('vector');
+    wikiRows = wikiSchemaVector
+      ? db.prepare(`SELECT e.wiki_page_id AS key, i.title, i.content
+                    FROM wiki_page_embeddings e JOIN wiki_page_index i ON i.id = e.wiki_page_id`).all()
+      : db.prepare(`SELECT e.page_id AS key, i.title, i.content
+                    FROM wiki_page_embeddings e JOIN wiki_page_index i ON i.page_id = e.page_id`).all();
+  }
+  log(`wiki pages to re-embed: ${wikiRows.length}`);
+  const wikiVecs = [];
+  for (const row of wikiRows) {
+    const text = `${row.title || ''}\n${row.content || ''}`.trim();
+    const vec = await embedWiki(text);
+    wikiVecs.push({ key: row.key, buf: Buffer.from(vec.buffer, vec.byteOffset, vec.byteLength) });
+  }
+
+  // 3) One sync transaction: overwrite vectors + flip marker last.
+  const writeAll = db.transaction(() => {
+    const putDec = db.prepare('INSERT OR REPLACE INTO embeddings (rowid, embedding) VALUES (?, ?)');
+    for (const d of decVecs) putDec.run(d.rid, d.buf);
+    if (wikiVecs.length) {
+      const putWiki = wikiSchemaVector
+        ? db.prepare('UPDATE wiki_page_embeddings SET vector = ? WHERE wiki_page_id = ?')
+        : db.prepare('UPDATE wiki_page_embeddings SET embedding = ? WHERE page_id = ?');
+      for (const w of wikiVecs) putWiki.run(w.buf, w.key);
+    }
+    db.prepare("INSERT OR REPLACE INTO embedding_meta (key, value) VALUES ('embedding_prefix_scheme', ?)")
+      .run(EMBEDDING_PREFIX_SCHEME);
+  });
+  writeAll();
+
+  log(`done: ${decVecs.length} decisions, ${wikiVecs.length} wiki pages; marker=${EMBEDDING_PREFIX_SCHEME}`);
+  return { decisions: decVecs.length, wikiPages: wikiVecs.length };
+}
+
+async function main() {
+  const dbPath = process.env.MAMA_DB_PATH;
+  if (!dbPath) {
+    throw new Error('MAMA_DB_PATH is required (no default - refusing to guess a personal DB path).');
+  }
+  const Database = (await import('better-sqlite3')).default;
+  const { generateEnhancedEmbedding, generateEmbedding } = await import('../dist/embeddings.js');
+  const db = new Database(dbPath); // writable
+  db.pragma('journal_mode = WAL');
+  const log = (m) => console.error(`[re-embed] ${m}`);
+  log(`opening ${dbPath}`);
+  const result = await reEmbedDatabase({
+    db,
+    embedDecision: (row) =>
+      generateEnhancedEmbedding(
+        {
+          topic: row.topic,
+          decision: row.decision,
+          reasoning: row.reasoning || undefined,
+          outcome: row.outcome || undefined,
+          confidence: row.confidence ?? undefined,
+        },
+        'passage'
+      ),
+    embedWiki: (text) => generateEmbedding(text || ' ', 'passage'),
+    log,
+  });
+  db.close();
+  console.log(JSON.stringify({ db: dbPath.split('/').pop(), ...result }));
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((e) => {
+    console.error(e instanceof Error ? e.message : String(e));
+    process.exit(1);
+  });
+}

--- a/packages/mama-core/src/db-manager.ts
+++ b/packages/mama-core/src/db-manager.ts
@@ -24,6 +24,7 @@ import { info, warn, error as logError } from './debug-logger.js';
 import { logComplete, logSearching } from './progress-indicator.js';
 import { createAdapter } from './db-adapter/index.js';
 import type { PreparedStatement } from './db-adapter/statement.js';
+import { EMBEDDING_PREFIX_SCHEME } from './embeddings.js';
 
 // Re-export PreparedStatement for consumers
 export type { PreparedStatement };
@@ -153,6 +154,63 @@ const REAL_USER_DB_PATH = path.join(os.homedir(), '.claude', 'mama-memory.db');
  *
  * @returns SQLite database connection
  */
+function countRows(adapter: DatabaseAdapter, table: string): number {
+  try {
+    const row = adapter.prepare(`SELECT COUNT(*) AS n FROM ${table}`).get() as
+      | { n: number }
+      | undefined;
+    return row?.n ?? 0;
+  } catch {
+    return 0; // table may not exist on very old DBs
+  }
+}
+
+/**
+ * Fail loud if stored vectors predate the e5 query/passage prefix scheme.
+ *
+ * Migration 042 records 'e5-prefixed-v1' on a fresh DB and 'legacy-unprefixed' on a DB
+ * that already held vectors at upgrade time. If the marker is not current AND legacy
+ * vectors exist, cosine search would be non-discriminative, so we throw with the exact
+ * re-embed command instead of silently serving degraded results. No-fallback by design.
+ */
+export function assertEmbeddingSchemeCurrent(adapter: DatabaseAdapter): void {
+  let scheme = 'legacy-unprefixed';
+  try {
+    const row = adapter
+      .prepare("SELECT value FROM embedding_meta WHERE key = 'embedding_prefix_scheme'")
+      .get() as { value?: string } | undefined;
+    if (row?.value) scheme = row.value;
+  } catch {
+    // embedding_meta missing (pre-042). runMigrations creates it, so this path
+    // only hits if migrations did not run; fall through to the vector check.
+  }
+
+  if (scheme === EMBEDDING_PREFIX_SCHEME) return; // current
+
+  const legacyVectors =
+    countRows(adapter, 'embeddings') + countRows(adapter, 'wiki_page_embeddings');
+  if (legacyVectors > 0) {
+    const dbPath = resolveAdapterDbPath(adapter) ?? '<db>';
+    throw new Error(
+      `[embedding-guard] ${dbPath} holds ${legacyVectors} vectors written WITHOUT the e5 ` +
+        `query/passage prefix (scheme='${scheme}', code requires '${EMBEDDING_PREFIX_SCHEME}'). ` +
+        `Cosine search would be non-discriminative. Re-embed before starting:\n` +
+        `  MAMA_DB_PATH="${dbPath}" node packages/mama-core/scripts/re-embed-migration.mjs`
+    );
+  }
+
+  // No legacy vectors present: safe. Upgrade the marker so we do not re-check.
+  try {
+    adapter
+      .prepare(
+        "INSERT OR REPLACE INTO embedding_meta (key, value) VALUES ('embedding_prefix_scheme', ?)"
+      )
+      .run(EMBEDDING_PREFIX_SCHEME);
+  } catch {
+    // best-effort; if embedding_meta truly missing, nothing to guard yet
+  }
+}
+
 export async function initDB(): Promise<unknown> {
   assertTestProcessIsNotUsingRealDb();
 
@@ -185,6 +243,8 @@ export async function initDB(): Promise<unknown> {
       if (typeof dbAdapter.reloadVectorCache === 'function') {
         dbAdapter.reloadVectorCache();
       }
+
+      assertEmbeddingSchemeCurrent(dbAdapter); // fail loud on legacy vectors + new code
 
       isInitialized = true;
 

--- a/packages/mama-core/src/db-manager.ts
+++ b/packages/mama-core/src/db-manager.ts
@@ -826,7 +826,7 @@ export async function queryVectorSearch(params: VectorSearchParams): Promise<Dec
 
   try {
     // Generate embedding for query
-    const embedding = await generateEmbedding(query);
+    const embedding = await generateEmbedding(query, 'query');
 
     const cutoffTime = Date.now() - timeWindow;
     const candidates = await adapter.vectorSearch(embedding, limit * 5);

--- a/packages/mama-core/src/db-manager.ts
+++ b/packages/mama-core/src/db-manager.ts
@@ -527,6 +527,7 @@ export async function insertDecisionWithEmbedding(decision: DecisionInput): Prom
     );
     let embedding: Float32Array | null = null;
     try {
+      // e5 passage role (default) - stored vector
       embedding = await generateEnhancedEmbedding({
         topic: decision.topic,
         decision: decision.decision,
@@ -1082,6 +1083,7 @@ export async function reindexEmbeddings(
 
   for (const row of decisions) {
     try {
+      // e5 passage role (default) - stored vector
       const embedding = await generateEnhancedEmbedding({
         topic: row.topic,
         decision: row.decision,

--- a/packages/mama-core/src/embedding-client.ts
+++ b/packages/mama-core/src/embedding-client.ts
@@ -15,6 +15,7 @@
 import fs from 'fs';
 import path from 'path';
 import { info, warn } from './debug-logger.js';
+import type { EmbeddingRole } from './embeddings.js';
 
 function resolveConfiguredPort(): number {
   const rawPort = process.env.MAMA_EMBEDDING_PORT || process.env.MAMA_HTTP_PORT || '';
@@ -80,9 +81,13 @@ export async function isServerRunning(): Promise<boolean> {
  * Generate embedding via HTTP server
  *
  * @param text - Text to embed
+ * @param role - e5 role: 'passage' (default, stored text) or 'query' (search)
  * @returns Embedding or null if failed
  */
-export async function getEmbeddingFromServer(text: string): Promise<Float32Array | null> {
+export async function getEmbeddingFromServer(
+  text: string,
+  role: EmbeddingRole = 'passage'
+): Promise<Float32Array | null> {
   const port = getServerPort();
 
   try {
@@ -92,7 +97,7 @@ export async function getEmbeddingFromServer(text: string): Promise<Float32Array
     const response = await fetch(`http://${HOST}:${port}/embed`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text }),
+      body: JSON.stringify({ text, role }),
       signal: controller.signal,
     });
 

--- a/packages/mama-core/src/embedding-server/index.ts
+++ b/packages/mama-core/src/embedding-server/index.ts
@@ -26,6 +26,7 @@ export const SHUTDOWN_TOKEN: string =
 
 // Import embedding functions from mama-core
 import { generateEmbedding } from '../embeddings.js';
+import type { EmbeddingRole } from '../embeddings.js';
 import { getModelName, getEmbeddingDim } from '../config-loader.js';
 import { initDB } from '../db-manager.js';
 
@@ -116,6 +117,13 @@ export interface ServerOptions {
 interface EmbedRequestBody {
   text?: string;
   texts?: string[];
+  role?: string;
+}
+
+// Resolve the e5 role from an HTTP body value. Absent/unknown -> passage, so old
+// clients that never send a role keep getting passage vectors (backward compatible).
+export function resolveEmbeddingRole(raw: unknown): EmbeddingRole {
+  return raw === 'query' ? 'query' : 'passage';
 }
 
 /**
@@ -219,7 +227,8 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
         return;
       }
 
-      const embedding = await generateEmbedding(body.text);
+      const role = resolveEmbeddingRole(body.role);
+      const embedding = await generateEmbedding(body.text, role);
       modelLoaded = true;
       const latency = Date.now() - startTime;
 
@@ -252,8 +261,9 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
         return;
       }
 
+      const role = resolveEmbeddingRole(body.role);
       const embeddings = await Promise.all(
-        body.texts.map((text) => generateEmbedding(text).then((e) => Array.from(e)))
+        body.texts.map((text) => generateEmbedding(text, role).then((e) => Array.from(e)))
       );
       modelLoaded = true;
       const latency = Date.now() - startTime;

--- a/packages/mama-core/src/embeddings.ts
+++ b/packages/mama-core/src/embeddings.ts
@@ -22,6 +22,17 @@ const DEFAULT_CACHE_DIR = path.join(os.homedir(), '.cache', 'huggingface', 'tran
 const TIER3_ENV_VALUES = new Set(['1', 'true', 'yes']);
 export const EMBEDDING_MODEL_MAX_LENGTH = 512;
 export const EMBEDDING_MAX_TOKENISH_SEGMENTS = 480;
+
+// e5 instruction-prefix scheme. e5 models are trained with two prefixes: stored
+// text is embedded as "passage: <text>", a search query as "query: <text>".
+// Omitting them collapses cosine into a narrow cone. This constant is the single
+// source of truth for the scheme identifier used by the runtime version guard.
+export type EmbeddingRole = 'passage' | 'query';
+export const EMBEDDING_PREFIX_SCHEME = 'e5-prefixed-v1';
+
+function applyRolePrefix(preparedText: string, role: EmbeddingRole): string {
+  return `${role}: ${preparedText}`;
+}
 const TOKENISH_SEGMENT_PATTERN =
   /[\p{Script=Hangul}\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]|\S+/gu;
 
@@ -158,7 +169,10 @@ async function loadModel(): Promise<PipelineFunction> {
  * @returns Embedding vector (dimension from config)
  * @throws Error if text is empty or embedding fails
  */
-export async function generateEmbedding(text: string): Promise<Float32Array> {
+export async function generateEmbedding(
+  text: string,
+  role: EmbeddingRole = 'passage'
+): Promise<Float32Array> {
   if (typeof text !== 'string' || text.trim().length === 0) {
     throw new Error('Text cannot be empty');
   }
@@ -166,9 +180,10 @@ export async function generateEmbedding(text: string): Promise<Float32Array> {
   assertEmbeddingsEnabled();
 
   const preparedText = prepareEmbeddingText(text);
+  const modelInput = applyRolePrefix(preparedText, role); // e5 instruction prefix
 
-  // Task 2: Check cache first (AC #3)
-  const cached = embeddingCache.get(preparedText);
+  // Cache key is the PREFIXED input: a passage vector can never be served for a query.
+  const cached = embeddingCache.get(modelInput);
   if (cached) {
     return cached;
   }
@@ -180,7 +195,7 @@ export async function generateEmbedding(text: string): Promise<Float32Array> {
     const expectedDim = getEmbeddingDim();
 
     // Generate embedding
-    const output = await model(preparedText, {
+    const output = await model(modelInput, {
       pooling: 'mean', // Mean pooling over tokens
       normalize: true, // L2 normalization
       truncation: true,
@@ -199,7 +214,7 @@ export async function generateEmbedding(text: string): Promise<Float32Array> {
     const _latency = Date.now() - startTime;
 
     // Task 2: Store in cache (AC #3)
-    embeddingCache.set(preparedText, embedding);
+    embeddingCache.set(modelInput, embedding);
 
     return embedding;
   } catch (error) {
@@ -218,7 +233,8 @@ export async function generateEmbedding(text: string): Promise<Float32Array> {
  * @returns 1024-dim enhanced embedding
  */
 export async function generateEnhancedEmbedding(
-  decision: DecisionForEmbedding
+  decision: DecisionForEmbedding,
+  role: EmbeddingRole = 'passage'
 ): Promise<Float32Array> {
   // Construct enriched text representation with narrative fields (Story 2.2)
   const parts = [
@@ -255,7 +271,7 @@ export async function generateEnhancedEmbedding(
 
   const enrichedText = parts.join('\n').trim();
 
-  return generateEmbedding(enrichedText);
+  return generateEmbedding(enrichedText, role);
 }
 
 /**
@@ -269,7 +285,10 @@ export async function generateEnhancedEmbedding(
  * @param texts - Array of texts to embed (max 10 per batch)
  * @returns Array of embeddings
  */
-export async function generateBatchEmbeddings(texts: string[]): Promise<Float32Array[]> {
+export async function generateBatchEmbeddings(
+  texts: string[],
+  role: EmbeddingRole = 'passage'
+): Promise<Float32Array[]> {
   if (!Array.isArray(texts) || texts.length === 0) {
     throw new Error('Texts must be a non-empty array');
   }
@@ -290,6 +309,8 @@ export async function generateBatchEmbeddings(texts: string[]): Promise<Float32A
     }
   }
 
+  const modelInputs = preparedTexts.map((t) => applyRolePrefix(t, role));
+
   const startTime = Date.now();
 
   try {
@@ -298,7 +319,7 @@ export async function generateBatchEmbeddings(texts: string[]): Promise<Float32A
 
     // Native batch processing - single model forward pass
     // This is significantly faster than sequential calls
-    const outputs = await model(preparedTexts, {
+    const outputs = await model(modelInputs, {
       pooling: 'mean',
       normalize: true,
       truncation: true,

--- a/packages/mama-core/src/index.ts
+++ b/packages/mama-core/src/index.ts
@@ -16,6 +16,8 @@ export {
   embeddingCache,
   EMBEDDING_DIM,
   MODEL_NAME,
+  EMBEDDING_PREFIX_SCHEME,
+  type EmbeddingRole,
 } from './embeddings.js';
 
 export { EmbeddingCache } from './embedding-cache.js';

--- a/packages/mama-core/src/mama-api.ts
+++ b/packages/mama-core/src/mama-api.ts
@@ -1925,7 +1925,7 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
       }
 
       // Generate query embedding
-      const queryEmbedding = await generateEmbedding(userQuestion);
+      const queryEmbedding = await generateEmbedding(userQuestion, 'query');
 
       // Adaptive threshold (shorter queries need higher confidence)
       const wordCount = userQuestion.split(/\s+/).length;

--- a/packages/mama-core/src/memory-inject.ts
+++ b/packages/mama-core/src/memory-inject.ts
@@ -92,7 +92,7 @@ async function performMemoryInjection(
 ): Promise<string | null> {
   // 1. Generate query embedding
   const { generateEmbedding } = await import('./embeddings.js');
-  const queryEmbedding = await generateEmbedding(userMessage);
+  const queryEmbedding = await generateEmbedding(userMessage, 'query');
 
   const embeddingLatency = Date.now() - startTime;
   info(`[MAMA] Embedding generation: ${embeddingLatency}ms`);

--- a/packages/mama-core/src/memory/api.ts
+++ b/packages/mama-core/src/memory/api.ts
@@ -695,7 +695,7 @@ async function saveMemoryInternal(
   if (shouldApplyEvolution && existingCandidates.length === 0) {
     try {
       const queryText = `${input.topic} ${input.summary}`;
-      const embedding = await generateEmbedding(queryText);
+      const embedding = await generateEmbedding(queryText, 'query');
       const semanticResults = await vectorSearch(embedding, 3, 0.82);
 
       // Scope-filter semantic candidates when a primary scope is available
@@ -996,7 +996,7 @@ export async function promoteMemoryStatus(input: {
     if (existingCandidates.length === 0) {
       try {
         const queryText = `${topic} ${summary}`;
-        const embedding = await generateEmbedding(queryText);
+        const embedding = await generateEmbedding(queryText, 'query');
         const semanticResults = await vectorSearch(embedding, 3, 0.82);
 
         let scopeFiltered = semanticResults;
@@ -1179,7 +1179,7 @@ export async function recallMemory(
   let primaryQueryEmbedding: Float32Array | null = null;
   try {
     for (const sq of subQueries) {
-      const queryEmbedding = await generateEmbedding(sq);
+      const queryEmbedding = await generateEmbedding(sq, 'query');
       if (sq === query && primaryQueryEmbedding === null) {
         primaryQueryEmbedding = queryEmbedding;
       }

--- a/packages/mama-core/tests/cases/embedding-scheme-guard.test.ts
+++ b/packages/mama-core/tests/cases/embedding-scheme-guard.test.ts
@@ -1,0 +1,65 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import { readFileSync, readdirSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const MIGRATIONS_DIR = join(__dirname, '..', '..', 'db', 'migrations');
+function applyAll(db: Database.Database): void {
+  for (const f of readdirSync(MIGRATIONS_DIR).filter((x) => /^\d{3}-.+\.sql$/.test(x)).sort()) {
+    db.exec(readFileSync(join(MIGRATIONS_DIR, f), 'utf8'));
+  }
+}
+
+let dir: string;
+let dbPath: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'mama-guard-'));
+  dbPath = join(dir, 'mama.db');
+  process.env.MAMA_DB_PATH = dbPath;
+  process.env.MAMA_TEST_MODE = 'true';
+});
+afterEach(async () => {
+  const { resetDBState } = await import('../../src/db-manager.js');
+  resetDBState();
+  delete process.env.MAMA_DB_PATH;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('M5: embedding scheme guard', () => {
+  it('fresh DB is marked e5-prefixed-v1 and initDB succeeds', async () => {
+    const { initDB, getAdapter, closeDB } = await import('../../src/db-manager.js');
+    await initDB();
+    const row = getAdapter()
+      .prepare("SELECT value FROM embedding_meta WHERE key='embedding_prefix_scheme'")
+      .get() as { value: string };
+    expect(row.value).toBe('e5-prefixed-v1');
+    await closeDB();
+  });
+
+  it('legacy vectors + legacy marker -> initDB throws with the re-embed command', async () => {
+    // Seed a pre-042 style DB: apply migrations, insert a vector, force legacy marker.
+    const seed = new Database(dbPath);
+    applyAll(seed);
+    const buf = Buffer.from(new Float32Array(1024).fill(0.02).buffer);
+    seed
+      .prepare('INSERT INTO decisions (id, topic, decision, created_at) VALUES (?, ?, ?, ?)')
+      .run('d1', 't', 'x', Date.now());
+    const rowid = (seed.prepare('SELECT rowid FROM decisions WHERE id=?').get('d1') as {
+      rowid: number;
+    }).rowid;
+    seed
+      .prepare('INSERT OR REPLACE INTO embeddings (rowid, embedding) VALUES (?, ?)')
+      .run(rowid, buf);
+    seed
+      .prepare(
+        "INSERT OR REPLACE INTO embedding_meta (key, value) VALUES ('embedding_prefix_scheme','legacy-unprefixed')"
+      )
+      .run();
+    seed.close();
+
+    const { initDB } = await import('../../src/db-manager.js');
+    await expect(initDB()).rejects.toThrow(/embedding-guard.*re-embed-migration\.mjs/s);
+  });
+});

--- a/packages/mama-core/tests/cases/embedding-scheme-guard.test.ts
+++ b/packages/mama-core/tests/cases/embedding-scheme-guard.test.ts
@@ -6,10 +6,27 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const MIGRATIONS_DIR = join(__dirname, '..', '..', 'db', 'migrations');
+function migrationFiles(): string[] {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((x) => /^\d{3}-.+\.sql$/.test(x))
+    .sort();
+}
 function applyAll(db: Database.Database): void {
-  for (const f of readdirSync(MIGRATIONS_DIR).filter((x) => /^\d{3}-.+\.sql$/.test(x)).sort()) {
+  for (const f of migrationFiles()) {
     db.exec(readFileSync(join(MIGRATIONS_DIR, f), 'utf8'));
   }
+}
+// Apply every migration with a version strictly below the given number.
+function applyBelow(db: Database.Database, version: number): void {
+  for (const f of migrationFiles()) {
+    if (parseInt(f.slice(0, 3), 10) >= version) break;
+    db.exec(readFileSync(join(MIGRATIONS_DIR, f), 'utf8'));
+  }
+}
+function applyOne(db: Database.Database, version: number): void {
+  const f = migrationFiles().find((x) => parseInt(x.slice(0, 3), 10) === version);
+  if (!f) throw new Error(`migration ${version} not found`);
+  db.exec(readFileSync(join(MIGRATIONS_DIR, f), 'utf8'));
 }
 
 let dir: string;
@@ -61,5 +78,55 @@ describe('M5: embedding scheme guard', () => {
 
     const { initDB } = await import('../../src/db-manager.js');
     await expect(initDB()).rejects.toThrow(/embedding-guard.*re-embed-migration\.mjs/s);
+  });
+
+  it('wiki-only legacy vectors -> migration 042 marks legacy and initDB throws', async () => {
+    // Seed a DB where the ONLY stored vector lives in wiki_page_embeddings
+    // (decisions/embeddings empty). Migration 042 must still mark it legacy,
+    // otherwise the guard early-returns on a current marker and the legacy wiki
+    // vector would be cosine-compared silently.
+    const seed = new Database(dbPath);
+    applyBelow(seed, 42); // everything up to and including 041
+    const buf = Buffer.from(new Float32Array(1024).fill(0.03).buffer);
+    seed
+      .prepare(
+        `INSERT INTO wiki_page_index
+           (page_id, source_locator, title, page_type, content, compiled_at, updated_at)
+         VALUES ('wp1', 'loc1', 't', 'entity', 'c', '2026-01-01', '2026-01-01')`
+      )
+      .run();
+    seed
+      .prepare('INSERT INTO wiki_page_embeddings (page_id, embedding) VALUES (?, ?)')
+      .run('wp1', buf);
+    applyOne(seed, 42);
+    const marker = (
+      seed
+        .prepare("SELECT value FROM embedding_meta WHERE key='embedding_prefix_scheme'")
+        .get() as { value: string }
+    ).value;
+    seed.close();
+    expect(marker).toBe('legacy-unprefixed');
+
+    const { initDB } = await import('../../src/db-manager.js');
+    await expect(initDB()).rejects.toThrow(/embedding-guard.*re-embed-migration\.mjs/s);
+  });
+
+  it('migration 042 tolerates a partial legacy schema without wiki_page_embeddings', () => {
+    // Mirror of the schema-40 legacy-recovery scenario: embeddings exists,
+    // wiki_page_embeddings does not. 042 must not crash and must mark by the
+    // stored-vector state (none here -> current).
+    const seed = new Database(dbPath);
+    seed.exec(`
+      CREATE TABLE schema_version (version INTEGER PRIMARY KEY, description TEXT);
+      CREATE TABLE embeddings (rowid INTEGER PRIMARY KEY, embedding BLOB NOT NULL);
+    `);
+    applyOne(seed, 42); // must not throw despite the missing wiki table
+    const marker = (
+      seed
+        .prepare("SELECT value FROM embedding_meta WHERE key='embedding_prefix_scheme'")
+        .get() as { value: string }
+    ).value;
+    seed.close();
+    expect(marker).toBe('e5-prefixed-v1'); // no vectors anywhere -> current
   });
 });

--- a/packages/mama-core/tests/scripts/re-embed-migration.test.ts
+++ b/packages/mama-core/tests/scripts/re-embed-migration.test.ts
@@ -44,6 +44,24 @@ describe('M5: reEmbedDatabase', () => {
     db.close();
   });
 
+  it('fails loud naming the page when a wiki page has empty title and content', async () => {
+    const db = new Database(':memory:');
+    applyAll(db);
+    db.prepare(
+      `INSERT INTO wiki_page_index
+         (page_id, source_locator, title, page_type, content, compiled_at, updated_at)
+       VALUES ('w1', 'loc1', '', 'entity', '', '2026-01-01', '2026-01-01')`
+    ).run();
+    db.prepare('INSERT INTO wiki_page_embeddings (page_id, embedding) VALUES (?, ?)').run('w1', Buffer.from(new Float32Array(1024).fill(0.5).buffer));
+    db.prepare("INSERT OR REPLACE INTO embedding_meta (key, value) VALUES ('embedding_prefix_scheme','legacy-unprefixed')").run();
+    const stub = async () => new Float32Array(1024).fill(0.9);
+    await expect(reEmbedDatabase({ db, embedDecision: stub, embedWiki: stub })).rejects.toThrow(/wiki page "w1" has empty title\+content/);
+    // marker must stay legacy-or-absent so the guard keeps the DB quarantined
+    const marker = db.prepare("SELECT value FROM embedding_meta WHERE key='embedding_prefix_scheme'").get() as { value: string } | undefined;
+    expect(marker?.value ?? 'legacy-unprefixed').not.toBe(EMBEDDING_PREFIX_SCHEME);
+    db.close();
+  });
+
   it('CLI mode exits 1 with the MAMA_DB_PATH error when the env var is unset', () => {
     // Real enforcement check: spawn the script with MAMA_DB_PATH stripped from the
     // environment. It must refuse (exit 1) BEFORE opening any DB or loading a model.

--- a/packages/mama-core/tests/scripts/re-embed-migration.test.ts
+++ b/packages/mama-core/tests/scripts/re-embed-migration.test.ts
@@ -1,4 +1,5 @@
 import Database from 'better-sqlite3';
+import { spawnSync } from 'node:child_process';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -43,8 +44,14 @@ describe('M5: reEmbedDatabase', () => {
     db.close();
   });
 
-  it('requires MAMA_DB_PATH in CLI mode (guarded separately)', () => {
-    // main() throws without MAMA_DB_PATH; covered by manual run in Task 6.
-    expect(EMBEDDING_PREFIX_SCHEME).toBe('e5-prefixed-v1');
+  it('CLI mode exits 1 with the MAMA_DB_PATH error when the env var is unset', () => {
+    // Real enforcement check: spawn the script with MAMA_DB_PATH stripped from the
+    // environment. It must refuse (exit 1) BEFORE opening any DB or loading a model.
+    const scriptPath = join(__dirname, '..', '..', 'scripts', 're-embed-migration.mjs');
+    const env = { ...process.env };
+    delete env.MAMA_DB_PATH;
+    const res = spawnSync(process.execPath, [scriptPath], { env, encoding: 'utf8', timeout: 20000 });
+    expect(res.status).toBe(1);
+    expect(res.stderr).toContain('MAMA_DB_PATH is required');
   });
 });

--- a/packages/mama-core/tests/scripts/re-embed-migration.test.ts
+++ b/packages/mama-core/tests/scripts/re-embed-migration.test.ts
@@ -1,0 +1,50 @@
+import Database from 'better-sqlite3';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { reEmbedDatabase, EMBEDDING_PREFIX_SCHEME } from '../../scripts/re-embed-migration.mjs';
+
+const MIGRATIONS_DIR = join(__dirname, '..', '..', 'db', 'migrations');
+function applyAll(db: Database.Database) {
+  for (const f of readdirSync(MIGRATIONS_DIR).filter((x) => /^\d{3}-.+\.sql$/.test(x)).sort()) {
+    db.exec(readFileSync(join(MIGRATIONS_DIR, f), 'utf8'));
+  }
+}
+
+describe('M5: reEmbedDatabase', () => {
+  it('overwrites decision vectors and flips the marker', async () => {
+    const db = new Database(':memory:');
+    applyAll(db);
+    db.prepare('INSERT INTO decisions (id, topic, decision, created_at) VALUES (?,?,?,?)').run('d1', 't', 'x', Date.now());
+    const rid = (db.prepare('SELECT rowid FROM decisions WHERE id=?').get('d1') as { rowid: number }).rowid;
+    db.prepare('INSERT INTO embeddings (rowid, embedding) VALUES (?, ?)').run(rid, Buffer.from(new Float32Array(1024).fill(0.5).buffer));
+    db.prepare("INSERT OR REPLACE INTO embedding_meta (key, value) VALUES ('embedding_prefix_scheme','legacy-unprefixed')").run();
+
+    let called = 0;
+    const stub = async () => { called++; return new Float32Array(1024).fill(0.9); };
+    const res = await reEmbedDatabase({ db, embedDecision: stub, embedWiki: stub });
+
+    expect(res.decisions).toBe(1);
+    expect(called).toBe(1);
+    const marker = (db.prepare("SELECT value FROM embedding_meta WHERE key='embedding_prefix_scheme'").get() as { value: string }).value;
+    expect(marker).toBe(EMBEDDING_PREFIX_SCHEME);
+    const stored = db.prepare('SELECT embedding FROM embeddings WHERE rowid=?').get(rid) as { embedding: Buffer };
+    expect(new Float32Array(stored.embedding.buffer, stored.embedding.byteOffset, 1024)[0]).toBeCloseTo(0.9);
+    db.close();
+  });
+
+  it('is idempotent / resumable when re-run', async () => {
+    const db = new Database(':memory:');
+    applyAll(db);
+    db.prepare('INSERT INTO decisions (id, topic, decision, created_at) VALUES (?,?,?,?)').run('d1', 't', 'x', Date.now());
+    const stub = async () => new Float32Array(1024).fill(0.1);
+    await reEmbedDatabase({ db, embedDecision: stub, embedWiki: stub });
+    await expect(reEmbedDatabase({ db, embedDecision: stub, embedWiki: stub })).resolves.toMatchObject({ decisions: 1 });
+    db.close();
+  });
+
+  it('requires MAMA_DB_PATH in CLI mode (guarded separately)', () => {
+    // main() throws without MAMA_DB_PATH; covered by manual run in Task 6.
+    expect(EMBEDDING_PREFIX_SCHEME).toBe('e5-prefixed-v1');
+  });
+});

--- a/packages/mama-core/tests/unit/embedding-server-role.test.ts
+++ b/packages/mama-core/tests/unit/embedding-server-role.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { resolveEmbeddingRole } from '../../src/embedding-server/index.js';
+
+describe('M5: HTTP embed role resolution (backward compatible)', () => {
+  it('absent role defaults to passage', () => {
+    expect(resolveEmbeddingRole(undefined)).toBe('passage');
+  });
+  it('explicit query is honored', () => {
+    expect(resolveEmbeddingRole('query')).toBe('query');
+  });
+  it('unknown value falls back to passage', () => {
+    expect(resolveEmbeddingRole('garbage')).toBe('passage');
+  });
+});

--- a/packages/mama-core/tests/unit/embeddings-prefix.test.ts
+++ b/packages/mama-core/tests/unit/embeddings-prefix.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const captured: string[] = [];
+
+function mockPipeline(dim: number) {
+  vi.doMock('@huggingface/transformers', () => ({
+    env: {},
+    pipeline: async () => async (text: string | string[]) => {
+      const list = Array.isArray(text) ? text : [text];
+      for (const t of list) captured.push(t);
+      const data = new Float32Array(dim * list.length).fill(0.01);
+      return { data };
+    },
+  }));
+}
+
+afterEach(() => {
+  vi.doUnmock('@huggingface/transformers');
+  vi.resetModules();
+  captured.length = 0;
+});
+
+describe('M5: e5 role prefixes', () => {
+  it('prepends "passage: " by default and "query: " on request', async () => {
+    mockPipeline(1024);
+    const mod = await import('../../src/embeddings.js');
+    mod.embeddingCache.clear();
+    await mod.generateEmbedding('hello world'); // default
+    await mod.generateEmbedding('hello world', 'query'); // query
+    expect(captured).toContain('passage: hello world');
+    expect(captured).toContain('query: hello world');
+  });
+
+  it('cache is role-aware: same text, different roles -> two model calls', async () => {
+    mockPipeline(1024);
+    const mod = await import('../../src/embeddings.js');
+    mod.embeddingCache.clear();
+    await mod.generateEmbedding('same text', 'passage');
+    await mod.generateEmbedding('same text', 'query');
+    await mod.generateEmbedding('same text', 'passage'); // cache hit, no new call
+    expect(captured).toEqual(['passage: same text', 'query: same text']);
+  });
+
+  it('generateEnhancedEmbedding forwards role to the model input', async () => {
+    mockPipeline(1024);
+    const mod = await import('../../src/embeddings.js');
+    mod.embeddingCache.clear();
+    await mod.generateEnhancedEmbedding({ topic: 't', decision: 'd' }, 'passage');
+    expect(captured.some((c) => c.startsWith('passage: Topic: t'))).toBe(true);
+  });
+
+  it('batch prefixes every text', async () => {
+    mockPipeline(1024);
+    const mod = await import('../../src/embeddings.js');
+    mod.embeddingCache.clear();
+    await mod.generateBatchEmbeddings(['a', 'b'], 'query');
+    expect(captured).toEqual(['query: a', 'query: b']);
+  });
+});

--- a/packages/mama-core/tests/unit/embeddings-prefix.test.ts
+++ b/packages/mama-core/tests/unit/embeddings-prefix.test.ts
@@ -7,7 +7,9 @@ function mockPipeline(dim: number) {
     env: {},
     pipeline: async () => async (text: string | string[]) => {
       const list = Array.isArray(text) ? text : [text];
-      for (const t of list) captured.push(t);
+      for (const t of list) {
+        captured.push(t);
+      }
       const data = new Float32Array(dim * list.length).fill(0.01);
       return { data };
     },
@@ -20,40 +22,44 @@ afterEach(() => {
   captured.length = 0;
 });
 
-describe('M5: e5 role prefixes', () => {
-  it('prepends "passage: " by default and "query: " on request', async () => {
-    mockPipeline(1024);
-    const mod = await import('../../src/embeddings.js');
-    mod.embeddingCache.clear();
-    await mod.generateEmbedding('hello world'); // default
-    await mod.generateEmbedding('hello world', 'query'); // query
-    expect(captured).toContain('passage: hello world');
-    expect(captured).toContain('query: hello world');
+describe('Story M5: e5 role prefixes', () => {
+  describe('AC #1: model inputs carry the e5 role prefix', () => {
+    it('prepends "passage: " by default and "query: " on request', async () => {
+      mockPipeline(1024);
+      const mod = await import('../../src/embeddings.js');
+      mod.embeddingCache.clear();
+      await mod.generateEmbedding('hello world'); // default
+      await mod.generateEmbedding('hello world', 'query'); // query
+      expect(captured).toContain('passage: hello world');
+      expect(captured).toContain('query: hello world');
+    });
+
+    it('generateEnhancedEmbedding forwards role to the model input', async () => {
+      mockPipeline(1024);
+      const mod = await import('../../src/embeddings.js');
+      mod.embeddingCache.clear();
+      await mod.generateEnhancedEmbedding({ topic: 't', decision: 'd' }, 'passage');
+      expect(captured.some((c) => c.startsWith('passage: Topic: t'))).toBe(true);
+    });
+
+    it('batch prefixes every text', async () => {
+      mockPipeline(1024);
+      const mod = await import('../../src/embeddings.js');
+      mod.embeddingCache.clear();
+      await mod.generateBatchEmbeddings(['a', 'b'], 'query');
+      expect(captured).toEqual(['query: a', 'query: b']);
+    });
   });
 
-  it('cache is role-aware: same text, different roles -> two model calls', async () => {
-    mockPipeline(1024);
-    const mod = await import('../../src/embeddings.js');
-    mod.embeddingCache.clear();
-    await mod.generateEmbedding('same text', 'passage');
-    await mod.generateEmbedding('same text', 'query');
-    await mod.generateEmbedding('same text', 'passage'); // cache hit, no new call
-    expect(captured).toEqual(['passage: same text', 'query: same text']);
-  });
-
-  it('generateEnhancedEmbedding forwards role to the model input', async () => {
-    mockPipeline(1024);
-    const mod = await import('../../src/embeddings.js');
-    mod.embeddingCache.clear();
-    await mod.generateEnhancedEmbedding({ topic: 't', decision: 'd' }, 'passage');
-    expect(captured.some((c) => c.startsWith('passage: Topic: t'))).toBe(true);
-  });
-
-  it('batch prefixes every text', async () => {
-    mockPipeline(1024);
-    const mod = await import('../../src/embeddings.js');
-    mod.embeddingCache.clear();
-    await mod.generateBatchEmbeddings(['a', 'b'], 'query');
-    expect(captured).toEqual(['query: a', 'query: b']);
+  describe('AC #2: the embedding cache is role-aware', () => {
+    it('same text, different roles -> two model calls; same role -> cache hit', async () => {
+      mockPipeline(1024);
+      const mod = await import('../../src/embeddings.js');
+      mod.embeddingCache.clear();
+      await mod.generateEmbedding('same text', 'passage');
+      await mod.generateEmbedding('same text', 'query');
+      await mod.generateEmbedding('same text', 'passage'); // cache hit, no new call
+      expect(captured).toEqual(['passage: same text', 'query: same text']);
+    });
   });
 });

--- a/packages/mama-core/tests/unit/recall-query-role.test.ts
+++ b/packages/mama-core/tests/unit/recall-query-role.test.ts
@@ -1,0 +1,58 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Mock the model so no 560MB pipeline is ever loaded. Both save (enhanced) and recall
+// (query) resolve to fixed 1024-dim vectors; we only assert the role argument.
+const generateEmbeddingMock = vi.fn(async () => new Float32Array(1024).fill(0.01));
+const generateEnhancedEmbeddingMock = vi.fn(async () => new Float32Array(1024).fill(0.01));
+vi.mock('../../src/embeddings.js', () => ({
+  generateEmbedding: generateEmbeddingMock,
+  generateEnhancedEmbedding: generateEnhancedEmbeddingMock,
+  generateBatchEmbeddings: vi.fn(async (texts: string[]) =>
+    texts.map(() => new Float32Array(1024).fill(0.01))
+  ),
+  cosineSimilarity: () => 0.5,
+  embeddingCache: { clear: () => {}, get: () => undefined, set: () => {} },
+  EMBEDDING_DIM: 1024,
+  MODEL_NAME: 'x',
+  EMBEDDING_PREFIX_SCHEME: 'e5-prefixed-v1',
+}));
+
+const tmpDir = mkdtempSync(join(tmpdir(), 'recall-query-role-'));
+process.env.MAMA_DB_PATH = join(tmpDir, 'test-memory.db');
+
+const { initDB, closeDB } = await import('../../src/db-manager.js');
+const { saveMemory, recallMemory } = await import('../../src/memory/api.js');
+
+describe('M5: recall embeds queries with the query role', () => {
+  beforeAll(async () => {
+    await initDB();
+    for (let i = 0; i < 4; i++) {
+      await saveMemory({
+        topic: `deploy-note-${i}`,
+        kind: 'decision',
+        summary: `Deployment rollout note ${i} about the canary pipeline`,
+        details: `Deployment rollout detail ${i} about the canary pipeline stage`,
+        scopes: [{ kind: 'global', id: 'global' }],
+        source: { package: 'mama-core', source_type: 'test' },
+      });
+    }
+  }, 30000);
+
+  afterAll(async () => {
+    await closeDB();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => generateEmbeddingMock.mockClear());
+
+  it('recallMemory passes role="query" to every generateEmbedding call', async () => {
+    await recallMemory('deployment canary', { limit: 3 });
+    expect(generateEmbeddingMock).toHaveBeenCalled();
+    for (const call of generateEmbeddingMock.mock.calls) {
+      expect(call[1]).toBe('query');
+    }
+  });
+});

--- a/packages/mcp-server/src/mama/search-engine.js
+++ b/packages/mcp-server/src/mama/search-engine.js
@@ -46,7 +46,7 @@ class SearchEngine {
       info(`[SearchEngine] Searching for: "${query}" (limit: ${limit}, threshold: ${threshold})`);
 
       // 1. Generate embedding for query
-      const queryEmbedding = await generateEmbedding(query);
+      const queryEmbedding = await generateEmbedding(query, 'query');
 
       if (!queryEmbedding || queryEmbedding.length === 0) {
         logError('[SearchEngine] Failed to generate query embedding');

--- a/packages/mcp-server/src/tools/search-decisions-and-contracts.js
+++ b/packages/mcp-server/src/tools/search-decisions-and-contracts.js
@@ -52,7 +52,7 @@ const searchDecisionsAndContractsTool = {
       // Decision search
       if (decisionLimit > 0 && query) {
         try {
-          const queryEmbedding = await generateEmbedding(query);
+          const queryEmbedding = await generateEmbedding(query, 'query');
           const results = await vectorSearch(queryEmbedding, decisionLimit, similarityThreshold);
           if (Array.isArray(results)) {
             decisionResults = results.slice(0, decisionLimit);
@@ -79,7 +79,7 @@ const searchDecisionsAndContractsTool = {
 
         if (contractQuery) {
           try {
-            const contractEmbedding = await generateEmbedding(contractQuery);
+            const contractEmbedding = await generateEmbedding(contractQuery, 'query');
             const contractMatches = await vectorSearch(contractEmbedding, 10, similarityThreshold);
             if (Array.isArray(contractMatches)) {
               contractResults = contractMatches

--- a/packages/memorybench/bunfig.toml
+++ b/packages/memorybench/bunfig.toml
@@ -1,0 +1,4 @@
+[test]
+# Restrict bun test discovery to src/. The retrieval-audit tests under eval/ use
+# node:test and MUST run under node (see "test:audit" script), never under bun.
+root = "src"

--- a/packages/memorybench/eval/retrieval-audit/audit-lib.mjs
+++ b/packages/memorybench/eval/retrieval-audit/audit-lib.mjs
@@ -5,32 +5,45 @@ export const VEC_BYTES = 4096; // 1024 float32
 
 // Byte-safe: build a fresh 4096-byte ArrayBuffer at offset 0, then L2-normalize.
 export function parseVec(buf) {
-  if (!buf || buf.length !== VEC_BYTES) return null;
+  if (!buf || buf.length !== VEC_BYTES) {
+    return null;
+  }
   const u = new Uint8Array(VEC_BYTES);
   u.set(buf);
   const f = new Float32Array(u.buffer);
   let n = 0;
-  for (let i = 0; i < f.length; i++) n += f[i] * f[i];
+  for (let i = 0; i < f.length; i++) {
+    n += f[i] * f[i];
+  }
   n = Math.sqrt(n);
-  if (!(n > 0)) return null;
+  if (!(n > 0)) {
+    return null;
+  }
   const out = new Float32Array(f.length);
-  for (let i = 0; i < f.length; i++) out[i] = f[i] / n;
+  for (let i = 0; i < f.length; i++) {
+    out[i] = f[i] / n;
+  }
   return out;
 }
 
 export function dot(a, b) {
   let s = 0;
-  for (let i = 0; i < a.length; i++) s += a[i] * b[i];
+  for (let i = 0; i < a.length; i++) {
+    s += a[i] * b[i];
+  }
   return s;
 }
 
 export function statsOf(arr) {
+  if (arr.length === 0) {
+    return { n: 0, min: null, p50: null, mean: null, p90: null, max: null, pct_gt_090: null, pct_gt_095: null };
+  }
   const a = arr.slice().sort((x, y) => x - y);
-  const n = a.length || 1;
+  const n = a.length;
   const q = (p) => a[Math.min(a.length - 1, Math.max(0, Math.floor(p * (a.length - 1))))];
   const mean = a.reduce((s, x) => s + x, 0) / n;
   return {
-    n: a.length,
+    n,
     min: +(+q(0)).toFixed(4),
     p50: +(+q(0.5)).toFixed(4),
     mean: +mean.toFixed(4),
@@ -49,13 +62,21 @@ export function computeTop1(items) {
     let best = -1;
     let bestDistinct = -1;
     for (let j = 0; j < items.length; j++) {
-      if (i === j) continue;
+      if (i === j) {
+        continue;
+      }
       const s = dot(items[i].vec, items[j].vec);
-      if (s > best) best = s;
-      if (s > bestDistinct && items[j].dtext !== items[i].dtext) bestDistinct = s;
+      if (s > best) {
+        best = s;
+      }
+      if (s > bestDistinct && items[j].dtext !== items[i].dtext) {
+        bestDistinct = s;
+      }
     }
     top1.push(best);
-    if (bestDistinct >= 0) top1Distinct.push(bestDistinct);
+    if (bestDistinct >= 0) {
+      top1Distinct.push(bestDistinct);
+    }
   }
   return { top1, top1Distinct };
 }
@@ -80,14 +101,28 @@ export function computeLeakage(itemsSortedByTime, linkOf, K = 5) {
     let lin = false;
     let hi = false;
     for (const { m, s } of scored) {
-      if (m.dtext === h.dtext) ex = true;
-      if (nbrs.has(m.id)) lin = true;
-      if (s > 0.9) hi = true;
+      if (m.dtext === h.dtext) {
+        ex = true;
+      }
+      if (nbrs.has(m.id)) {
+        lin = true;
+      }
+      if (s > 0.9) {
+        hi = true;
+      }
     }
-    if (ex) leakExact++;
-    if (lin) leakLineage++;
-    if (ex || lin) leakAny++;
-    if (hi) leakHiCos++;
+    if (ex) {
+      leakExact++;
+    }
+    if (lin) {
+      leakLineage++;
+    }
+    if (ex || lin) {
+      leakAny++;
+    }
+    if (hi) {
+      leakHiCos++;
+    }
   }
   const dz = held.length || 1;
   return {
@@ -105,8 +140,12 @@ export function computeLeakage(itemsSortedByTime, linkOf, K = 5) {
 export function buildLineage(rows, edges) {
   const linkOf = new Map();
   const link = (a, b) => {
-    if (!a || !b) return;
-    if (!linkOf.has(a)) linkOf.set(a, new Set());
+    if (!a || !b) {
+      return;
+    }
+    if (!linkOf.has(a)) {
+      linkOf.set(a, new Set());
+    }
     linkOf.get(a).add(b);
   };
   for (const r of rows) {

--- a/packages/memorybench/eval/retrieval-audit/audit-lib.mjs
+++ b/packages/memorybench/eval/retrieval-audit/audit-lib.mjs
@@ -6,7 +6,8 @@ export const VEC_BYTES = 4096; // 1024 float32
 // Byte-safe: build a fresh 4096-byte ArrayBuffer at offset 0, then L2-normalize.
 export function parseVec(buf) {
   if (!buf || buf.length !== VEC_BYTES) return null;
-  const u = Uint8Array.from(buf);
+  const u = new Uint8Array(VEC_BYTES);
+  u.set(buf);
   const f = new Float32Array(u.buffer);
   let n = 0;
   for (let i = 0; i < f.length; i++) n += f[i] * f[i];

--- a/packages/memorybench/eval/retrieval-audit/audit-lib.mjs
+++ b/packages/memorybench/eval/retrieval-audit/audit-lib.mjs
@@ -1,0 +1,122 @@
+// audit-lib.mjs - pure aggregate helpers for the e5 retrieval audit.
+// No DB access, no model, no decision content. Numbers only.
+
+export const VEC_BYTES = 4096; // 1024 float32
+
+// Byte-safe: build a fresh 4096-byte ArrayBuffer at offset 0, then L2-normalize.
+export function parseVec(buf) {
+  if (!buf || buf.length !== VEC_BYTES) return null;
+  const u = Uint8Array.from(buf);
+  const f = new Float32Array(u.buffer);
+  let n = 0;
+  for (let i = 0; i < f.length; i++) n += f[i] * f[i];
+  n = Math.sqrt(n);
+  if (!(n > 0)) return null;
+  const out = new Float32Array(f.length);
+  for (let i = 0; i < f.length; i++) out[i] = f[i] / n;
+  return out;
+}
+
+export function dot(a, b) {
+  let s = 0;
+  for (let i = 0; i < a.length; i++) s += a[i] * b[i];
+  return s;
+}
+
+export function statsOf(arr) {
+  const a = arr.slice().sort((x, y) => x - y);
+  const n = a.length || 1;
+  const q = (p) => a[Math.min(a.length - 1, Math.max(0, Math.floor(p * (a.length - 1))))];
+  const mean = a.reduce((s, x) => s + x, 0) / n;
+  return {
+    n: a.length,
+    min: +(+q(0)).toFixed(4),
+    p50: +(+q(0.5)).toFixed(4),
+    mean: +mean.toFixed(4),
+    p90: +(+q(0.9)).toFixed(4),
+    max: +(+q(1)).toFixed(4),
+    pct_gt_090: +(a.filter((x) => x > 0.9).length / n).toFixed(4),
+    pct_gt_095: +(a.filter((x) => x > 0.95).length / n).toFixed(4),
+  };
+}
+
+// items: [{ vec, dtext }]. Returns { top1, top1Distinct } arrays of best cosine.
+export function computeTop1(items) {
+  const top1 = [];
+  const top1Distinct = [];
+  for (let i = 0; i < items.length; i++) {
+    let best = -1;
+    let bestDistinct = -1;
+    for (let j = 0; j < items.length; j++) {
+      if (i === j) continue;
+      const s = dot(items[i].vec, items[j].vec);
+      if (s > best) best = s;
+      if (s > bestDistinct && items[j].dtext !== items[i].dtext) bestDistinct = s;
+    }
+    top1.push(best);
+    if (bestDistinct >= 0) top1Distinct.push(bestDistinct);
+  }
+  return { top1, top1Distinct };
+}
+
+// Temporal split leakage@K. items sorted by created_at ascending by caller.
+// linkOf: Map(id -> Set(neighbourId)) lineage adjacency.
+export function computeLeakage(itemsSortedByTime, linkOf, K = 5) {
+  const cut = Math.floor(itemsSortedByTime.length * 0.8);
+  const memory = itemsSortedByTime.slice(0, cut);
+  const held = itemsSortedByTime.slice(cut);
+  let leakExact = 0;
+  let leakLineage = 0;
+  let leakAny = 0;
+  let leakHiCos = 0;
+  for (const h of held) {
+    const scored = memory
+      .map((m) => ({ m, s: dot(h.vec, m.vec) }))
+      .sort((a, b) => b.s - a.s)
+      .slice(0, K);
+    const nbrs = linkOf.get(h.id) || new Set();
+    let ex = false;
+    let lin = false;
+    let hi = false;
+    for (const { m, s } of scored) {
+      if (m.dtext === h.dtext) ex = true;
+      if (nbrs.has(m.id)) lin = true;
+      if (s > 0.9) hi = true;
+    }
+    if (ex) leakExact++;
+    if (lin) leakLineage++;
+    if (ex || lin) leakAny++;
+    if (hi) leakHiCos++;
+  }
+  const dz = held.length || 1;
+  return {
+    held_n: held.length,
+    memory_n: memory.length,
+    K,
+    exact_dup_rate: +(leakExact / dz).toFixed(4),
+    lineage_rate: +(leakLineage / dz).toFixed(4),
+    any_leak_rate: +(leakAny / dz).toFixed(4),
+    topk_hi_cos_rate: +(leakHiCos / dz).toFixed(4),
+  };
+}
+
+// rows: [{ id, supersedes, superseded_by, refined_from }]; edges: [{ from_id, to_id }]
+export function buildLineage(rows, edges) {
+  const linkOf = new Map();
+  const link = (a, b) => {
+    if (!a || !b) return;
+    if (!linkOf.has(a)) linkOf.set(a, new Set());
+    linkOf.get(a).add(b);
+  };
+  for (const r of rows) {
+    for (const nb of [r.supersedes, r.superseded_by, r.refined_from]) {
+      link(r.id, nb);
+      link(nb, r.id);
+    }
+  }
+  for (const e of edges) {
+    link(e.from_id, e.to_id);
+    link(e.to_id, e.from_id);
+  }
+  return linkOf;
+}

--- a/packages/memorybench/eval/retrieval-audit/audit-lib.test.mjs
+++ b/packages/memorybench/eval/retrieval-audit/audit-lib.test.mjs
@@ -1,0 +1,65 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseVec, dot, statsOf, computeTop1, computeLeakage, buildLineage, VEC_BYTES } from './audit-lib.mjs';
+
+test('parseVec rejects wrong-size buffers', () => {
+  assert.equal(parseVec(Buffer.alloc(10)), null);
+  assert.equal(parseVec(null), null);
+});
+
+test('parseVec normalizes a 4096-byte float32 buffer to unit length', () => {
+  const f = new Float32Array(1024);
+  f[0] = 3;
+  f[1] = 4; // norm 5
+  const v = parseVec(Buffer.from(f.buffer));
+  assert.equal(v.length, 1024);
+  assert.ok(Math.abs(dot(v, v) - 1) < 1e-6);
+});
+
+test('dot of orthogonal unit vectors is 0, identical is 1', () => {
+  const a = new Float32Array(4); a[0] = 1;
+  const b = new Float32Array(4); b[1] = 1;
+  assert.ok(Math.abs(dot(a, b)) < 1e-9);
+  assert.ok(Math.abs(dot(a, a) - 1) < 1e-9);
+});
+
+test('statsOf reports mean and >0.90 fraction', () => {
+  const s = statsOf([0.8, 0.95, 0.99, 0.7]);
+  assert.equal(s.n, 4);
+  assert.equal(s.pct_gt_090, 0.5);
+  assert.ok(s.min <= s.p50 && s.p50 <= s.max);
+});
+
+test('computeTop1 isolates distinct-text nearest neighbour', () => {
+  const e = (i) => { const v = new Float32Array(4); v[i] = 1; return v; };
+  const items = [
+    { vec: e(0), dtext: 'A' },
+    { vec: e(0), dtext: 'A' }, // duplicate text of item 0
+    { vec: e(1), dtext: 'B' },
+  ];
+  const { top1, top1Distinct } = computeTop1(items);
+  assert.equal(top1.length, 3);
+  // item 0 best overall = its duplicate (cos 1); best distinct-text = B (cos 0)
+  assert.ok(Math.abs(top1[0] - 1) < 1e-9);
+  assert.ok(Math.abs(top1Distinct[0] - 0) < 1e-9);
+});
+
+test('buildLineage + computeLeakage flag a retrieved lineage relative', () => {
+  const e = (i) => { const v = new Float32Array(4); v[i % 4] = 1; return v; };
+  const rows = [
+    { id: 'old', supersedes: null, superseded_by: 'new', refined_from: null },
+    { id: 'new', supersedes: 'old', superseded_by: null, refined_from: null },
+  ];
+  const linkOf = buildLineage(rows, []);
+  const items = [
+    { id: 'old', vec: e(0), dtext: 'x', created_at: 1 },
+    { id: 'new', vec: e(0), dtext: 'y', created_at: 2 }, // held (last 20%)
+  ];
+  const sorted = items.sort((a, b) => a.created_at - b.created_at);
+  const leak = computeLeakage(sorted, linkOf, 1);
+  assert.equal(leak.lineage_rate, 1);
+});
+
+test('VEC_BYTES is 4096', () => {
+  assert.equal(VEC_BYTES, 4096);
+});

--- a/packages/memorybench/eval/retrieval-audit/audit-lib.test.mjs
+++ b/packages/memorybench/eval/retrieval-audit/audit-lib.test.mjs
@@ -30,6 +30,15 @@ test('statsOf reports mean and >0.90 fraction', () => {
   assert.ok(s.min <= s.p50 && s.p50 <= s.max);
 });
 
+test('statsOf returns n=0 with null stats for an empty array (no NaN)', () => {
+  const s = statsOf([]);
+  assert.equal(s.n, 0);
+  assert.equal(s.mean, null);
+  assert.equal(s.min, null);
+  assert.equal(s.max, null);
+  assert.ok(!Object.values(s).some((v) => Number.isNaN(v)));
+});
+
 test('computeTop1 isolates distinct-text nearest neighbour', () => {
   const e = (i) => { const v = new Float32Array(4); v[i] = 1; return v; };
   const items = [

--- a/packages/memorybench/eval/retrieval-audit/audit.mjs
+++ b/packages/memorybench/eval/retrieval-audit/audit.mjs
@@ -1,0 +1,48 @@
+// audit.mjs - read-only aggregate retrieval audit. Usage: AUDIT_DB=/path node audit.mjs
+import Database from 'better-sqlite3';
+import { parseVec, statsOf, computeTop1, computeLeakage, buildLineage } from './audit-lib.mjs';
+
+const dbPath = process.env.AUDIT_DB;
+if (!dbPath) {
+  console.error('AUDIT_DB is required (read-only path to a mama DB). Refusing to guess.');
+  process.exit(2);
+}
+const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+
+const rows = db.prepare(`
+  SELECT d.rowid AS rid, d.id AS id, d.decision AS decision, d.topic AS topic,
+         d.supersedes AS supersedes, d.superseded_by AS superseded_by, d.refined_from AS refined_from,
+         d.created_at AS created_at, e.embedding AS embedding
+  FROM decisions d JOIN embeddings e ON e.rowid = d.rowid
+  WHERE d.kind = 'decision'
+`).all();
+
+const items = [];
+let dropped = 0;
+for (const r of rows) {
+  const v = parseVec(r.embedding);
+  if (!v) { dropped++; continue; }
+  items.push({ id: r.id, vec: v, dtext: r.decision || '', created_at: r.created_at || 0 });
+}
+
+const { top1, top1Distinct } = computeTop1(items);
+const edges = (() => { try { return db.prepare('SELECT from_id, to_id FROM decision_edges').all(); } catch { return []; } })();
+const linkOf = buildLineage(
+  rows.map((r) => ({ id: r.id, supersedes: r.supersedes, superseded_by: r.superseded_by, refined_from: r.refined_from })),
+  edges
+);
+const sorted = items.slice().sort((a, b) => a.created_at - b.created_at);
+const leakage = computeLeakage(sorted, linkOf, 5);
+
+const distinctTexts = new Set(items.map((i) => i.dtext)).size;
+console.log(JSON.stringify({
+  db_basename: dbPath.split('/').pop(),
+  usable_vectors: items.length,
+  dropped_non4096: dropped,
+  distinct_texts: distinctTexts,
+  dup_rate: items.length ? +(1 - distinctTexts / items.length).toFixed(4) : 0,
+  top1_cosine: statsOf(top1),
+  top1_cosine_distinct_text: statsOf(top1Distinct),
+  leakage,
+}, null, 2));
+db.close();

--- a/packages/memorybench/package.json
+++ b/packages/memorybench/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "bun run src/index.ts",
     "test": "bun test",
+    "test:audit": "node --test eval/retrieval-audit/*.test.mjs",
     "format": "prettier --write \"src/**/*.ts\" \"ui/**/*.tsx\" \"ui/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\" \"ui/**/*.tsx\" \"ui/**/*.ts\""
   },
@@ -25,6 +26,7 @@
   "devDependencies": {
     "@types/bun": "^1.2.14",
     "@types/node": "^25.0.0",
+    "better-sqlite3": "^12.8.0",
     "prettier": "^3.7.4",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"

--- a/packages/standalone/src/api/graph-api.ts
+++ b/packages/standalone/src/api/graph-api.ts
@@ -843,7 +843,7 @@ async function getSimilarityEdges(): Promise<SimilarityEdge[]> {
   for (const decision of decisions.slice(0, 50)) {
     try {
       const query = `${decision.topic} ${decision.decision}`;
-      const embedding = await generateEmbedding(query);
+      const embedding = await generateEmbedding(query, 'query');
       const similar = (await vectorSearch(embedding, 3, 0.7)) as Array<{
         id: string;
         similarity: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       '@types/node':
         specifier: ^25.0.0
         version: 25.3.0
+      better-sqlite3:
+        specifier: ^12.8.0
+        version: 12.8.0
       prettier:
         specifier: ^3.7.4
         version: 3.8.1
@@ -3500,6 +3503,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:


### PR DESCRIPTION
## M5: e5 query/passage prefix scheme + version-guarded re-embed

multilingual-e5-large requires `"query: "` / `"passage: "` input prefixes; `generateEmbedding` omitted them for every vector ever stored or searched. This PR makes the embedding scheme correct per the model's documented usage, and adds the infrastructure to migrate existing stores safely and to measure retrieval geometry.

### What changed

- **`generateEmbedding(text, role?)`** - new optional `role: 'query' | 'passage'` (default `'passage'`, fully backward compatible). The embedding cache is keyed on the **prefixed** model input, so the same text as query vs passage can never collide. `generateEnhancedEmbedding` / `generateBatchEmbeddings` thread the role.
- **12 query-side call sites** now pass `'query'` (mama-core memory/api x3, db-manager vector search, mama-api, memory-inject, standalone graph-api, mcp-server x3, plugin pretooluse-hook + precompact-hook). 2 save sites keep `'passage'`; warmups untouched.
- **HTTP embedding server (port 3849)**: `/embed` + `/embed/batch` accept an optional `role` field (absent -> passage, unchanged behavior for old clients); `getEmbeddingFromServer` threads it.
- **Migration 042 + guard**: new `embedding_meta` marker table. A DB with pre-existing vectors is marked `legacy-unprefixed`; `initDB` then **throws** with the exact re-embed command (fail loud, no silent mixed-scheme comparison). Fresh DBs are marked current and never trip the guard. Covers both `embeddings` and `wiki_page_embeddings` (incl. wiki-only-legacy and partial-schema DBs).
- **`scripts/re-embed-migration.mjs`**: standalone backfill (direct better-sqlite3, requires `MAMA_DB_PATH`, idempotent, single transaction, marker flipped last so a crashed run stays guarded).
- **Retrieval-audit instrument** (`packages/memorybench/eval/retrieval-audit/`): read-only aggregate geometry/leakage audit, run via `pnpm run test:audit` + `node eval/retrieval-audit/audit.mjs`; fenced from `bun test` via `bunfig.toml [test] root = "src"`.

### Measured outcome (honest record - no quality-lift claim)

Deployed and re-embedded on real local stores, then re-audited. Aggregate numbers only.

Stored-vector geometry (richest corpus, distinct-text top-1 cosine):

| metric | before | after |
|---|---|---|
| mean | 0.9408 | 0.9350 |
| pct > 0.90 | 0.9827 | 0.9609 |
| pct > 0.95 | 0.2390 | 0.0906 |
| leakage topk_hi_cos_rate | 0.8516 | 0.7813 |

The plan's headline GO target (mean < ~0.85) was **not met**: passage-passage anisotropy is inherent to e5, not caused by the missing prefixes. Runtime query->passage A/B (old unprefixed vs new prefixed, same temporal split): discrimination gap +11~23%, exact-dup margin +40% (weak sample), lineage recall@5 flat (89.6% -> 87.5%, median rank 1 both). **Verdict: correctness + infrastructure transition, quality-neutral on the legacy corpus.** The corpus itself (dup_rate 0.59, near-duplicate operational messages) is the retrieval bottleneck; that is follow-up work (dedup/rerank), not more embedding changes.

### Deployment notes

- Load-bearing order: stop ALL writers (daemon + plugin sessions) -> build -> migrate -> start. The guard turns any missed DB into a loud `initDB` failure instead of silent degradation.
- External consumers pinning an older mama-core must migrate their DB when they upgrade; until then their (old code + old vectors) state stays internally consistent and the new guard never runs there.

### Follow-ups

- Corpus dedup + rerank investigation (the actual retrieval-quality lever measured here).
- Sync vendored-mama-core consumers to the new scheme (upgrade + run the re-embed script on their stores).
- Exit-time native `mutex lock failed` crash in the transformers/onnxruntime stack on macOS (pre-existing, cosmetic, surfaced during migration runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search and memory retrieval now use more accurate query embeddings, improving similarity results.
  * Added a migration and repair flow to handle embedding scheme updates for existing databases.
  * Introduced a retrieval audit workflow for reviewing embedding quality and leakage metrics.

* **Bug Fixes**
  * Startup now detects outdated embedding data and prompts a re-embedding step instead of returning degraded matches.
  * Improved compatibility with partially migrated databases so upgrades complete more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->