### PR TITLE
fix(standalone): invalid gateway-tool args made scheduled-report data empty

### DIFF
--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -1188,8 +1188,8 @@ export async function runAgentLoop(
         // reports "quiet" whenever polling is between batches).
         fullReportSelfGather: [
           'kagemusha_overview() for room/task/message counts',
-          'kagemusha_tasks({ status: "needs_review" }) and kagemusha_tasks({ status: "blocked" }) for the task board state',
-          'kagemusha_entities({ activeOnly: true }) for active channels, then kagemusha_messages({ channelId, since: "24h ago" }) on the busiest 2-3',
+          'kagemusha_tasks({}) for the open task board, plus kagemusha_tasks({ status: "review" }) for items awaiting review (status values must be real board statuses like pending/in_progress/review - invented labels match nothing)',
+          'kagemusha_entities({ activeOnly: true }) for active channels, then kagemusha_messages({ channelId }) on the busiest 2-3 (since defaults to the last 7 days; pass an ISO-8601 timestamp like since: "2026-07-09T00:00:00Z" to narrow it - never a phrase like "24h ago")',
           'mama_recall(query) for memory relevant to what you find',
         ],
         config: {

--- a/packages/standalone/src/connectors/kagemusha/query-tools.ts
+++ b/packages/standalone/src/connectors/kagemusha/query-tools.ts
@@ -224,7 +224,9 @@ export function queryMessages(options: {
   // Validate BEFORE any DB access: new Date("24h ago") is NaN, and a NaN bind
   // makes `created_at > ?` silently match zero rows (empty-success). Fail loud.
   let sinceMs: number;
-  if (options.since !== undefined) {
+  // != null also treats a JSON null (common in LLM-produced payloads) as absent -
+  // new Date(null) would otherwise parse to epoch 0 and match ALL history.
+  if (options.since != null) {
     sinceMs = new Date(options.since).getTime();
     if (Number.isNaN(sinceMs)) {
       throw new Error(

--- a/packages/standalone/src/connectors/kagemusha/query-tools.ts
+++ b/packages/standalone/src/connectors/kagemusha/query-tools.ts
@@ -221,11 +221,21 @@ export function queryMessages(options: {
   limit?: number;
   search?: string; // text search in content
 }): MessageInfo[] {
+  // Validate BEFORE any DB access: new Date("24h ago") is NaN, and a NaN bind
+  // makes `created_at > ?` silently match zero rows (empty-success). Fail loud.
+  let sinceMs: number;
+  if (options.since !== undefined) {
+    sinceMs = new Date(options.since).getTime();
+    if (Number.isNaN(sinceMs)) {
+      throw new Error(
+        `since must be an ISO-8601 date/timestamp (got "${options.since}"); phrases like "24h ago" are not parseable`
+      );
+    }
+  } else {
+    sinceMs = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  }
   const d = getDB();
   const limit = options.limit ?? 50;
-  const sinceMs = options.since
-    ? new Date(options.since).getTime()
-    : Date.now() - 7 * 24 * 60 * 60 * 1000;
 
   const conditions = ['channel_id = ?', 'created_at > ?'];
   const params: unknown[] = [options.channelId, sinceMs];

--- a/packages/standalone/src/operator/situation-report.ts
+++ b/packages/standalone/src/operator/situation-report.ts
@@ -184,7 +184,7 @@ export class SituationReporter {
                   'Emit each call as a fenced tool_call JSON block and wait for the result before',
                   'the next call. The block format is exactly:',
                   '```tool_call',
-                  '{"name": "kagemusha_tasks", "input": {"status": "needs_review"}}',
+                  '{"name": "kagemusha_tasks", "input": {"status": "in_progress"}}',
                   '```',
                   'Gather with these gateway tool calls:',
                   ...this.opts.selfGatherLines.map((line) => `- ${line}`),

--- a/packages/standalone/tests/connectors/kagemusha-query-tools.test.ts
+++ b/packages/standalone/tests/connectors/kagemusha-query-tools.test.ts
@@ -10,5 +10,14 @@ describe('Story R2: kagemusha query tools fail loud on bad arguments', () => {
         /since.*ISO-8601/i
       );
     });
+
+    it('treats a JSON null since as absent (default window), not epoch 0', () => {
+      // new Date(null) parses to epoch 0, which would silently match ALL history.
+      // A null since must fall through to the default window - so validation must
+      // not throw for it (the DB open failing later on CI is a different error).
+      expect(() => queryMessages({ channelId: 'c1', since: null as unknown as string })).not.toThrow(
+        /since.*ISO-8601/i
+      );
+    });
   });
 });

--- a/packages/standalone/tests/connectors/kagemusha-query-tools.test.ts
+++ b/packages/standalone/tests/connectors/kagemusha-query-tools.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { queryMessages } from '../../src/connectors/kagemusha/query-tools.js';
+
+describe('Story R2: kagemusha query tools fail loud on bad arguments', () => {
+  describe('AC #1: an unparseable since value throws instead of matching zero rows', () => {
+    it('rejects a human phrase like "24h ago" before touching the database', () => {
+      // Historic bug: new Date("24h ago") -> NaN, better-sqlite3 binds NaN and
+      // created_at > NaN silently matches nothing -> {"success":true,messages:[]}.
+      expect(() => queryMessages({ channelId: 'c1', since: '24h ago' })).toThrow(
+        /since.*ISO-8601/i
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Root cause (investigated on the live daemon + real data)

The operator full-report prompt itself hardcoded invalid argument literals, so on every scheduled report two of the four self-gather tools returned misleading `{"success":true, ...: []}`:

- `kagemusha_tasks({ status: "needs_review" })` / `({ status: "blocked" })` - neither is a real board status (real: pending/in_progress/review/done/...), `WHERE status = ?` matched 0 of 527 tasks.
- `kagemusha_messages({ since: "24h ago" })` - `new Date("24h ago")` is `NaN`; better-sqlite3 binds NaN and `created_at > NaN` matches zero rows (a valid 24h window returns 86 messages on the same data).

`kagemusha_overview`/`kagemusha_entities` worked because they take no filters - which is why reports had SOME substance and the gap went unnoticed.

## Fix

- Prompt lines (`start.ts` fullReportSelfGather): open task board via `kagemusha_tasks({})` + `{ status: "review" }`, with an explicit warning against invented labels; messages rely on the tool's 7-day default or an ISO-8601 `since`, with the "never a phrase" warning. Copy-paste example in `situation-report.ts` corrected too.
- Fail loud (repo no-fallback convention): `queryMessages` now throws on an unparseable `since` BEFORE any DB access, instead of silently comparing against NaN. TDD'd (RED confirmed).

Status-enum validation on `kagemusha_tasks` is deliberately NOT added: the enum belongs to the consumer's board data, and hardcoding it in MAMA would drift.

## Tests

Standalone 3343 -> **3344 passed / 6 skipped** (+1), typecheck clean.