### PR TITLE
fix(mama-core): keep superseded history out of vectorSearch top-K

### DIFF
--- a/packages/mama-core/src/db-adapter/node-sqlite-adapter.ts
+++ b/packages/mama-core/src/db-adapter/node-sqlite-adapter.ts
@@ -121,6 +121,11 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
   private _vectorSearchEnabled = true;
   private vectorCache: Map<number, Float32Array> = new Map();
   private topicCache: Map<number, string> = new Map();
+  // Effective status (status, falling back to outcome) per decision rowid. Used as a
+  // search-time optimization only - recallMemory's post-filter stays the authority
+  // (this cache can lag a status UPDATE until the next reloadVectorCache).
+  private statusCache: Map<number, string> = new Map();
+  private decisionsHasStatusColumns = false;
 
   constructor(config: SQLiteAdapterConfig = {}) {
     super();
@@ -196,6 +201,16 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
     this.loadVectorCache();
   }
 
+  private refreshDecisionColumnInfo(): void {
+    if (!this.db) return;
+    const decisionCols = new Set(
+      (this.db.prepare('PRAGMA table_info(decisions)').all() as Array<{ name: string }>).map(
+        (c) => c.name
+      )
+    );
+    this.decisionsHasStatusColumns = decisionCols.has('status') && decisionCols.has('outcome');
+  }
+
   private loadVectorCache(): void {
     if (!this.db) return;
 
@@ -206,6 +221,7 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
     if (tableCheck.length === 0) {
       this.vectorCache.clear();
       this.topicCache.clear();
+      this.statusCache.clear();
       return;
     }
 
@@ -224,14 +240,36 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
       }
     }
 
-    // Load topic cache for scoped vector search
+    // Load topic + effective-status caches for scoped/filtered vector search.
+    // Legacy partial schemas may lack status/outcome (they are added by later
+    // migrations, and loadVectorCache also runs at connect time, before
+    // runMigrations) - introspect columns so prepare() cannot crash on them.
+    // A missing column just leaves statusCache empty; the api-layer post-filter
+    // remains the authority.
     this.topicCache.clear();
