### PR TITLE
fix(standalone): cron jobs never completed — UUID session id + test config pollution

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ open-source components.
 | ------------------------------------------------ | ------- | ----------------------------------------------------- |
 | [@jungjaehoon/mama-os](packages/standalone/)     | 0.20.1  | Always-on runtime, envelopes, connectors, worker APIs |
 | [@jungjaehoon/mama-server](packages/mcp-server/) | 1.14.0  | MCP server for Claude Desktop/Code and any MCP client |
-| [@jungjaehoon/mama-core](packages/mama-core/)    | 1.7.0   | Core memory, provenance, raw refs, graph, embeddings  |
+| [@jungjaehoon/mama-core](packages/mama-core/)    | 1.8.1   | Core memory, provenance, raw refs, graph, embeddings  |
 | [mama plugin](packages/claude-code-plugin/)      | 1.10.0  | Claude Code plugin (marketplace)                      |
 | [memorybench](packages/memorybench/)             | 1.0.0   | Memory retrieval benchmarking framework               |
 

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -256,7 +256,7 @@ pnpm clean
 
 Each package has independent versioning:
 
-- **mama-core:** 1.7.0 (stable API)
+- **mama-core:** 1.8.1 (stable API)
 - **mama-server:** 1.14.0 (follows MAMA version)
 - **claude-code-plugin:** 1.10.0 (follows MAMA version)
 - **mama-os:** 0.20.1 (standalone agent)

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -12,7 +12,7 @@ MAMA is a pnpm workspace-based monorepo with four packages:
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
 | MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.20.1  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.14.0  |
-| MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 1.7.0   |
+| MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 1.8.1   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.10.0  |
 
 ---
@@ -62,7 +62,7 @@ Synchronize versions across these files before deployment:
 | -------------------------------------------------------- | --------- | --------------- |
 | `packages/standalone/package.json`                       | `version` | 0.20.1          |
 | `packages/mcp-server/package.json`                       | `version` | 1.14.0          |
-| `packages/mama-core/package.json`                        | `version` | 1.7.0           |
+| `packages/mama-core/package.json`                        | `version` | 1.8.1           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.10.0          |
 | `packages/claude-code-plugin/.claude-plugin/plugin.json` | `version` | 1.10.0          |
 

--- a/packages/standalone/src/scheduler/cron-worker.ts
+++ b/packages/standalone/src/scheduler/cron-worker.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import { randomUUID } from 'node:crypto';
 import { PersistentClaudeProcess } from '../agent/persistent-cli-process.js';
 
 const CRON_SYSTEM_PROMPT = `You are a cron job executor. Execute the given task and return the result.
@@ -54,7 +55,8 @@ export class CronWorker {
   private ensureCLI(): PersistentClaudeProcess {
     if (!this.cli) {
       this.cli = new PersistentClaudeProcess({
-        sessionId: `cron-worker-${Date.now()}`,
+        // Claude CLI validates --session-id as a UUID; anything else fails every run
+        sessionId: randomUUID(),
         model: this.model,
         systemPrompt: this.systemPrompt,
         dangerouslySkipPermissions: true,

--- a/packages/standalone/tests/api/cron-handler.test.ts
+++ b/packages/standalone/tests/api/cron-handler.test.ts
@@ -2,30 +2,38 @@
  * Unit tests for Cron API handler
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import express from 'express';
-
-// The router's syncJobsToConfig persists scheduler state through the real
-// config-manager; without this mock every suite run rewrites the developer's
-// live ~/.mama/config.yaml (the daemon then keeps executing leftover jobs).
-vi.mock('../../src/cli/config/config-manager.js', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../../src/cli/config/config-manager.js')>()),
-  loadConfig: vi.fn(async () => ({})),
-  saveConfig: vi.fn(async () => undefined),
-}));
-
+import { mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { createCronRouter, InMemoryLogStore } from '../../src/api/cron-handler.js';
 import { errorHandler, notFoundHandler } from '../../src/api/error-handler.js';
 import { CronScheduler } from '../../src/scheduler/index.js';
-import { saveConfig } from '../../src/cli/config/config-manager.js';
+import { loadConfig, saveConfig } from '../../src/cli/config/config-manager.js';
+import { DEFAULT_CONFIG } from '../../src/cli/config/types.js';
 
 describe('Cron API', () => {
   let app: express.Express;
   let scheduler: CronScheduler;
   let logStore: InMemoryLogStore;
+  let testDir: string;
+  let originalHome: string | undefined;
 
-  beforeEach(() => {
+  // The router's syncJobsToConfig persists scheduler state through the real
+  // config-manager (~/.mama/config.yaml). Sandbox HOME so suite runs never
+  // touch the developer's live config (which left hourly "Test" jobs behind).
+  beforeEach(async () => {
+    testDir = join(
+      tmpdir(),
+      `mama-cron-handler-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    await mkdir(join(testDir, '.mama'), { recursive: true });
+    originalHome = process.env.HOME;
+    process.env.HOME = testDir;
+    await saveConfig(DEFAULT_CONFIG);
+
     scheduler = new CronScheduler();
     logStore = new InMemoryLogStore();
 
