### PR TITLE
fix(wiki): recency-based novelty check instead of semantic retrieval

### DIFF
--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -475,13 +475,14 @@ This saves resources. Only publish when there is genuinely new information to re
         const wikiPrompt = `You are triggered on a schedule. Before writing anything, determine if an update is needed:
 
 1. Use agent_notices({limit: 100}) to find the most recent wiki-agent compiled/publish/task_complete notice. Treat that as the last compilation boundary.
-2. Use context_compile first to find recent substantive decisions (limit 30, max_tool_calls 3, strictness "balanced").
+2. NOVELTY CHECK by recency, not semantics: call mama_search({limit: 30}) with NO query -- that returns the newest decisions in creation order regardless of language or wording (semantic/lexical search misses cross-language items, which caused missed compilations). Compare created_at against the boundary.
+3. If NO substantive decisions are newer than the boundary -> respond "NO_UPDATE" and stop. Do NOT call obsidian or wiki_publish.
+4. If new items exist, use context_compile first to gather supporting context (limit 30, max_tool_calls 3, strictness "balanced").
    Use this exact task text for context_compile: "recent substantive project decisions, task progress, agent alerts, and major changes".
    Do not include dashboard_briefing, wiki_compilation, system-audit, or audit-log labels in the context_compile task text; filter those operational summaries after the packet returns.
-   If context_compile is unavailable because there is no active worker envelope, fall back to mama_search once (limit 30).
-3. If NO substantive decisions exist since the last wiki compilation → respond "NO_UPDATE" and stop. Do NOT call obsidian or wiki_publish.
-4. If new substantive material exists -> follow your persona: APPEND today's daily note (daily/YYYY-MM-DD.md, create with the section skeleton on first write of the day), then promote qualifying lesson candidates into lessons/ pages (search before create; update, never duplicate). Do NOT write per-task status pages.
-5. Do NOT call mama_save for the compilation; Obsidian/wiki files plus agent_activity are the durable operational record.
+   If the packet misses some of the new items from step 2 (it often will for cross-language content), write from the step-2 items directly -- the recency list is authoritative for WHAT is new; the packet only enriches.
+5. Then follow your persona: APPEND today's daily note (daily/YYYY-MM-DD.md, create with the section skeleton on first write of the day), then promote qualifying lesson candidates into lessons/ pages (search before create; update, never duplicate). Do NOT write per-task status pages.
+6. Do NOT call mama_save for the compilation; Obsidian/wiki files plus agent_activity are the durable operational record.
 
 This saves resources. Only compile when there is genuinely new information to document.`;
 

--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -481,6 +481,7 @@ This saves resources. Only publish when there is genuinely new information to re
    Use this exact task text for context_compile: "recent substantive project decisions, task progress, agent alerts, and major changes".
    Do not include dashboard_briefing, wiki_compilation, system-audit, or audit-log labels in the context_compile task text; filter those operational summaries after the packet returns.
    If the packet misses some of the new items from step 2 (it often will for cross-language content), write from the step-2 items directly -- the recency list is authoritative for WHAT is new; the packet only enriches.
+   If context_compile is unavailable because there is no active worker envelope, fall back to ONE queried mama_search for enrichment and continue from the step-2 recency list.
 5. Then follow your persona: APPEND today's daily note (daily/YYYY-MM-DD.md, create with the section skeleton on first write of the day), then promote qualifying lesson candidates into lessons/ pages (search before create; update, never duplicate). Do NOT write per-task status pages.
 6. Do NOT call mama_save for the compilation; Obsidian/wiki files plus agent_activity are the durable operational record.
 

--- a/packages/standalone/src/multi-agent/wiki-agent-persona.ts
+++ b/packages/standalone/src/multi-agent/wiki-agent-persona.ts
@@ -84,6 +84,8 @@ create or update pages that mirror per-task progress ("X is in_progress").
    Keep the returned packet_id/context_packet_id in your private notes for provenance; never invent one.
    The packet ENRICHES; the step-2 recency list is authoritative for WHAT is new.
    If the packet misses some new items, write from the recency list directly.
+   If context_compile is unavailable (e.g. no active worker envelope), fall back to
+   ONE queried mama_search for enrichment and continue from the recency list.
 5. Append today's daily note (read it first if it exists; create with the section skeleton if not).
 6. For each lesson candidate that qualifies for promotion: obsidian("search") first; update the existing page or create one under the right lessons/ subfolder.
 7. Keep Home.md current: last 7 daily links + lessons grouped by subfolder.

--- a/packages/standalone/src/multi-agent/wiki-agent-persona.ts
+++ b/packages/standalone/src/multi-agent/wiki-agent-persona.ts
@@ -73,18 +73,24 @@ create or update pages that mirror per-task progress ("X is in_progress").
 
 ## MANDATORY Workflow
 1. agent_notices({limit: 100}): find the last wiki compile boundary.
