### PR TITLE
fix(code-act): board reads real task lifecycle -- tier filter + persona v11 + run serialization

### DIFF
--- a/packages/standalone/src/agent/code-act/host-bridge.ts
+++ b/packages/standalone/src/agent/code-act/host-bridge.ts
@@ -636,6 +636,13 @@ export const READ_ONLY_TOOLS = new Set([
   'os_get_config',
   'pr_review_threads',
   'agent_notices',
+  // Kagemusha bridge queries: pure reads of the business-data db. Without these
+  // the tier-2 dashboard agent cannot see real task lifecycle state and falls
+  // back to guessing task status from message archaeology.
+  'kagemusha_overview',
+  'kagemusha_entities',
+  'kagemusha_tasks',
+  'kagemusha_messages',
 ]);
 
 /** Memory-write tools additionally allowed for Tier 2 */

--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -382,7 +382,9 @@ This saves resources. Only publish when there is genuinely new information to re
     // 'Process is busy' errors (same pattern as CronWorker's executionQueue).
     let dashboardRunChain: Promise<void> = Promise.resolve();
     const runDashboardAgent = (opts?: { force?: boolean }): Promise<void> => {
-      dashboardRunChain = dashboardRunChain.then(() => doDashboardRun(opts));
+      // Trailing catch keeps one failed link from poisoning every future run:
+      // a rejected chain would silently skip all subsequent .then() links.
+      dashboardRunChain = dashboardRunChain.then(() => doDashboardRun(opts)).catch(() => {});
       return dashboardRunChain;
     };
 

--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -344,33 +344,56 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
 
 This saves resources. Only publish when there is genuinely new information to report.`;
 
-    const runDashboardAgent = async () => {
+    // Owner-initiated refresh skips the NO_UPDATE delta gate: an explicit
+    // request means "rebuild the board now", not "tell me nothing changed".
+    const forcedDashboardPrompt = dashboardPrompt.replace(
+      /3\. If NO substantive decisions[^\n]*\n/,
+      '3. The owner explicitly requested a fresh board: do NOT reply NO_UPDATE. Rebuild and publish even if nothing changed since the last publish.\n'
+    );
+
+    const doDashboardRun = async (opts?: { force?: boolean }) => {
       const pm = toolExecutor.getAgentProcessManager();
       if (!pm) {
         routesLogger.warn('[Dashboard Agent] AgentProcessManager not available yet');
         return;
       }
       try {
-        routesLogger.debug('[Dashboard Agent] Checking for updates...');
-        const { noUpdate } = await executeValidatedRun('dashboard-agent', dashboardPrompt);
-        if (noUpdate) {
-          routesLogger.debug('[Dashboard Agent] No changes detected, skipped');
-        } else {
-          routesLogger.debug('[Dashboard Agent] Briefing published');
-        }
+        // console.log on run outcomes: the DebugLogger only surfaces warn/error in the
+        // daemon log, and a silent outcome reads as a hang from the outside.
+        console.log(
+          `[Dashboard Agent] run started${opts?.force ? ' (owner-forced, delta gate bypassed)' : ''}`
+        );
+        const { noUpdate } = await executeValidatedRun(
+          'dashboard-agent',
+          opts?.force ? forcedDashboardPrompt : dashboardPrompt
+        );
+        console.log(
+          noUpdate
+            ? '[Dashboard Agent] no changes detected, publish skipped'
+            : '[Dashboard Agent] board published'
+        );
       } catch (err) {
         routesLogger.error('[Dashboard Agent] Error:', err instanceof Error ? err.message : err);
       }
+    };
+
+    // Serialize ALL dashboard runs (boot, interval, manual) on one chain -- the shared
+    // agent process rejects concurrent requests, so unserialized triggers raced into
+    // 'Process is busy' errors (same pattern as CronWorker's executionQueue).
+    let dashboardRunChain: Promise<void> = Promise.resolve();
+    const runDashboardAgent = (opts?: { force?: boolean }): Promise<void> => {
+      dashboardRunChain = dashboardRunChain.then(() => doDashboardRun(opts));
+      return dashboardRunChain;
     };
 
     // First run after 10s (let connectors poll first), then every 30 min
     setTimeout(runDashboardAgent, 10_000);
     setInterval(runDashboardAgent, 30 * 60 * 1000);
 
-    // Manual trigger
+    // Manual trigger (owner-forced: bypasses the delta gate)
     apiServer.app.post('/api/report/agent-refresh', requireAuth, async (_req, res) => {
-      runDashboardAgent().catch(() => {});
-      res.json({ ok: true, message: 'Dashboard agent triggered' });
+      runDashboardAgent({ force: true }).catch(() => {});
+      res.json({ ok: true, message: 'Dashboard agent triggered (forced refresh)' });
     });
   } else {
     routesLogger.debug('[Dashboard Agent] Skipped; dashboard-agent is not configured');

--- a/packages/standalone/src/multi-agent/dashboard-agent-persona.ts
+++ b/packages/standalone/src/multi-agent/dashboard-agent-persona.ts
@@ -13,7 +13,7 @@ import { join } from 'path';
 import { homedir } from 'os';
 import { buildBoardHtmlVocabulary } from '../operator/board-slot-instructions.js';
 
-const MANAGED_DASHBOARD_PERSONA_MARKER = '<!-- MAMA managed dashboard persona v10 -->';
+const MANAGED_DASHBOARD_PERSONA_MARKER = '<!-- MAMA managed dashboard persona v11 -->';
 
 export const DASHBOARD_AGENT_PERSONA = `${MANAGED_DASHBOARD_PERSONA_MARKER}
 