-    const topicRows = this.db.prepare('SELECT rowid, topic FROM decisions').all() as Array<{
+    this.statusCache.clear();
+    const decisionCols = new Set(
+      (this.db.prepare('PRAGMA table_info(decisions)').all() as Array<{ name: string }>).map(
+        (c) => c.name
+      )
+    );
+    this.refreshDecisionColumnInfo();
+    const statusSelect = decisionCols.has('status') ? 'status' : 'NULL AS status';
+    const outcomeSelect = decisionCols.has('outcome') ? 'outcome' : 'NULL AS outcome';
+    const topicRows = this.db
+      .prepare(`SELECT rowid, topic, ${statusSelect}, ${outcomeSelect} FROM decisions`)
+      .all() as Array<{
       rowid: number;
       topic: string;
+      status: string | null;
+      outcome: string | null;
     }>;
     for (const row of topicRows) {
       this.topicCache.set(row.rowid, row.topic);
+      const effectiveStatus = row.status || row.outcome;
+      if (effectiveStatus) {
+        this.statusCache.set(row.rowid, effectiveStatus);
+      }
     }
 
     const count = this.vectorCache.size;
@@ -298,7 +336,8 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
   vectorSearch(
     embedding: Float32Array | number[],
     limit = 5,
-    topicPrefix?: string
+    topicPrefix?: string,
+    excludeStatuses?: readonly string[]
   ): VectorSearchResult[] | null {
     if (!this.isConnected()) {
       throw new Error('Database not connected');
@@ -310,6 +349,8 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
     const effectiveLimit = Math.max(limit, 1);
     const bestMatches: VectorSearchResult[] = [];
     let minScore = -Infinity;
+    const excluded =
+      excludeStatuses && excludeStatuses.length > 0 ? new Set(excludeStatuses) : null;
 
     for (const [rowid, candidate] of this.vectorCache) {
       if (candidate.length !== queryVector.length) continue;
@@ -318,6 +359,13 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
       if (topicPrefix) {
         const topic = this.topicCache.get(rowid);
         if (!topic || !topic.startsWith(topicPrefix)) continue;
+      }
+
+      // Pre-filter by effective status so superseded history does not occupy
+      // top-K slots (the api-layer post-filter remains the authority)
+      if (excluded) {
+        const status = this.statusCache.get(rowid);
+        if (status && excluded.has(status)) continue;
       }
 
       const similarity = cosineSimilarity(candidate, queryVector);
@@ -357,12 +405,28 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
 
     const result = stmt.run(rowid, buffer);
 
-    // Keep in-memory caches in sync
+    // Keep in-memory caches in sync. The column flag is stamped at loadVectorCache
+    // time, which can predate runMigrations (connect-time load on a fresh DB) - so
+    // while it reads false, re-introspect before deciding the select shape.
     this.vectorCache.set(rowid, vec);
-    const topicRow = this.prepare('SELECT topic FROM decisions WHERE rowid = ?').get(rowid) as
-      | { topic: string }
+    if (!this.decisionsHasStatusColumns) {
+      this.refreshDecisionColumnInfo();
+    }
+    const cacheSelect = this.decisionsHasStatusColumns
+      ? 'SELECT topic, status, outcome FROM decisions WHERE rowid = ?'
+      : 'SELECT topic, NULL AS status, NULL AS outcome FROM decisions WHERE rowid = ?';
+    const topicRow = this.prepare(cacheSelect).get(rowid) as
+      | { topic: string; status: string | null; outcome: string | null }
       | undefined;
-    if (topicRow) this.topicCache.set(rowid, topicRow.topic);
+    if (topicRow) {
+      this.topicCache.set(rowid, topicRow.topic);
+      const effectiveStatus = topicRow.status || topicRow.outcome;
+      if (effectiveStatus) {
+        this.statusCache.set(rowid, effectiveStatus);
+      } else {
+        this.statusCache.delete(rowid);
+      }
+    }
 
     return result;
   }

--- a/packages/mama-core/src/db-adapter/node-sqlite-adapter.ts
+++ b/packages/mama-core/src/db-adapter/node-sqlite-adapter.ts
@@ -126,6 +126,7 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
   // (this cache can lag a status UPDATE until the next reloadVectorCache).
   private statusCache: Map<number, string> = new Map();
   private decisionsHasStatusColumns = false;
+  private decisionsColumnInfoChecked = false;
 
   constructor(config: SQLiteAdapterConfig = {}) {
     super();
@@ -210,7 +211,7 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
     if (!this.isConnected()) {
       throw new Error('Database not connected');
     }
-    if (!this.decisionsHasStatusColumns) {
+    if (!this.decisionsColumnInfoChecked) {
       this.refreshDecisionColumnInfo();
     }
     const cacheSelect = this.decisionsHasStatusColumns
@@ -221,6 +222,7 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
       | undefined;
     if (!row) {
       this.statusCache.delete(rowid);
+      this.topicCache.delete(rowid);
       return;
     }
     this.topicCache.set(rowid, row.topic);
@@ -232,14 +234,18 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
     }
   }
 
-  private refreshDecisionColumnInfo(): void {
-    if (!this.db) return;
+  private refreshDecisionColumnInfo(): Set<string> {
+    if (!this.db) return new Set();
     const decisionCols = new Set(
       (this.db.prepare('PRAGMA table_info(decisions)').all() as Array<{ name: string }>).map(
         (c) => c.name
       )
     );
     this.decisionsHasStatusColumns = decisionCols.has('status') && decisionCols.has('outcome');
+    // Only latch "checked" once the decisions table actually exists - introspecting
+    // a not-yet-migrated DB must not stop later calls from re-checking.
+    this.decisionsColumnInfoChecked = decisionCols.size > 0;
+    return decisionCols;
   }
 
   private loadVectorCache(): void {
@@ -279,12 +285,7 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
     // remains the authority.
     this.topicCache.clear();
     this.statusCache.clear();
-    const decisionCols = new Set(
-      (this.db.prepare('PRAGMA table_info(decisions)').all() as Array<{ name: string }>).map(
-        (c) => c.name
-      )
-    );
-    this.refreshDecisionColumnInfo();
+    const decisionCols = this.refreshDecisionColumnInfo();
     const statusSelect = decisionCols.has('status') ? 'status' : 'NULL AS status';
     const outcomeSelect = decisionCols.has('outcome') ? 'outcome' : 'NULL AS outcome';
     const topicRows = this.db

--- a/packages/mama-core/src/db-adapter/node-sqlite-adapter.ts
+++ b/packages/mama-core/src/db-adapter/node-sqlite-adapter.ts
@@ -201,6 +201,37 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
     this.loadVectorCache();
   }
 
+  // Re-read one decision's effective status into the cache. MUST be called after
+  // any status transition that can move a row OUT of an excluded state (e.g.
+  // promoteMemoryStatus staging->active): the vectorSearch pre-filter drops
+  // excluded rowids before the api post-filter ever sees them, so a stale
+  // excluded entry would make an active row unrecallable until restart.
+  refreshDecisionStatusCache(rowid: number): void {
+    if (!this.isConnected()) {
+      throw new Error('Database not connected');
+    }
+    if (!this.decisionsHasStatusColumns) {
+      this.refreshDecisionColumnInfo();
+    }
+    const cacheSelect = this.decisionsHasStatusColumns
+      ? 'SELECT topic, status, outcome FROM decisions WHERE rowid = ?'
+      : 'SELECT topic, NULL AS status, NULL AS outcome FROM decisions WHERE rowid = ?';
+    const row = this.prepare(cacheSelect).get(rowid) as
+      | { topic: string; status: string | null; outcome: string | null }
+      | undefined;
+    if (!row) {
+      this.statusCache.delete(rowid);
+      return;
+    }
+    this.topicCache.set(rowid, row.topic);
+    const effectiveStatus = row.status || row.outcome;
+    if (effectiveStatus) {
+      this.statusCache.set(rowid, effectiveStatus);
+    } else {
+      this.statusCache.delete(rowid);
+    }
+  }
+
   private refreshDecisionColumnInfo(): void {
     if (!this.db) return;
     const decisionCols = new Set(
@@ -405,28 +436,9 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
 
     const result = stmt.run(rowid, buffer);
 
-    // Keep in-memory caches in sync. The column flag is stamped at loadVectorCache
-    // time, which can predate runMigrations (connect-time load on a fresh DB) - so
-    // while it reads false, re-introspect before deciding the select shape.
+    // Keep in-memory caches in sync
     this.vectorCache.set(rowid, vec);
-    if (!this.decisionsHasStatusColumns) {
-      this.refreshDecisionColumnInfo();
-    }
-    const cacheSelect = this.decisionsHasStatusColumns
-      ? 'SELECT topic, status, outcome FROM decisions WHERE rowid = ?'
-      : 'SELECT topic, NULL AS status, NULL AS outcome FROM decisions WHERE rowid = ?';
-    const topicRow = this.prepare(cacheSelect).get(rowid) as
-      | { topic: string; status: string | null; outcome: string | null }
-      | undefined;
-    if (topicRow) {
-      this.topicCache.set(rowid, topicRow.topic);
-      const effectiveStatus = topicRow.status || topicRow.outcome;
-      if (effectiveStatus) {
-        this.statusCache.set(rowid, effectiveStatus);
-      } else {
-        this.statusCache.delete(rowid);
-      }
-    }
+    this.refreshDecisionStatusCache(rowid);
 
     return result;
   }

--- a/packages/mama-core/src/db-manager.ts
+++ b/packages/mama-core/src/db-manager.ts
@@ -48,6 +48,7 @@ export interface DatabaseAdapter {
   ) => Promise<VectorSearchResult[] | null> | VectorSearchResult[] | null;
   vectorSearchEnabled: boolean;
   reloadVectorCache?: () => void;
+  refreshDecisionStatusCache?: (rowid: number) => void;
   getDbPath?: () => string;
   dbPath?: string;
   constructor: { name: string };

--- a/packages/mama-core/src/db-manager.ts
+++ b/packages/mama-core/src/db-manager.ts
@@ -43,7 +43,8 @@ export interface DatabaseAdapter {
   vectorSearch: (
     embedding: Float32Array | number[],
     limit: number,
-    topicPrefix?: string
+    topicPrefix?: string,
+    excludeStatuses?: readonly string[]
   ) => Promise<VectorSearchResult[] | null> | VectorSearchResult[] | null;
   vectorSearchEnabled: boolean;
   reloadVectorCache?: () => void;
@@ -459,13 +460,14 @@ export async function vectorSearch(
   queryEmbedding: Float32Array | number[],
   limit = 5,
   threshold = 0.7,
-  topicPrefix?: string
+  topicPrefix?: string,
+  excludeStatuses?: readonly string[]
 ): Promise<DecisionRecord[]> {
   const adapter = getAdapter();
 
   try {
-    // Brute-force cosine similarity over all embeddings (with optional topic pre-filter)
-    const results = await adapter.vectorSearch(queryEmbedding, limit * 3, topicPrefix);
+    // Brute-force cosine similarity over all embeddings (with optional topic/status pre-filter)
+    const results = await adapter.vectorSearch(queryEmbedding, limit * 3, topicPrefix, excludeStatuses);
 
     if (!results || results.length === 0) {
       return []; // No keyword fallback - fast fail

--- a/packages/mama-core/src/memory/api.ts
+++ b/packages/mama-core/src/memory/api.ts
@@ -696,7 +696,16 @@ async function saveMemoryInternal(
     try {
       const queryText = `${input.topic} ${input.summary}`;
       const embedding = await generateEmbedding(queryText, 'query');
-      const semanticResults = await vectorSearch(embedding, 3, 0.82);
+      // Exclude superseded history so a dense supersede chain cannot fill all 3
+      // candidate slots and hide the prior ACTIVE decision (which would break the
+      // evolution link and create an active duplicate).
+      const semanticResults = await vectorSearch(
+        embedding,
+        3,
+        0.82,
+        undefined,
+        Array.from(EXCLUDED_STATUSES)
+      );
 
       // Scope-filter semantic candidates when a primary scope is available
       let scopeFiltered = semanticResults;
@@ -876,10 +885,9 @@ async function saveMemoryInternal(
       id,
       ...evolution.edges.filter((e) => e.type === 'supersedes').map((e) => e.to_id),
     ];
+    const ridStmt = adapter.prepare('SELECT rowid FROM decisions WHERE id = ?');
     for (const changedId of changedIds) {
-      const ridRow = adapter
-        .prepare('SELECT rowid FROM decisions WHERE id = ?')
-        .get(changedId) as { rowid: number } | undefined;
+      const ridRow = ridStmt.get(changedId) as { rowid: number } | undefined;
       if (ridRow) {
         adapter.refreshDecisionStatusCache(ridRow.rowid);
       }
@@ -1016,7 +1024,15 @@ export async function promoteMemoryStatus(input: {
       try {
         const queryText = `${topic} ${summary}`;
         const embedding = await generateEmbedding(queryText, 'query');
-        const semanticResults = await vectorSearch(embedding, 3, 0.82);
+        // Same exclusion as saveMemoryInternal's fallback: superseded history must
+        // not crowd out the prior ACTIVE decision from the 3 candidate slots.
+        const semanticResults = await vectorSearch(
+          embedding,
+          3,
+          0.82,
+          undefined,
+          Array.from(EXCLUDED_STATUSES)
+        );
 
         let scopeFiltered = semanticResults;
         if (primaryScope) {
@@ -1129,10 +1145,9 @@ export async function promoteMemoryStatus(input: {
       memoryId,
       ...evolution.edges.filter((e) => e.type === 'supersedes').map((e) => e.to_id),
     ];
+    const ridStmt = adapter.prepare('SELECT rowid FROM decisions WHERE id = ?');
     for (const id of changedIds) {
-      const ridRow = adapter.prepare('SELECT rowid FROM decisions WHERE id = ?').get(id) as
-        | { rowid: number }
-        | undefined;
+      const ridRow = ridStmt.get(id) as { rowid: number } | undefined;
       if (ridRow) {
         adapter.refreshDecisionStatusCache(ridRow.rowid);
       }

--- a/packages/mama-core/src/memory/api.ts
+++ b/packages/mama-core/src/memory/api.ts
@@ -867,6 +867,25 @@ async function saveMemoryInternal(
     throw rollbackError;
   }
 
+  // Sync the adapter's status cache for every row whose status changed in the
+  // post-insert transaction: the saved row itself (status is written AFTER
+  // insertEmbedding populated the cache) and any rows just superseded. This makes
+  // the vectorSearch pre-filter correct within this session, not only after reload.
+  if (adapter.refreshDecisionStatusCache) {
+    const changedIds = [
+      id,
+      ...evolution.edges.filter((e) => e.type === 'supersedes').map((e) => e.to_id),
+    ];
+    for (const changedId of changedIds) {
+      const ridRow = adapter
+        .prepare('SELECT rowid FROM decisions WHERE id = ?')
+        .get(changedId) as { rowid: number } | undefined;
+      if (ridRow) {
+        adapter.refreshDecisionStatusCache(ridRow.rowid);
+      }
+    }
+  }
+
   if (options?.projectTruth !== false) {
     // Project to memory_truth table (best-effort; failure should not break save)
     try {
@@ -1101,6 +1120,24 @@ export async function promoteMemoryStatus(input: {
         .run(memoryId, edge.to_id, edge.type, edge.reason ?? null, 1.0, now);
     }
   });
+
+  // Sync the adapter's status cache for every row whose status changed above.
+  // Without this, a row promoted OUT of an excluded status (e.g. stale->active)
+  // stays invisible to the vectorSearch pre-filter until the next full reload.
+  if (adapter.refreshDecisionStatusCache) {
+    const changedIds = [
+      memoryId,
+      ...evolution.edges.filter((e) => e.type === 'supersedes').map((e) => e.to_id),
+    ];
+    for (const id of changedIds) {
+      const ridRow = adapter.prepare('SELECT rowid FROM decisions WHERE id = ?').get(id) as
+        | { rowid: number }
+        | undefined;
+      if (ridRow) {
+        adapter.refreshDecisionStatusCache(ridRow.rowid);
+      }
+    }
+  }
 }
 
 export async function buildProfile(scopes: MemoryScopeRef[]): Promise<ProfileSnapshot> {

--- a/packages/mama-core/src/memory/api.ts
+++ b/packages/mama-core/src/memory/api.ts
@@ -1187,7 +1187,10 @@ export async function recallMemory(
         queryEmbedding,
         vectorLimit,
         searchOptions.threshold,
-        searchOptions.topicPrefix
+        searchOptions.topicPrefix,
+        // Keep superseded history out of the candidate top-K at search time; the
+        // post-filter below stays the authority (and includeHistory restores it).
+        options.includeHistory ? undefined : Array.from(EXCLUDED_STATUSES)
       );
 
       let filtered = vectorResults;

--- a/packages/mama-core/tests/unit/memory-v2-recall-ranking.test.ts
+++ b/packages/mama-core/tests/unit/memory-v2-recall-ranking.test.ts
@@ -116,7 +116,13 @@ describe('memory v2 recall ranking', () => {
       diagnostics: true,
     });
 
-    expect(vectorSearchMock).toHaveBeenCalledWith(expect.any(Float32Array), 20, 0.6, undefined);
+    expect(vectorSearchMock).toHaveBeenCalledWith(
+      expect.any(Float32Array),
+      20,
+      0.6,
+      undefined,
+      expect.arrayContaining(['superseded', 'quarantined', 'contradicted', 'stale'])
+    );
     expect(bundle.memories).toEqual([]);
     expect((bundle as { fused_hits?: unknown[] }).fused_hits).toEqual([]);
     expect(bundle.search_meta.diagnostics?.candidate_counts.vector_only).toBeGreaterThan(0);

--- a/packages/mama-core/tests/unit/promote-status-vector-visibility.test.ts
+++ b/packages/mama-core/tests/unit/promote-status-vector-visibility.test.ts
@@ -1,0 +1,61 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Mock the model so no 560MB pipeline is ever loaded. All embeddings resolve to the
+// same fixed vector, so any query matches every stored row with cosine 1.0.
+const FIXED = () => new Float32Array(1024).fill(0.01);
+vi.mock('../../src/embeddings.js', () => ({
+  generateEmbedding: vi.fn(async () => FIXED()),
+  generateEnhancedEmbedding: vi.fn(async () => FIXED()),
+  generateBatchEmbeddings: vi.fn(async (texts: string[]) => texts.map(() => FIXED())),
+  cosineSimilarity: () => 1,
+  embeddingCache: { clear: () => {}, get: () => undefined, set: () => {} },
+  EMBEDDING_DIM: 1024,
+  MODEL_NAME: 'x',
+  EMBEDDING_PREFIX_SCHEME: 'e5-prefixed-v1',
+}));
+
+const tmpDir = mkdtempSync(join(tmpdir(), 'promote-status-visibility-'));
+process.env.MAMA_DB_PATH = join(tmpDir, 'test-memory.db');
+
+const { initDB, closeDB, vectorSearch } = await import('../../src/db-manager.js');
+const { saveMemory, promoteMemoryStatus } = await import('../../src/memory/api.js');
+
+const EXCLUDED = ['superseded', 'quarantined', 'contradicted', 'stale'];
+
+describe('Story R1: promoted memories stay vector-searchable', () => {
+  beforeAll(async () => {
+    await initDB();
+  }, 30000);
+
+  afterAll(async () => {
+    await closeDB();
+  });
+
+  describe('AC #4: staging->active promotion re-enters the pre-filtered search', () => {
+    it('finds a stale-staged memory after promoteMemoryStatus(active) without a cache reload', async () => {
+      const saved = await saveMemory({
+        topic: 'staged-note',
+        kind: 'decision',
+        summary: 'Staged observation awaiting review',
+        details: 'Held in stale status until promotion',
+        status: 'stale',
+        scopes: [{ kind: 'global', id: 'global' }],
+        source: { package: 'mama-core', source_type: 'test' },
+      });
+      const memoryId = (saved as { id: string }).id;
+
+      // Staged (excluded) -> the pre-filter hides it.
+      const before = await vectorSearch(FIXED(), 5, 0.1, undefined, EXCLUDED);
+      expect(before.map((d) => d.id)).not.toContain(memoryId);
+
+      await promoteMemoryStatus({ memoryId, status: 'active' });
+
+      // Promotion must sync the adapter status cache - no reloadVectorCache here.
+      const after = await vectorSearch(FIXED(), 5, 0.1, undefined, EXCLUDED);
+      expect(after.map((d) => d.id)).toContain(memoryId);
+    });
+  });
+});

--- a/packages/mama-core/tests/unit/vector-search-status-filter.test.ts
+++ b/packages/mama-core/tests/unit/vector-search-status-filter.test.ts
@@ -84,6 +84,25 @@ describe('Story R1: vectorSearch status pre-filter', () => {
     });
   });
 
+  describe('AC #3: a row promoted back to active becomes searchable without a full reload', () => {
+    it('refreshDecisionStatusCache re-includes a previously excluded row', () => {
+      const adapter = setupAdapter();
+      const rid = seedDecision(adapter, 'p1', 'stale', null, 1);
+      const excluded = ['superseded', 'quarantined', 'contradicted', 'stale'];
+
+      expect(adapter.vectorSearch(vec(1), 5, undefined, excluded)!.length).toBe(0);
+
+      // A promotion path flips the row back to active in SQL only - the cache
+      // refresh must make it searchable again without reloadVectorCache.
+      adapter.prepare(`UPDATE decisions SET status = 'active' WHERE id = 'p1'`).run();
+      adapter.refreshDecisionStatusCache(rid);
+
+      const after = adapter.vectorSearch(vec(1), 5, undefined, excluded);
+      expect(after!.map((r) => r.rowid)).toEqual([rid]);
+      adapter.disconnect();
+    });
+  });
+
   describe('AC #2: the status cache follows reloadVectorCache after status changes', () => {
     it('excludes a row that was superseded after the initial cache load', () => {
       const adapter = setupAdapter();

--- a/packages/mama-core/tests/unit/vector-search-status-filter.test.ts
+++ b/packages/mama-core/tests/unit/vector-search-status-filter.test.ts
@@ -1,0 +1,105 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { NodeSQLiteAdapter } from '../../src/db-adapter/node-sqlite-adapter.js';
+
+const MIGRATIONS_DIR = join(__dirname, '..', '..', 'db', 'migrations');
+const tempPaths = new Set<string>();
+
+function tempDbPath(): string {
+  const path = join(os.tmpdir(), `test-vector-status-filter-${randomUUID()}.db`);
+  tempPaths.add(path);
+  return path;
+}
+
+afterEach(() => {
+  for (const path of tempPaths) {
+    for (const file of [path, `${path}-journal`, `${path}-wal`, `${path}-shm`]) {
+      try {
+        fs.unlinkSync(file);
+      } catch {
+        // best effort
+      }
+    }
+  }
+  tempPaths.clear();
+});
+
+function vec(seed: number): Float32Array {
+  const v = new Float32Array(1024);
+  v[0] = 1;
+  v[1] = seed * 0.001;
+  return v;
+}
+
+function seedDecision(
+  adapter: NodeSQLiteAdapter,
+  id: string,
+  status: string | null,
+  outcome: string | null,
+  seed: number
+): number {
+  adapter
+    .prepare(
+      `INSERT INTO decisions (id, topic, decision, status, outcome, created_at) VALUES (?, ?, ?, ?, ?, ?)`
+    )
+    .run(id, `topic-${id}`, `decision text ${id}`, status, outcome, Date.now());
+  const row = adapter.prepare(`SELECT rowid FROM decisions WHERE id = ?`).get(id) as {
+    rowid: number;
+  };
+  adapter.insertEmbedding(row.rowid, vec(seed));
+  return row.rowid;
+}
+
+function setupAdapter(): NodeSQLiteAdapter {
+  const adapter = new NodeSQLiteAdapter({ dbPath: tempDbPath() });
+  adapter.connect();
+  (adapter as unknown as { runMigrations: (dir: string) => void }).runMigrations(MIGRATIONS_DIR);
+  return adapter;
+}
+
+describe('Story R1: vectorSearch status pre-filter', () => {
+  describe('AC #1: excludeStatuses skips superseded/stale rows at search time', () => {
+    it('returns all rows without the filter and only non-excluded rows with it', () => {
+      const adapter = setupAdapter();
+      const activeRid = seedDecision(adapter, 'a1', 'active', null, 1);
+      seedDecision(adapter, 's1', 'superseded', null, 2);
+      seedDecision(adapter, 's2', null, 'stale', 3); // status NULL -> outcome fallback
+
+      const unfiltered = adapter.vectorSearch(vec(1), 5);
+      expect(unfiltered).not.toBeNull();
+      expect(unfiltered!.length).toBe(3);
+
+      const filtered = adapter.vectorSearch(vec(1), 5, undefined, [
+        'superseded',
+        'quarantined',
+        'contradicted',
+        'stale',
+      ]);
+      expect(filtered).not.toBeNull();
+      expect(filtered!.map((r) => r.rowid)).toEqual([activeRid]);
+      adapter.disconnect();
+    });
+  });
+
+  describe('AC #2: the status cache follows reloadVectorCache after status changes', () => {
+    it('excludes a row that was superseded after the initial cache load', () => {
+      const adapter = setupAdapter();
+      const rid1 = seedDecision(adapter, 'a1', 'active', null, 1);
+      const rid2 = seedDecision(adapter, 'a2', 'active', null, 2);
+
+      const excluded = ['superseded', 'quarantined', 'contradicted', 'stale'];
+      const before = adapter.vectorSearch(vec(1), 5, undefined, excluded);
+      expect(before!.map((r) => r.rowid).sort()).toEqual([rid1, rid2].sort());
+
+      adapter.prepare(`UPDATE decisions SET status = 'superseded' WHERE id = 'a2'`).run();
+      adapter.reloadVectorCache();
+
+      const after = adapter.vectorSearch(vec(1), 5, undefined, excluded);
+      expect(after!.map((r) => r.rowid)).toEqual([rid1]);
+      adapter.disconnect();
+    });
+  });
+});


### PR DESCRIPTION
## Problem (measured on a real corpus)

`vectorSearch` brute-forces cosine over ALL embeddings including superseded supersede-chain history; `recallMemory` drops excluded statuses only AFTER the top-K cut. A recurring topic accumulated a 381-copy superseded chain, and any query landing near that cluster returned **0 usable memories** (all top-5 slots filled by superseded copies; measured 74/128 held-out probes returned an empty top-5, avg 2.11 distinct-active in top-5).

## Fix

- `NodeSQLiteAdapter` gains an effective-status cache (`status || outcome` per rowid) and `vectorSearch` an optional `excludeStatuses` pre-filter, mirroring the existing `topicPrefix` pattern. `recallMemory` passes `EXCLUDED_STATUSES` unless `options.includeHistory`.
- The api-layer post-filter remains the authority for the demote direction (a stale cache entry can only make a superseded row *appear* as a candidate, which the post-filter removes).
- **Status-cache sync on transitions** (adversarial-review HIGH): the pre-filter can never *re-include* a dropped rowid, so every status-writing transaction now refreshes the cache — `promoteMemoryStatus` (staging `stale` -> `active` previously left the promoted row invisible to vector recall until restart) and `saveMemoryInternal` (the saved row itself: `decisions.status` is written by the post-insert UPDATE *after* `insertEmbedding` cached the row, plus superseded edge targets).
- Column introspection keeps legacy partial schemas (no `status`/`outcome` columns yet) loading cleanly at connect time.

## Measured after (same real corpus, same cluster-adjacent query)

top-5: **0/5 active -> 5/5 active across 5 distinct topics**. Lineage recall@5 unchanged (verified flat across variants before building).

## Not done (with evidence)

- MMR/diversity rerank: near-dup redundancy among ACTIVE texts is negligible (1 pair >0.98 cosine of 33,411) - solves a problem that isn't there.
- Known LOW residual (reviewer-flagged, pre-existing-shaped): legacy `updateDecisionOutcome` can theoretically flip an excluded `outcome` on status-NULL rows without a cache refresh; no first-party code writes `outcome='superseded'` today. Follow-up candidate.
- Save-side root cause for ACTIVE duplicate rows seen in other DBs is tracked separately.

## Tests

mama-core 840 -> **844 passed** (4 new: adapter filter, reload-follow, re-include-after-promote, api-level staged-save->promote->visible regression that FAILS on the first commit alone - empirically verified in a scratch worktree). Typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vector search now supports filtering out memories by status, helping results better match the current state of records.
  * Promoted memories can become visible in search again after their status changes.

* **Bug Fixes**
  * Search results now stay in sync with recent status updates.
  * Legacy databases are handled more reliably when status-related fields are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->