### PR TITLE
feat(operator): G2 success circuit and report attribution discipline

### DIFF
--- a/packages/standalone/src/operator/operator-trigger-loop.ts
+++ b/packages/standalone/src/operator/operator-trigger-loop.ts
@@ -92,14 +92,32 @@ export class OperatorTriggerLoop {
   private recentEvents: OperatorChannelEvent[] = [];
   private running = false;
   private nudgeTimer: ReturnType<typeof setTimeout> | null = null;
-  private digest = new SituationReporter();
+  private digest: SituationReporter;
   private fullReporter: SituationReporter;
 
   constructor(deps: TriggerLoopDeps) {
     this.deps = deps;
+    // G2 success signal: when a sent report cites fired triggers (USED_TRIGGERS
+    // trailer, window-validated), record 'succeeded' on each. Uncited fires stay
+    // neutral; elimination still comes from the review pass. Detector-based fires
+    // carry the detector name as id and are not in the registry -- skip loudly.
+    const recordTriggerUse = (ids: string[]): void => {
+      for (const id of ids) {
+        try {
+          deps.registry.recordOutcome(id, 'succeeded');
+          deps.log(`[trigger-loop] outcome succeeded trigger=${id} (cited in owner report)`);
+        } catch (err) {
+          deps.log(
+            `[trigger-loop] outcome skip trigger=${id}: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
+    };
+    this.digest = new SituationReporter({ recordTriggerUse });
     this.fullReporter = new SituationReporter({
       selfGatherLines: deps.fullReportSelfGather,
       boardPublishLines: deps.fullReportBoardLines,
+      recordTriggerUse,
     });
   }
 

--- a/packages/standalone/src/operator/situation-report.ts
+++ b/packages/standalone/src/operator/situation-report.ts
@@ -46,6 +46,7 @@ interface ChannelWindow {
 }
 
 interface FireAgg {
+  triggerId: string;
   kind: string;
   channelId: string;
   count: number;
@@ -69,7 +70,18 @@ export interface SituationReporterOptions {
    * never publishes the board.
    */
   boardPublishLines?: string[];
+  /**
+   * G2 success signal: called with the trigger ids the agent says it actually
+   * drew on for the sent report (parsed from the stripped USED_TRIGGERS
+   * trailer, validated against this window's fires). The wiring records
+   * 'succeeded' outcomes so evolution finally gets a positive signal instead
+   * of being elimination-only. Uncited fires stay NEUTRAL - not failures.
+   */
+  recordTriggerUse?: (triggerIds: string[]) => void;
 }
+
+/** Machine trailer the agent appends; stripped before the owner sees the report. */
+const USED_TRIGGERS_PATTERN = /\n?^USED_TRIGGERS:\s*(.*)\s*$/im;
 
 export class SituationReporter {
   private windowByChannel = new Map<string, ChannelWindow>();
@@ -104,6 +116,7 @@ export class SituationReporter {
   recordFire(activity: FireActivity): void {
     const key = `${activity.triggerId}|${activity.channelId}`;
     const agg = this.fireAgg.get(key) ?? {
+      triggerId: activity.triggerId,
       kind: activity.kind,
       channelId: activity.channelId,
       count: 0,
@@ -141,9 +154,29 @@ export class SituationReporter {
     // (the owner relies on it arriving; a quiet window is itself the news). Digests stay gated.
     if (mode !== 'full' && !this.hasActivity()) return false;
 
-    const text = (await askAgent(this.buildPrompt(mode))).trim();
-    if (text === '' || /^NOTHING\b/i.test(text)) {
+    const raw = (await askAgent(this.buildPrompt(mode))).trim();
+    if (raw === '' || /^NOTHING\b/i.test(raw)) {
       this.reset(); // agent judged nothing worth reporting - drop the buffer quietly
+      return false;
+    }
+
+    // Parse + strip the USED_TRIGGERS machine trailer (the owner never sees it),
+    // validate the ids against THIS window's fires (no hallucinated credit), and
+    // hand them to the wiring for 'succeeded' outcome recording.
+    const match = raw.match(USED_TRIGGERS_PATTERN);
+    const text = raw.replace(USED_TRIGGERS_PATTERN, '').trim();
+    if (match && this.opts.recordTriggerUse) {
+      const windowIds = new Set([...this.fireAgg.values()].map((f) => f.triggerId));
+      const cited = match[1]
+        .split(',')
+        .map((id) => id.trim())
+        .filter((id) => id.length > 0 && id.toLowerCase() !== 'none' && windowIds.has(id));
+      if (cited.length > 0) {
+        this.opts.recordTriggerUse([...new Set(cited)]);
+      }
+    }
+    if (text === '') {
+      this.reset(); // trailer-only reply: nothing for the owner
       return false;
     }
 
@@ -177,7 +210,7 @@ export class SituationReporter {
 
     const fireLines = [...this.fireAgg.values()].map(
       (f) =>
-        `- trigger "${f.kind}" fired ${f.count}x on ${f.channelId}; recalled: ${[...f.topics].join(', ') || '(none)'}`
+        `- trigger "${f.kind}" [id: ${f.triggerId}] fired ${f.count}x on ${f.channelId}; recalled: ${[...f.topics].join(', ') || '(none)'}`
     );
     const memoryLines = [...this.recalled.entries()].map(
       ([topic, content]) => `- ${topic}: ${content}`
@@ -238,6 +271,17 @@ export class SituationReporter {
 
     return [
       ...framing,
+      // Attribution discipline (owner feedback: the only quality complaint on day-1
+      // reports was merged sender/room identities).
+      'Attribute people and rooms EXACTLY as they appear in the source lines: a channel/room',
+      'name is never a person, and a sender is never a room. If you cannot tell who said',
+      'something, write "(sender unclear)" instead of guessing or merging names.',
+      // G2 success signal: machine trailer, stripped before delivery.
+      'After the report body, add ONE final line exactly in this form:',
+      'USED_TRIGGERS: <comma-separated ids of the fired triggers (from [id: ...] in the fire',
+      'activity below) whose fire or recalled memory you actually drew on>, or',
+      'USED_TRIGGERS: none if you drew on none. This line is machine-read and stripped',
+      'before the owner sees the report.',
       'Reply in the language the owner uses on these channels if you can tell; otherwise English.',
       // Local wall-clock, not UTC: the first live report stamped itself in UTC because the
       // agent had no local time reference (Kagemusha injects local time the same way).

--- a/packages/standalone/src/operator/situation-report.ts
+++ b/packages/standalone/src/operator/situation-report.ts
@@ -160,27 +160,34 @@ export class SituationReporter {
       return false;
     }
 
-    // Parse + strip the USED_TRIGGERS machine trailer (the owner never sees it),
-    // validate the ids against THIS window's fires (no hallucinated credit), and
-    // hand them to the wiring for 'succeeded' outcome recording.
+    // Parse + strip the USED_TRIGGERS machine trailer (the owner never sees it)
+    // and validate the ids against THIS window's fires (no hallucinated credit).
     const match = raw.match(USED_TRIGGERS_PATTERN);
     const text = raw.replace(USED_TRIGGERS_PATTERN, '').trim();
-    if (match && this.opts.recordTriggerUse) {
+    let cited: string[] = [];
+    if (match) {
       const windowIds = new Set([...this.fireAgg.values()].map((f) => f.triggerId));
-      const cited = match[1]
-        .split(',')
-        .map((id) => id.trim())
-        .filter((id) => id.length > 0 && id.toLowerCase() !== 'none' && windowIds.has(id));
-      if (cited.length > 0) {
-        this.opts.recordTriggerUse([...new Set(cited)]);
-      }
+      cited = [
+        ...new Set(
+          match[1]
+            .split(',')
+            .map((id) => id.trim())
+            .filter((id) => id.length > 0 && id.toLowerCase() !== 'none' && windowIds.has(id))
+        ),
+      ];
     }
     if (text === '') {
-      this.reset(); // trailer-only reply: nothing for the owner
+      this.reset(); // trailer-only reply: nothing was delivered, so no credit either
       return false;
     }
 
     await output.send(text); // throws loudly on failure; buffer kept for retry (no-fallback)
+    // Credit only AFTER a successful send: success means "cited in a DELIVERED
+    // report". Crediting before send would double-count on the retry path
+    // (send throws -> buffer kept -> next cadence re-cites the same fires).
+    if (cited.length > 0) {
+      this.opts.recordTriggerUse?.(cited);
+    }
     this.reset();
     return true;
   }

--- a/packages/standalone/src/operator/trigger-author.ts
+++ b/packages/standalone/src/operator/trigger-author.ts
@@ -29,7 +29,12 @@ export interface TriggerSpec {
   id?: string;
   kind: string;
   memoryQuery: string;
-  match: { keywords: string[]; keywordMode: 'any' | 'every'; scopeChannelIds?: string[]; minConfidence: number };
+  match: {
+    keywords: string[];
+    keywordMode: 'any' | 'every';
+    scopeChannelIds?: string[];
+    minConfidence: number;
+  };
   procedure: { action: string; description: string }[];
   requiredEvidence: string[];
 }
@@ -50,7 +55,10 @@ export async function authorTriggers(
   const specs = parseTriggerSpecs(answer); // throws on unparseable output (no-fallback)
 
   const created: TriggerRecord[] = [];
-  const seen = existing.map((t) => ({ keywords: t.match.keywords, scopeChannelIds: t.match.scopeChannelIds }));
+  const seen = existing.map((t) => ({
+    keywords: t.match.keywords,
+    scopeChannelIds: t.match.scopeChannelIds,
+  }));
   for (const spec of specs) {
     if (isDuplicate(spec, seen)) continue;
     const id = spec.id ?? deriveId(spec);
@@ -71,15 +79,23 @@ export async function authorTriggers(
   return created;
 }
 
-export function buildAuthorPrompt(events: OperatorChannelEvent[], existing: TriggerRecord[]): string {
+export function buildAuthorPrompt(
+  events: OperatorChannelEvent[],
+  existing: TriggerRecord[]
+): string {
   // English default. Personal phrasing overrides load from ~/.mama/operator/*.json (later refinement).
   const window = events.map((e) => `- [${e.channelId}] ${e.content}`).join('\n');
   const existingList =
     existing.length === 0
       ? '(none yet)'
-      : existing.map((t) => `- ${t.id}: keywords=[${t.match.keywords.join(', ')}] memoryQuery="${t.memoryQuery}"`).join('\n');
+      : existing
+          .map(
+            (t) =>
+              `- ${t.id}: keywords=[${t.match.keywords.join(', ')}] memoryQuery="${t.memoryQuery}"`
+          )
+          .join('\n');
   return [
-    'You maintain a personal operator\'s library of TRIGGERS. A trigger fires on future messages',
+    "You maintain a personal operator's library of TRIGGERS. A trigger fires on future messages",
     'that match its keywords and then recalls a memory to help the operator intervene proactively.',
     '',
     'Look at the recent messages below. Propose new triggers ONLY for situations that genuinely',
@@ -91,6 +107,11 @@ export function buildAuthorPrompt(events: OperatorChannelEvent[], existing: Trig
     '',
     'Existing triggers (do not duplicate these):',
     existingList,
+    '',
+    'A situation already covered by an existing trigger -- even with different wording or a',
+    'partial keyword overlap -- does NOT need a new trigger. Near-variants make several',
+    'triggers fire on the same message, which wastes recall and dilutes the report. Prefer',
+    'proposing NOTHING over proposing a variant of an existing trigger.',
     '',
     'Return ONLY a JSON array (no prose) of trigger objects with this shape:',
     '[{ "kind": string, "memoryQuery": string,',
@@ -119,31 +140,43 @@ export function validateTriggerSpec(spec: unknown): TriggerSpec {
   const nonEmptyString = (v: unknown): v is string => typeof v === 'string' && v.trim() !== '';
 
   if (!nonEmptyString(spec.kind)) throw new Error('trigger.kind must be a non-empty string');
-  if (!nonEmptyString(spec.memoryQuery)) throw new Error('trigger.memoryQuery must be a non-empty string');
+  if (!nonEmptyString(spec.memoryQuery))
+    throw new Error('trigger.memoryQuery must be a non-empty string');
 
   if (!isObject(spec.match)) throw new Error('trigger.match must be an object');
   const match = spec.match;
-  if (!Array.isArray(match.keywords) || match.keywords.length === 0 || !match.keywords.every(nonEmptyString)) {
+  if (
+    !Array.isArray(match.keywords) ||
+    match.keywords.length === 0 ||
+    !match.keywords.every(nonEmptyString)
+  ) {
     throw new Error('trigger.match.keywords must be a non-empty string[]');
   }
   if (match.keywordMode !== 'any' && match.keywordMode !== 'every') {
     throw new Error("trigger.match.keywordMode must be 'any' or 'every'");
   }
-  if (typeof match.minConfidence !== 'number') throw new Error('trigger.match.minConfidence must be a number');
+  if (typeof match.minConfidence !== 'number')
+    throw new Error('trigger.match.minConfidence must be a number');
   if (
     match.scopeChannelIds !== undefined &&
-    (!Array.isArray(match.scopeChannelIds) || !match.scopeChannelIds.every((c) => typeof c === 'string'))
+    (!Array.isArray(match.scopeChannelIds) ||
+      !match.scopeChannelIds.every((c) => typeof c === 'string'))
   ) {
     throw new Error('trigger.match.scopeChannelIds must be string[] when present');
   }
 
   if (
     !Array.isArray(spec.procedure) ||
-    !spec.procedure.every((p) => isObject(p) && typeof p.action === 'string' && typeof p.description === 'string')
+    !spec.procedure.every(
+      (p) => isObject(p) && typeof p.action === 'string' && typeof p.description === 'string'
+    )
   ) {
     throw new Error('trigger.procedure must be an array of {action, description}');
   }
-  if (!Array.isArray(spec.requiredEvidence) || !spec.requiredEvidence.every((e) => typeof e === 'string')) {
+  if (
+    !Array.isArray(spec.requiredEvidence) ||
+    !spec.requiredEvidence.every((e) => typeof e === 'string')
+  ) {
     throw new Error('trigger.requiredEvidence must be string[]');
   }
 
@@ -194,12 +227,30 @@ function normalizedKeywordSet(keywords: string[]): string {
   return [...new Set(keywords.map((k) => k.trim().toLocaleLowerCase()))].sort().join('|');
 }
 
-function isDuplicate(spec: TriggerSpec, seen: { keywords: string[]; scopeChannelIds?: string[] }[]): boolean {
-  const specKeys = normalizedKeywordSet(spec.match.keywords);
+/**
+ * Near-duplicate gate. Exact keyword-set equality alone let near-variants pile
+ * up: day-1 live data showed 65% of fires were co-fires of overlapping triggers
+ * on the same message. Within the same scope, a spec is a duplicate when its
+ * keyword set is a subset/superset of an existing trigger's, or the Jaccard
+ * overlap is >= 0.6. This is authoring HYGIENE (like the exact check before
+ * it), not outcome judgment -- keep/retire decisions stay with the agent (G2).
+ */
+function isDuplicate(
+  spec: TriggerSpec,
+  seen: { keywords: string[]; scopeChannelIds?: string[] }[]
+): boolean {
+  const specKeys = new Set(spec.match.keywords.map((k) => k.trim().toLowerCase()).filter(Boolean));
   const specScope = (spec.match.scopeChannelIds ?? []).slice().sort().join(',');
-  return seen.some(
-    (s) => normalizedKeywordSet(s.keywords) === specKeys && (s.scopeChannelIds ?? []).slice().sort().join(',') === specScope
-  );
+  return seen.some((s) => {
+    if ((s.scopeChannelIds ?? []).slice().sort().join(',') !== specScope) return false;
+    const seenKeys = new Set(s.keywords.map((k) => k.trim().toLowerCase()).filter(Boolean));
+    if (specKeys.size === 0 || seenKeys.size === 0) return false;
+    let shared = 0;
+    for (const k of specKeys) if (seenKeys.has(k)) shared += 1;
+    if (shared === specKeys.size || shared === seenKeys.size) return true; // subset either way
+    const jaccard = shared / (specKeys.size + seenKeys.size - shared);
+    return jaccard >= 0.6;
+  });
 }
 
 function deriveId(spec: TriggerSpec): string {

--- a/packages/standalone/tests/operator/situation-report.test.ts
+++ b/packages/standalone/tests/operator/situation-report.test.ts
@@ -277,14 +277,33 @@ describe('SituationReporter (M2, supersedes TriggerReporter M1.5)', () => {
     expect(send).toHaveBeenCalledWith('Quiet day.');
   });
 
-  it('trailer-only reply is treated as nothing to send', async () => {
+  it('trailer-only reply is treated as nothing to send and earns no credit', async () => {
     const askAgent = vi.fn(async () => 'USED_TRIGGERS: t1');
     const send = vi.fn(async () => {});
     const recordTriggerUse = vi.fn();
     const r = new SituationReporter({ recordTriggerUse });
     r.recordFire(fire('t1', 'weekly_report', 'slack:c1'));
     expect(await r.report(askAgent, { send }, 'digest')).toBe(false);
-    expect(recordTriggerUse).toHaveBeenCalledWith(['t1']);
+    // nothing was delivered to the owner -> no success credit
+    expect(recordTriggerUse).not.toHaveBeenCalled();
     expect(send).not.toHaveBeenCalled();
+  });
+
+  it('send failure earns no credit; the retry that delivers credits exactly once', async () => {
+    const askAgent = vi.fn(async () => 'Brief.\nUSED_TRIGGERS: t1');
+    const recordTriggerUse = vi.fn();
+    const r = new SituationReporter({ recordTriggerUse });
+    r.recordFire(fire('t1', 'weekly_report', 'slack:c1'));
+
+    const failingSend = vi.fn(async () => {
+      throw new Error('gateway down');
+    });
+    await expect(r.report(askAgent, { send: failingSend }, 'digest')).rejects.toThrow();
+    expect(recordTriggerUse).not.toHaveBeenCalled(); // no credit without delivery
+
+    const send = vi.fn(async () => {});
+    expect(await r.report(askAgent, { send }, 'digest')).toBe(true); // buffer kept -> retry
+    expect(recordTriggerUse).toHaveBeenCalledTimes(1);
+    expect(recordTriggerUse).toHaveBeenCalledWith(['t1']);
   });
 });

--- a/packages/standalone/tests/operator/situation-report.test.ts
+++ b/packages/standalone/tests/operator/situation-report.test.ts
@@ -239,4 +239,52 @@ describe('SituationReporter (M2, supersedes TriggerReporter M1.5)', () => {
     // digest never invites a write
     expect(r.buildPrompt('digest')).not.toContain('mama_save');
   });
+
+  // ---- G2 success circuit: USED_TRIGGERS citation -> recordTriggerUse ----
+  it('prompt exposes trigger ids, attribution discipline, and the USED_TRIGGERS trailer contract', () => {
+    const r = new SituationReporter();
+    r.recordFire(fire('t1', 'weekly_report', 'slack:c1'));
+    for (const mode of ['digest', 'full'] as const) {
+      const prompt = r.buildPrompt(mode);
+      expect(prompt).toContain('[id: t1]');
+      expect(prompt).toContain('USED_TRIGGERS:');
+      expect(prompt).toContain('never a room');
+      expect(prompt).toContain('(sender unclear)');
+    }
+  });
+
+  it('report strips the USED_TRIGGERS trailer and records only window-validated ids', async () => {
+    const askAgent = vi.fn(async () => 'Owner brief line.\nUSED_TRIGGERS: t1, t-unknown, none, t1');
+    const send = vi.fn(async () => {});
+    const used: string[][] = [];
+    const r = new SituationReporter({ recordTriggerUse: (ids) => used.push(ids) });
+    r.recordFire(fire('t1', 'weekly_report', 'slack:c1'));
+    expect(await r.report(askAgent, { send }, 'digest')).toBe(true);
+    // hallucinated ids filtered, duplicates collapsed, 'none' token ignored
+    expect(used).toEqual([['t1']]);
+    // the owner never sees the machine trailer
+    expect(send).toHaveBeenCalledWith('Owner brief line.');
+  });
+
+  it('USED_TRIGGERS: none records nothing and sends the body untouched', async () => {
+    const askAgent = vi.fn(async () => 'Quiet day.\nUSED_TRIGGERS: none');
+    const send = vi.fn(async () => {});
+    const recordTriggerUse = vi.fn();
+    const r = new SituationReporter({ recordTriggerUse });
+    r.recordFire(fire('t1', 'weekly_report', 'slack:c1'));
+    expect(await r.report(askAgent, { send }, 'digest')).toBe(true);
+    expect(recordTriggerUse).not.toHaveBeenCalled();
+    expect(send).toHaveBeenCalledWith('Quiet day.');
+  });
+
+  it('trailer-only reply is treated as nothing to send', async () => {
+    const askAgent = vi.fn(async () => 'USED_TRIGGERS: t1');
+    const send = vi.fn(async () => {});
+    const recordTriggerUse = vi.fn();
+    const r = new SituationReporter({ recordTriggerUse });
+    r.recordFire(fire('t1', 'weekly_report', 'slack:c1'));
+    expect(await r.report(askAgent, { send }, 'digest')).toBe(false);
+    expect(recordTriggerUse).toHaveBeenCalledWith(['t1']);
+    expect(send).not.toHaveBeenCalled();
+  });
 });

--- a/packages/standalone/tests/operator/trigger-author.test.ts
+++ b/packages/standalone/tests/operator/trigger-author.test.ts
@@ -8,7 +8,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database, { type SQLiteDatabase } from '../../src/sqlite.js';
 import { TriggerRegistry } from '../../src/operator/trigger-registry.js';
-import { authorTriggers, parseTriggerSpecs, validateTriggerSpec } from '../../src/operator/trigger-author.js';
+import {
+  authorTriggers,
+  parseTriggerSpecs,
+  validateTriggerSpec,
+} from '../../src/operator/trigger-author.js';
 import type { OperatorChannelEvent } from '../../src/operator/operator-interfaces.js';
 
 const cannedSpec = JSON.stringify([
@@ -22,7 +26,15 @@ const cannedSpec = JSON.stringify([
 ]);
 
 function ev(content: string, id = 1): OperatorChannelEvent {
-  return { id, channel: 'discord', channelId: 'c1', userId: 'u1', role: 'user', content, createdAt: id * 100 };
+  return {
+    id,
+    channel: 'discord',
+    channelId: 'c1',
+    userId: 'u1',
+    role: 'user',
+    content,
+    createdAt: id * 100,
+  };
 }
 
 describe('authorTriggers', () => {
@@ -36,7 +48,11 @@ describe('authorTriggers', () => {
   afterEach(() => reg.close());
 
   it('persists an agent-authored trigger with open kind/action (G3)', async () => {
-    const created = await authorTriggers([ev('rollback again'), ev('another rollback', 2)], reg, async () => cannedSpec);
+    const created = await authorTriggers(
+      [ev('rollback again'), ev('another rollback', 2)],
+      reg,
+      async () => cannedSpec
+    );
     expect(created).toHaveLength(1);
     expect(created[0].kind).toBe('weird_new_kind_the_agent_invented'); // arbitrary value accepted, not an enum
     expect(created[0].procedure[0].action).toBe('novel_action');
@@ -65,6 +81,66 @@ describe('authorTriggers', () => {
     expect(created).toHaveLength(0);
   });
 
+  it('rejects near-duplicates: keyword subset or >=0.6 Jaccard overlap in the same scope', async () => {
+    // Day-1 live data: 65% of fires were co-fires of overlapping triggers.
+    reg.create({
+      id: 'existing-wide',
+      kind: 'k',
+      memoryQuery: 'q',
+      match: { keywords: ['rollback', 'deploy', 'hotfix'], keywordMode: 'any', minConfidence: 0.7 },
+      procedure: [],
+      requiredEvidence: [],
+      authoredBy: 'agent',
+      provenance: { createdFrom: 'seed', note: '' },
+    });
+    // subset of existing-wide's keywords -> rejected
+    const subsetSpec = JSON.stringify([
+      {
+        kind: 'k2',
+        memoryQuery: 'q2',
+        match: { keywords: ['rollback', 'deploy'], keywordMode: 'any', minConfidence: 0.7 },
+        procedure: [{ action: 'a', description: 'd' }],
+        requiredEvidence: [],
+      },
+    ]);
+    expect(await authorTriggers([ev('x')], reg, async () => subsetSpec)).toHaveLength(0);
+
+    // high-overlap variant (3 shared of 4 union = 0.75) -> rejected
+    const overlapSpec = JSON.stringify([
+      {
+        kind: 'k3',
+        memoryQuery: 'q3',
+        match: {
+          keywords: ['rollback', 'deploy', 'hotfix', 'incident'],
+          keywordMode: 'any',
+          minConfidence: 0.7,
+        },
+        procedure: [{ action: 'a', description: 'd' }],
+        requiredEvidence: [],
+      },
+    ]);
+    expect(await authorTriggers([ev('x')], reg, async () => overlapSpec)).toHaveLength(0);
+
+    // disjoint keywords -> accepted
+    const disjointSpec = JSON.stringify([
+      {
+        kind: 'k4',
+        memoryQuery: 'q4',
+        match: { keywords: ['invoice', 'billing'], keywordMode: 'any', minConfidence: 0.7 },
+        procedure: [{ action: 'a', description: 'd' }],
+        requiredEvidence: [],
+      },
+    ]);
+    expect(await authorTriggers([ev('x')], reg, async () => disjointSpec)).toHaveLength(1);
+  });
+
+  it('author prompt warns against near-variants of existing triggers', async () => {
+    const { buildAuthorPrompt } = await import('../../src/operator/trigger-author.js');
+    const prompt = buildAuthorPrompt([ev('x')], reg.listActive());
+    expect(prompt).toContain('partial keyword overlap');
+    expect(prompt).toContain('proposing NOTHING over proposing a variant');
+  });
+
   it('parseTriggerSpecs extracts the JSON array even with surrounding prose', () => {
     const specs = parseTriggerSpecs(`Sure, here you go:\n${cannedSpec}\nHope that helps.`);
     expect(specs).toHaveLength(1);
@@ -83,7 +159,13 @@ describe('authorTriggers', () => {
     ).not.toThrow();
     expect(() => validateTriggerSpec({ kind: 'k' })).toThrow(); // missing required fields
     expect(() =>
-      validateTriggerSpec({ kind: '', memoryQuery: 'q', match: { keywords: [], keywordMode: 'any', minConfidence: 0.5 }, procedure: [], requiredEvidence: [] })
+      validateTriggerSpec({
+        kind: '',
+        memoryQuery: 'q',
+        match: { keywords: [], keywordMode: 'any', minConfidence: 0.5 },
+        procedure: [],
+        requiredEvidence: [],
+      })
     ).toThrow(); // empty kind + empty keywords = malformed shape
   });
 });


### PR DESCRIPTION
## Summary
A2 of the loop-quality track. Day-1 evaluation showed `succeeded: 0` across 333 fires: `evolveTrigger` was built but had no production caller, so trigger evolution was elimination-only (review pass disables, nothing ever strengthens).

**Success circuit (citation-based):**
- Fire lines in the report prompt now expose `[id: <triggerId>]`.
- Both framings instruct the agent to append one machine line: `USED_TRIGGERS: <ids>` (or `none`) naming the fired triggers whose fire/recalled memory it actually drew on.
- `SituationReporter.report()` strips the trailer before the owner sees the text, validates ids against THIS window's fires (hallucinated ids are dropped, duplicates collapsed), and calls the new `recordTriggerUse` hook.
- The loop wires the hook to `registry.recordOutcome(id, 'succeeded')` with per-id guards (detector-name fires aren't registry rows -- logged and skipped). Uncited fires stay NEUTRAL, not failures; elimination remains the review pass's job.

**Attribution discipline (owner's only day-1 quality complaint):** both framings now state a room is never a person, a sender is never a room, and unclear identity is written as "(sender unclear)" instead of guessed.

## Test plan
- [x] 4 new SituationReporter tests: prompt contract, trailer strip + window validation, none-token, trailer-only reply
- [x] Full operator suite (112 passed) + typecheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)