@@ -26,7 +26,8 @@ operator board (/ui): a four-slot, card-based situation report.
 ## Tools
 - kagemusha_tasks({status?}) -- the LIVE task board. Statuses are real lifecycle states: pending, in_progress, review, done, completed, cancelled, dismissed. Includes title, priority, deadline, source_room, confirmed.
 - kagemusha_overview() -- room/task/message counts for the stat line
-- channel_recent({since}) / channel_search / channel_history / channel_overview -- recent channel messages for deltas and evidence
+- kagemusha_entities({channel?, activeOnly?}) -- list rooms/people with activity stats; find the busiest rooms
+- kagemusha_messages({channelId, since?, limit?}) -- read recent raw messages from a room for deltas and evidence
 - context_compile({task, limit?, max_tool_calls?, strictness?}) -- compile a scoped evidence packet for the board
 - mama_search({query, limit}) -- fallback search when context_compile returns any non-success result (e.g. service unavailable, missing worker envelope, permission denied, or other failure)
 - agent_notices({limit}) -- inspect recent agent notices for delegations, errors, and warnings
@@ -61,13 +62,13 @@ Keep each slot under 6KB. No emoji.
 
 ## How to Write
 1. Read the REAL task state first: kagemusha_tasks({}) for open work, plus kagemusha_tasks({status: "review"}) and kagemusha_tasks({status: "pending"}) slices; kagemusha_overview() for the stat line
-2. Gather channel deltas with channel_recent (last 24-48h) on the busiest rooms for what changed since the last board
+2. Gather deltas: kagemusha_entities({activeOnly: true}), then kagemusha_messages({channelId, since}) on the busiest 2-3 rooms (since = ISO timestamp for the last 24-48h) for what changed since the last board
 3. Compile memory evidence with context_compile using this exact task text: "recent substantive project decisions, task progress, agent alerts, and major changes" (limit 20, max_tool_calls 2, strictness "balanced"); if it returns any non-success result, fall back to mama_search once (limit 20)
 4. Check agent_notices for recent agent activity (delegations, errors); reflect notable items in the briefing or action_required cards
 5. Analyze content, identify patterns and risks -- no raw data listings, only analysis and insights; apply the task-state and evidence discipline above
 6. Compose all four slots with the vocabulary above and publish them with a SINGLE report_publish call
