### PR TITLE
feat(operator): Kagemusha-style board authoring -- 4-slot vocabulary everywhere

### DIFF
--- a/packages/standalone/src/api/graph-api.ts
+++ b/packages/standalone/src/api/graph-api.ts
@@ -1333,10 +1333,11 @@ function createGraphHandler(options: GraphHandlerOptions = {}): GraphHandlerFn {
       return true;
     }
 
-    // Route: GET / - redirect to /viewer
+    // Route: GET / - redirect to the operator board (M7 phase 2: /ui is the
+    // default face; the legacy viewer stays reachable at /viewer)
     if (pathname === '/' && req.method === 'GET') {
-      console.log('[GraphHandler] Redirecting / to /viewer');
-      res.writeHead(302, { Location: '/viewer' });
+      console.log('[GraphHandler] Redirecting / to /ui');
+      res.writeHead(302, { Location: '/ui' });
       res.end();
       return true;
     }

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -1084,6 +1084,7 @@ export async function runAgentLoop(
       const { createPersonaReportAsk, OPERATOR_REPORT_SESSION_KEY } =
         await import('../../operator/report-run.js');
       const { OPERATOR_FULL_REPORT_TAG } = await import('../../operator/situation-report.js');
+      const { buildBoardPublishLines } = await import('../../operator/board-slot-instructions.js');
 
       const triggerDbPath = expandPath('~/.mama/operator/triggers.db');
       mkdirSync(dirname(triggerDbPath), { recursive: true });
@@ -1192,6 +1193,9 @@ export async function runAgentLoop(
           'kagemusha_entities({ activeOnly: true }) for active channels, then kagemusha_messages({ channelId }) on the busiest 2-3 (since defaults to the last 7 days; pass an ISO-8601 timestamp like since: "2026-07-09T00:00:00Z" to narrow it - never a phrase like "24h ago")',
           'mama_recall(query) for memory relevant to what you find',
         ],
+        // Kagemusha dual output: the same scheduled run updates the /ui operator board
+        // slots via report_publish, then writes the plain-text owner report.
+        fullReportBoardLines: buildBoardPublishLines(),
         config: {
           tickMs: Number(process.env.MAMA_TRIGGER_LOOP_TICK_MS || 60_000),
           drainLimit: Number(process.env.MAMA_TRIGGER_LOOP_DRAIN_LIMIT || 200),

--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -339,7 +339,7 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
    Do not include dashboard_briefing, wiki_compilation, system-audit, or audit-log labels in the context_compile task text; filter those operational summaries after the packet returns.
    If context_compile is unavailable because there is no active worker envelope, fall back to mama_search once (limit 20).
 3. If NO substantive decisions or agent alerts exist since the last dashboard publish → respond "NO_UPDATE" and stop. Do NOT call report_publish.
-4. If new substantive information exists → analyze it, write a new briefing, and publish via report_publish in the "briefing" slot.
+4. If new substantive information exists -> analyze it and publish ALL FOUR board slots (briefing, action_required, decisions, pipeline) in a SINGLE report_publish call, using the board HTML vocabulary from your persona.
 5. Do NOT call mama_save for the briefing; report_publish and agent_activity are the durable operational record.
 
 This saves resources. Only publish when there is genuinely new information to report.`;

--- a/packages/standalone/src/multi-agent/dashboard-agent-persona.ts
+++ b/packages/standalone/src/multi-agent/dashboard-agent-persona.ts
@@ -1,60 +1,58 @@
 /**
- * Default persona for the dashboard briefing agent.
+ * Default persona for the dashboard (operator board) agent.
  * Written to ~/.mama/personas/dashboard.md on first use if not present.
  * Follows the same pattern as memory-agent-persona.ts.
+ *
+ * v9: Kagemusha authoring mechanism -- the agent publishes ALL FOUR board
+ * slots with the shared card/badge HTML vocabulary (board-slot-instructions.ts)
+ * instead of a single prose briefing with inline styles.
  */
 
 import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { buildBoardHtmlVocabulary } from '../operator/board-slot-instructions.js';
 
-const MANAGED_DASHBOARD_PERSONA_MARKER = '<!-- MAMA managed dashboard persona v8 -->';
+const MANAGED_DASHBOARD_PERSONA_MARKER = '<!-- MAMA managed dashboard persona v9 -->';
 
 export const DASHBOARD_AGENT_PERSONA = `${MANAGED_DASHBOARD_PERSONA_MARKER}
 
-You are the MAMA OS briefing agent. You analyze project data and produce concise briefings.
-
-The dashboard already displays notifications, timeline, and pipeline via API.
-Write only the briefing section — analysis and insights that the API does not provide.
+You are the MAMA OS operator-board agent. You analyze project data and publish the
+operator board (/ui): a four-slot, card-based situation report.
 
 ## Language
-- Always write in Korean. No exceptions.
+- Write all published board CONTENT in Korean. No exceptions. (Markup stays as specified below.)
 
 ## Tools
-- context_compile({task, limit?, max_tool_calls?, strictness?}) — compile a scoped evidence packet for this briefing
-- mama_search({query, limit}) — fallback search when context_compile returns any non-success result (e.g. service unavailable, missing worker envelope, permission denied, or other failure)
-- agent_notices({limit}) — inspect recent agent notices for delegations, errors, and warnings
-- report_publish({slots: {briefing: "<html>", ...}}) -- publish report slots to the operator board. The board renders known slots first, in this order: "briefing" (summary), "action_required", "decisions", "pipeline"; any additional custom slot ids render after them by priority.
+- context_compile({task, limit?, max_tool_calls?, strictness?}) -- compile a scoped evidence packet for the board
+- mama_search({query, limit}) -- fallback search when context_compile returns any non-success result (e.g. service unavailable, missing worker envelope, permission denied, or other failure)
+- agent_notices({limit}) -- inspect recent agent notices for delegations, errors, and warnings
+- report_publish({slots: {briefing, action_required, decisions, pipeline}}) -- publish ALL FOUR slots in ONE call. The board renders them in that order; any additional custom slot ids render after them by priority.
 
-## What to Write
-- Project status summary (3-5 lines max)
-- Items requiring immediate attention
-- Cross-project patterns or risks
-- Agent activity summary (if agents are active): delegations, errors, test scores
+## Board slots (what each must contain)
+- briefing: one report-summary block (title + stat highlights), then up to 4 report-cards for the key situations
+- action_required: a report-section-title, then up to 5 cards; every card-action states the concrete next step
+- decisions: cards for items waiting on an owner decision or confirmation; when none exist, publish a one-line quiet note instead of filler
+- pipeline: one report-table of workstreams with their current state
+
+## HTML vocabulary
+${buildBoardHtmlVocabulary().join('\n')}
+Keep each slot under 6KB. No emoji.
 
 ## How to Write
-1. Compile briefing evidence with context_compile using this exact task text: "recent substantive project decisions, task progress, agent alerts, and major changes" (limit 20, max_tool_calls 2, strictness "balanced")
+1. Compile evidence with context_compile using this exact task text: "recent substantive project decisions, task progress, agent alerts, and major changes" (limit 20, max_tool_calls 2, strictness "balanced")
 2. If context_compile returns any non-success result (e.g. service unavailable, missing worker envelope, permission denied, or other error), fall back to mama_search once (limit 20)
-3. Analyze content and identify patterns
-4. Check agent_notices for recent agent activity (delegations, errors)
-5. If active agents exist, add "Agent Activity" section to briefing
-6. Write a concise briefing — no raw data listings, only analysis and insights
-7. Publish with report_publish
-8. Keep any context_packet_id from context_compile in mind for audit language, but do not invent one or pass one to report_publish
-9. Do not save the briefing with mama_save; report_publish and agent_activity already record operational output
-
-## HTML Rules
-- Inline styles only
-- Headings: font-family:Fredoka,sans-serif;font-size:14px;font-weight:600;color:#1A1A1A
-- Body text: font-size:12px;color:#6B6560;line-height:1.6
-- Warning: color:#D94F4F, Normal: color:#3A9E7E
-- border-radius 4px max, no emoji
+3. Check agent_notices for recent agent activity (delegations, errors); reflect notable items in the briefing or action_required cards
+4. Analyze content, identify patterns and risks -- no raw data listings, only analysis and insights
+5. Compose all four slots with the vocabulary above and publish them with a SINGLE report_publish call
+6. Keep any context_packet_id from context_compile in mind for audit language, but do not invent one or pass one to report_publish
+7. Do not save board content with mama_save; report_publish and agent_activity already record operational output
 
 ## Strict Constraints
 - Prefer context_compile over mama_search for evidence gathering
 - Do not include dashboard_briefing, wiki_compilation, system-audit, or audit-log labels in the context_compile task text
 - Call mama_search at most once, and only as a fallback after context_compile returns a non-success result
-- Call report_publish exactly once
+- Call report_publish exactly once, carrying all four slots
 - Do not call mama_save for dashboard_briefing or other operational summaries
 - Do not ask follow-up questions
 - Do not perform additional reasoning after publishing

--- a/packages/standalone/src/operator/board-slot-instructions.ts
+++ b/packages/standalone/src/operator/board-slot-instructions.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared board-authoring vocabulary (Kagemusha mechanism port).
+ *
+ * Every report producer (dashboard agent persona, its scheduled prompt, the
+ * trigger loop's scheduled full report) injects THESE lines so the operator
+ * board at /ui receives the same 4-slot, card-based HTML regardless of which
+ * agent wrote it. The classes are styled by ui/src/styles/global.css --
+ * agents write structure, the board owns look.
+ *
+ * Generic mechanism only: no personal strings, English source; the agent is
+ * told to write CONTENT in the owner's language.
+ */
+
+export const BOARD_SLOT_ORDER = ['briefing', 'action_required', 'decisions', 'pipeline'] as const;
+
+/** The exact HTML shapes the board stylesheet understands. */
+export function buildBoardHtmlVocabulary(): string[] {
+  return [
+    'Slot HTML must use ONLY this class vocabulary (the board styles it; inline styles are unnecessary):',
+    '- Summary header: <div class="report-summary"><div class="summary-title">TITLE</div>',
+    '  <div class="summary-stats">label <span class="stat-highlight">N</span> / label <span class="stat-highlight">N</span></div></div>',
+    '- Section heading: <div class="report-section-title">HEADING</div>',
+    '- Item card: <div class="report-card"><div class="card-header"><div class="card-title">TITLE</div>',
+    '  <span class="card-badge badge-warning">STATE</span></div>',
+    '  <div class="card-tags"><span class="tag tag-channel">CHANNEL</span></div>',
+    '  <div class="card-action">CONCRETE NEXT ACTION</div></div>',
+    '- Badge classes by state: badge-danger (blocked/overdue), badge-warning (waiting/needs confirmation),',
+    '  badge-info (in progress), badge-success (done/quiet).',
+    '- Pipeline table: <table class="report-table"><thead><tr><th>...</th></tr></thead><tbody>rows</tbody></table>',
+    'No <script>, <iframe>, or event handlers: the board sanitizes them out and the CSP blocks them.',
+  ];
+}
+
+/** Instruction block that makes a report run also publish the board slots. */
+export function buildBoardPublishLines(): string[] {
+  return [
+    'BEFORE writing your text report, update the operator board: call the report_publish',
+    'gateway tool EXACTLY once with ALL four slots:',
+    '  report_publish({ slots: { briefing: "<html>", action_required: "<html>", decisions: "<html>", pipeline: "<html>" } })',
+    '- briefing: one report-summary block (title + stat highlights), then up to 4 item cards for the key situations.',
+    '- action_required: a report-section-title, then up to 5 cards; every card-action states the concrete next step.',
+    '- decisions: cards for items waiting on an owner decision or confirmation; omit filler when none exist,',
+    '  but still publish the slot with a one-line quiet note.',
+    '- pipeline: one report-table of workstreams with their current state.',
+    ...buildBoardHtmlVocabulary(),
+    "Write all slot CONTENT in the owner's language (match the channels); keep each slot under 6KB.",
+    'The plain-text report you write afterwards is a separate output: no HTML in it.',
+  ];
+}

--- a/packages/standalone/src/operator/operator-trigger-loop.ts
+++ b/packages/standalone/src/operator/operator-trigger-loop.ts
@@ -14,7 +14,11 @@
  * injected so the pipeline is unit-testable.
  */
 
-import type { OperatorChannelEvent, OperatorMemoryPort, OutputSink } from './operator-interfaces.js';
+import type {
+  OperatorChannelEvent,
+  OperatorMemoryPort,
+  OutputSink,
+} from './operator-interfaces.js';
 import type { TriggerRecord } from './trigger-types.js';
 import type { TriggerRegistry } from './trigger-registry.js';
 import { matchTriggers } from './trigger-matcher.js';
@@ -66,6 +70,8 @@ export interface TriggerLoopDeps {
   reportScheduler?: ReportSchedule;
   /** M2.3: tool-call instructions for the FULL report so the agent self-gathers context. */
   fullReportSelfGather?: string[];
+  /** Kagemusha dual output: FULL report also publishes the operator board slots. */
+  fullReportBoardLines?: string[];
   config: TriggerLoopConfig;
   log: (line: string) => void;
 }
@@ -91,7 +97,10 @@ export class OperatorTriggerLoop {
 
   constructor(deps: TriggerLoopDeps) {
     this.deps = deps;
-    this.fullReporter = new SituationReporter({ selfGatherLines: deps.fullReportSelfGather });
+    this.fullReporter = new SituationReporter({
+      selfGatherLines: deps.fullReportSelfGather,
+      boardPublishLines: deps.fullReportBoardLines,
+    });
   }
 
   async tick(): Promise<TickResult> {
@@ -200,7 +209,9 @@ export class OperatorTriggerLoop {
       if (fire) {
         fullReported = await this.fullReporter.report(reportAsk, output, 'full');
         reportScheduler.markFired(hourKey); // reached only if report() did not throw (sent OR agent-suppressed)
-        log(`[trigger-loop] tick ${tick}: full report ${fullReported ? 'SENT' : 'suppressed by agent'} (${hourKey})`);
+        log(
+          `[trigger-loop] tick ${tick}: full report ${fullReported ? 'SENT' : 'suppressed by agent'} (${hourKey})`
+        );
       }
     }
 
@@ -229,7 +240,9 @@ export class OperatorTriggerLoop {
     this.nudgeTimer = setTimeout(() => {
       this.nudgeTimer = null;
       if (this.running) {
-        this.deps.log('[trigger-loop] nudge: tick already running - skipped (deltas wait for next tick)');
+        this.deps.log(
+          '[trigger-loop] nudge: tick already running - skipped (deltas wait for next tick)'
+        );
         return;
       }
       this.running = true;
@@ -261,7 +274,9 @@ export class OperatorTriggerLoop {
       this.running = true;
       void this.tick()
         .catch((error: unknown) => {
-          log(`[trigger-loop] tick failed: ${error instanceof Error ? error.message : String(error)}`);
+          log(
+            `[trigger-loop] tick failed: ${error instanceof Error ? error.message : String(error)}`
+          );
         })
         .finally(() => {
           this.running = false;

--- a/packages/standalone/src/operator/situation-report.ts
+++ b/packages/standalone/src/operator/situation-report.ts
@@ -62,6 +62,13 @@ export interface SituationReporterOptions {
    * module stays generic. Digest mode never uses them (frequent + must stay light).
    */
   selfGatherLines?: string[];
+  /**
+   * Kagemusha dual-output mechanism: lines instructing the FULL report run to also
+   * publish the operator board slots (report_publish) before writing the text
+   * report. Injected from runtime wiring (board-slot-instructions.ts); digest mode
+   * never publishes the board.
+   */
+  boardPublishLines?: string[];
 }
 
 export class SituationReporter {
@@ -96,8 +103,12 @@ export class SituationReporter {
   /** Fold one fire into the aggregate; merge the memory it recalled (agent-query-driven). */
   recordFire(activity: FireActivity): void {
     const key = `${activity.triggerId}|${activity.channelId}`;
-    const agg =
-      this.fireAgg.get(key) ?? { kind: activity.kind, channelId: activity.channelId, count: 0, topics: new Set<string>() };
+    const agg = this.fireAgg.get(key) ?? {
+      kind: activity.kind,
+      channelId: activity.channelId,
+      count: 0,
+      topics: new Set<string>(),
+    };
     agg.count += 1;
     for (const r of activity.recalled) {
       agg.topics.add(r.topic);
@@ -121,7 +132,11 @@ export class SituationReporter {
    * Agent composes the report from the aggregate; sink delivers it. Returns true if a report was
    * sent, false if there was nothing to say or the agent suppressed it (NOTHING).
    */
-  async report(askAgent: AskAgent, output: Pick<OutputSink, 'send'>, mode: ReportMode): Promise<boolean> {
+  async report(
+    askAgent: AskAgent,
+    output: Pick<OutputSink, 'send'>,
+    mode: ReportMode
+  ): Promise<boolean> {
     // M2.1: the scheduled FULL report is a duty report - it composes even on an empty window
     // (the owner relies on it arriving; a quiet window is itself the news). Digests stay gated.
     if (mode !== 'full' && !this.hasActivity()) return false;
@@ -150,17 +165,23 @@ export class SituationReporter {
     const channels = [...this.windowByChannel.entries()].sort((a, b) => b[1].count - a[1].count);
     const shown = channels.slice(0, MAX_CHANNELS_IN_PROMPT);
     const windowLines = shown.map(
-      ([channelId, w]) => `- ${channelId}: ${w.count} msg(s); recent: ${w.excerpts.join(' | ') || '(none)'}`
+      ([channelId, w]) =>
+        `- ${channelId}: ${w.count} msg(s); recent: ${w.excerpts.join(' | ') || '(none)'}`
     );
     if (channels.length > shown.length) {
       const restCount = channels.slice(shown.length).reduce((n, [, w]) => n + w.count, 0);
-      windowLines.push(`- (+${channels.length - shown.length} more channel(s), ${restCount} msg(s))`);
+      windowLines.push(
+        `- (+${channels.length - shown.length} more channel(s), ${restCount} msg(s))`
+      );
     }
 
     const fireLines = [...this.fireAgg.values()].map(
-      (f) => `- trigger "${f.kind}" fired ${f.count}x on ${f.channelId}; recalled: ${[...f.topics].join(', ') || '(none)'}`
+      (f) =>
+        `- trigger "${f.kind}" fired ${f.count}x on ${f.channelId}; recalled: ${[...f.topics].join(', ') || '(none)'}`
     );
-    const memoryLines = [...this.recalled.entries()].map(([topic, content]) => `- ${topic}: ${content}`);
+    const memoryLines = [...this.recalled.entries()].map(
+      ([topic, content]) => `- ${topic}: ${content}`
+    );
 
     // M2.1 posture: the full report is a DUTY report (always arrives - a quiet window is
     // reported as quiet, the aliveness signal owners rely on); the digest defaults to briefing
@@ -174,7 +195,7 @@ export class SituationReporter {
             "what recurred, what is new, and what needs the owner's attention. Plain language, no",
             'markdown tables. This scheduled report must ALWAYS arrive: if the window was quiet,',
             'say so in one or two lines instead of skipping.',
-            'Structure the report with these sections (render the headings in the owner\'s language;',
+            "Structure the report with these sections (render the headings in the owner's language;",
             'omit a section only when it is truly empty):',
             '1) Key situation  2) Action required  3) Decisions needed  4) Pipeline  5) Next actions',
             ...(this.opts.selfGatherLines && this.opts.selfGatherLines.length > 0
@@ -202,6 +223,9 @@ export class SituationReporter {
                   '"decision", with topic, decision, reasoning). Only save when it is genuinely',
                   'durable; skip the save otherwise. This is your judgement, not a requirement.',
                 ]
+              : []),
+            ...(this.opts.boardPublishLines && this.opts.boardPublishLines.length > 0
+              ? ['', ...this.opts.boardPublishLines]
               : []),
           ]
         : [

--- a/packages/standalone/tests/api/ui-static-serving.test.ts
+++ b/packages/standalone/tests/api/ui-static-serving.test.ts
@@ -111,4 +111,10 @@ describe('/ui static serving', () => {
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toContain('text/html');
   });
+
+  it('redirects / to the operator board (the board is the default face)', async () => {
+    const res = await requestGraph('/');
+    expect(res.status).toBe(302);
+    expect(res.headers['location']).toBe('/ui');
+  });
 });

--- a/packages/standalone/tests/operator/board-slot-instructions.test.ts
+++ b/packages/standalone/tests/operator/board-slot-instructions.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Board slot authoring vocabulary (Kagemusha mechanism port) -- the shared
+ * instruction text that makes every report producer publish the same 4-slot,
+ * card-based board HTML. Generic mechanism only; no personal strings.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  BOARD_SLOT_ORDER,
+  buildBoardHtmlVocabulary,
+  buildBoardPublishLines,
+} from '../../src/operator/board-slot-instructions.js';
+
+describe('board slot instructions', () => {
+  it('pins the four-slot order the board renders', () => {
+    expect([...BOARD_SLOT_ORDER]).toEqual(['briefing', 'action_required', 'decisions', 'pipeline']);
+  });
+
+  it('vocabulary names every CSS class the board stylesheet defines', () => {
+    const vocab = buildBoardHtmlVocabulary().join('\n');
+    for (const cls of [
+      'report-summary',
+      'summary-title',
+      'summary-stats',
+      'stat-highlight',
+      'report-section-title',
+      'report-card',
+      'card-header',
+      'card-title',
+      'card-badge',
+      'badge-danger',
+      'badge-warning',
+      'badge-info',
+      'badge-success',
+      'card-tags',
+      'tag-channel',
+      'card-action',
+      'report-table',
+    ]) {
+      expect(vocab).toContain(cls);
+    }
+  });
+
+  it('publish lines instruct one report_publish call carrying all four slots', () => {
+    const lines = buildBoardPublishLines().join('\n');
+    expect(lines).toContain('report_publish');
+    for (const slot of BOARD_SLOT_ORDER) {
+      expect(lines).toContain(slot);
+    }
+    // content language follows the owner, source stays English
+    expect(lines.toLowerCase()).toContain("owner's language");
+    // no scripts/styles: the board sanitizes and the CSP blocks them anyway
+    expect(lines).toContain('class');
+  });
+});

--- a/packages/standalone/tests/operator/situation-report.test.ts
+++ b/packages/standalone/tests/operator/situation-report.test.ts
@@ -5,13 +5,29 @@
  * Agent injected (vi.fn) - no real CLI. Synthetic data only.
  */
 import { describe, it, expect, vi } from 'vitest';
-import { SituationReporter, OPERATOR_FULL_REPORT_TAG } from '../../src/operator/situation-report.js';
+import {
+  SituationReporter,
+  OPERATOR_FULL_REPORT_TAG,
+} from '../../src/operator/situation-report.js';
 import type { OperatorChannelEvent } from '../../src/operator/operator-interfaces.js';
 
 function ev(id: number, channelId: string, content: string): OperatorChannelEvent {
-  return { id, channel: 'slack', channelId, userId: 'u1', role: 'user', content, createdAt: id * 100 };
+  return {
+    id,
+    channel: 'slack',
+    channelId,
+    userId: 'u1',
+    role: 'user',
+    content,
+    createdAt: id * 100,
+  };
 }
-function fire(triggerId: string, kind: string, channelId: string, recalled: { topic: string; content: string }[] = []) {
+function fire(
+  triggerId: string,
+  kind: string,
+  channelId: string,
+  recalled: { topic: string; content: string }[] = []
+) {
   return { triggerId, kind, channelId, recalled };
 }
 
@@ -30,13 +46,17 @@ describe('SituationReporter (M2, supersedes TriggerReporter M1.5)', () => {
     const askAgent = vi.fn(async () => 'DIGEST: report-trigger fired on slack.');
     const send = vi.fn(async () => {});
     const r = new SituationReporter();
-    r.recordFire(fire('t1', 'weekly_report', 'slack:c1', [{ topic: 'report-cadence', content: 'Fridays' }]));
-    r.recordFire(fire('t1', 'weekly_report', 'slack:c1', [{ topic: 'report-cadence', content: 'Fridays' }]));
+    r.recordFire(
+      fire('t1', 'weekly_report', 'slack:c1', [{ topic: 'report-cadence', content: 'Fridays' }])
+    );
+    r.recordFire(
+      fire('t1', 'weekly_report', 'slack:c1', [{ topic: 'report-cadence', content: 'Fridays' }])
+    );
     r.recordAuthored(1);
     expect(await r.report(askAgent, { send }, 'digest')).toBe(true);
     const prompt = askAgent.mock.calls[0][0] as string;
-    expect(prompt).toContain('weekly_report');  // aggregate fire activity reaches the agent
-    expect(prompt).toContain('report-cadence');  // recalled memory reaches the agent
+    expect(prompt).toContain('weekly_report'); // aggregate fire activity reaches the agent
+    expect(prompt).toContain('report-cadence'); // recalled memory reaches the agent
     expect(send).toHaveBeenCalledWith('DIGEST: report-trigger fired on slack.');
     expect(await r.report(askAgent, { send }, 'digest')).toBe(false); // buffer cleared
     expect(send).toHaveBeenCalledTimes(1);
@@ -53,7 +73,9 @@ describe('SituationReporter (M2, supersedes TriggerReporter M1.5)', () => {
 
   it('send failure propagates loudly (no-fallback), buffer preserved for retry', async () => {
     const askAgent = vi.fn(async () => 'digest');
-    const send = vi.fn(async () => { throw new Error('telegram down'); });
+    const send = vi.fn(async () => {
+      throw new Error('telegram down');
+    });
     const r = new SituationReporter();
     r.recordFire(fire('t1', 'k', 'c'));
     await expect(r.report(askAgent, { send }, 'digest')).rejects.toThrow('telegram down');
@@ -67,7 +89,11 @@ describe('SituationReporter (M2, supersedes TriggerReporter M1.5)', () => {
     const askAgent = vi.fn(async () => 'situation');
     const send = vi.fn(async () => {});
     const r = new SituationReporter();
-    r.recordWindow([ev(1, 'slack:a', 'deploy is failing again'), ev(2, 'slack:b', 'lunch?'), ev(3, 'slack:a', 'still failing')]);
+    r.recordWindow([
+      ev(1, 'slack:a', 'deploy is failing again'),
+      ev(2, 'slack:b', 'lunch?'),
+      ev(3, 'slack:a', 'still failing'),
+    ]);
     expect(r.hasActivity()).toBe(true);
     expect(await r.report(askAgent, { send }, 'full')).toBe(true);
     const prompt = askAgent.mock.calls[0][0] as string;
@@ -87,10 +113,10 @@ describe('SituationReporter (M2, supersedes TriggerReporter M1.5)', () => {
     }
     await r.report(askAgent, { send }, 'full');
     const prompt = askAgent.mock.calls[0][0] as string;
-    expect(prompt).toContain('slack:a: 20 msg');   // exact count
-    expect(prompt).toContain('mark_020_');          // last excerpt kept
-    expect(prompt).not.toContain('mark_001_');      // early excerpts dropped (last-K only)
-    expect(prompt).not.toContain('y'.repeat(200));  // each excerpt truncated
+    expect(prompt).toContain('slack:a: 20 msg'); // exact count
+    expect(prompt).toContain('mark_020_'); // last excerpt kept
+    expect(prompt).not.toContain('mark_001_'); // early excerpts dropped (last-K only)
+    expect(prompt).not.toContain('y'.repeat(200)); // each excerpt truncated
   });
 
   it('digest keeps the NOTHING option (noise-only bar); full is a DUTY report without it (M2.1)', () => {
@@ -122,11 +148,30 @@ describe('SituationReporter (M2, supersedes TriggerReporter M1.5)', () => {
     expect(plain.buildPrompt('full')).not.toContain('primary source');
   });
 
+  it('full mode injects board publish lines when configured; digest never does', () => {
+    const r = new SituationReporter({
+      boardPublishLines: ['BOARD: call report_publish with all four slots'],
+    });
+    r.recordWindow([ev(1, 'slack:a', 'hi')]);
+    expect(r.buildPrompt('full')).toContain('BOARD: call report_publish with all four slots');
+    expect(r.buildPrompt('digest')).not.toContain('report_publish');
+    // without the option nothing board-related is injected
+    const plain = new SituationReporter();
+    plain.recordWindow([ev(1, 'slack:a', 'hi')]);
+    expect(plain.buildPrompt('full')).not.toContain('report_publish');
+  });
+
   it('full mode fixes the report skeleton: 5 generic sections, owner language (M2.2)', () => {
     const r = new SituationReporter();
     r.recordWindow([ev(1, 'slack:a', 'hi')]);
     const full = r.buildPrompt('full');
-    for (const section of ['Key situation', 'Action required', 'Decisions needed', 'Pipeline', 'Next actions']) {
+    for (const section of [
+      'Key situation',
+      'Action required',
+      'Decisions needed',
+      'Pipeline',
+      'Next actions',
+    ]) {
       expect(full).toContain(section);
     }
     expect(r.buildPrompt('digest')).not.toContain('Key situation'); // digest stays free-form short
@@ -150,7 +195,7 @@ describe('SituationReporter (M2, supersedes TriggerReporter M1.5)', () => {
     }
     const prompt = r.buildPrompt('full');
     expect(prompt).toContain('more channel(s)'); // collapsed tail
-    expect(prompt).toContain('ch:19');           // busiest channel shown
+    expect(prompt).toContain('ch:19'); // busiest channel shown
   });
 
   it('full self-gather teaches the tool_call protocol and forbids native gathering (M3 GAP1)', () => {
@@ -159,12 +204,12 @@ describe('SituationReporter (M2, supersedes TriggerReporter M1.5)', () => {
     });
     r.recordWindow([ev(1, 'slack:a', 'hi')]);
     const full = r.buildPrompt('full');
-    expect(full).toContain(OPERATOR_FULL_REPORT_TAG);            // machine frame tag present
-    expect(full).toContain('```tool_call');                     // protocol block shown
-    expect(full).toContain('"name":');                          // JSON block shape shown
-    expect(full).toMatch(/Do NOT read log files/i);             // anti-native directive
+    expect(full).toContain(OPERATOR_FULL_REPORT_TAG); // machine frame tag present
+    expect(full).toContain('```tool_call'); // protocol block shown
+    expect(full).toContain('"name":'); // JSON block shape shown
+    expect(full).toMatch(/Do NOT read log files/i); // anti-native directive
     expect(full).toContain('kagemusha_tasks({status:"needs_review"}) for the board'); // raw line kept
-    expect(full).toContain('primary source');                   // window is only a hint
+    expect(full).toContain('primary source'); // window is only a hint
     // digest stays protocol-free and tag-free
     const digest = r.buildPrompt('digest');
     expect(digest).not.toContain('```tool_call');

--- a/packages/standalone/ui/src/styles/global.css
+++ b/packages/standalone/ui/src/styles/global.css
@@ -41,3 +41,126 @@ body {
   background-color: var(--color-bg);
   color: var(--color-text);
 }
+
+/* -- Board slot vocabulary -----------------------------------------------
+ * Agent-authored slot HTML uses these classes (single source of truth for
+ * the writing side: src/operator/board-slot-instructions.ts). Agents write
+ * structure; the board owns the look. */
+
+.report-summary {
+  margin-bottom: 12px;
+}
+.summary-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text);
+  margin-bottom: 4px;
+}
+.summary-stats {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+.stat-highlight {
+  color: var(--color-agent);
+  font-weight: 700;
+}
+
+.report-section-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+  margin: 4px 0 10px;
+}
+
+.report-card {
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: var(--color-surface);
+  margin-bottom: 8px;
+}
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.card-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.card-badge {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+.badge-danger {
+  color: var(--color-danger);
+  background: color-mix(in srgb, var(--color-danger) 12%, transparent);
+}
+.badge-warning {
+  color: color-mix(in srgb, var(--color-warning) 70%, black);
+  background: color-mix(in srgb, var(--color-warning) 16%, transparent);
+}
+.badge-info {
+  color: var(--color-agent);
+  background: var(--color-agent-light);
+}
+.badge-success {
+  color: var(--color-success);
+  background: color-mix(in srgb, var(--color-success) 12%, transparent);
+}
+.card-tags {
+  margin-top: 4px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.tag {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--color-surface-secondary);
+  color: var(--color-text-tertiary);
+}
+.tag-channel {
+  background: var(--color-agent-light);
+  color: var(--color-agent);
+}
+.card-action {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+.card-action::before {
+  content: '\2192  ';
+  color: var(--color-agent);
+}
+
+.report-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.report-table th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--color-text-tertiary);
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--color-border);
+}
+.report-table td {
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text-secondary);
+}
+.report-table tr:last-child td {
+  border-bottom: none;
+}


### PR DESCRIPTION
## What

M7 phase 2, first tranche: the board **renderer** shipped in phase 1 -- this makes every agent **write for it** the way Kagemusha's report pipeline does.

- `board-slot-instructions.ts`: single source of truth for the 4-slot order (`briefing / action_required / decisions / pipeline`) and the card/badge/stats/table HTML class vocabulary. The board stylesheet styles those classes -- agents write structure, the board owns look.
- Dashboard persona v9 (managed, auto-upgrades local file): publishes ALL FOUR slots in one `report_publish` call using the vocabulary (was: one prose briefing with inline styles). The 30-min scheduled prompt keeps its delta gate.
- Trigger loop's scheduled full report gains Kagemusha's dual output: the same agent run updates the board slots, then writes the plain-text owner report (`SituationReporter.boardPublishLines`, injected from runtime wiring; digests never touch the board).
- `/` now redirects to `/ui` -- the operator board is the default face; the legacy viewer stays at `/viewer`.

## Verification

- TDD: vocabulary module (3 tests), reporter injection full-vs-digest (1), `/` redirect (1); full standalone suite 242 files green, typecheck + ui build clean
- Live smoke: daemon restarted on this build; persona auto-upgraded to v9; `/` 302 -> `/ui` verified; dashboard agent manually triggered via `POST /api/report/agent-refresh` (4-slot publish being verified in the daemon log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)