### PR TITLE
fix(wiki): live-run defects -- sandbox exposure, daily type, run serialization

### DIFF
--- a/packages/standalone/src/agent/code-act/host-bridge.ts
+++ b/packages/standalone/src/agent/code-act/host-bridge.ts
@@ -654,6 +654,10 @@ export const MEMORY_WRITE_TOOLS = new Set([
   'mama_ingest',
   'report_publish',
   'wiki_publish',
+  // The Obsidian CLI is the tier-2 wiki agent's primary write path; without it
+  // the code-act sandbox never injects the function and every run silently
+  // degrades to the wiki_publish fallback.
+  'obsidian',
 ]);
 
 export class HostBridge {

--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -464,7 +464,7 @@ This saves resources. Only publish when there is genuinely new information to re
     });
 
     // Wiki trigger via executeValidatedRun
-    const runWikiAgent = async () => {
+    const doWikiRun = async () => {
       if (!toolExecutor.getAgentProcessManager()) {
         routesLogger.warn('[Wiki Agent] AgentProcessManager not available yet');
         return;
@@ -496,6 +496,16 @@ This saves resources. Only compile when there is genuinely new information to do
       } catch (err) {
         routesLogger.error('[Wiki Agent] Error:', err instanceof Error ? err.message : err);
       }
+    };
+
+    // Serialize ALL wiki runs (boot, event-driven, manual) on one chain -- the
+    // shared agent process rejects concurrent requests, so the boot run and a
+    // manual trigger raced into 'Process is busy' (same pattern as the
+    // dashboard agent's runDashboardAgent chain above).
+    let wikiRunChain: Promise<void> = Promise.resolve();
+    const runWikiAgent = (): Promise<void> => {
+      wikiRunChain = wikiRunChain.then(doWikiRun).catch(() => {});
+      return wikiRunChain;
     };
 
     // Event-driven: compile when extraction completes. Trailing-edge debounce so

--- a/packages/standalone/src/multi-agent/wiki-agent-persona.ts
+++ b/packages/standalone/src/multi-agent/wiki-agent-persona.ts
@@ -92,7 +92,10 @@ create or update pages that mirror per-task progress ("X is in_progress").
 
 ## Fallback
 If obsidian() calls fail with "CLI unavailable", use wiki_publish for the same
-pages (path = the same relative path, e.g. "daily/2026-07-10.md").`;
+pages (path = the same relative path, e.g. "daily/2026-07-10.md").
+wiki_publish page type must be one of: entity, lesson, synthesis, process, daily.
+Use type "daily" for daily notes and "lesson" for lesson pages; do not probe
+other type values or create throwaway test pages.`;
 
 /**
  * Ensure persona file exists at ~/.mama/personas/wiki.md

--- a/packages/standalone/src/wiki/types.ts
+++ b/packages/standalone/src/wiki/types.ts
@@ -1,4 +1,4 @@
-export const WIKI_PAGE_TYPES = ['entity', 'lesson', 'synthesis', 'process'] as const;
+export const WIKI_PAGE_TYPES = ['entity', 'lesson', 'synthesis', 'process', 'daily'] as const;
 export type WikiPageType = (typeof WIKI_PAGE_TYPES)[number];
 
 export function isValidPageType(type: string): type is WikiPageType {

--- a/packages/standalone/tests/code-act/host-bridge.test.ts
+++ b/packages/standalone/tests/code-act/host-bridge.test.ts
@@ -62,6 +62,18 @@ describe('HostBridge', () => {
       expect(t2Names).not.toContain('Bash');
     });
 
+    it('tier 2 exposes the wiki write path (obsidian CLI + wiki_publish fallback)', () => {
+      // The wiki agent runs at tier 2 with useCodeAct; without obsidian in the
+      // sandbox every run silently degrades to the wiki_publish fallback.
+      const bridge = new HostBridge(makeExecutor());
+      const t2Names = bridge.getAvailableFunctions(2).map((f) => f.name);
+      expect(t2Names).toContain('obsidian');
+      expect(t2Names).toContain('wiki_publish');
+      const t3Names = bridge.getAvailableFunctions(3).map((f) => f.name);
+      expect(t3Names).not.toContain('obsidian');
+      expect(t3Names).not.toContain('wiki_publish');
+    });
+
     it('tier 3 is strictly read-only (no memory-write)', () => {
       const bridge = new HostBridge(makeExecutor());
       const t3 = bridge.getAvailableFunctions(3);

--- a/packages/standalone/tests/wiki/types.test.ts
+++ b/packages/standalone/tests/wiki/types.test.ts
@@ -8,10 +8,12 @@ describe('Wiki types', () => {
     expect(WIKI_PAGE_TYPES).toContain('lesson');
     expect(WIKI_PAGE_TYPES).toContain('synthesis');
     expect(WIKI_PAGE_TYPES).toContain('process');
+    expect(WIKI_PAGE_TYPES).toContain('daily');
   });
 
   it('validates page types', () => {
     expect(isValidPageType('entity')).toBe(true);
+    expect(isValidPageType('daily')).toBe(true);
     expect(isValidPageType('garbage')).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
First live wiki-v5 run (post #132) wrote today's daily note and promoted two lessons, but surfaced three defects -- the agent reported them itself inside the note:

1. **obsidian missing from the tier-2 sandbox**: `obsidian` was not in `MEMORY_WRITE_TOOLS`, so the code-act sandbox never injected it and every run silently degraded to the `wiki_publish` fallback. Added with a comment; tier 3 still excludes it (regression-tested).
2. **No `daily` page type**: `WIKI_PAGE_TYPES` lacked `daily`, so the daily journal note had to masquerade as `type: process` and the agent probed types with throwaway pages. Added `daily`; persona now states the allowed types explicitly and bans probe pages.
3. **'Process is busy' race**: the boot-scheduled run and the manual `POST /api/wiki/compile` trigger hit the shared agent process concurrently. Wiki runs now serialize on one promise chain (same pattern as the dashboard agent, incl. trailing catch).

## Test plan
- [x] `tests/code-act/host-bridge.test.ts` -- tier-2 exposes obsidian/wiki_publish, tier 3 does not
- [x] `tests/wiki/types.test.ts` -- daily is a valid page type
- [x] full wiki suite + typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)