### PR TITLE
feat(wiki): daily+lessons wiki purpose and pinned vault targeting

### DIFF
--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -505,8 +505,10 @@ export class GatewayToolExecutor {
   private wikiPublisher: WikiPagePublisher | null = null;
   private wikiPublishAdapter: WikiPublishAdapter | null = null;
   private obsidianVaultPath: string | null = null;
-  setObsidianVaultPath(vaultPath: string): void {
+  private obsidianVaultName: string | null = null;
+  setObsidianVaultPath(vaultPath: string, vaultName?: string): void {
     this.obsidianVaultPath = vaultPath;
+    this.obsidianVaultName = vaultName ?? null;
   }
   private agentEventBus: AgentEventBus | null = null;
   setAgentEventBus(bus: AgentEventBus): void {
@@ -3656,8 +3658,12 @@ export class GatewayToolExecutor {
     }
 
     // Obsidian CLI syntax: obsidian <command> key=value ... [flags]
-    // Vault is not passed as path — Obsidian uses the default/focused vault
+    // Without vault=<name> the CLI targets the FOCUSED vault, so wiki writes
+    // could land in whatever vault the owner has open. Pin it when configured.
     const cliArgs = [command];
+    if (this.obsidianVaultName) {
+      cliArgs.push(`vault=${this.obsidianVaultName}`);
+    }
     for (const [key, value] of Object.entries(args || {})) {
       if (value === 'true' && ['silent', 'overwrite', 'total'].includes(key)) {
         cliArgs.push(key);

--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -425,7 +425,11 @@ This saves resources. Only publish when there is genuinely new information to re
       `[Wiki Agent] Obsidian CLI vault: ${fullWikiPath} (vault=${obsidianVaultName})`
     );
 
-    // Ensure Obsidian is running with the wiki vault open (macOS only)
+    // Ensure Obsidian is running with the wiki vault open (macOS only).
+    // NOTE: obsidian://open?vault= only opens vaults ALREADY registered in
+    // Obsidian; registering the wiki directory as a vault is a one-time manual
+    // setup step. If it is not registered, the CLI reports unavailable and the
+    // agent falls back to wiki_publish (direct file writes still work).
     if (process.platform === 'darwin') {
       try {
         const { execFile: execFileChild } = await import('child_process');

--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -426,15 +426,20 @@ This saves resources. Only publish when there is genuinely new information to re
     );
 
     // Ensure Obsidian is running with the wiki vault open (macOS only)
-    try {
-      const { execFileSync: execFileSyncChild } = await import('child_process');
-      execFileSyncChild(
-        'open',
-        [`obsidian://open?vault=${encodeURIComponent(obsidianVaultName)}`],
-        { timeout: 5000, stdio: 'ignore' }
-      );
-    } catch {
-      /* non-fatal: CLI will return error, agent falls back to wiki_publish */
+    if (process.platform === 'darwin') {
+      try {
+        const { execFile: execFileChild } = await import('child_process');
+        execFileChild(
+          'open',
+          [`obsidian://open?vault=${encodeURIComponent(obsidianVaultName)}`],
+          { timeout: 5000 },
+          () => {
+            /* non-fatal: CLI will return error, agent falls back to wiki_publish */
+          }
+        );
+      } catch {
+        /* non-fatal */
+      }
     }
 
     // Wire wiki_publish tool to shared gateway executor (used by code-act path)

--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -415,18 +415,24 @@ This saves resources. Only publish when there is genuinely new information to re
     obsWriter.ensureDirectories();
     routesLogger.debug(`[Wiki Agent] Persona ensured, vault: ${obsWriter.getWikiPath()}`);
 
-    // Wire Obsidian vault path for CLI tool
+    // Wire Obsidian vault path for CLI tool. The wiki directory itself is what
+    // gets registered as an Obsidian vault (agent-facing paths like daily/... are
+    // relative to it), so the CLI vault name is the wiki path's basename.
     const fullWikiPath = obsWriter.getWikiPath();
-    toolExecutor.setObsidianVaultPath(fullWikiPath);
-    routesLogger.debug(`[Wiki Agent] Obsidian CLI vault: ${fullWikiPath}`);
+    const obsidianVaultName = path.basename(fullWikiPath);
+    toolExecutor.setObsidianVaultPath(fullWikiPath, obsidianVaultName);
+    routesLogger.debug(
+      `[Wiki Agent] Obsidian CLI vault: ${fullWikiPath} (vault=${obsidianVaultName})`
+    );
 
-    // Ensure Obsidian is running for CLI access (macOS only)
+    // Ensure Obsidian is running with the wiki vault open (macOS only)
     try {
-      const { execSync: execSyncChild } = await import('child_process');
-      execSyncChild('pgrep -x Obsidian || open -a Obsidian', {
-        timeout: 5000,
-        stdio: 'ignore',
-      });
+      const { execFileSync: execFileSyncChild } = await import('child_process');
+      execFileSyncChild(
+        'open',
+        [`obsidian://open?vault=${encodeURIComponent(obsidianVaultName)}`],
+        { timeout: 5000, stdio: 'ignore' }
+      );
     } catch {
       /* non-fatal: CLI will return error, agent falls back to wiki_publish */
     }
@@ -465,7 +471,7 @@ This saves resources. Only publish when there is genuinely new information to re
    Do not include dashboard_briefing, wiki_compilation, system-audit, or audit-log labels in the context_compile task text; filter those operational summaries after the packet returns.
    If context_compile is unavailable because there is no active worker envelope, fall back to mama_search once (limit 30).
 3. If NO substantive decisions exist since the last wiki compilation → respond "NO_UPDATE" and stop. Do NOT call obsidian or wiki_publish.
-4. If new substantive decisions exist → use obsidian("search") to check existing pages, then update or create pages as needed. Clean up duplicates.
+4. If new substantive material exists -> follow your persona: APPEND today's daily note (daily/YYYY-MM-DD.md, create with the section skeleton on first write of the day), then promote qualifying lesson candidates into lessons/ pages (search before create; update, never duplicate). Do NOT write per-task status pages.
 5. Do NOT call mama_save for the compilation; Obsidian/wiki files plus agent_activity are the durable operational record.
 
 This saves resources. Only compile when there is genuinely new information to document.`;

--- a/packages/standalone/src/multi-agent/wiki-agent-persona.ts
+++ b/packages/standalone/src/multi-agent/wiki-agent-persona.ts
@@ -1,95 +1,98 @@
 /**
  * Default persona for the wiki agent.
  * Written to ~/.mama/personas/wiki.md on first use if not present.
+ *
+ * v5: purpose narrowed to LESSONS + DAILY HISTORY. Current task state lives on
+ * the operator board (kagemusha_tasks is the truth source), so the wiki no
+ * longer mirrors per-task status into entity pages. Daily notes are an
+ * append-only journal; lesson pages are durable judgments that strengthen with
+ * recurring evidence and get superseded (never deleted) when contradicted.
  */
 
 import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 
-const MANAGED_WIKI_PERSONA_MARKER = '<!-- MAMA managed wiki persona v4 -->';
+const MANAGED_WIKI_PERSONA_MARKER = '<!-- MAMA managed wiki persona v5 -->';
 
 export const WIKI_AGENT_PERSONA = `${MANAGED_WIKI_PERSONA_MARKER}
 
-You are MAMA's Wiki Compiler — an internal agent that maintains an Obsidian wiki from structured decisions in the memory database.
+You are MAMA's Wiki Compiler. The wiki has exactly TWO purposes:
+1. DAILY HISTORY: an append-only journal of what actually happened each day.
+2. LESSONS: durable judgments, policies, and patterns worth re-reading months later.
 
-## Your Role
-- Search existing wiki pages before creating new ones (PREVENT DUPLICATES)
-- Update existing pages with new information (append, not replace)
-- Create new pages only when no existing page covers the topic
-- Maintain consistent tags and clean up duplicates
+It is NOT a task board. Current task state lives on the operator board; NEVER
+create or update pages that mirror per-task progress ("X is in_progress").
+
+## Vault Layout (fixed -- do not invent new top-level folders)
+- Home.md -- index: links to the last 7 daily notes and the lesson map
+- daily/YYYY-MM-DD.md -- one page per day, append-only
+- lessons/clients/<name>.md -- per-client policies, preferences, boundaries
+- lessons/process/<slug>.md -- recurring workflow rules
+- lessons/system/<slug>.md -- operational lessons about MAMA/agents themselves
+
+## Language
+- Write page CONTENT in Korean (proper nouns stay as-is). Markup and frontmatter keys stay English.
 
 ## Tools
-- **context_compile**({task, limit?, max_tool_calls?, strictness?}) — Compile a scoped evidence packet for this wiki update.
-- **mama_search**(query, limit?) — Fallback search when context_compile is unavailable.
-- **agent_notices**(limit?) — Inspect recent wiki/dashboard/conductor activity notices.
-- **obsidian**(command, args) — Obsidian vault CLI. Commands:
-  - search: Find existing pages. obsidian("search", {query: "KMS", limit: "5"})
-  - read: Read page content. obsidian("read", {file: "projects/KMS-General"})
-  - create: Create or overwrite page. obsidian("create", {name: "projects/New", content: "...", silent: "true"})
-  - append: Add to existing page. obsidian("append", {file: "projects/KMS", content: "## New Section\\n..."})
-  - prepend: Add to top of page. obsidian("prepend", {file: "...", content: "..."})
-  - move: Rename/move (auto-updates all backlinks). obsidian("move", {file: "old-name", to: "new-path"})
-  - delete: Trash a page. obsidian("delete", {file: "duplicates/Old"})
-  - find: List files. obsidian("find")
-  - property:set: Set frontmatter. obsidian("property:set", {file: "...", name: "compiled_at", value: "2026-04-09"})
-  - property:get: Read frontmatter. obsidian("property:get", {file: "...", name: "type"})
-  - tags: List all vault tags. obsidian("tags")
-  - tags:counts: Tag frequency. obsidian("tags:counts")
-  - tags:rename: Bulk rename tag. obsidian("tags:rename", {old: "meeting", new: "meetings"})
-  - backlinks: Pages linking to a file. obsidian("backlinks", {file: "projects/KMS"})
-  - js: Execute JS in Obsidian context. obsidian("js", {code: "app.vault.getFiles().length"})
-  - daily:append: Add to daily note. obsidian("daily:append", {content: "Wiki compiled"})
-- **wiki_publish**(pages) — Fallback only. Used when Obsidian is not running.
+- **context_compile**({task, limit?, max_tool_calls?, strictness?}) -- compile a scoped evidence packet for this update.
+- **mama_search**(query, limit?) -- fallback search when context_compile is unavailable.
+- **agent_notices**(limit?) -- find the last wiki compile boundary.
+- **obsidian**(command, args) -- Obsidian vault CLI. Commands:
+  - search: obsidian("search", {query: "keywords", limit: "5"})
+  - read: obsidian("read", {path: "daily/2026-07-10.md"})
+  - create: obsidian("create", {path: "lessons/process/new-rule.md", content: "...", silent: "true"})
+    IMPORTANT: always pass path= with the full relative path INCLUDING .md; name= rejects "/".
+  - append: obsidian("append", {path: "daily/2026-07-10.md", content: "..."})
+  - move / delete: reorganize (delete only for true duplicates)
+  - find: list files. obsidian("find")
+  - property:set: frontmatter. obsidian("property:set", {file: "...", name: "status", value: "active"})
+  - backlinks: obsidian("backlinks", {file: "lessons/process/X"})
+- **wiki_publish**(pages) -- fallback ONLY when the Obsidian CLI is unavailable.
 
-## Page Types
-- **entity**: Project/person/client page (projects/ folder)
-- **lesson**: Extracted pattern or learning (lessons/ folder)
-- **synthesis**: Cross-project analysis or weekly summary (synthesis/ folder)
-- **process**: Workflow or procedure (process/ folder)
+## Daily note rules
+- Target ONLY today's file: daily/YYYY-MM-DD.md (owner timezone). Create it on
+  first write of the day; afterwards APPEND. Never rewrite past days.
+- Sections (create on first write, append under them later):
+  - ## Progress -- what moved today: submissions, approvals, deliveries, replies. Summarize movement, not status inventory.
+  - ## Decisions -- substantive judgments made today (by the owner or agents)
+  - ## Issues -- problems, risks, unanswered questions that surfaced today
+  - ## Lesson candidates -- possible durable rules noticed today, each linking to an existing or proposed [[lessons/...]] page
+- Every bullet cites evidence: date + channel (e.g. "07-10, kakao:room"). No uncited claims.
+- Attribute people and rooms exactly as in the source; never merge a sender with a room name.
+
+## Lesson rules
+- One durable rule per page. A lesson is something that changes future behavior:
+  a client's standing preference, a pricing/revision policy, a process rule, a
+  failure pattern. One-off events and task states are NOT lessons.
+- Frontmatter via property:set: status (active | superseded), confidence (high | medium | low), last_verified (YYYY-MM-DD).
+- Page body: the rule in 1-3 sentences, then ## Evidence with dated entries.
+- Recurring evidence: APPEND one Evidence line and update last_verified. Do not duplicate the page.
+- Contradicted: set status to superseded, append why. NEVER delete a lesson.
+- Promote a lesson only when the pattern repeats OR the owner explicitly states a rule. Otherwise leave it as a daily-note lesson candidate.
 
 ## MANDATORY Workflow
-
-### Step 1: Get decisions from memory
-Use context_compile first with this exact task text: "recent substantive project decisions, task progress, agent alerts, and major changes" (limit 30, max_tool_calls 3, strictness "balanced").
-Do not include dashboard_briefing, wiki_compilation, system-audit, or audit-log labels in the context_compile task text; filter those operational summaries after the packet returns.
-Keep the packet_id/context_packet_id visible in your private notes for audit language and provenance checks.
-If context_compile fails because no active worker envelope is available, fall back to mama_search once with relevant queries.
-
-### Step 2: Search existing wiki pages (CRITICAL — do this BEFORE writing)
-obsidian("search", {query: "topic keywords"}) for each topic.
-Check results carefully — if a page exists, UPDATE it, don't create a new one.
-
-### Step 3: For each topic
-- If page EXISTS: obsidian("read") the current content, then obsidian("append") new information or obsidian("create") with overwrite if major rewrite needed.
-- If NO page exists: obsidian("create", {name: "type/Title", content: "...", silent: "true"})
-
-### Step 4: Metadata
-obsidian("property:set") to update compiled_at on each touched page.
-
-### Step 5: Cleanup (if needed)
-- Merge duplicates: obsidian("read") both, obsidian("create") merged, obsidian("delete") duplicate
-- Fix tags: obsidian("tags:rename") for inconsistencies
-- Move misplaced pages: obsidian("move")
-
-## Compilation Rules
-1. SYNTHESIZE, don't list — the goal is human understanding, not data dump
-2. Write in the same language as the decisions (Korean/Japanese/English)
-3. Use [[wikilinks]] to reference related pages
-4. Include ## Timeline with key events (reverse chronological)
-5. Include ## Key Decisions summarizing active decisions
-6. Flag contradictions or stale information explicitly
-7. Keep pages focused — one project per entity page
+1. agent_notices({limit: 100}): find the last wiki compile boundary.
+2. context_compile with this exact task text: "recent substantive project decisions, task progress, agent alerts, and major changes" (limit 30, max_tool_calls 3, strictness "balanced").
+   Do not include dashboard_briefing, wiki_compilation, system-audit, or audit-log labels in the task text; filter those operational summaries after the packet returns.
+   Keep the returned packet_id/context_packet_id in your private notes for provenance; never invent one.
+   If context_compile is unavailable, fall back to mama_search once.
+3. If nothing substantive is new since the boundary, respond NO_UPDATE and stop.
+4. Append today's daily note (read it first if it exists; create with the section skeleton if not).
+5. For each lesson candidate that qualifies for promotion: obsidian("search") first; update the existing page or create one under the right lessons/ subfolder.
+6. Keep Home.md current: last 7 daily links + lessons grouped by subfolder.
 
 ## Strict Limits
-- Prefer context_compile over mama_search for evidence gathering
-- Call mama_search only as a fallback after context_compile is unavailable
-- Do NOT ask follow-up questions
-- Do NOT call mama_save for wiki_compilation or other operational summaries
+- SYNTHESIZE, do not dump raw data.
+- Prefer context_compile over mama_search; mama_search at most once as fallback.
+- Do NOT create pages outside daily/ and lessons/ (Home.md is the only root page).
+- Do NOT call mama_save; wiki files plus agent_activity are the durable record.
+- Do NOT ask follow-up questions.
 - After completing all operations, respond with: DONE
 
 ## Fallback
-If obsidian() calls fail with "CLI unavailable", fall back to wiki_publish for write operations.`;
+If obsidian() calls fail with "CLI unavailable", use wiki_publish for the same
+pages (path = the same relative path, e.g. "daily/2026-07-10.md").`;
 
 /**
  * Ensure persona file exists at ~/.mama/personas/wiki.md

--- a/packages/standalone/src/wiki/obsidian-writer.ts
+++ b/packages/standalone/src/wiki/obsidian-writer.ts
@@ -127,14 +127,9 @@ export class ObsidianWriter {
       const dir = join(this.wikiPath, sub);
       if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
     }
-    const indexPath = join(this.wikiPath, 'index.md');
-    if (!existsSync(indexPath)) {
-      writeFileSync(indexPath, '# Wiki Index\n\nAuto-compiled by MAMA.\n\n## Pages\n\n', 'utf8');
-    }
-    const logPath = join(this.wikiPath, 'log.md');
-    if (!existsSync(logPath)) {
-      writeFileSync(logPath, '# Compilation Log\n\n', 'utf8');
-    }
+    // index.md/log.md are NOT bootstrapped here: in the v5 layout the agent owns
+    // the root (Home.md). updateIndex()/appendLog() create them on demand when
+    // the wiki_publish fallback path is actually used.
   }
 
   writePage(page: WikiPage): string {

--- a/packages/standalone/src/wiki/obsidian-writer.ts
+++ b/packages/standalone/src/wiki/obsidian-writer.ts
@@ -114,7 +114,16 @@ export class ObsidianWriter {
   }
 
   ensureDirectories(): void {
-    for (const sub of ['', 'projects', 'lessons', 'synthesis']) {
+    // v5 wiki layout: daily journal + lesson subfolders. writePage() still
+    // accepts any relative path, so legacy pages keep working.
+    for (const sub of [
+      '',
+      'daily',
+      'lessons',
+      'lessons/clients',
+      'lessons/process',
+      'lessons/system',
+    ]) {
       const dir = join(this.wikiPath, sub);
       if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
     }

--- a/packages/standalone/tests/agent/obsidian-gateway.test.ts
+++ b/packages/standalone/tests/agent/obsidian-gateway.test.ts
@@ -2,14 +2,19 @@ import { describe, it, expect } from 'vitest';
 
 /**
  * Build CLI arguments for the obsidian gateway tool.
- * Extracted here for unit testing — same logic used in GatewayToolExecutor.executeObsidian().
+ * Extracted here for unit testing -- same logic used in GatewayToolExecutor.executeObsidian():
+ * command first, then vault=<name> when a vault is configured (otherwise the CLI
+ * would target whatever vault the owner has focused), then key=value pairs.
  */
 function buildObsidianArgs(
-  vaultPath: string,
   command: string,
-  args?: Record<string, string>
+  args?: Record<string, string>,
+  vaultName?: string | null
 ): string[] {
-  const cliArgs = [vaultPath, command];
+  const cliArgs = [command];
+  if (vaultName) {
+    cliArgs.push(`vault=${vaultName}`);
+  }
   for (const [key, value] of Object.entries(args || {})) {
     if (value === 'true' && ['silent', 'overwrite', 'total'].includes(key)) {
       cliArgs.push(key);
@@ -23,63 +28,73 @@ function buildObsidianArgs(
 describe('obsidian gateway tool', () => {
   describe('argument building', () => {
     it('builds search command with query and limit', () => {
-      const args = buildObsidianArgs('/vault', 'search', { query: 'KMS billing', limit: '5' });
-      expect(args).toEqual(['/vault', 'search', 'query=KMS billing', 'limit=5']);
+      const args = buildObsidianArgs('search', { query: 'KMS billing', limit: '5' });
+      expect(args).toEqual(['search', 'query=KMS billing', 'limit=5']);
+    });
+
+    it('pins the configured vault so writes never land in the focused vault', () => {
+      const args = buildObsidianArgs(
+        'append',
+        { path: 'daily/2026-07-10.md', content: 'entry' },
+        'mama-operator'
+      );
+      expect(args).toEqual([
+        'append',
+        'vault=mama-operator',
+        'path=daily/2026-07-10.md',
+        'content=entry',
+      ]);
+    });
+
+    it('omits vault targeting when no vault name is configured', () => {
+      const args = buildObsidianArgs('tags', undefined, null);
+      expect(args).toEqual(['tags']);
     });
 
     it('builds create command with silent flag', () => {
-      const args = buildObsidianArgs('/vault', 'create', {
-        name: 'projects/New-Page',
+      // Nested creates must use path= (the CLI rejects "/" in name=).
+      const args = buildObsidianArgs('create', {
+        path: 'lessons/process/new-page.md',
         content: '# New Page',
         silent: 'true',
       });
       expect(args).toEqual([
-        '/vault',
         'create',
-        'name=projects/New-Page',
+        'path=lessons/process/new-page.md',
         'content=# New Page',
         'silent',
       ]);
     });
 
     it('builds property:set command', () => {
-      const args = buildObsidianArgs('/vault', 'property:set', {
-        file: 'projects/KMS',
-        name: 'compiled_at',
-        value: '2026-04-09',
+      const args = buildObsidianArgs('property:set', {
+        file: 'lessons/clients/KMS',
+        name: 'last_verified',
+        value: '2026-07-10',
       });
       expect(args).toEqual([
-        '/vault',
         'property:set',
-        'file=projects/KMS',
-        'name=compiled_at',
-        'value=2026-04-09',
+        'file=lessons/clients/KMS',
+        'name=last_verified',
+        'value=2026-07-10',
       ]);
     });
 
     it('builds move command', () => {
-      const args = buildObsidianArgs('/vault', 'move', {
+      const args = buildObsidianArgs('move', {
         file: 'old-name',
-        to: 'projects/new-name',
+        to: 'lessons/process/new-name',
       });
-      expect(args).toEqual(['/vault', 'move', 'file=old-name', 'to=projects/new-name']);
-    });
-
-    it('builds tags:rename command', () => {
-      const args = buildObsidianArgs('/vault', 'tags:rename', {
-        old: 'meeting',
-        new: 'meetings',
-      });
-      expect(args).toEqual(['/vault', 'tags:rename', 'old=meeting', 'new=meetings']);
+      expect(args).toEqual(['move', 'file=old-name', 'to=lessons/process/new-name']);
     });
 
     it('handles empty args', () => {
-      const args = buildObsidianArgs('/vault', 'tags');
-      expect(args).toEqual(['/vault', 'tags']);
+      const args = buildObsidianArgs('tags');
+      expect(args).toEqual(['tags']);
     });
 
     it('handles overwrite boolean flag', () => {
-      const args = buildObsidianArgs('/vault', 'create', {
+      const args = buildObsidianArgs('create', {
         name: 'test',
         content: 'body',
         overwrite: 'true',

--- a/packages/standalone/tests/wiki/obsidian-writer.test.ts
+++ b/packages/standalone/tests/wiki/obsidian-writer.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -19,10 +19,16 @@ describe('ObsidianWriter', () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it('creates wiki directory if not exists', () => {
+  it('creates the v5 wiki layout without bootstrapping root index/log files', () => {
     const writer = new ObsidianWriter(tempDir, 'wiki');
     writer.ensureDirectories();
-    expect(readFileSync(join(wikiDir, 'index.md'), 'utf8')).toContain('# Wiki Index');
+    for (const sub of ['daily', 'lessons/clients', 'lessons/process', 'lessons/system']) {
+      expect(existsSync(join(wikiDir, sub))).toBe(true);
+    }
+    // The agent owns the vault root (Home.md); index.md/log.md appear on demand
+    // only when the wiki_publish fallback writes them.
+    expect(existsSync(join(wikiDir, 'index.md'))).toBe(false);
+    expect(existsSync(join(wikiDir, 'log.md'))).toBe(false);
   });
 
   it('writes a page with frontmatter', () => {


### PR DESCRIPTION
## Summary
- Wiki purpose narrows to what the operator board cannot do: an append-only **daily journal** (`daily/YYYY-MM-DD.md`) and durable **lesson pages** (`lessons/clients|process|system`). Persona v5 bans per-task status pages -- task lifecycle state is the board's job via `kagemusha_tasks` (PR #130).
- Daily notes: section skeleton (Progress / Decisions / Issues / Lesson candidates), evidence citation per bullet, never rewrite past days.
- Lessons: one durable rule per page, frontmatter status/confidence/last_verified, evidence accumulates on recurrence, superseded (never deleted) on contradiction.
- **Obsidian CLI vault pinning**: `executeObsidian` now passes `vault=<name>` (basename of the wiki path). Without it the CLI targets whatever vault the owner has focused, so wiki writes could land in a personal vault.
- CLI contract fix: nested page creation must use `path=` (the CLI rejects `/` in `name=`); persona and tests updated. Verified against the live CLI with a create/append/read/delete round-trip.
- `ensureDirectories` seeds the v5 layout; `writePage` still accepts any relative path so legacy pages keep working.

## Test plan
- [x] `tests/agent/obsidian-gateway.test.ts` -- vault pinning + path= contract
- [x] `tests/wiki/*`, `tests/multi-agent/system-agent-unification.test.ts`, `tests/agent/gateway-tool-executor.test.ts` pass
- [x] pnpm typecheck
- [ ] Live: POST /api/wiki/compile writes today's daily note into the new vault (after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Obsidian actions now target the configured vault explicitly, helping ensure notes are written to the intended location.
  * Wiki organization now supports daily notes and categorized lessons for clients, processes, and systems.
  * Wiki guidance now focuses on append-only daily history and durable lesson pages, avoiding task-status pages.
* **Improvements**
  * Opening the wiki on macOS now launches the selected vault directly.
  * Lesson creation includes search-before-create and update-without-duplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->