@@ -36,8 +44,14 @@ describe('Cron API', () => {
     app.use(errorHandler);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     scheduler.shutdown();
+    if (originalHome !== undefined) {
+      process.env.HOME = originalHome;
+    } else {
+      delete process.env.HOME;
+    }
+    await rm(testDir, { recursive: true, force: true });
   });
 
   describe('GET /api/cron', () => {
@@ -463,10 +477,8 @@ describe('Cron API', () => {
     });
   });
 
-  describe('config persistence isolation', () => {
-    it('should persist created jobs through config-manager saveConfig', async () => {
-      vi.mocked(saveConfig).mockClear();
-
+  describe('config persistence', () => {
+    it('should round-trip the created job into config.yaml with the mapped shape', async () => {
       const res = await request(app).post('/api/cron').send({
         name: 'Persisted Job',
         cron_expr: '0 * * * *',
@@ -474,12 +486,18 @@ describe('Cron API', () => {
       });
 
       expect(res.status).toBe(200);
-      expect(saveConfig).toHaveBeenCalledTimes(1);
-      const savedConfig = vi.mocked(saveConfig).mock.calls[0][0] as {
-        scheduling?: { jobs?: Array<{ name: string }> };
-      };
-      expect(savedConfig.scheduling?.jobs).toHaveLength(1);
-      expect(savedConfig.scheduling?.jobs?.[0].name).toBe('Persisted Job');
+
+      const persisted = (await loadConfig()) as Record<string, unknown>;
+      const scheduling = persisted.scheduling as { jobs?: unknown[] } | undefined;
+      expect(scheduling?.jobs).toEqual([
+        expect.objectContaining({
+          id: res.body.id,
+          name: 'Persisted Job',
+          cron: '0 * * * *',
+          prompt: 'do the thing',
+          enabled: true,
+        }),
+      ]);
     });
   });
 });

--- a/packages/standalone/tests/api/cron-handler.test.ts
+++ b/packages/standalone/tests/api/cron-handler.test.ts
@@ -2,12 +2,23 @@
  * Unit tests for Cron API handler
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import request from 'supertest';
 import express from 'express';
+
+// The router's syncJobsToConfig persists scheduler state through the real
+// config-manager; without this mock every suite run rewrites the developer's
+// live ~/.mama/config.yaml (the daemon then keeps executing leftover jobs).
+vi.mock('../../src/cli/config/config-manager.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/cli/config/config-manager.js')>()),
+  loadConfig: vi.fn(async () => ({})),
+  saveConfig: vi.fn(async () => undefined),
+}));
+
 import { createCronRouter, InMemoryLogStore } from '../../src/api/cron-handler.js';
 import { errorHandler, notFoundHandler } from '../../src/api/error-handler.js';
 import { CronScheduler } from '../../src/scheduler/index.js';
