### PR TITLE
feat(ui): M7 operator viewer phase 1 -- Kagemusha-style board at /ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ packages/standalone/bench/results/*.json
 
 # PII patterns (local only, never commit)
 .pii-patterns
+/packages/standalone/public/ui/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **Operator board (beta) at `/ui`** — New Kagemusha-style React viewer served next
+  to the legacy `/viewer`: agent-published report slots render live over SSE
+  (DOMPurify + `script-src 'self'` CSP), with trigger stat cards and an owner
+  veto tray backed by the new `/api/operator` endpoints. Report slots now
+  persist across daemon restarts (`~/.mama/report-slots.json`).
+- **Unconditional multi-slot report publishing** — `report_publish` is no longer
+  gated on the dashboard agent being configured and no longer drops every slot
+  except `briefing`; `createReportPublisher` is the single write path (64KB/slot,
+  24-slot caps, loud skips) reused by the heartbeat briefing writer.
 - **Message-router memory policy opt-ins** — Added `memory_policy.implicit_recall`
   and `memory_policy.implicit_legacy_context_search`, plus matching environment
   variable overrides, so startup-prompt memory recall and legacy context search

--- a/docs/guides/standalone-setup.md
+++ b/docs/guides/standalone-setup.md
@@ -515,7 +515,12 @@ Gateways:
 HTTP Server: http://localhost:3847
   Graph Viewer: http://localhost:3847/viewer
   Chat Shell: http://localhost:3847/viewer (floating overlay)
+  Operator Board (beta): http://localhost:3847/ui
 ```
+
+The Operator Board renders agent-published report slots live (SSE) with trigger
+stats and an owner veto tray. Agents feed it through the `report_publish` gateway
+tool; the heartbeat briefing fills the first slot automatically.
 
 ### Step 3: Test the Agent
 

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -11,7 +11,9 @@
   },
   "scripts": {
     "postinstall": "node scripts/postinstall.js",
-    "build": "tsc && pnpm exec tsx scripts/generate-gateway-tools.ts && rm -rf public/viewer/js && tsc -p public/viewer/tsconfig.viewer.json",
+    "build": "tsc && pnpm exec tsx scripts/generate-gateway-tools.ts && rm -rf public/viewer/js && tsc -p public/viewer/tsconfig.viewer.json && pnpm run build:ui",
+    "build:ui": "pnpm --dir ui run build",
+    "dev:ui": "pnpm --dir ui run dev",
     "build:watch": "tsc --watch",
     "build:viewer": "rm -rf public/viewer/js && tsc -p public/viewer/tsconfig.viewer.json",
     "build:viewer:watch": "tsc -p public/viewer/tsconfig.viewer.json --watch",

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "postinstall": "node scripts/postinstall.js",
     "build": "tsc && pnpm exec tsx scripts/generate-gateway-tools.ts && rm -rf public/viewer/js && tsc -p public/viewer/tsconfig.viewer.json && pnpm run build:ui",
-    "build:ui": "pnpm --dir ui run build",
+    "build:ui": "pnpm --dir ui run bundle",
     "dev:ui": "pnpm --dir ui run dev",
     "build:watch": "tsc --watch",
     "build:viewer": "rm -rf public/viewer/js && tsc -p public/viewer/tsconfig.viewer.json",

--- a/packages/standalone/public/viewer/viewer.html
+++ b/packages/standalone/public/viewer/viewer.html
@@ -438,6 +438,10 @@
             <i data-lucide="layout-dashboard"></i>
             <span>Dashboard</span>
           </button>
+          <a class="mama-nav-item" href="/ui" title="Operator Board (beta)">
+            <i data-lucide="zap"></i>
+            <span>Operator (beta)</span>
+          </a>
           <button
             class="mama-nav-item"
             data-tab="feed"

--- a/packages/standalone/src/api/graph-api.ts
+++ b/packages/standalone/src/api/graph-api.ts
@@ -106,7 +106,9 @@ const VIEWER_FAVICON_PATH = path.join(VIEWER_DIR, '..', 'favicon.ico');
 // the MAMA_UI_DIR override works for tests without module-load ordering games.
 function getUiDirectory(): string {
   if (process.env.MAMA_UI_DIR) {
-    return process.env.MAMA_UI_DIR;
+    // resolve() drops trailing slashes; without it the `uiRoot + path.sep`
+    // traversal guard below would 404 every request for '/foo/bar/'-style values.
+    return path.resolve(process.env.MAMA_UI_DIR);
   }
   const candidateDirs = [
     path.join(process.cwd(), 'public', 'ui'),

--- a/packages/standalone/src/api/graph-api.ts
+++ b/packages/standalone/src/api/graph-api.ts
@@ -101,6 +101,46 @@ const SW_JS_PATH = path.join(VIEWER_DIR, 'sw.js');
 const MANIFEST_JSON_PATH = path.join(VIEWER_DIR, 'manifest.json');
 const VIEWER_ICON_DIR = path.join(VIEWER_DIR, 'icons');
 const VIEWER_FAVICON_PATH = path.join(VIEWER_DIR, '..', 'favicon.ico');
+
+// Operator viewer SPA (built from ui/ into public/ui/). Resolved per request so
+// the MAMA_UI_DIR override works for tests without module-load ordering games.
+function getUiDirectory(): string {
+  if (process.env.MAMA_UI_DIR) {
+    return process.env.MAMA_UI_DIR;
+  }
+  const candidateDirs = [
+    path.join(process.cwd(), 'public', 'ui'),
+    path.join(PACKAGE_ROOT_DIR, 'public', 'ui'),
+    path.join(__dirname, '../../public/ui'),
+    path.join(__dirname, '../../../public/ui'),
+    path.join(process.cwd(), 'packages', 'standalone', 'public', 'ui'),
+  ];
+  for (const candidate of candidateDirs) {
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isDirectory()) {
+      return candidate;
+    }
+  }
+  return path.join(process.cwd(), 'public', 'ui');
+}
+
+// serveStaticFile requires an explicit content type and only reads bytes (not
+// utf-8) for image/* or octet-stream -- fonts map to octet-stream for integrity.
+const UI_STATIC_MIME: Record<string, string> = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.ico': 'image/x-icon',
+  '.woff2': 'application/octet-stream',
+};
+
+// Agent-authored slot HTML renders inside this SPA. Two independent XSS layers:
+// DOMPurify at render (ui/src/api/report.ts) + this CSP on the document.
+const UI_CSP =
+  "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'";
+
 const DEFAULT_GRAPH_LIMIT = 300;
 const MAX_GRAPH_LIMIT = 2000;
 const GRAPH_PREVIEW_CHARS = 220;
@@ -1336,6 +1376,34 @@ function createGraphHandler(options: GraphHandlerOptions = {}): GraphHandlerFn {
     // Route: GET/HEAD /favicon.ico - serve favicon
     if (pathname === '/favicon.ico' && (req.method === 'GET' || req.method === 'HEAD')) {
       serveStaticFile(res, VIEWER_FAVICON_PATH, 'image/x-icon');
+      return true;
+    }
+
+    // Route: GET/HEAD /ui/* - operator viewer SPA (public/ui, Vite build)
+    if (
+      (pathname === '/ui' || pathname.startsWith('/ui/')) &&
+      (req.method === 'GET' || req.method === 'HEAD')
+    ) {
+      const uiRoot = getUiDirectory();
+      // '/ui' and '/ui/' both mean the SPA shell; slicing '/ui/' yields '' which
+      // resolves to uiRoot itself and would fail the traversal guard below.
+      const rel =
+        pathname === '/ui' || pathname === '/ui/' ? 'index.html' : pathname.slice('/ui/'.length);
+      const resolved = path.resolve(uiRoot, rel);
+      if (!resolved.startsWith(uiRoot + path.sep)) {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Not found');
+        return true;
+      }
+      const isAsset = rel.startsWith('assets/');
+      const exists = fs.existsSync(resolved) && fs.statSync(resolved).isFile();
+      // Missing hashed assets must 404 (via serveStaticFile's ENOENT path) -- an
+      // index.html fallback would mask them as 200 text/html.
+      const target = exists || isAsset ? resolved : path.join(uiRoot, 'index.html');
+      const contentType = UI_STATIC_MIME[path.extname(target)] ?? 'application/octet-stream';
+      const extraHeaders: Record<string, string> =
+        contentType === 'text/html' ? { 'Content-Security-Policy': UI_CSP } : {};
+      serveStaticFile(res, target, contentType, extraHeaders);
       return true;
     }
 

--- a/packages/standalone/src/api/index.ts
+++ b/packages/standalone/src/api/index.ts
@@ -24,7 +24,7 @@ import { CronScheduler } from '../scheduler/index.js';
 import { SkillRegistry } from '../skills/skill-registry.js';
 import type { SystemHealthReport } from '../observability/health-check.js';
 import { createSecurityMiddleware } from '../security/security-monitor.js';
-import { createReportRouter, createReportStore } from './report-handler.js';
+import { createReportRouter, createReportStore, type ReportStore } from './report-handler.js';
 import { createOperatorRouter } from './operator-handler.js';
 import { createWikiRouter } from './wiki-handler.js';
 import { createIntelligenceRouter } from './intelligence-handler.js';
@@ -71,6 +71,12 @@ export interface ApiServerOptions {
   onHeartbeat?: (prompt: string) => Promise<{ success: boolean; error?: string }>;
   /** Enable automatic process killing on port conflicts (default: false) */
   enableAutoKillPort?: boolean;
+  /**
+   * Report slot store (default: in-memory). The daemon runtime injects the
+   * persistent store; the in-memory default keeps every test call site free
+   * of real ~/.mama file writes.
+   */
+  reportStore?: ReportStore;
   /** Sessions database instance (for token tracking) */
   db?: SQLiteDatabase;
   /** Memory database instance (for intelligence queries — mama-memory.db) */