-6. Keep any context_packet_id from context_compile in mind for audit language, but do not invent one or pass one to report_publish
-7. Do not save board content with mama_save; report_publish and agent_activity already record operational output
+7. Keep any context_packet_id from context_compile in mind for audit language, but do not invent one or pass one to report_publish
+8. Do not save board content with mama_save; report_publish and agent_activity already record operational output
 
 ## Strict Constraints
 - Prefer context_compile over mama_search for evidence gathering

--- a/packages/standalone/src/multi-agent/dashboard-agent-persona.ts
+++ b/packages/standalone/src/multi-agent/dashboard-agent-persona.ts
@@ -13,7 +13,7 @@ import { join } from 'path';
 import { homedir } from 'os';
 import { buildBoardHtmlVocabulary } from '../operator/board-slot-instructions.js';
 
-const MANAGED_DASHBOARD_PERSONA_MARKER = '<!-- MAMA managed dashboard persona v9 -->';
+const MANAGED_DASHBOARD_PERSONA_MARKER = '<!-- MAMA managed dashboard persona v10 -->';
 
 export const DASHBOARD_AGENT_PERSONA = `${MANAGED_DASHBOARD_PERSONA_MARKER}
 
@@ -24,10 +24,30 @@ operator board (/ui): a four-slot, card-based situation report.
 - Write all published board CONTENT in Korean. No exceptions. (Markup stays as specified below.)
 
 ## Tools
+- kagemusha_tasks({status?}) -- the LIVE task board. Statuses are real lifecycle states: pending, in_progress, review, done, completed, cancelled, dismissed. Includes title, priority, deadline, source_room, confirmed.
+- kagemusha_overview() -- room/task/message counts for the stat line
+- channel_recent({since}) / channel_search / channel_history / channel_overview -- recent channel messages for deltas and evidence
 - context_compile({task, limit?, max_tool_calls?, strictness?}) -- compile a scoped evidence packet for the board
 - mama_search({query, limit}) -- fallback search when context_compile returns any non-success result (e.g. service unavailable, missing worker envelope, permission denied, or other failure)
 - agent_notices({limit}) -- inspect recent agent notices for delegations, errors, and warnings
 - report_publish({slots: {briefing, action_required, decisions, pipeline}}) -- publish ALL FOUR slots in ONE call. The board renders them in that order; any additional custom slot ids render after them by priority.
+
+## Task state discipline (NON-NEGOTIABLE)
+- Task completion/progress state comes ONLY from kagemusha_tasks. NEVER infer a task's
+  state from message archaeology ("no approval message found" is not a status).
+- Card badges map to the REAL status: pending/review -> badge-warning, in_progress -> badge-info,
+  overdue deadline or explicitly blocked -> badge-danger, done/completed -> badge-success.
+- Deadlines come from the task's deadline field, never guessed from chat.
+- The pipeline slot is a report-table built from the kagemusha_tasks status distribution
+  (counts per status) plus the most important open items.
+
+## Evidence discipline (NON-NEGOTIABLE)
+- Every card cites its evidence in the details line: the newest supporting message's
+  date and channel (e.g. "07-09, kakao:..." ). No uncited claims.
+- If the newest evidence for an item is older than 7 days, do NOT issue a same-day
+  action directive for it; mark it "needs re-check" (badge-warning) instead.
+- Attribute people and rooms exactly as they appear in the source data; never merge
+  a sender with a room name.
 
 ## Board slots (what each must contain)
 - briefing: one report-summary block (title + stat highlights), then up to 4 report-cards for the key situations
@@ -40,11 +60,12 @@ ${buildBoardHtmlVocabulary().join('\n')}
 Keep each slot under 6KB. No emoji.
 
 ## How to Write
-1. Compile evidence with context_compile using this exact task text: "recent substantive project decisions, task progress, agent alerts, and major changes" (limit 20, max_tool_calls 2, strictness "balanced")
-2. If context_compile returns any non-success result (e.g. service unavailable, missing worker envelope, permission denied, or other error), fall back to mama_search once (limit 20)
-3. Check agent_notices for recent agent activity (delegations, errors); reflect notable items in the briefing or action_required cards
-4. Analyze content, identify patterns and risks -- no raw data listings, only analysis and insights
-5. Compose all four slots with the vocabulary above and publish them with a SINGLE report_publish call
+1. Read the REAL task state first: kagemusha_tasks({}) for open work, plus kagemusha_tasks({status: "review"}) and kagemusha_tasks({status: "pending"}) slices; kagemusha_overview() for the stat line
+2. Gather channel deltas with channel_recent (last 24-48h) on the busiest rooms for what changed since the last board
+3. Compile memory evidence with context_compile using this exact task text: "recent substantive project decisions, task progress, agent alerts, and major changes" (limit 20, max_tool_calls 2, strictness "balanced"); if it returns any non-success result, fall back to mama_search once (limit 20)
+4. Check agent_notices for recent agent activity (delegations, errors); reflect notable items in the briefing or action_required cards
+5. Analyze content, identify patterns and risks -- no raw data listings, only analysis and insights; apply the task-state and evidence discipline above
+6. Compose all four slots with the vocabulary above and publish them with a SINGLE report_publish call
 6. Keep any context_packet_id from context_compile in mind for audit language, but do not invent one or pass one to report_publish
 7. Do not save board content with mama_save; report_publish and agent_activity already record operational output
 

--- a/packages/standalone/tests/code-act/host-bridge.test.ts
+++ b/packages/standalone/tests/code-act/host-bridge.test.ts
@@ -72,6 +72,24 @@ describe('HostBridge', () => {
       expect(t3Names).not.toContain('Write');
     });
 
+    it('kagemusha query tools are read-only: available at tier 2 AND tier 3', () => {
+      // The dashboard agent (tier 2) reads real task lifecycle state through these;
+      // they are pure queries against the kagemusha bridge db, so tier 3 gets them too.
+      const bridge = new HostBridge(makeExecutor());
+      const queryTools = [
+        'kagemusha_overview',
+        'kagemusha_entities',
+        'kagemusha_tasks',
+        'kagemusha_messages',
+      ];
+      for (const tier of [2, 3] as const) {
+        const names = bridge.getAvailableFunctions(tier).map((f) => f.name);
+        for (const tool of queryTools) {
+          expect(names, `tier ${tier} should expose ${tool}`).toContain(tool);
+        }
+      }
+    });
+
     it('returns FunctionDescriptor shape', () => {
       const bridge = new HostBridge(makeExecutor());
       const [fn] = bridge.getAvailableFunctions(1);


### PR DESCRIPTION
## Problem
The operator board could not tell whether tasks were done or in progress: the tier-2 dashboard agent's code-act sandbox never injected the kagemusha query tools (tier filter in host-bridge, not the gateway allowlist), so it inferred states from message archaeology.

## Fix
- `READ_ONLY_TOOLS` gains the four kagemusha query tools (pure reads; tiers 2 AND 3). TDD.
- Persona v10->v11: task state ONLY from `kagemusha_tasks` (never inferred), badges map to real statuses, every card cites newest evidence (date+channel), stale evidence (>7d) demotes to re-check, delta gathering via `kagemusha_entities -> kagemusha_messages`.
- Dashboard runs serialized (boot/interval/manual raced into 'Process is busy'), owner-forced refresh bypasses the NO_UPDATE gate, outcomes now visible in the daemon log.

## Verification
- Full standalone suite green; host-bridge tier tests 18/18
- Sandbox probe as dashboard-agent: 4/4 functions injected (was 0/4)
- Live forced run: published board counts match the task db EXACTLY (in_progress 121 / pending 52 / review 21), cards cite same-day evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dashboard access to overview, entity, task, and message information.
  * Manual dashboard refreshes now force a fresh report update.
  * Dashboard runs are queued to prevent overlapping refreshes.

* **Improvements**
  * Enhanced dashboard reporting guidance for task tracking, evidence gathering, and publishing.

* **Tests**
  * Added coverage confirming the new dashboard tools are available at supported access tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->