+import { saveConfig } from '../../src/cli/config/config-manager.js';
 
 describe('Cron API', () => {
   let app: express.Express;
@@ -449,6 +460,26 @@ describe('Cron API', () => {
         );
 
       expect(res.status).toBe(200);
+    });
+  });
+
+  describe('config persistence isolation', () => {
+    it('should persist created jobs through config-manager saveConfig', async () => {
+      vi.mocked(saveConfig).mockClear();
+
+      const res = await request(app).post('/api/cron').send({
+        name: 'Persisted Job',
+        cron_expr: '0 * * * *',
+        prompt: 'do the thing',
+      });
+
+      expect(res.status).toBe(200);
+      expect(saveConfig).toHaveBeenCalledTimes(1);
+      const savedConfig = vi.mocked(saveConfig).mock.calls[0][0] as {
+        scheduling?: { jobs?: Array<{ name: string }> };
+      };
+      expect(savedConfig.scheduling?.jobs).toHaveLength(1);
+      expect(savedConfig.scheduling?.jobs?.[0].name).toBe('Persisted Job');
     });
   });
 });

--- a/packages/standalone/tests/scheduler/cron-worker.test.ts
+++ b/packages/standalone/tests/scheduler/cron-worker.test.ts
@@ -50,9 +50,10 @@ describe('CronWorker', () => {
 
       expect(PersistentClaudeProcess).toHaveBeenCalledWith(
         expect.objectContaining({
-          // Claude CLI rejects non-UUID --session-id values ("Invalid session ID")
+          // Claude CLI rejects non-UUID --session-id values ("Invalid session ID");
+          // randomUUID() emits v4: version nibble '4', variant nibble '8'-'b'
           sessionId: expect.stringMatching(
-            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+            /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
           ),
           model: 'claude-haiku-4-5-20251001',
           dangerouslySkipPermissions: true,

--- a/packages/standalone/tests/scheduler/cron-worker.test.ts
+++ b/packages/standalone/tests/scheduler/cron-worker.test.ts
@@ -50,7 +50,10 @@ describe('CronWorker', () => {
 
       expect(PersistentClaudeProcess).toHaveBeenCalledWith(
         expect.objectContaining({
-          sessionId: expect.stringMatching(/^cron-worker-\d+$/),
+          // Claude CLI rejects non-UUID --session-id values ("Invalid session ID")
+          sessionId: expect.stringMatching(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+          ),
           model: 'claude-haiku-4-5-20251001',
           dangerouslySkipPermissions: true,
           allowedTools: ['Bash', 'Read', 'Write', 'Glob', 'Grep'],


### PR DESCRIPTION
## Problem

The live daemon log accumulated **1,204** `Invalid session ID. Must be a valid UUID` errors with **zero** `[Cron] Completed` entries. Two independent root causes:

1. **CronWorker passed a non-UUID session id to the CLI.** `cron-worker.ts` used `cron-worker-${Date.now()}` as `sessionId`, which `persistent-cli-process` forwards as `--session-id`. The Claude CLI validates it as a UUID, so **every config-driven cron job failed on every run**.

2. **cron-handler tests polluted the real `~/.mama/config.yaml`.** `syncJobsToConfig` writes through the real config-manager, and `tests/api/cron-handler.test.ts` never mocked it — every `pnpm test` run left an enabled hourly `Test` job in the developer's live config (verified: job ids in config matched test-run timestamps exactly). The daemon then executed that leftover job hourly, hitting bug #1 each time.

## Fix

- `cron-worker.ts`: `sessionId: randomUUID()` (same pattern as `mama-core-init.ts`); one CLI session is still reused across executions.
- `cron-worker.test.ts`: session id assertion now requires a UUID (previous assertion had codified the bug).
- `cron-handler.test.ts`: mock the config-manager module; new test asserts persistence goes through `saveConfig`. Verified the suite no longer touches the real config file (mtime/size identical before/after).

## Verification

- `tests/scheduler/` 121/121, `tests/api/cron-handler.test.ts` 32/32, full standalone suite 3,333 passed
- `pnpm typecheck` clean
- Live: leftover Test job deleted via `DELETE /api/cron/:id`, config resynced to `jobs: []`

(README/docs 1.7.0→1.8.1 version bumps were auto-applied by the pre-commit doc-sync hook.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documented MAMA Core version references from 1.7.0 to 1.8.1 across package, architecture, and deployment guides.

* **Bug Fixes**
  * Improved scheduled task session identification by using unique UUIDs, reducing potential session collisions.
  * Prevented cron API tests from writing to real configuration files while verifying configuration persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->