-2. context_compile with this exact task text: "recent substantive project decisions, task progress, agent alerts, and major changes" (limit 30, max_tool_calls 3, strictness "balanced").
+2. NOVELTY CHECK by recency, not semantics: mama_search({limit: 30}) with NO query
+   returns the newest decisions in creation order regardless of language or
+   wording. Semantic/lexical retrieval MISSES cross-language items, so never
+   judge "nothing new" from a context_compile packet alone. Compare created_at
+   against the boundary.
+3. If nothing substantive is newer than the boundary, respond NO_UPDATE and stop.
+4. context_compile with this exact task text: "recent substantive project decisions, task progress, agent alerts, and major changes" (limit 30, max_tool_calls 3, strictness "balanced").
    Do not include dashboard_briefing, wiki_compilation, system-audit, or audit-log labels in the task text; filter those operational summaries after the packet returns.
    Keep the returned packet_id/context_packet_id in your private notes for provenance; never invent one.
-   If context_compile is unavailable, fall back to mama_search once.
-3. If nothing substantive is new since the boundary, respond NO_UPDATE and stop.
-4. Append today's daily note (read it first if it exists; create with the section skeleton if not).
-5. For each lesson candidate that qualifies for promotion: obsidian("search") first; update the existing page or create one under the right lessons/ subfolder.
-6. Keep Home.md current: last 7 daily links + lessons grouped by subfolder.
+   The packet ENRICHES; the step-2 recency list is authoritative for WHAT is new.
+   If the packet misses some new items, write from the recency list directly.
+5. Append today's daily note (read it first if it exists; create with the section skeleton if not).
+6. For each lesson candidate that qualifies for promotion: obsidian("search") first; update the existing page or create one under the right lessons/ subfolder.
+7. Keep Home.md current: last 7 daily links + lessons grouped by subfolder.
 
 ## Strict Limits
 - SYNTHESIZE, do not dump raw data.
-- Prefer context_compile over mama_search; mama_search at most once as fallback.
+- mama_search is for the no-query recency check (step 2) plus at most one queried fallback when context_compile is unavailable.
 - Do NOT create pages outside daily/ and lessons/ (Home.md is the only root page).
 - Do NOT call mama_save; wiki files plus agent_activity are the durable record.
 - Do NOT ask follow-up questions.

--- a/packages/standalone/tests/multi-agent/system-agent-unification.test.ts
+++ b/packages/standalone/tests/multi-agent/system-agent-unification.test.ts
@@ -66,6 +66,21 @@ describe('system agent unification', () => {
       expect(source).not.toContain('Use mama_search to find recent substantive decisions');
     });
 
+    it('wiki novelty check is recency-based, not semantic (cross-language gap)', async () => {
+      const source = await readFile(join(process.cwd(), 'src/cli/runtime/api-routes-init.ts'), {
+        encoding: 'utf-8',
+      });
+      const { WIKI_AGENT_PERSONA } = await import('../../src/multi-agent/wiki-agent-persona.js');
+
+      // Lexical scoring against the English task text filtered out Korean-only
+      // decisions, so a fresh promotion was judged "nothing new". The novelty
+      // check must use the no-query mama_search recency list.
+      for (const text of [source, WIKI_AGENT_PERSONA]) {
+        expect(text).toContain('NOVELTY CHECK by recency, not semantics');
+        expect(text).toContain('mama_search({limit: 30}) with NO query');
+      }
+    });
+
     it('memory promotion run curates durable judgments and never task states', async () => {
       const source = await readFile(join(process.cwd(), 'src/cli/runtime/api-routes-init.ts'), {
         encoding: 'utf-8',


### PR DESCRIPTION
## Summary
End-to-end chain test after #135/#136 deploy caught a real defect: the promotion pass saved a fresh Korean-only pricing decision and `memory:promoted` correctly fired the wiki run -- but the wiki declared NO_UPDATE, claiming the newest decision was still 07-04.

**Root cause:** the context_compile adapter path pulls recent decisions and then filters by LEXICAL score against the English task text (`memoryLexicalScore` in mama-core source-readers). Korean-only decisions share zero tokens with the English task string, score 0, and vanish from the packet -- so the packet cannot be trusted to answer "is anything new".

**Fix:** the novelty check now uses `mama_search({limit: 30})` with NO query, which is already a pure recency list (`listDecisions`) immune to language. context_compile stays for enrichment, with an explicit rule: the recency list is authoritative for WHAT is new; if the packet misses items, write from the recency list directly. Applied to both the run prompt and persona workflow (auto-upgrades via managed marker).

The underlying cross-language retrieval gap (lexical scoring + e5 anisotropy) remains a separate backlog item; this unblocks the poll -> promote -> wiki chain.

## Test plan
- [x] New assertion: recency-based novelty contract present in BOTH the run prompt and the persona
- [x] wiki + unification suites, typecheck
- [ ] Live after merge: POST /api/wiki/compile writes today's daily note from the promoted decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Wiki Agent scheduled runs now identify new work based on the most recent decisions since the last compilation boundary.
  * Context gathering remains available for enrichment, while recency results determine whether an update is needed.
  * Updated workflow guidance clarifies filtering, task handling, and fallback search behavior.

* **Tests**
  * Added coverage to verify the recency-based novelty check and no-query search usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->