@@ -279,7 +285,7 @@ export function createApiServer(options: ApiServerOptions): ApiServer {
 
   // Mount report store (created early so intelligence router can reference it)
   const reportSseClients = new Set<ServerResponse>();
-  const reportStore = createReportStore();
+  const reportStore = options.reportStore ?? createReportStore();
 
   // Mount token router if database is available
   if (db) {

--- a/packages/standalone/src/api/index.ts
+++ b/packages/standalone/src/api/index.ts
@@ -25,6 +25,7 @@ import { SkillRegistry } from '../skills/skill-registry.js';
 import type { SystemHealthReport } from '../observability/health-check.js';
 import { createSecurityMiddleware } from '../security/security-monitor.js';
 import { createReportRouter, createReportStore } from './report-handler.js';
+import { createOperatorRouter } from './operator-handler.js';
 import { createWikiRouter } from './wiki-handler.js';
 import { createIntelligenceRouter } from './intelligence-handler.js';
 import { createConnectorFeedRouter } from './connector-feed-handler.js';
@@ -231,6 +232,12 @@ export function createApiServer(options: ApiServerOptions): ApiServer {
 
   app.use('/api/cron', cronRouter);
   app.use('/api/heartbeat', heartbeatRouter);
+  // Lazy-opening router: touches ~/.mama/operator/triggers.db only on first
+  // /api/operator request, so createApiServer stays side-effect-free for tests.
+  app.use(
+    '/api/operator',
+    createOperatorRouter({ dbPath: join(homedir(), '.mama', 'operator', 'triggers.db') })
+  );
 
   if (memoryDb) {
     app.use(

--- a/packages/standalone/src/api/operator-handler.ts
+++ b/packages/standalone/src/api/operator-handler.ts
@@ -1,0 +1,89 @@
+/**
+ * /api/operator -- read-mostly operator surface for the /ui board.
+ *
+ * Reads the trigger loop's own store (~/.mama/operator/triggers.db by default)
+ * through a second in-process connection. triggers.db uses the default rollback
+ * journal (TriggerRegistry sets no WAL pragma), so this connection sets an
+ * explicit busy_timeout: reads and the rare owner disable() retry instead of
+ * throwing SQLITE_BUSY when the loop holds the file.
+ *
+ * The dbPath is injection-only: tests pass a temp path; the production path is
+ * resolved solely at the mount site in api/index.ts (never inside this module).
+ */
+
+import { Router } from 'express';
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import Database from '../sqlite.js';
+import { TriggerRegistry } from '../operator/trigger-registry.js';
+import type { TriggerRecord } from '../operator/trigger-types.js';
+
+/** TriggerRecord nests counters (stats.*) -- flatten explicitly, never spread. */
+function toWire(t: TriggerRecord) {
+  return {
+    id: t.id,
+    kind: t.kind,
+    memoryQuery: t.memoryQuery,
+    status: t.status,
+    authoredBy: t.authoredBy,
+    createdAt: t.createdAt,
+    fired: t.stats.fired,
+    succeeded: t.stats.succeeded,
+    failed: t.stats.failed,
+    disabledReason: t.disabledReason ?? null,
+  };
+}
+
+export function createOperatorRouter(opts: { dbPath: string }): Router {
+  // Lazy open on first request: createApiServer mounts this router in ~30
+  // existing tests that never call /api/operator -- an eager open would touch
+  // the real ~/.mama path from every one of them (the PR #126 pollution class)
+  // and crash on fresh installs where the parent directory does not exist yet.
+  let registry: TriggerRegistry | null = null;
+  const getRegistry = (): TriggerRegistry => {
+    if (!registry) {
+      mkdirSync(dirname(opts.dbPath), { recursive: true });
+      const db = new Database(opts.dbPath);
+      db.prepare('PRAGMA busy_timeout = 5000').get();
+      registry = new TriggerRegistry(db);
+    }
+    return registry;
+  };
+  const router = Router();
+
+  router.get('/summary', (_req, res) => {
+    const all = getRegistry().listAll();
+    const active = all.filter((t) => t.status === 'active');
+    const disabled = all.filter((t) => t.status === 'disabled');
+    res.json({
+      triggers: {
+        active: active.length,
+        disabled: disabled.length,
+        fired: all.reduce((n, t) => n + t.stats.fired, 0),
+        succeeded: all.reduce((n, t) => n + t.stats.succeeded, 0),
+        failed: all.reduce((n, t) => n + t.stats.failed, 0),
+      },
+    });
+  });
+
+  router.get('/triggers', (_req, res) => {
+    res.json({ triggers: getRegistry().listAll().map(toWire) });
+  });
+
+  router.post('/triggers/:id/disable', (req, res) => {
+    const reason = (req.body as { reason?: string } | undefined)?.reason?.trim();
+    if (!reason) {
+      return res.status(400).json({ error: 'reason required' });
+    }
+    const id = req.params.id as string;
+    if (!getRegistry().getById(id)) {
+      return res.status(404).json({ error: 'trigger not found' });
+    }
+    const trigger = getRegistry().disable(id, reason);
+    // Owner veto is loud by design (observability over restriction).
+    console.log(`[operator-api] trigger ${id} disabled by owner: ${reason}`);
+    return res.json({ ok: true, trigger: toWire(trigger) });
+  });
+
+  return router;
+}

--- a/packages/standalone/src/api/report-handler.ts
+++ b/packages/standalone/src/api/report-handler.ts
@@ -64,6 +64,42 @@ export function broadcastReportUpdate(
   }
 }
 
+const MAX_SLOT_BYTES = 65_536;
+const MAX_SLOTS_PER_PUBLISH = 24;
+
+/**
+ * The single write path for agent/heartbeat report publishing: store every slot
+ * (any slot id -- the board renders known slots first, then custom), broadcast
+ * one full snapshot. Oversized slots are skipped LOUDLY, never truncated
+ * silently (observability over restriction).
+ */
+export function createReportPublisher(
+  store: ReportStore,
+  sseClients: Set<ServerResponse>
+): (slots: Record<string, string>) => void {
+  return (slots) => {
+    const entries = Object.entries(slots);
+    if (entries.length > MAX_SLOTS_PER_PUBLISH) {
+      console.warn(
+        `[Report] publish carried ${entries.length} slots; keeping the first ${MAX_SLOTS_PER_PUBLISH}`
+      );
+    }
+    const published: string[] = [];
+    for (const [slotId, html] of entries.slice(0, MAX_SLOTS_PER_PUBLISH)) {
+      if (Buffer.byteLength(html, 'utf-8') > MAX_SLOT_BYTES) {
+        console.warn(`[Report] slot '${slotId}' exceeds ${MAX_SLOT_BYTES} bytes -- skipped`);
+        continue;
+      }
+      store.update(slotId, html, store.get(slotId)?.priority ?? 0);
+      published.push(slotId);
+    }
+    broadcastReportUpdate(sseClients, { slots: store.getAllSorted() });
+    if (published.length > 0) {
+      console.log(`[Report] published slots: ${published.join(', ')}`);
+    }
+  };
+}
+
 /**
  * Create an Express Router that exposes report slot CRUD + SSE stream.
  */

--- a/packages/standalone/src/api/report-persistence.ts
+++ b/packages/standalone/src/api/report-persistence.ts
@@ -1,0 +1,64 @@
+/**
+ * ReportStore implementation that survives daemon restarts.
+ *
+ * Owns its Map directly (rather than wrapping createReportStore) so restored
+ * slots keep their original updatedAt verbatim. Writes are debounced 250ms to
+ * coalesce publish bursts into one snapshot.
+ *
+ * filePath is injection-only: the production path is resolved solely at the
+ * daemon runtime call site (api-server-init.ts), never inside this module --
+ * createApiServer's default stays the in-memory store so its ~30 test call
+ * sites never touch the real ~/.mama (the PR #126 pollution class).
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import type { ReportSlot, ReportStore } from './report-handler.js';
+
+const WRITE_DEBOUNCE_MS = 250;
+
+export function createPersistentReportStore(opts: { filePath: string }): ReportStore {
+  const slots = new Map<string, ReportSlot>();
+
+  if (existsSync(opts.filePath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(opts.filePath, 'utf-8')) as Record<string, ReportSlot>;
+      for (const [id, slot] of Object.entries(parsed)) {
+        slots.set(id, slot);
+      }
+    } catch (err) {
+      // fail loud, start empty -- a corrupt snapshot must never take the board down
+      console.warn(`[Report] corrupt slot snapshot at ${opts.filePath}, starting empty:`, err);
+    }
+  }
+
+  let writeTimer: ReturnType<typeof setTimeout> | null = null;
+  const scheduleWrite = (): void => {
+    if (writeTimer) clearTimeout(writeTimer);
+    writeTimer = setTimeout(() => {
+      writeTimer = null;
+      try {
+        mkdirSync(dirname(opts.filePath), { recursive: true });
+        writeFileSync(opts.filePath, JSON.stringify(Object.fromEntries(slots)), 'utf-8');
+      } catch (err) {
+        console.warn(`[Report] failed to persist slots to ${opts.filePath}:`, err);
+      }
+    }, WRITE_DEBOUNCE_MS);
+    // Never keep the daemon alive just to flush a board snapshot.
+    writeTimer.unref?.();
+  };
+
+  return {
+    get: (slotId) => slots.get(slotId),
+    update(slotId, html, priority) {
+      slots.set(slotId, { slotId, html, priority, updatedAt: Date.now() });
+      scheduleWrite();
+    },
+    delete(slotId) {
+      slots.delete(slotId);
+      scheduleWrite();
+    },
+    getAll: () => Object.fromEntries(slots),
+    getAllSorted: () => Array.from(slots.values()).sort((a, b) => a.priority - b.priority),
+  };
+}

--- a/packages/standalone/src/api/report-persistence.ts
+++ b/packages/standalone/src/api/report-persistence.ts
@@ -17,6 +17,20 @@ import type { ReportSlot, ReportStore } from './report-handler.js';
 
 const WRITE_DEBOUNCE_MS = 250;
 
+// One process-exit hook flushes every store's pending debounced write, so a
+// publish landing right before a graceful stop (SIGTERM path) is not lost.
+// SIGKILL restarts still lose the window -- unavoidable, and self-healing on
+// the next publish.
+const pendingExitFlushes = new Set<() => void>();
+let exitHookInstalled = false;
+function installExitHook(): void {
+  if (exitHookInstalled) return;
+  exitHookInstalled = true;
+  process.on('exit', () => {
+    for (const flush of pendingExitFlushes) flush();
+  });
+}
+
 export function createPersistentReportStore(opts: { filePath: string }): ReportStore {
   const slots = new Map<string, ReportSlot>();
 
@@ -33,16 +47,29 @@ export function createPersistentReportStore(opts: { filePath: string }): ReportS
   }
 
   let writeTimer: ReturnType<typeof setTimeout> | null = null;
+  const writeSnapshot = (): void => {
+    try {
+      mkdirSync(dirname(opts.filePath), { recursive: true });
+      writeFileSync(opts.filePath, JSON.stringify(Object.fromEntries(slots)), 'utf-8');
+    } catch (err) {
+      console.warn(`[Report] failed to persist slots to ${opts.filePath}:`, err);
+    }
+  };
+
+  const flushPending = (): void => {
+    if (!writeTimer) return;
+    clearTimeout(writeTimer);
+    writeTimer = null;
+    writeSnapshot();
+  };
+  installExitHook();
+  pendingExitFlushes.add(flushPending);
+
   const scheduleWrite = (): void => {
     if (writeTimer) clearTimeout(writeTimer);
     writeTimer = setTimeout(() => {
       writeTimer = null;
-      try {
-        mkdirSync(dirname(opts.filePath), { recursive: true });
-        writeFileSync(opts.filePath, JSON.stringify(Object.fromEntries(slots)), 'utf-8');
-      } catch (err) {
-        console.warn(`[Report] failed to persist slots to ${opts.filePath}:`, err);
-      }
+      writeSnapshot();
     }, WRITE_DEBOUNCE_MS);
     // Never keep the daemon alive just to flush a board snapshot.
     writeTimer.unref?.();

--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -314,27 +314,17 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
     }
   }
 
+  // report_publish is a core surface (feeds the /ui operator board), not a
+  // multi-agent feature: wire it unconditionally. All slot ids are accepted;
+  // size/count caps and loud logging live in createReportPublisher.
+  {
+    const { createReportPublisher } = await import('../../api/report-handler.js');
+    toolExecutor.setReportPublisher(
+      createReportPublisher(apiServer.reportStore, apiServer.reportSseClients)
+    );
+  }
+
   if (dashboardAgentConfigured) {
-    const { broadcastReportUpdate } = await import('../../api/report-handler.js');
-
-    // Wire report_publish tool to Dashboard Agent — only briefing slot
-    toolExecutor.setReportPublisher((slots) => {
-      for (const [slotId, html] of Object.entries(slots)) {
-        if (slotId !== 'briefing') continue; // only accept briefing slot
-        apiServer.reportStore.update(slotId, html, 0);
-      }
-      broadcastReportUpdate(apiServer.reportSseClients, {
-        slots: apiServer.reportStore.getAllSorted(),
-      });
-      routesLogger.debug(`[Report] Agent published briefing slot`);
-      eventBus.emit({
-        type: 'agent:action',
-        agent: 'dashboard-agent',
-        action: 'publish',
-        target: 'briefing',
-      });
-    });
-
     // ── Dashboard Agent ───────────────────────────────────────────────
     const { ensureDashboardPersona } = await import('../../multi-agent/dashboard-agent-persona.js');
     ensureDashboardPersona();

--- a/packages/standalone/src/cli/runtime/api-server-init.ts
+++ b/packages/standalone/src/cli/runtime/api-server-init.ts
@@ -7,9 +7,11 @@
  */
 
 import { join } from 'node:path';
+import { homedir } from 'node:os';
 
 import { createApiServer } from '../../api/index.js';
 import type { ApiServer } from '../../api/index.js';
+import { createPersistentReportStore } from '../../api/report-persistence.js';
 import type { AgentSituationAdapter } from '../../api/agent-situation-handler.js';
 import {
   createContextCompileService,
@@ -114,6 +116,11 @@ export async function initApiServer(params: InitApiServerParams): Promise<InitAp
   const apiServer = createApiServer({
     scheduler,
     port: API_PORT,
+    // Daemon runtime is the ONLY place the persistent store is wired; the
+    // in-memory default keeps test call sites off the real ~/.mama.
+    reportStore: createPersistentReportStore({
+      filePath: join(homedir(), '.mama', 'report-slots.json'),
+    }),
     db,
     memoryDb: memoryDb as unknown as SQLiteDatabase,
     memoryAdapter: mamaCoreAdapter,

--- a/packages/standalone/src/cli/runtime/api-server-init.ts
+++ b/packages/standalone/src/cli/runtime/api-server-init.ts
@@ -130,17 +130,15 @@ export async function initApiServer(params: InitApiServerParams): Promise<InitAp
     onHeartbeat: async (prompt) => {
       try {
         const result = await agentLoop.run(prompt);
-        // Capture agent's text response and use it as the briefing slot
-        const { broadcastReportUpdate: broadcast } = await import('../../api/report-handler.js');
+        // Capture agent's text response and use it as the briefing slot,
+        // through the same single write path the report_publish tool uses.
+        const { createReportPublisher } = await import('../../api/report-handler.js');
         const agentText = result?.response || '';
         if (agentText.length > 50 && apiServer.reportStore) {
           // Wrap agent's analysis in styled HTML
           const briefingHtml = `<div style="font-family:Nunito,sans-serif;font-size:13px;color:#1A1A1A;line-height:1.6">${agentText.replace(/\n/g, '<br>').replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')}</div>`;
-          apiServer.reportStore.update('briefing', briefingHtml, 0);
-          broadcast(apiServer.reportSseClients, {
-            slots: apiServer.reportStore.getAllSorted(),
-          });
-          console.log(`[Report] Agent briefing published (${agentText.length} chars)`);
+          const publish = createReportPublisher(apiServer.reportStore, apiServer.reportSseClients);
+          publish({ briefing: briefingHtml });
         }
         return { success: true };
       } catch (error) {

--- a/packages/standalone/src/multi-agent/dashboard-agent-persona.ts
+++ b/packages/standalone/src/multi-agent/dashboard-agent-persona.ts
@@ -24,7 +24,7 @@ Write only the briefing section — analysis and insights that the API does not 
 - context_compile({task, limit?, max_tool_calls?, strictness?}) — compile a scoped evidence packet for this briefing
 - mama_search({query, limit}) — fallback search when context_compile returns any non-success result (e.g. service unavailable, missing worker envelope, permission denied, or other failure)
 - agent_notices({limit}) — inspect recent agent notices for delegations, errors, and warnings
-- report_publish({slots: {briefing: "<html>"}}) — publish a briefing. Only the "briefing" slot is allowed.
+- report_publish({slots: {briefing: "<html>", ...}}) -- publish report slots to the operator board. The board renders known slots first, in this order: "briefing" (summary), "action_required", "decisions", "pipeline"; any additional custom slot ids render after them by priority.
 
 ## What to Write
 - Project status summary (3-5 lines max)

--- a/packages/standalone/src/operator/trigger-registry.ts
+++ b/packages/standalone/src/operator/trigger-registry.ts
@@ -102,6 +102,14 @@ export class TriggerRegistry {
     return rows.map(rowToRecord);
   }
 
+  /** Every trigger regardless of status (owner tray view). id DESC breaks same-ms ties. */
+  listAll(): TriggerRecord[] {
+    const rows = this.db
+      .prepare(`SELECT * FROM operator_triggers ORDER BY created_at DESC, id DESC`)
+      .all() as TriggerRow[];
+    return rows.map(rowToRecord);
+  }
+
   getById(id: string): TriggerRecord | null {
     const row = this.db.prepare(`SELECT * FROM operator_triggers WHERE id = ?`).get(id) as
       | TriggerRow
@@ -166,5 +174,6 @@ function rowToRecord(row: TriggerRow): TriggerRecord {
     updatedAt: row.updated_at,
     provenance: JSON.parse(row.provenance_json),
     stats: { fired: row.fired, succeeded: row.succeeded, failed: row.failed },
+    disabledReason: row.disabled_reason ?? undefined,
   };
 }

--- a/packages/standalone/src/operator/trigger-types.ts
+++ b/packages/standalone/src/operator/trigger-types.ts
@@ -84,7 +84,12 @@ export interface TriggerRecord {
   updatedAt: number;
   provenance: TriggerProvenance;
   stats: TriggerStats;
+  /** Owner/agent-supplied reason recorded by disable(); absent while active. */
+  disabledReason?: string;
 }
 
 /** Input to author a trigger. Server manages status/timestamps/stats. */
-export type CreateTriggerInput = Omit<TriggerRecord, 'status' | 'createdAt' | 'updatedAt' | 'stats'>;
+export type CreateTriggerInput = Omit<
+  TriggerRecord,
+  'status' | 'createdAt' | 'updatedAt' | 'stats' | 'disabledReason'
+>;

--- a/packages/standalone/tests/api/operator-handler.test.ts
+++ b/packages/standalone/tests/api/operator-handler.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for the /api/operator router (trigger stats + owner veto).
+ * The dbPath is a temp dir per test -- never the real ~/.mama (Constraint 5).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createOperatorRouter } from '../../src/api/operator-handler.js';
+import Database from '../../src/sqlite.js';
+import { TriggerRegistry } from '../../src/operator/trigger-registry.js';
+import type { CreateTriggerInput } from '../../src/operator/trigger-types.js';
+
+function sampleInput(id: string): CreateTriggerInput {
+  return {
+    id,
+    kind: 'recurring_report_request',
+    memoryQuery: 'weekly status report cadence',
+    match: { keywords: ['report'], keywordMode: 'any', minConfidence: 0.7 },
+    procedure: [{ action: 'recall_and_surface', description: 'surface the cadence memory' }],
+    requiredEvidence: ['current_message'],
+    authoredBy: 'agent',
+    provenance: { createdFrom: 'agent-authored', note: '' },
+  };
+}
+
+describe('Operator API', () => {
+  let dir: string;
+  let dbPath: string;
+  let app: express.Express;
+  let seedReg: TriggerRegistry;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'operator-api-'));
+    dbPath = join(dir, 'triggers.db');
+    seedReg = new TriggerRegistry(new Database(dbPath));
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/operator', createOperatorRouter({ dbPath }));
+  });
+
+  afterEach(() => {
+    seedReg.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('GET /summary aggregates trigger counters across statuses', async () => {
+    seedReg.create(sampleInput('t1'));
+    seedReg.recordOutcome('t1', 'succeeded');
+    seedReg.recordOutcome('t1', 'succeeded');
+    seedReg.recordOutcome('t1', 'failed');
+    seedReg.create(sampleInput('t2'));
+    seedReg.disable('t2', 'noisy');
+
+    const res = await request(app).get('/api/operator/summary');
+
+    expect(res.status).toBe(200);
+    expect(res.body.triggers).toEqual({
+      active: 1,
+      disabled: 1,
+      fired: 3,
+      succeeded: 2,
+      failed: 1,
+    });
+  });
+
+  it('GET /summary returns zeros on an empty registry (fresh install)', async () => {
+    const res = await request(app).get('/api/operator/summary');
+
+    expect(res.status).toBe(200);
+    expect(res.body.triggers).toEqual({
+      active: 0,
+      disabled: 0,
+      fired: 0,
+      succeeded: 0,
+      failed: 0,
+    });
+  });
+
+  it('GET /triggers lists all statuses newest first with flat counters', async () => {
+    seedReg.create(sampleInput('t1'));
+    seedReg.recordFire('t1');
+    seedReg.create(sampleInput('t2'));
+    seedReg.disable('t2', 'owner veto');
+
+    const res = await request(app).get('/api/operator/triggers');
+
+    expect(res.status).toBe(200);
+    expect(res.body.triggers.map((t: { id: string }) => t.id)).toEqual(['t2', 't1']);
+    expect(res.body.triggers[0]).toMatchObject({
+      status: 'disabled',
+      disabledReason: 'owner veto',
+      fired: 0,
+    });
+    expect(res.body.triggers[1]).toMatchObject({
+      status: 'active',
+      disabledReason: null,
+      fired: 1,
+    });
+  });
+
+  it('POST /triggers/:id/disable stores the reason', async () => {
+    seedReg.create(sampleInput('t1'));
+
+    const res = await request(app)
+      .post('/api/operator/triggers/t1/disable')
+      .send({ reason: 'owner veto' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.trigger).toMatchObject({ status: 'disabled', disabledReason: 'owner veto' });
+    expect(seedReg.getById('t1')?.status).toBe('disabled');
+  });
+
+  it('POST disable without reason returns 400; unknown id returns 404', async () => {
+    seedReg.create(sampleInput('t1'));
+
+    const noReason = await request(app).post('/api/operator/triggers/t1/disable').send({});
+    expect(noReason.status).toBe(400);
+
+    const unknown = await request(app)
+      .post('/api/operator/triggers/nope/disable')
+      .send({ reason: 'x' });
+    expect(unknown.status).toBe(404);
+  });
+});

--- a/packages/standalone/tests/api/report-handler.test.ts
+++ b/packages/standalone/tests/api/report-handler.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   createReportStore,
+  createReportPublisher,
   broadcastReportUpdate,
   type ReportStore,
 } from '../../src/api/report-handler.js';
@@ -76,5 +77,56 @@ describe('broadcastReportUpdate', () => {
     expect(written).toHaveLength(2);
     expect(written[0]).toContain('event: report-update');
     expect(written[0]).toContain('"slot":"briefing"');
+  });
+});
+
+describe('createReportPublisher', () => {
+  it('publishes multiple slots and broadcasts one full snapshot', () => {
+    const store = createReportStore();
+    const written: string[] = [];
+    const clients = new Set<{ write: (d: string) => void }>([
+      { write: (d: string) => written.push(d) },
+    ]);
+    const publish = createReportPublisher(
+      store,
+      clients as unknown as Set<import('node:http').ServerResponse>
+    );
+
+    publish({ briefing: '<p>b</p>', action_required: '<p>a</p>' });
+
+    expect(store.get('briefing')?.html).toBe('<p>b</p>');
+    expect(store.get('action_required')?.html).toBe('<p>a</p>');
+    expect(written).toHaveLength(1);
+    expect(written[0]).toContain('"slots"');
+  });
+
+  it('skips an oversized slot loudly and keeps the rest', () => {
+    const store = createReportStore();
+    const publish = createReportPublisher(
+      store,
+      new Set() as unknown as Set<import('node:http').ServerResponse>
+    );
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    publish({ ok: '<p>x</p>', huge: 'x'.repeat(70_000) });
+
+    expect(store.get('ok')).toBeDefined();
+    expect(store.get('huge')).toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('preserves an existing slot priority on republish', () => {
+    const store = createReportStore();
+    store.update('briefing', '<p>old</p>', 7);
+    const publish = createReportPublisher(
+      store,
+      new Set() as unknown as Set<import('node:http').ServerResponse>
+    );
+
+    publish({ briefing: '<p>new</p>' });
+
+    expect(store.get('briefing')?.html).toBe('<p>new</p>');
+    expect(store.get('briefing')?.priority).toBe(7);
   });
 });

--- a/packages/standalone/tests/api/report-persistence.test.ts
+++ b/packages/standalone/tests/api/report-persistence.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Persistent report store -- slots survive daemon restarts.
+ * filePath is injected per test (Constraint 5: never the real ~/.mama).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createPersistentReportStore } from '../../src/api/report-persistence.js';
+
+const flushDebounce = () => new Promise((resolve) => setTimeout(resolve, 350));
+
+describe('createPersistentReportStore', () => {
+  let dir: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'report-persist-'));
+    filePath = join(dir, 'report-slots.json');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('restores slots from disk on creation, preserving updatedAt', async () => {
+    const a = createPersistentReportStore({ filePath });
+    a.update('briefing', '<p>persisted</p>', 3);
+    const savedAt = a.get('briefing')!.updatedAt;
+    await flushDebounce();
+    expect(existsSync(filePath)).toBe(true);
+
+    const b = createPersistentReportStore({ filePath });
+    expect(b.get('briefing')?.html).toBe('<p>persisted</p>');
+    expect(b.get('briefing')?.priority).toBe(3);
+    expect(b.get('briefing')?.updatedAt).toBe(savedAt);
+  });
+
+  it('starts empty and warns when the snapshot is corrupt', () => {
+    writeFileSync(filePath, '{not json');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const store = createPersistentReportStore({ filePath });
+
+    expect(store.getAllSorted()).toEqual([]);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('persists deletions and coalesces bursts into one snapshot', async () => {
+    const a = createPersistentReportStore({ filePath });
+    a.update('one', '<p>1</p>', 0);
+    a.update('two', '<p>2</p>', 1);
+    a.delete('one');
+    await flushDebounce();
+
+    const b = createPersistentReportStore({ filePath });
+    expect(b.get('one')).toBeUndefined();
+    expect(b.get('two')?.html).toBe('<p>2</p>');
+    expect(b.getAllSorted()).toHaveLength(1);
+  });
+});

--- a/packages/standalone/tests/api/ui-static-serving.test.ts
+++ b/packages/standalone/tests/api/ui-static-serving.test.ts
@@ -104,4 +104,11 @@ describe('/ui static serving', () => {
     const res = await requestGraph('/ui');
     expect(res.headers['content-security-policy']).toContain("script-src 'self'");
   });
+
+  it('tolerates a trailing slash in MAMA_UI_DIR', async () => {
+    process.env.MAMA_UI_DIR = `${uiDir}/`;
+    const res = await requestGraph('/ui');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+  });
 });

--- a/packages/standalone/tests/api/ui-static-serving.test.ts
+++ b/packages/standalone/tests/api/ui-static-serving.test.ts
@@ -1,0 +1,107 @@
+/**
+ * /ui static serving -- operator viewer SPA (public/ui, built by ui/).
+ *
+ * Uses the MAMA_UI_DIR env override so tests never depend on a real Vite build
+ * artifact (and never read outside the temp fixture).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { IncomingMessage, ServerResponse } from 'http';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createGraphHandler } from '../../src/api/graph-api.js';
+
+function createMockRes() {
+  return {
+    _status: 0,
+    _body: '' as string | Buffer,
+    _headers: {} as Record<string, string>,
+    setHeader(name: string, value: string) {
+      this._headers[name.toLowerCase()] = value;
+    },
+    writeHead(status: number, headers?: Record<string, string>) {
+      this._status = status;
+      for (const [k, v] of Object.entries(headers ?? {})) {
+        this._headers[k.toLowerCase()] = v;
+      }
+    },
+    end(body?: string | Buffer) {
+      this._body = body ?? '';
+    },
+  };
+}
+
+async function requestGraph(pathname: string) {
+  const handler = createGraphHandler({});
+  const req = {
+    method: 'GET',
+    url: pathname,
+    headers: { host: 'localhost' },
+    socket: { remoteAddress: '127.0.0.1' },
+  } as IncomingMessage;
+  const res = createMockRes();
+  const handled = await handler(req, res as unknown as ServerResponse);
+  return { handled, status: res._status, headers: res._headers, body: res._body };
+}
+
+describe('/ui static serving', () => {
+  let uiDir: string;
+
+  beforeEach(() => {
+    uiDir = join(tmpdir(), `mama-ui-static-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(join(uiDir, 'assets'), { recursive: true });
+    writeFileSync(join(uiDir, 'index.html'), '<!doctype html><div id="root"></div>');
+    writeFileSync(join(uiDir, 'assets', 'app.js'), 'console.log(1);');
+    process.env.MAMA_UI_DIR = uiDir;
+  });
+
+  afterEach(() => {
+    delete process.env.MAMA_UI_DIR;
+    rmSync(uiDir, { recursive: true, force: true });
+  });
+
+  it('serves /ui as the SPA index.html', async () => {
+    const res = await requestGraph('/ui');
+    expect(res.handled).toBe(true);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+  });
+
+  it('serves /ui/ (trailing slash) as index.html', async () => {
+    const res = await requestGraph('/ui/');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+  });
+
+  it('serves hashed assets with a js content type', async () => {
+    const res = await requestGraph('/ui/assets/app.js');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('javascript');
+  });
+
+  it('SPA-falls back unknown /ui routes to index.html', async () => {
+    const res = await requestGraph('/ui/triggers');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+  });
+
+  it('does NOT fall back for missing assets -- real 404', async () => {
+    const res = await requestGraph('/ui/assets/gone.js');
+    expect(res.status).toBe(404);
+  });
+
+  it('never serves files above the ui root for traversal attempts', async () => {
+    // WHATWG URL parsing normalizes dot segments before routing, so this never
+    // reaches the /ui route (handled=false); the in-route resolve() guard is
+    // defense-in-depth for any non-normalizing caller. Either way: no 200.
+    const res = await requestGraph('/ui/../../etc/passwd');
+    expect(res.status === 404 || res.handled === false).toBe(true);
+    expect(res.status).not.toBe(200);
+  });
+
+  it('sets a script-src-self CSP on the SPA document', async () => {
+    const res = await requestGraph('/ui');
+    expect(res.headers['content-security-policy']).toContain("script-src 'self'");
+  });
+});

--- a/packages/standalone/tests/operator/trigger-registry.test.ts
+++ b/packages/standalone/tests/operator/trigger-registry.test.ts
@@ -77,4 +77,15 @@ describe('TriggerRegistry', () => {
   it('recordFire on unknown id throws (no-fallback)', () => {
     expect(() => reg.recordFire('nope')).toThrow();
   });
+
+  it('listAll returns active and disabled triggers, newest first, with disabledReason', () => {
+    reg.create(sampleInput('t6'));
+    reg.create(sampleInput('t7'));
+    reg.disable('t7', 'noisy');
+    const all = reg.listAll();
+    expect(all.map((r) => r.id)).toEqual(['t7', 't6']);
+    expect(all[0].status).toBe('disabled');
+    expect(all[0].disabledReason).toBe('noisy');
+    expect(all[1].disabledReason).toBeUndefined();
+  });
 });

--- a/packages/standalone/tests/ui/report-merge.test.ts
+++ b/packages/standalone/tests/ui/report-merge.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure-function tests for the operator board's SSE merge + ordering logic
+ * (ui/src/api/report.ts). Node environment -- no DOM needed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mergeReportEvent, orderSlots } from '../../ui/src/api/report';
+
+describe('mergeReportEvent', () => {
+  it('replaces the record with a bulk slots snapshot', () => {
+    const prev = { stale: { slotId: 'stale', html: 'x', priority: 0, updatedAt: 1 } };
+    const next = mergeReportEvent(prev, {
+      slots: [{ slotId: 'briefing', html: '<p>x</p>', priority: 0, updatedAt: 5 }],
+    });
+    expect(next.briefing.html).toBe('<p>x</p>');
+    expect(next.stale).toBeUndefined();
+  });
+
+  it('merges a single-slot event and stamps updatedAt', () => {
+    const next = mergeReportEvent({}, { slot: 'decisions', html: '<p>d</p>', priority: 2 });
+    expect(next.decisions.html).toBe('<p>d</p>');
+    expect(next.decisions.updatedAt).toBeGreaterThan(0);
+  });
+
+  it('removes a slot on a deleted event', () => {
+    const prev = { briefing: { slotId: 'briefing', html: 'b', priority: 0, updatedAt: 1 } };
+    const next = mergeReportEvent(prev, { deleted: 'briefing' });
+    expect(next.briefing).toBeUndefined();
+  });
+
+  it('ignores malformed payloads', () => {
+    const prev = { briefing: { slotId: 'briefing', html: 'b', priority: 0, updatedAt: 1 } };
+    expect(mergeReportEvent(prev, { nonsense: true })).toEqual(prev);
+    expect(mergeReportEvent(prev, null)).toEqual(prev);
+  });
+});
+
+describe('orderSlots', () => {
+  it('orders known slots first, then custom by priority', () => {
+    const rec = {
+      zebra: { slotId: 'zebra', html: 'z', priority: 9, updatedAt: 1 },
+      alpha: { slotId: 'alpha', html: 'a', priority: 1, updatedAt: 1 },
+      pipeline: { slotId: 'pipeline', html: 'p', priority: 99, updatedAt: 1 },
+      briefing: { slotId: 'briefing', html: 'b', priority: 5, updatedAt: 1 },
+    };
+    expect(orderSlots(rec).map((s) => s.slotId)).toEqual([
+      'briefing',
+      'pipeline',
+      'alpha',
+      'zebra',
+    ]);
+  });
+
+  it('returns empty for an empty record', () => {
+    expect(orderSlots({})).toEqual([]);
+  });
+});

--- a/packages/standalone/ui/index.html
+++ b/packages/standalone/ui/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="ko">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/packages/standalone/ui/index.html
+++ b/packages/standalone/ui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MAMA Operator</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/standalone/ui/package.json
+++ b/packages/standalone/ui/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@jungjaehoon/mama-os-ui",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -p tsconfig.json --noEmit && vite build"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.80.7",
+    "dompurify": "^3.2.5",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.6.2"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.1.8",
+    "@types/react": "^19.1.6",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react": "^4.5.2",
+    "tailwindcss": "^4.1.8",
+    "typescript": "^5.8.3",
+    "vite": "^6.3.5"
+  }
+}

--- a/packages/standalone/ui/package.json
+++ b/packages/standalone/ui/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -p tsconfig.json --noEmit && vite build"
+    "bundle": "tsc -p tsconfig.json --noEmit && vite build"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.80.7",

--- a/packages/standalone/ui/src/App.tsx
+++ b/packages/standalone/ui/src/App.tsx
@@ -1,12 +1,15 @@
 import { Routes, Route } from 'react-router-dom';
+import Layout from './components/Layout';
+import Board from './pages/Board';
+import Triggers from './pages/Triggers';
 
 export default function App() {
   return (
     <Routes>
-      <Route
-        index
-        element={<div className="p-4 text-text">MAMA Operator -- walking skeleton</div>}
-      />
+      <Route element={<Layout />}>
+        <Route index element={<Board />} />
+        <Route path="triggers" element={<Triggers />} />
+      </Route>
     </Routes>
   );
 }

--- a/packages/standalone/ui/src/App.tsx
+++ b/packages/standalone/ui/src/App.tsx
@@ -1,0 +1,12 @@
+import { Routes, Route } from 'react-router-dom';
+
+export default function App() {
+  return (
+    <Routes>
+      <Route
+        index
+        element={<div className="p-4 text-text">MAMA Operator -- walking skeleton</div>}
+      />
+    </Routes>
+  );
+}

--- a/packages/standalone/ui/src/api/client.ts
+++ b/packages/standalone/ui/src/api/client.ts
@@ -1,0 +1,69 @@
+import type { ReportSlot } from './report';
+
+export interface OperatorSummary {
+  triggers: {
+    active: number;
+    disabled: number;
+    fired: number;
+    succeeded: number;
+    failed: number;
+  };
+}
+
+export interface TriggerRow {
+  id: string;
+  kind: string;
+  memoryQuery: string;
+  status: string;
+  authoredBy: string;
+  createdAt: number;
+  fired: number;
+  succeeded: number;
+  failed: number;
+  disabledReason: string | null;
+}
+
+async function request<T>(path: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(path, {
+    headers: { 'content-type': 'application/json' },
+    ...options,
+  });
+  if (!res.ok) {
+    throw new Error(`API ${res.status}: ${await res.text()}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+export const api = {
+  getReport: () => request<{ slots: ReportSlot[] }>('/api/report'),
+  getOperatorSummary: () => request<OperatorSummary>('/api/operator/summary'),
+  listTriggers: () => request<{ triggers: TriggerRow[] }>('/api/operator/triggers'),
+  disableTrigger: async (id: string, reason: string): Promise<void> => {
+    await request<{ ok: boolean }>(`/api/operator/triggers/${encodeURIComponent(id)}/disable`, {
+      method: 'POST',
+      body: JSON.stringify({ reason }),
+    });
+  },
+};
+
+/**
+ * Native EventSource on the report SSE stream. Auto-reconnects; onOpen fires on
+ * every (re)connect so callers can refetch state missed while disconnected.
+ */
+export function connectReportSse(handlers: {
+  onUpdate: (data: unknown) => void;
+  onOpen?: () => void;
+}): () => void {
+  const es = new EventSource('/api/report/events');
+  es.addEventListener('report-update', (ev) => {
+    try {
+      handlers.onUpdate(JSON.parse((ev as MessageEvent).data));
+    } catch {
+      // malformed frame: ignore; the next full update self-heals
+    }
+  });
+  if (handlers.onOpen) {
+    es.addEventListener('open', handlers.onOpen);
+  }
+  return () => es.close();
+}

--- a/packages/standalone/ui/src/api/report.ts
+++ b/packages/standalone/ui/src/api/report.ts
@@ -1,0 +1,62 @@
+export interface ReportSlot {
+  slotId: string;
+  html: string;
+  priority: number;
+  updatedAt: number;
+}
+
+export const SLOT_ORDER = ['briefing', 'action_required', 'decisions', 'pipeline'] as const;
+
+export type SlotRecord = Record<string, ReportSlot>;
+
+/**
+ * Fold an SSE `report-update` payload into the slot record.
+ *
+ * Wire shapes from src/api/report-handler.ts:
+ *  - bulk:    { slots: ReportSlot[] }  (full snapshot -- replaces the record)
+ *  - single:  { slot, html, priority } (no updatedAt -- stamped client-side)
+ *  - removal: { deleted: slotId }
+ */
+export function mergeReportEvent(prev: SlotRecord, data: unknown): SlotRecord {
+  const d = data as {
+    slots?: ReportSlot[];
+    slot?: string;
+    html?: string;
+    priority?: number;
+    deleted?: string;
+  };
+  if (Array.isArray(d?.slots)) {
+    const next: SlotRecord = {};
+    for (const slot of d.slots) {
+      next[slot.slotId] = slot;
+    }
+    return next;
+  }
+  if (d?.deleted) {
+    const next = { ...prev };
+    delete next[d.deleted];
+    return next;
+  }
+  if (d?.slot && d.html !== undefined) {
+    return {
+      ...prev,
+      [d.slot]: {
+        slotId: d.slot,
+        html: d.html,
+        priority: d.priority ?? 0,
+        updatedAt: Date.now(),
+      },
+    };
+  }
+  return prev;
+}
+
+/** Known slots first in fixed order, then custom slots by priority. */
+export function orderSlots(slots: SlotRecord): ReportSlot[] {
+  const knownIds = SLOT_ORDER as readonly string[];
+  const known = knownIds.filter((id) => slots[id]).map((id) => slots[id]);
+  const custom = Object.values(slots)
+    .filter((s) => !knownIds.includes(s.slotId))
+    .sort((a, b) => a.priority - b.priority);
+  return [...known, ...custom];
+}

--- a/packages/standalone/ui/src/api/sanitize.ts
+++ b/packages/standalone/ui/src/api/sanitize.ts
@@ -1,0 +1,14 @@
+import DOMPurify from 'dompurify';
+
+/**
+ * Slot HTML is attacker-influenceable (a prompt-injected agent can emit hostile
+ * markup), so sanitize with DOMPurify at render. Second, independent layer:
+ * the script-src 'self' CSP set on the /ui document by graph-api.
+ */
+export function sanitizeReportHtml(html: string): string {
+  return DOMPurify.sanitize(html, {
+    FORBID_TAGS: ['script', 'iframe', 'object', 'embed', 'form', 'link', 'meta', 'base'],
+    ALLOW_DATA_ATTR: false,
+    USE_PROFILES: { html: true },
+  });
+}

--- a/packages/standalone/ui/src/components/Layout.tsx
+++ b/packages/standalone/ui/src/components/Layout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from 'react-router-dom';
+import Sidebar from './Sidebar';
+
+export default function Layout() {
+  return (
+    <div className="flex h-full bg-bg">
+      <Sidebar />
+      <main className="flex-1 overflow-y-auto pb-14 md:pb-0">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/packages/standalone/ui/src/components/Sidebar.tsx
+++ b/packages/standalone/ui/src/components/Sidebar.tsx
@@ -1,0 +1,113 @@
+import { NavLink } from 'react-router-dom';
+
+interface NavItem {
+  to: string;
+  label: string;
+  d: string;
+}
+
+// Stock outline icon paths (heroicons-style), no branding.
+const navItems: NavItem[] = [
+  {
+    to: '/',
+    label: 'Board',
+    d: 'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4',
+  },
+  {
+    to: '/triggers',
+    label: 'Triggers',
+    d: 'M13 10V3L4 14h7v7l9-11h-7z',
+  },
+];
+
+const legacyLinks = [{ href: '/viewer', label: 'Legacy viewer' }];
+
+export default function Sidebar() {
+  const linkClass = ({ isActive }: { isActive: boolean }) =>
+    `flex items-center gap-2 px-2 py-1.5 text-[13px] rounded-lg transition-all duration-150 ${
+      isActive
+        ? 'bg-sidebar-active text-text font-medium shadow-[var(--shadow-xs)]'
+        : 'text-text-secondary hover:text-text hover:bg-sidebar-hover'
+    }`;
+
+  const mobileLinkClass = ({ isActive }: { isActive: boolean }) =>
+    `flex flex-col items-center justify-center gap-0.5 py-1.5 text-[10px] transition-colors ${
+      isActive ? 'text-agent font-medium' : 'text-text-tertiary'
+    }`;
+
+  return (
+    <>
+      {/* Desktop sidebar */}
+      <aside className="hidden md:flex w-60 bg-sidebar flex-col flex-shrink-0 border-r border-sidebar-border">
+        <div className="px-3 pt-3 pb-1">
+          <div className="flex items-center gap-2.5 px-2 mb-3">
+            <div className="w-7 h-7 rounded-lg bg-agent flex items-center justify-center">
+              <span className="text-white text-xs font-bold">M</span>
+            </div>
+            <span className="text-[14px] font-semibold text-text tracking-tight">
+              MAMA Operator
+            </span>
+          </div>
+        </div>
+        <nav className="flex-1 py-2 px-2 overflow-y-auto">
+          <div className="space-y-0.5">
+            {navItems.map((link) => (
+              <NavLink key={link.to} to={link.to} end={link.to === '/'} className={linkClass}>
+                {({ isActive }: { isActive: boolean }) => (
+                  <>
+                    <svg
+                      className={`w-5 h-5 flex-shrink-0 ${isActive ? 'text-text' : 'text-text-tertiary'}`}
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth={1.5}
+                      viewBox="0 0 24 24"
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" d={link.d} />
+                    </svg>
+                    <span className="flex-1">{link.label}</span>
+                  </>
+                )}
+              </NavLink>
+            ))}
+          </div>
+          <div className="mt-4 pt-3 border-t border-sidebar-border space-y-0.5">
+            {legacyLinks.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                className="flex items-center gap-2 px-2 py-1.5 text-[13px] rounded-lg text-text-tertiary hover:text-text hover:bg-sidebar-hover transition-colors"
+              >
+                {link.label}
+              </a>
+            ))}
+          </div>
+        </nav>
+        <div className="px-4 py-3">
+          <div className="text-[10px] text-text-tertiary">MAMA Operator (beta)</div>
+        </div>
+      </aside>
+
+      {/* Mobile bottom tab bar */}
+      <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-surface border-t border-border z-50 flex justify-around">
+        {navItems.map((link) => (
+          <NavLink key={link.to} to={link.to} end={link.to === '/'} className={mobileLinkClass}>
+            {({ isActive }: { isActive: boolean }) => (
+              <>
+                <svg
+                  className={`w-5 h-5 ${isActive ? 'text-agent' : 'text-text-tertiary'}`}
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                  viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d={link.d} />
+                </svg>
+                <span>{link.label}</span>
+              </>
+            )}
+          </NavLink>
+        ))}
+      </nav>
+    </>
+  );
+}

--- a/packages/standalone/ui/src/components/StatCard.tsx
+++ b/packages/standalone/ui/src/components/StatCard.tsx
@@ -1,0 +1,18 @@
+export default function StatCard({
+  label,
+  value,
+  tone = 'default',
+}: {
+  label: string;
+  value: string | number;
+  tone?: 'default' | 'success' | 'danger';
+}) {
+  const toneClass =
+    tone === 'success' ? 'text-success' : tone === 'danger' ? 'text-danger' : 'text-text';
+  return (
+    <div className="bg-surface rounded-xl px-4 py-3 shadow-[var(--shadow-xs)] border border-border">
+      <div className="text-[11px] text-text-tertiary">{label}</div>
+      <div className={`text-lg font-semibold ${toneClass}`}>{value}</div>
+    </div>
+  );
+}

--- a/packages/standalone/ui/src/components/TriggerRow.tsx
+++ b/packages/standalone/ui/src/components/TriggerRow.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import type { TriggerRow as TriggerRowData } from '../api/client';
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max)}...` : text;
+}
+
+export default function TriggerRow({
+  trigger,
+  onDisable,
+}: {
+  trigger: TriggerRowData;
+  onDisable: (id: string, reason: string) => void;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  const [reason, setReason] = useState('');
+  const disabled = trigger.status !== 'active';
+
+  return (
+    <div
+      className={`px-4 py-3 border-b border-border last:border-b-0 ${disabled ? 'opacity-60' : ''}`}
+    >
+      <div className="flex items-center gap-3">
+        <span className="text-[11px] px-2 py-0.5 rounded-full bg-agent-light text-agent font-medium shrink-0">
+          {trigger.kind}
+        </span>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm text-text truncate">{truncate(trigger.memoryQuery, 80)}</p>
+          <p className="text-[11px] text-text-tertiary">
+            fired {trigger.fired} / ok {trigger.succeeded} / fail {trigger.failed} /{' '}
+            {trigger.authoredBy} /{' '}
+            {new Date(trigger.createdAt).toLocaleDateString('ko-KR', {
+              month: 'short',
+              day: 'numeric',
+            })}
+          </p>
+          {disabled && trigger.disabledReason && (
+            <p className="text-[11px] text-danger mt-0.5">
+              {trigger.status}: {trigger.disabledReason}
+            </p>
+          )}
+        </div>
+        {!disabled && !confirming && (
+          <button
+            onClick={() => setConfirming(true)}
+            className="shrink-0 px-3 py-1 text-xs font-medium rounded-full bg-surface-secondary text-text-tertiary hover:bg-danger/10 hover:text-danger transition-colors"
+          >
+            Disable
+          </button>
+        )}
+      </div>
+      {confirming && (
+        <div className="flex items-center gap-2 mt-2">
+          <input
+            autoFocus
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="Reason (required)"
+            className="flex-1 px-2 py-1 text-xs bg-surface-selected rounded border border-border focus:outline-none focus:ring-1 focus:ring-agent"
+          />
+          <button
+            onClick={() => {
+              if (reason.trim()) onDisable(trigger.id, reason.trim());
+            }}
+            disabled={!reason.trim()}
+            className="px-3 py-1 text-xs font-medium rounded-full bg-danger/10 text-danger disabled:opacity-40 hover:opacity-80 transition-opacity"
+          >
+            Confirm
+          </button>
+          <button
+            onClick={() => {
+              setConfirming(false);
+              setReason('');
+            }}
+            className="px-3 py-1 text-xs font-medium rounded-full bg-surface-secondary text-text-tertiary hover:opacity-80"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/standalone/ui/src/components/TriggerRow.tsx
+++ b/packages/standalone/ui/src/components/TriggerRow.tsx
@@ -32,7 +32,7 @@ export default function TriggerRow({
           <p className="text-[11px] text-text-tertiary">
             fired {trigger.fired} / ok {trigger.succeeded} / fail {trigger.failed} /{' '}
             {trigger.authoredBy} /{' '}
-            {new Date(trigger.createdAt).toLocaleDateString('ko-KR', {
+            {new Date(trigger.createdAt).toLocaleDateString(undefined, {
               month: 'short',
               day: 'numeric',
             })}

--- a/packages/standalone/ui/src/components/TriggerRow.tsx
+++ b/packages/standalone/ui/src/components/TriggerRow.tsx
@@ -21,7 +21,10 @@ export default function TriggerRow({
       className={`px-4 py-3 border-b border-border last:border-b-0 ${disabled ? 'opacity-60' : ''}`}
     >
       <div className="flex items-center gap-3">
-        <span className="text-[11px] px-2 py-0.5 rounded-full bg-agent-light text-agent font-medium shrink-0">
+        <span
+          className="text-[11px] px-2 py-0.5 rounded-full bg-agent-light text-agent font-medium max-w-[40%] truncate"
+          title={trigger.kind}
+        >
           {trigger.kind}
         </span>
         <div className="flex-1 min-w-0">

--- a/packages/standalone/ui/src/main.tsx
+++ b/packages/standalone/ui/src/main.tsx
@@ -1,0 +1,18 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import App from './App';
+import './styles/global.css';
+
+const queryClient = new QueryClient();
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter basename="/ui">
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
+  </StrictMode>
+);

--- a/packages/standalone/ui/src/pages/Board.tsx
+++ b/packages/standalone/ui/src/pages/Board.tsx
@@ -96,7 +96,7 @@ export default function Board() {
           <h1 className="text-base font-semibold text-text">Operator Board</h1>
           {lastUpdate && (
             <span className="text-[10px] text-text-tertiary">
-              {new Date(lastUpdate).toLocaleTimeString('ko-KR', {
+              {new Date(lastUpdate).toLocaleTimeString(undefined, {
                 hour: '2-digit',
                 minute: '2-digit',
               })}{' '}

--- a/packages/standalone/ui/src/pages/Board.tsx
+++ b/packages/standalone/ui/src/pages/Board.tsx
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../api/client';
+import {
+  mergeReportEvent,
+  orderSlots,
+  type ReportSlot,
+  type SlotRecord,
+} from '../api/report';
+import { sanitizeReportHtml } from '../api/sanitize';
+import { connectReportSse } from '../api/client';
+import StatCard from '../components/StatCard';
+
+function SlotRenderer({ slot }: { slot: ReportSlot }) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    ref.current.innerHTML = sanitizeReportHtml(slot.html);
+  }, [slot.html]);
+
+  return (
+    <section
+      className="bg-surface rounded-xl border border-border shadow-[var(--shadow-xs)] p-4"
+      data-slot={slot.slotId}
+    >
+      <div ref={ref} />
+    </section>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full text-center px-6 py-16">
+      <h2 className="text-lg font-semibold text-text mb-2">No reports published yet</h2>
+      <p className="text-sm text-text-secondary max-w-md">
+        Slots appear here once an agent publishes them via report_publish. The heartbeat
+        briefing or the dashboard agent fills the first slot.
+      </p>
+    </div>
+  );
+}
+
+export default function Board() {
+  const [slots, setSlots] = useState<SlotRecord>({});
+  const [loading, setLoading] = useState(true);
+  const [lastUpdate, setLastUpdate] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const data = await api.getReport();
+      const record: SlotRecord = {};
+      for (const slot of data.slots ?? []) {
+        record[slot.slotId] = slot;
+      }
+      setSlots(record);
+      const latest = Math.max(0, ...(data.slots ?? []).map((s) => s.updatedAt));
+      if (latest > 0) setLastUpdate(latest);
+    } catch {
+      // board stays on previous state; SSE reconnect will refetch
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // SSE hot-reload; onOpen refetches state missed while disconnected.
+  useEffect(() => {
+    const disconnect = connectReportSse({
+      onUpdate: (data) => {
+        setSlots((prev) => mergeReportEvent(prev, data));
+        setLastUpdate(Date.now());
+      },
+      onOpen: () => {
+        void load();
+      },
+    });
+    return disconnect;
+  }, [load]);
+
+  const { data: summary } = useQuery({
+    queryKey: ['operatorSummary'],
+    queryFn: api.getOperatorSummary,
+    refetchInterval: 60_000,
+  });
+
+  const ordered = orderSlots(slots);
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border flex-shrink-0 bg-surface">
+        <div className="flex items-center gap-3">
+          <h1 className="text-base font-semibold text-text">Operator Board</h1>
+          {lastUpdate && (
+            <span className="text-[10px] text-text-tertiary">
+              {new Date(lastUpdate).toLocaleTimeString('ko-KR', {
+                hour: '2-digit',
+                minute: '2-digit',
+              })}{' '}
+              updated
+            </span>
+          )}
+        </div>
+        <button
+          onClick={() => void load()}
+          className="text-xs px-3 py-1.5 rounded bg-surface-hover hover:bg-surface-selected text-text-secondary transition-colors"
+        >
+          Refresh
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        <div className="p-4 max-w-4xl mx-auto">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+            <StatCard label="Active triggers" value={summary?.triggers.active ?? '-'} />
+            <StatCard label="Total fires" value={summary?.triggers.fired ?? '-'} />
+            <StatCard
+              label="Succeeded"
+              value={summary?.triggers.succeeded ?? '-'}
+              tone="success"
+            />
+            <StatCard
+              label="Failed"
+              value={summary?.triggers.failed ?? '-'}
+              tone={summary && summary.triggers.failed > 0 ? 'danger' : 'default'}
+            />
+          </div>
+
+          {loading ? (
+            <div className="flex items-center justify-center py-16 text-sm text-text-tertiary">
+              Loading report...
+            </div>
+          ) : ordered.length === 0 ? (
+            <EmptyState />
+          ) : (
+            <div className="space-y-3">
+              {ordered.map((slot) => (
+                <SlotRenderer key={slot.slotId} slot={slot} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/standalone/ui/src/pages/Triggers.tsx
+++ b/packages/standalone/ui/src/pages/Triggers.tsx
@@ -1,0 +1,90 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '../api/client';
+import TriggerRow from '../components/TriggerRow';
+
+export default function Triggers() {
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['operatorTriggers'],
+    queryFn: api.listTriggers,
+    refetchInterval: 30_000,
+  });
+
+  const disable = useMutation({
+    mutationFn: ({ id, reason }: { id: string; reason: string }) =>
+      api.disableTrigger(id, reason),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['operatorTriggers'] });
+      void queryClient.invalidateQueries({ queryKey: ['operatorSummary'] });
+    },
+  });
+
+  const triggers = data?.triggers ?? [];
+  const active = triggers.filter((t) => t.status === 'active');
+  const inactive = triggers.filter((t) => t.status !== 'active');
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-border flex-shrink-0 bg-surface">
+        <h1 className="text-base font-semibold text-text">Triggers</h1>
+        <span className="text-[11px] px-2 py-0.5 rounded-full bg-success/10 text-success font-medium">
+          active {active.length}
+        </span>
+        {inactive.length > 0 && (
+          <span className="text-[11px] px-2 py-0.5 rounded-full bg-surface-secondary text-text-tertiary font-medium">
+            inactive {inactive.length}
+          </span>
+        )}
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        <div className="p-4 max-w-4xl mx-auto space-y-4">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-16 text-sm text-text-tertiary">
+              Loading triggers...
+            </div>
+          ) : triggers.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+                      <p className="text-sm text-text-secondary">
+                No triggers yet. The agent authors them itself once the trigger
+                loop observes events.
+              </p>
+            </div>
+          ) : (
+            <>
+              <div className="bg-surface rounded-xl border border-border shadow-[var(--shadow-xs)]">
+                {active.map((t) => (
+                  <TriggerRow
+                    key={t.id}
+                    trigger={t}
+                    onDisable={(id, reason) => disable.mutate({ id, reason })}
+                  />
+                ))}
+                {active.length === 0 && (
+                  <p className="px-4 py-6 text-sm text-text-tertiary text-center">
+                    No active triggers.
+                  </p>
+                )}
+              </div>
+              {inactive.length > 0 && (
+                <details className="bg-surface rounded-xl border border-border shadow-[var(--shadow-xs)]">
+                  <summary className="px-4 py-3 text-sm text-text-secondary cursor-pointer select-none">
+                    Inactive triggers: {inactive.length}
+                  </summary>
+                  {inactive.map((t) => (
+                    <TriggerRow
+                      key={t.id}
+                      trigger={t}
+                      onDisable={(id, reason) => disable.mutate({ id, reason })}
+                    />
+                  ))}
+                </details>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/standalone/ui/src/styles/global.css
+++ b/packages/standalone/ui/src/styles/global.css
@@ -1,0 +1,43 @@
+@import 'tailwindcss';
+
+/* MAMA Operator theme tokens -- components must consume ONLY these tokens,
+ * never hardcoded hex in TSX (learning: mama-dual-color-system).
+ * Brand alignment with the legacy palette is a one-token swap on --color-agent. */
+@theme {
+  --color-bg: #f1f1f1;
+  --color-surface: #ffffff;
+  --color-surface-hover: #f7f7f7;
+  --color-surface-selected: #f3f3f3;
+  --color-surface-secondary: #f7f7f7;
+
+  --color-sidebar: #ebebeb;
+  --color-sidebar-hover: #e0e0e0;
+  --color-sidebar-active: #fafafa;
+  --color-sidebar-border: #e3e3e3;
+
+  --color-agent: #6366f1;
+  --color-agent-hover: #4f46e5;
+  --color-agent-light: #eef2ff;
+
+  --color-text: #1a1a1a;
+  --color-text-secondary: #616161;
+  --color-text-tertiary: #8a8a8a;
+  --color-border: #e3e3e3;
+
+  --color-success: #047b5d;
+  --color-warning: #ffb800;
+  --color-danger: #d72c0d;
+
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  background-color: var(--color-bg);
+  color: var(--color-text);
+}

--- a/packages/standalone/ui/tsconfig.json
+++ b/packages/standalone/ui/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "useDefineForClassFields": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/packages/standalone/ui/vite.config.ts
+++ b/packages/standalone/ui/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  base: '/ui/',
+  build: { outDir: '../public/ui', emptyOutDir: true },
+  server: {
+    proxy: {
+      '/api': 'http://127.0.0.1:3847',
+      '/health': 'http://127.0.0.1:3847',
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
         version: 2.8.10
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@25.3.0)
+        version: 1.6.1(@types/node@25.3.0)(lightningcss@1.32.0)
 
   packages/claude-code-plugin:
     dependencies:
@@ -51,7 +51,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@25.3.0)
+        version: 1.6.1(@types/node@25.3.0)(lightningcss@1.32.0)
 
   packages/mama-core:
     dependencies:
@@ -79,7 +79,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@22.19.11)
+        version: 1.6.1(@types/node@22.19.11)(lightningcss@1.32.0)
 
   packages/mcp-server:
     dependencies:
@@ -95,7 +95,7 @@ importers:
         version: 12.8.0
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@25.3.0)
+        version: 1.6.1(@types/node@25.3.0)(lightningcss@1.32.0)
 
   packages/memorybench:
     dependencies:
@@ -250,7 +250,47 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@22.19.11)
+        version: 1.6.1(@types/node@22.19.11)(lightningcss@1.32.0)
+
+  packages/standalone/ui:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.80.7
+        version: 5.101.2(react@19.2.7)
+      dompurify:
+        specifier: ^3.2.5
+        version: 3.4.11
+      react:
+        specifier: ^19.1.0
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.7(react@19.2.7)
+      react-router-dom:
+        specifier: ^7.6.2
+        version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.1.8
+        version: 4.3.2(vite@6.4.3(@types/node@25.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@types/react':
+        specifier: ^19.1.6
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.1.6
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^4.5.2
+        version: 4.7.0(vite@6.4.3(@types/node@25.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+      tailwindcss:
+        specifier: ^4.1.8
+        version: 4.3.2
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.3.5
+        version: 6.4.3(@types/node@25.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 
@@ -363,12 +403,95 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@cfworker/json-schema@4.1.1':
@@ -414,6 +537,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.4':
     resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
     engines: {node: '>=18'}
@@ -423,6 +552,12 @@ packages:
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -438,6 +573,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-arm@0.27.4':
     resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
     engines: {node: '>=18'}
@@ -447,6 +588,12 @@ packages:
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -462,6 +609,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.4':
     resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
     engines: {node: '>=18'}
@@ -471,6 +624,12 @@ packages:
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -486,6 +645,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.4':
     resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
     engines: {node: '>=18'}
@@ -495,6 +660,12 @@ packages:
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -510,6 +681,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.4':
     resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
     engines: {node: '>=18'}
@@ -519,6 +696,12 @@ packages:
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -534,6 +717,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.4':
     resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
     engines: {node: '>=18'}
@@ -543,6 +732,12 @@ packages:
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -558,6 +753,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.4':
     resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
     engines: {node: '>=18'}
@@ -567,6 +768,12 @@ packages:
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -582,6 +789,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.4':
     resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
     engines: {node: '>=18'}
@@ -591,6 +804,12 @@ packages:
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -606,11 +825,23 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.4':
     resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
 
   '@esbuild/netbsd-arm64@0.27.4':
     resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
@@ -624,11 +855,23 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.27.4':
     resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-arm64@0.27.4':
     resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
@@ -642,11 +885,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.27.4':
     resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
 
   '@esbuild/openharmony-arm64@0.27.4':
     resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
@@ -657,6 +912,12 @@ packages:
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -672,6 +933,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.4':
     resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
     engines: {node: '>=18'}
@@ -684,6 +951,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.4':
     resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
     engines: {node: '>=18'}
@@ -693,6 +966,12 @@ packages:
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -950,8 +1229,21 @@ packages:
   '@jitl/quickjs-wasmfile-release-sync@0.32.0':
     resolution: {integrity: sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg==}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@langchain/core@1.1.36':
     resolution: {integrity: sha512-9NWsdzU3uZD13lJwunXK0t6SIwew+UwcbHggW5yUdaiMmzKeNkDpp1lRD6p49N8+D0Vv4qmQBEKB4Ukh2jfnvw==}
@@ -1061,6 +1353,9 @@ packages:
     resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
     peerDependencies:
       '@redis/client': ^1.0.0
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
@@ -1264,6 +1559,120 @@ packages:
     resolution: {integrity: sha512-CAeFm5sfX8sbTzxoxRafhohreIzl9a7R6qHTck3MrgTqm5M5g/u0IHfEKYzI9w/17r8NINl8UZrw2i08wrO7Iw==}
     engines: {node: '>=20.0.0'}
 
+  '@tailwindcss/node@4.3.2':
+    resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.2':
+    resolution: {integrity: sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.2':
+    resolution: {integrity: sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.2':
+    resolution: {integrity: sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.2':
+    resolution: {integrity: sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
+    resolution: {integrity: sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
+    resolution: {integrity: sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
+    resolution: {integrity: sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
+    resolution: {integrity: sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
+    resolution: {integrity: sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
+    resolution: {integrity: sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
+    resolution: {integrity: sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
+    resolution: {integrity: sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.2':
+    resolution: {integrity: sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.3.2':
+    resolution: {integrity: sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/query-core@5.101.2':
+    resolution: {integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==}
+
+  '@tanstack/react-query@5.101.2':
+    resolution: {integrity: sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==}
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
@@ -1340,6 +1749,14 @@ packages:
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
@@ -1357,6 +1774,9 @@ packages:
 
   '@types/supertest@6.0.3':
     resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
@@ -1439,6 +1859,12 @@ packages:
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitest/expect@1.6.1':
     resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
@@ -1567,6 +1993,11 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  baseline-browser-mapping@2.10.42:
+    resolution: {integrity: sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   better-sqlite3@12.8.0:
     resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
@@ -1598,6 +2029,11 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  browserslist@4.28.5:
+    resolution: {integrity: sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -1649,6 +2085,9 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
+
+  caniuse-lite@1.0.30001803:
+    resolution: {integrity: sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==}
 
   chai@4.5.0:
     resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
@@ -1740,6 +2179,9 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
@@ -1747,6 +2189,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
@@ -1765,6 +2211,9 @@ packages:
 
   crypt@0.0.2:
     resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -1853,6 +2302,9 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   drizzle-orm@0.45.2:
     resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
@@ -1956,6 +2408,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  electron-to-chromium@1.5.389:
+    resolution: {integrity: sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -1965,6 +2420,10 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  enhanced-resolve@5.21.6:
+    resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
+    engines: {node: '>=10.13.0'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -1994,10 +2453,19 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -2231,6 +2699,10 @@ packages:
   generic-pool@3.9.0:
     resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
     engines: {node: '>= 4'}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-east-asian-width@1.5.0:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
@@ -2472,6 +2944,10 @@ packages:
     resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
@@ -2486,6 +2962,11 @@ packages:
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
     hasBin: true
 
   json-bigint@1.0.0:
@@ -2515,6 +2996,11 @@ packages:
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
@@ -2552,6 +3038,80 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -2613,6 +3173,9 @@ packages:
 
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
@@ -2802,6 +3365,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-releases@2.0.51:
+    resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
+    engines: {node: '>=18'}
 
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
@@ -3111,8 +3678,38 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react-router-dom@7.18.1:
+    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.18.1:
+    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
 
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -3181,8 +3778,15 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -3200,6 +3804,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -3338,6 +3945,13 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  tailwindcss@4.3.2:
+    resolution: {integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
 
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
@@ -3495,6 +4109,12 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -3556,6 +4176,46 @@ packages:
       sugarss:
         optional: true
       terser:
+        optional: true
+
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
         optional: true
 
   vitest@1.6.1:
@@ -3640,6 +4300,9 @@ packages:
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
@@ -3841,9 +4504,121 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.5
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
 
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/runtime@7.28.6': {}
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@cfworker/json-schema@4.1.1': {}
 
@@ -3906,10 +4681,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.4':
@@ -3918,10 +4699,16 @@ snapshots:
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.4':
     optional: true
 
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.4':
@@ -3930,10 +4717,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.4':
     optional: true
 
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.4':
@@ -3942,10 +4735,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.4':
     optional: true
 
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.4':
@@ -3954,10 +4753,16 @@ snapshots:
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.4':
     optional: true
 
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.4':
@@ -3966,10 +4771,16 @@ snapshots:
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.4':
     optional: true
 
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.4':
@@ -3978,10 +4789,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.4':
     optional: true
 
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.4':
@@ -3990,10 +4807,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.4':
     optional: true
 
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.4':
@@ -4002,7 +4825,13 @@ snapshots:
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.4':
@@ -4011,7 +4840,13 @@ snapshots:
   '@esbuild/netbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.4':
@@ -4020,7 +4855,13 @@ snapshots:
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.4':
@@ -4029,10 +4870,16 @@ snapshots:
   '@esbuild/sunos-x64@0.21.5':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.4':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.4':
@@ -4041,10 +4888,16 @@ snapshots:
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.4':
     optional: true
 
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.4':
@@ -4254,7 +5107,24 @@ snapshots:
     dependencies:
       '@jitl/quickjs-ffi-types': 0.32.0
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@langchain/core@1.1.36(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)':
     dependencies:
@@ -4411,6 +5281,8 @@ snapshots:
   '@redis/time-series@1.1.0(@redis/client@1.6.1)':
     dependencies:
       '@redis/client': 1.6.1
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
@@ -4578,6 +5450,102 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@tailwindcss/node@4.3.2':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.21.6
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.2
+
+  '@tailwindcss/oxide-android-arm64@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.2':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.2
+      '@tailwindcss/oxide-darwin-arm64': 4.3.2
+      '@tailwindcss/oxide-darwin-x64': 4.3.2
+      '@tailwindcss/oxide-freebsd-x64': 4.3.2
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.2
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.2
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.2
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.2
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.2
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.2
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.2
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.2
+
+  '@tailwindcss/vite@4.3.2(vite@6.4.3(@types/node@25.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@tailwindcss/node': 4.3.2
+      '@tailwindcss/oxide': 4.3.2
+      tailwindcss: 4.3.2
+      vite: 6.4.3(@types/node@25.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@tanstack/query-core@5.101.2': {}
+
+  '@tanstack/react-query@5.101.2(react@19.2.7)':
+    dependencies:
+      '@tanstack/query-core': 5.101.2
+      react: 19.2.7
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 25.3.0
@@ -4670,6 +5638,14 @@ snapshots:
 
   '@types/range-parser@1.2.7': {}
 
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
+
   '@types/retry@0.12.0': {}
 
   '@types/send@1.2.1':
@@ -4694,6 +5670,9 @@ snapshots:
     dependencies:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/uuid@10.0.0': {}
 
@@ -4809,6 +5788,18 @@ snapshots:
   '@ungap/structured-clone@1.3.0': {}
 
   '@vercel/oidc@3.1.0': {}
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@25.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.3(@types/node@25.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/expect@1.6.1':
     dependencies:
@@ -4942,6 +5933,8 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  baseline-browser-mapping@2.10.42: {}
+
   better-sqlite3@12.8.0:
     dependencies:
       bindings: 1.5.0
@@ -4988,6 +5981,14 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  browserslist@4.28.5:
+    dependencies:
+      baseline-browser-mapping: 2.10.42
+      caniuse-lite: 1.0.30001803
+      electron-to-chromium: 1.5.389
+      node-releases: 2.0.51
+      update-browserslist-db: 1.2.3(browserslist@4.28.5)
+
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
@@ -5033,6 +6034,8 @@ snapshots:
   callsites@3.1.0: {}
 
   camelcase@6.3.0: {}
+
+  caniuse-lite@1.0.30001803: {}
 
   chai@4.5.0:
     dependencies:
@@ -5123,9 +6126,13 @@ snapshots:
 
   content-type@1.0.5: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookie@1.1.1: {}
 
   cookiejar@2.1.4: {}
 
@@ -5145,6 +6152,8 @@ snapshots:
       which: 2.0.2
 
   crypt@0.0.2: {}
+
+  csstype@3.2.3: {}
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -5232,6 +6241,10 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dompurify@3.4.11:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260329.1)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.11.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.11.3):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260329.1
@@ -5254,6 +6267,8 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  electron-to-chromium@1.5.389: {}
+
   emoji-regex@10.6.0: {}
 
   encodeurl@2.0.0: {}
@@ -5261,6 +6276,11 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  enhanced-resolve@5.21.6:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
 
   environment@1.1.0: {}
 
@@ -5307,6 +6327,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
   esbuild@0.27.4:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.4
@@ -5335,6 +6384,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.4
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
+
+  escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
 
@@ -5616,6 +6667,8 @@ snapshots:
 
   generic-pool@3.9.0: {}
 
+  gensync@1.0.0-beta.2: {}
+
   get-east-asian-width@1.5.0: {}
 
   get-func-name@2.0.2: {}
@@ -5875,6 +6928,8 @@ snapshots:
       graceful-fs: 4.2.11
       picomatch: 2.3.1
 
+  jiti@2.7.0: {}
+
   jose@6.1.3: {}
 
   js-tiktoken@1.0.21:
@@ -5888,6 +6943,8 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsesc@3.1.0: {}
 
   json-bigint@1.0.0:
     dependencies:
@@ -5911,6 +6968,8 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stringify-safe@5.0.1: {}
+
+  json5@2.2.3: {}
 
   jsonwebtoken@9.0.3:
     dependencies:
@@ -5957,6 +7016,55 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lilconfig@3.1.3: {}
 
@@ -6026,6 +7134,10 @@ snapshots:
   loupe@2.3.7:
     dependencies:
       get-func-name: 2.0.2
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   luxon@3.7.2: {}
 
@@ -6195,6 +7307,8 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-releases@2.0.51: {}
 
   npm-run-path@5.3.0:
     dependencies:
@@ -6508,7 +7622,30 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
   react-is@18.3.1: {}
+
+  react-refresh@0.17.0: {}
+
+  react-router-dom@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-router: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
+  react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.7
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
+
+  react@19.2.7: {}
 
   readable-stream@3.6.2:
     dependencies:
@@ -6610,7 +7747,11 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  scheduler@0.27.0: {}
+
   semver-compare@1.0.0: {}
+
+  semver@6.3.1: {}
 
   semver@7.7.4: {}
 
@@ -6642,6 +7783,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.2: {}
 
   setprototypeof@1.2.0: {}
 
@@ -6812,6 +7955,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  tailwindcss@4.3.2: {}
+
+  tapable@2.3.3: {}
+
   tar-fs@2.1.4:
     dependencies:
       chownr: 1.1.4
@@ -6947,6 +8094,12 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  update-browserslist-db@1.2.3(browserslist@4.28.5):
+    dependencies:
+      browserslist: 4.28.5
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -6963,13 +8116,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@1.6.1(@types/node@22.19.11):
+  vite-node@1.6.1(@types/node@22.19.11)(lightningcss@1.32.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.21(@types/node@22.19.11)
+      vite: 5.4.21(@types/node@22.19.11)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -6981,13 +8134,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@1.6.1(@types/node@25.3.0):
+  vite-node@1.6.1(@types/node@25.3.0)(lightningcss@1.32.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.21(@types/node@25.3.0)
+      vite: 5.4.21(@types/node@25.3.0)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -6999,7 +8152,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.21(@types/node@22.19.11):
+  vite@5.4.21(@types/node@22.19.11)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
@@ -7007,8 +8160,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.11
       fsevents: 2.3.3
+      lightningcss: 1.32.0
 
-  vite@5.4.21(@types/node@25.3.0):
+  vite@5.4.21(@types/node@25.3.0)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
@@ -7016,8 +8170,25 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.3.0
       fsevents: 2.3.3
+      lightningcss: 1.32.0
 
-  vitest@1.6.1(@types/node@22.19.11):
+  vite@6.4.3(@types/node@25.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.3.0
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      tsx: 4.21.0
+      yaml: 2.8.2
+
+  vitest@1.6.1(@types/node@22.19.11)(lightningcss@1.32.0):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -7036,8 +8207,8 @@ snapshots:
       strip-literal: 2.1.1
       tinybench: 2.9.0
       tinypool: 0.8.4
-      vite: 5.4.21(@types/node@22.19.11)
-      vite-node: 1.6.1(@types/node@22.19.11)
+      vite: 5.4.21(@types/node@22.19.11)(lightningcss@1.32.0)
+      vite-node: 1.6.1(@types/node@22.19.11)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.11
@@ -7051,7 +8222,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@1.6.1(@types/node@25.3.0):
+  vitest@1.6.1(@types/node@25.3.0)(lightningcss@1.32.0):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -7070,8 +8241,8 @@ snapshots:
       strip-literal: 2.1.1
       tinybench: 2.9.0
       tinypool: 0.8.4
-      vite: 5.4.21(@types/node@25.3.0)
-      vite-node: 1.6.1(@types/node@25.3.0)
+      vite: 5.4.21(@types/node@25.3.0)(lightningcss@1.32.0)
+      vite-node: 1.6.1(@types/node@25.3.0)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.3.0
@@ -7124,6 +8295,8 @@ snapshots:
       is-wsl: 3.1.1
 
   xtend@4.0.2: {}
+
+  yallist@3.1.1: {}
 
   yallist@4.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - packages/*
+  - packages/standalone/ui
 
 enableScripts: true
 


### PR DESCRIPTION
## What

Phase 1 of the M7 operator viewer: a React shell (Kagemusha UI mechanism, MAMA contracts) served at `/ui` **parallel to** the legacy `/viewer`.

- **Operator board** (`/ui`): agent-published report slots render live over SSE (bulk/single/deleted payloads, reconnect refetch), ordered `briefing → action_required → decisions → pipeline → custom`, with trigger stat cards.
- **Trigger veto tray** (`/ui/triggers`): all trigger statuses with counters; owner disable requires a reason and is logged loudly.
- **`/api/operator`**: summary / list / disable, backed by the trigger loop's `triggers.db` through a lazily-opened second connection (`busy_timeout`), `TriggerRegistry.listAll()` + `disabledReason` (previously dropped by `rowToRecord`).
- **`report_publish` un-gated**: no longer requires `dashboardAgentConfigured` and no longer drops every slot except `briefing`; `createReportPublisher` is the single write path (64KB/slot, 24-slot caps, loud skips), reused by the heartbeat briefing writer (removed the duplicated inline pair).
- **Slot persistence**: `~/.mama/report-slots.json` (updatedAt preserved verbatim, 250ms debounced writes, exit flush on graceful stop, corrupt file → loud warn + empty board). `createApiServer` gained an optional `reportStore`; the in-memory default is preserved so its ~30 test call sites never touch the real `~/.mama`.
- **Security**: two independent XSS layers for agent-authored slot HTML — DOMPurify at render + `script-src 'self'` CSP on `/ui` documents (live-verified not to break the Vite SPA). Traversal guard + missing-asset 404 (no index fallback under `/ui/assets/`).

## Process

Plan reviewed by gstack plan-eng-review + an independent outside-voice pass (9 findings incl. 1 blocker — all incorporated before implementation). Implementation reviewed by an adversarial Opus pass: **PASS**, minors fixed in the last commit (kind pill truncation, exit flush).

## Verification

- Full standalone suite green (241 files), typecheck clean, ui `tsc --noEmit` + Vite build clean
- New tests: `/ui` static serving (7 incl. CSP header + traversal + asset-404), operator router (5, temp-db), publisher factory (3), persistence (3), SSE merge/order pure fns (6), registry `listAll` (1)
- Live smoke on the running daemon: `/ui` 200 with the exact CSP, `/api/operator/summary` returned live counters, slot publish landed in `GET /api/report` + the SSE stream, the persistence snapshot was written, legacy `/viewer` still 200
- Verified the full suite creates NO `~/.mama/report-slots.json` (file absent before/after)

## Known minors (reviewed, deliberately deferred)

- The operator router's lazily-opened db handle is not closed on shutdown (one handle for process lifetime, rollback journal, read-mostly — symmetric close needs ApiServer lifecycle plumbing; follow-up).
- Phase 2 (out of scope, documented in the plan): Channels/Insights/Settings pages, non-loopback auth, default-route flip, legacy `/viewer` CSP, multi-slot content producers beyond the heartbeat briefing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the MAMA Operator beta board at `/ui`, with live report updates, persistent report slots, trigger statistics, and responsive navigation.
  - Added a Triggers view for reviewing active and inactive triggers and disabling them with a required reason.
  - Reports can now publish multiple custom slots, with consistent ordering and size safeguards.
  - Added persistent report storage across restarts.
- **Documentation**
  - Updated standalone setup instructions with the Operator Board URL and usage details.
- **Security**
  - Added HTML sanitization and restrictive browser security policies for rendered reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->