### PR TITLE
feat(memory): scheduled observation-to-decision promotion pass

### DIFF
--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -512,6 +512,10 @@ This saves resources. Only compile when there is genuinely new information to do
     // bursts of extraction:completed events coalesce into one wiki compile run.
     eventBus.onDebounced('extraction:completed', () => runWikiAgent(), 30_000);
 
+    // Promotion feeds the wiki: freshly promoted decisions are exactly the
+    // material daily notes and lessons compile from.
+    eventBus.onDebounced('memory:promoted', () => runWikiAgent(), 30_000);
+
     // Emit agent:action notices when wiki pages are compiled
     eventBus.on('wiki:compiled', (event) => {
       if (event.type === 'wiki:compiled') {
@@ -537,6 +541,84 @@ This saves resources. Only compile when there is genuinely new information to do
 
     routesLogger.info(
       '[Wiki Agent] Ready — triggers: extraction:completed event, POST /api/wiki/compile'
+    );
+  }
+
+  // -- Memory Promotion: scheduled observation->decision curation --
+  // Owner directive 2026-07-11: the decision layer starved after the 07-03/04
+  // backfill because nothing periodically judges connector-ingested business
+  // data (the M0 kill switch removed direct LLM extraction, and the memory
+  // agent only audits owner conversation turns). This pass has the memory
+  // agent promote DURABLE judgments only -- task states stay on the board.
+  const memoryAgentConfigured = hasEnabledAgentConfig('memory');
+  if (memoryAgentConfigured) {
+    const PROMOTION_INTERVAL_MS =
+      Math.max(1, Number(process.env.MAMA_MEMORY_PROMOTION_HOURS) || 6) * 60 * 60 * 1000;
+    const PROMOTION_INITIAL_DELAY_MS = 10 * 60 * 1000; // let connectors poll first
+
+    const buildPromotionPrompt = (nowIso: string): string =>
+      'PROMOTION RUN. You are curating durable business memory from recent data. ' +
+      `The current time is ${nowIso}.\n` +
+      '1. agent_notices({limit: 100}): find your latest promotion notice (action "promoted" ' +
+      'or "no_update") and treat it as the boundary; default to the last 24h when absent.\n' +
+      '2. kagemusha_entities({activeOnly: true}) to find the rooms active since the boundary, ' +
+      'then kagemusha_messages({channelId, since: <boundary ISO>}) on the busiest 3-4 rooms.\n' +
+      '3. For each candidate judgment, mama_search first to find the existing topic; reuse it ' +
+      'so the evolution chain stays intact.\n' +
+      '4. Promote at most 5 durable judgments per run via mama_save, following the PROMOTION RUN ' +
+      'rules in your persona (pricing/scope agreements, standing client preferences, process ' +
+      'rules, recurring risk patterns; NEVER task lifecycle states, greetings, or logistics). ' +
+      'Include scopes (the source channel, and the project when identifiable) and event_date.\n' +
+      '5. Finish with exactly PROMOTED <n> or NO_UPDATE.';
+
+    const doPromotionRun = async () => {
+      if (!toolExecutor.getAgentProcessManager()) {
+        routesLogger.warn('[Memory Promotion] AgentProcessManager not available yet');
+        return;
+      }
+      try {
+        const { response, noUpdate } = await executeValidatedRun(
+          'memory',
+          buildPromotionPrompt(new Date().toISOString()),
+          { requestTimeout: 600_000 }
+        );
+        const promotedMatch = response?.match(/PROMOTED\s+(\d+)/);
+        const saved = promotedMatch ? Number(promotedMatch[1]) : 0;
+        eventBus.emit({
+          type: 'agent:action',
+          agent: 'Memory Agent',
+          action: noUpdate || saved === 0 ? 'no_update' : 'promoted',
+          target: `promotion run: ${saved} saved`,
+        });
+        if (saved > 0) {
+          eventBus.emit({ type: 'memory:promoted', saved });
+          console.log(`[Memory Promotion] Promoted ${saved} durable judgments`);
+        } else {
+          routesLogger.debug('[Memory Promotion] Nothing qualified for promotion');
+        }
+      } catch (err) {
+        routesLogger.error('[Memory Promotion] Error:', err instanceof Error ? err.message : err);
+      }
+    };
+
+    // Serialize all promotion runs on one chain (same 'Process is busy' class
+    // as the dashboard and wiki agents).
+    let promotionRunChain: Promise<void> = Promise.resolve();
+    const runMemoryPromotion = (): Promise<void> => {
+      promotionRunChain = promotionRunChain.then(doPromotionRun).catch(() => {});
+      return promotionRunChain;
+    };
+
+    setTimeout(runMemoryPromotion, PROMOTION_INITIAL_DELAY_MS);
+    setInterval(runMemoryPromotion, PROMOTION_INTERVAL_MS);
+
+    apiServer.app.post('/api/memory/promote', requireAuth, (_req, res) => {
+      runMemoryPromotion().catch(() => {});
+      res.json({ ok: true, message: 'Memory promotion run triggered' });
+    });
+
+    console.log(
+      `[Memory Promotion] Ready: every ${PROMOTION_INTERVAL_MS / 3_600_000}h, POST /api/memory/promote`
     );
   }
 

--- a/packages/standalone/src/multi-agent/agent-event-bus.ts
+++ b/packages/standalone/src/multi-agent/agent-event-bus.ts
@@ -8,6 +8,7 @@ export interface AgentNotice {
 export type AgentEvent =
   | { type: 'memory:saved'; topic: string; project?: string }
   | { type: 'extraction:completed'; projects: string[] }
+  | { type: 'memory:promoted'; saved: number }
   | { type: 'wiki:compiled'; pages: string[] }
   | { type: 'dashboard:refresh' }
   | { type: 'agent:action'; agent: string; action: string; target: string };

--- a/packages/standalone/src/multi-agent/memory-agent-persona.ts
+++ b/packages/standalone/src/multi-agent/memory-agent-persona.ts
@@ -7,7 +7,7 @@ import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 
-const MANAGED_MEMORY_PERSONA_MARKER = '<!-- MAMA managed memory persona v5 -->';
+const MANAGED_MEMORY_PERSONA_MARKER = '<!-- MAMA managed memory persona v6 -->';
 
 export const MEMORY_AGENT_PERSONA = `${MANAGED_MEMORY_PERSONA_MARKER}
 
@@ -102,7 +102,27 @@ When the conversation contains relative time expressions, extract an explicit ev
 - Do not return JSON for the caller to parse
 - Do the memory work yourself with tools, then terminate immediately with \`DONE\` or \`SKIP\`
 - When in doubt, save — false negatives (missing a memory) are worse than false positives
-- You are an internal subagent, not the user-facing assistant`;
+- You are an internal subagent, not the user-facing assistant
+
+## PROMOTION RUN mode
+When an incoming message begins with "PROMOTION RUN", it is a scheduled batch
+pass over recent business data, NOT a turn audit. In this mode ONLY:
+- The per-audit limits above do not apply: you may call mama_search several
+  times and mama_save up to 5 times, and you gather evidence yourself with
+  kagemusha_entities / kagemusha_messages / agent_notices as the run
+  instructions describe.
+- Promote ONLY durable judgments: pricing/scope agreements, a client's standing
+  preference or boundary, a process rule, a recurring risk pattern. Things that
+  change how future work is done.
+- NEVER promote task lifecycle states ("X was submitted", "Y is in progress") --
+  the task board owns those. Never promote greetings, scheduling chatter, or
+  one-off logistics.
+- Every save needs scopes (parse from the run instructions or the source
+  channel) and an event_date for when the judgment was actually made.
+- Reuse existing topics found via mama_search so evolution chains stay intact.
+- Finish with exactly one line: \`PROMOTED <n>\` (n = number of saves) or
+  \`NO_UPDATE\` when nothing qualifies. When in doubt in THIS mode, do NOT save --
+  promotion is curation, and a wrong policy in memory misleads every consumer.`;
 
 function isLegacyManagedPersona(content: string): boolean {
   // v1: old JSON-return persona
@@ -151,9 +171,10 @@ export function ensureMemoryPersona(mamaHomeDir: string = join(homedir(), '.mama
     writeFileSync(personaPath, MEMORY_AGENT_PERSONA, 'utf-8');
   }
 
-  // Also normalize v4 managed personas that may have drifted
+  // Upgrade ANY older managed persona version (match the marker prefix, not the
+  // exact current version -- an exact match can never upgrade v5 -> v6).
   if (
-    existingContent.includes(MANAGED_MEMORY_PERSONA_MARKER) &&
+    existingContent.includes('<!-- MAMA managed memory persona') &&
     existingContent !== MEMORY_AGENT_PERSONA
   ) {
     writeFileSync(personaPath, MEMORY_AGENT_PERSONA, 'utf-8');

--- a/packages/standalone/tests/multi-agent/system-agent-unification.test.ts
+++ b/packages/standalone/tests/multi-agent/system-agent-unification.test.ts
@@ -65,6 +65,64 @@ describe('system agent unification', () => {
       expect(source).toContain('fall back to mama_search');
       expect(source).not.toContain('Use mama_search to find recent substantive decisions');
     });
+
+    it('memory promotion run curates durable judgments and never task states', async () => {
+      const source = await readFile(join(process.cwd(), 'src/cli/runtime/api-routes-init.ts'), {
+        encoding: 'utf-8',
+      });
+
+      // The prompt enters the persona's PROMOTION RUN mode and self-gathers.
+      expect(source).toContain('PROMOTION RUN. You are curating durable business memory');
+      expect(source).toContain('kagemusha_messages({channelId, since: <boundary ISO>})');
+      expect(source).toContain('Promote at most 5 durable judgments per run via mama_save');
+      expect(source).toContain('NEVER task lifecycle states');
+      expect(source).toContain('Finish with exactly PROMOTED <n> or NO_UPDATE');
+      // Promotion feeds the wiki chain.
+      expect(source).toContain("eventBus.onDebounced('memory:promoted'");
+      expect(source).toContain('/api/memory/promote');
+    });
+  });
+
+  describe('memory persona promotion mode', () => {
+    it('adds PROMOTION RUN mode with curation bias and keeps turn-audit rules', async () => {
+      const { MEMORY_AGENT_PERSONA } =
+        await import('../../src/multi-agent/memory-agent-persona.js');
+
+      expect(MEMORY_AGENT_PERSONA).toContain('## PROMOTION RUN mode');
+      expect(MEMORY_AGENT_PERSONA).toContain('mama_save up to 5 times');
+      expect(MEMORY_AGENT_PERSONA).toContain('NEVER promote task lifecycle states');
+      expect(MEMORY_AGENT_PERSONA).toContain('PROMOTED <n>');
+      // Opposite default biases: turn audit saves when in doubt, promotion does not.
+      expect(MEMORY_AGENT_PERSONA).toContain('When in doubt, save');
+      expect(MEMORY_AGENT_PERSONA).toContain('When in doubt in THIS mode, do NOT save');
+    });
+
+    it('upgrades a v5 managed memory persona to the current version', async () => {
+      const testDir = join(
+        tmpdir(),
+        `mama-memory-persona-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      );
+      const personaDir = join(testDir, 'personas');
+      const personaPath = join(personaDir, 'memory.md');
+      const { ensureMemoryPersona, MEMORY_AGENT_PERSONA } =
+        await import('../../src/multi-agent/memory-agent-persona.js');
+
+      await mkdir(personaDir, { recursive: true });
+      await writeFile(
+        personaPath,
+        '<!-- MAMA managed memory persona v5 -->\n\nOld turn-audit-only persona.',
+        'utf-8'
+      );
+
+      try {
+        ensureMemoryPersona(testDir);
+        const upgraded = await readFile(personaPath, 'utf-8');
+
+        expect(upgraded).toBe(MEMORY_AGENT_PERSONA);
+      } finally {
+        await rm(testDir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('process manager defaults', () => {


### PR DESCRIPTION
## Summary
Root fix for the starved decision layer (A1 of today's loop-quality track). Since the 07-03/04 backfill, organic decision supply was ~0/day: connector-ingested business data never gets a judgment pass (the M0 kill switch removed direct LLM extraction; the memory agent only audits owner conversation turns). Recall kept serving stale decisions and the wiki had no fresh feedstock.

- **Memory persona v6, PROMOTION RUN mode**: batch curation over recent rooms. Opposite default bias to turn audits (turn audit: when in doubt, save; promotion: when in doubt, do NOT save). Max 5 saves per run; durable judgments only (pricing/scope agreements, standing client preferences, process rules, risk patterns); NEVER task lifecycle states -- the board owns those (kagemusha_tasks, #130).
- **Scheduled runner**: default every 6h (`MAMA_MEMORY_PROMOTION_HOURS` override), 10min initial delay, serialized on one promise chain (same 'Process is busy' class as dashboard/wiki), manual `POST /api/memory/promote`.
- **Chain revival**: a successful run emits `memory:promoted`, which the wiki agent now subscribes to. The old `extraction:completed` event had NO emitter anywhere (dead wiring) -- the wiki's event trigger never fired; now poll -> promote -> wiki actually flows.
- **Persona upgrade fix**: the managed-marker check compared against the exact current marker, so a v5 file could never upgrade to v6; now matches the marker prefix (same pattern as wiki/dashboard personas).
- Local config (out-of-repo): memory agent got explicit tool/gateway permission blocks (tier-2 defaults only expose 5 CLI tools -- without an explicit allowlist the shared process would have no gateway tools at all).

## Test plan
- [x] system-agent-unification: promotion prompt contract, persona v6 content, v5->v6 upgrade, opposite-bias assertion
- [x] typecheck
- [ ] Live after merge: POST /api/memory/promote -> PROMOTED n, decisions saved with scopes, wiki compile follows

🤖 Generated with [Claude Code](https://claude.com/claude-code)