### PR TITLE
docs(packages): backfill per-package changelogs and npm README for 0.21.0

### DIFF
--- a/packages/mama-core/CHANGELOG.md
+++ b/packages/mama-core/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-07-12
+
+### Fixed
+
+- **vectorSearch superseded pre-filter** — Superseded history rows are filtered out of the
+  vector top-K before ranking, so current-truth results are no longer crowded out by their own
+  replaced versions; the adapter status cache stays in sync on status transitions
+
+## [1.8.0] - 2026-07-03
+
+### Added
+
+- **e5 query prefix scheme** — Search queries are embedded with the multilingual-e5 `query:`
+  prefix (documents keep `passage:`), fixing the anisotropy that made all-pairs similarity
+  cluster near 0.94; an embedding prefix-scheme guard plus migration 042 detect and mark legacy
+  vector stores
+- **Re-embed migration script** — CLI backfill re-embeds legacy vectors under the prefix scheme;
+  refuses to run without an explicit `MAMA_DB_PATH` and fails loud on empty wiki page text
+- **Embedding role threading** — The HTTP embedding server and client carry the query/passage
+  role end to end
+
 ## [1.7.0] - 2026-05-04
 
 ### Added

--- a/packages/standalone/CHANGELOG.md
+++ b/packages/standalone/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-07-12
+
+The operator runtime release. Full details in the repository root CHANGELOG.md.
+
+### Added
+
+- **Self-evolving trigger loop** — The agent authors its own triggers from recurring channel
+  situations, fires them on future messages to recall memory, and folds everything into owner
+  situation reports. A near-duplicate gate blocks variant triggers at authoring time, a review
+  pass retires noisy ones, and a citation success circuit records `succeeded` when a delivered
+  report names the fired triggers it drew on (`USED_TRIGGERS` machine trailer, stripped before
+  the owner sees the report)
+- **Operator board at `/ui`** — React viewer with four agent-published report slots (briefing,
+  action required, decisions, pipeline) rendered live over SSE, a Triggers tab, and an owner veto
+  tray; report slots persist across restarts (`~/.mama/report-slots.json`); task state comes from
+  the real task ledger via the kagemusha bridge query tools, never guessed from chat
+- **Wiki v5: daily journal + lessons** — The wiki agent maintains an Obsidian vault as an
+  append-only daily note per day plus durable lesson pages (`lessons/clients|process|system`);
+  configured via the new `wiki:` config section; Obsidian CLI calls are pinned with `vault=<name>`
+- **Scheduled memory promotion** — Every 6h (configurable, `POST /api/memory/promote`) the memory
+  agent promotes durable judgments from recent channel data into decisions — never task states;
+  successful runs emit `memory:promoted`, which chains into wiki compilation
+- **Audit alert dedup** — The hourly conductor audit diffs findings against
+  `~/.mama/state/audit-findings.json`; a persistent finding alerts the owner once per 24h instead
+  of every hour, MINOR findings never alert, and the audit never writes memory
+
+### Security
+
+- **Public-tree PII scrub and history rewrite** — Personal identifiers removed from the tree and
+  the full git history rewritten; personal configuration lives only under `~/.mama`
+
 ## [0.20.1] - 2026-05-04
 
 ### Added

--- a/packages/standalone/README.md
+++ b/packages/standalone/README.md
@@ -23,7 +23,8 @@ records into scoped, auditable context for agents and humans.
 - **Operate inside envelopes** — Gateway and worker calls carry signed scope boundaries and audit rows
 - **Preserve provenance** — Memory writes can point back to source refs, model runs, tool traces, and envelope hashes
 - **Search with evidence** — Strict memory search can reject vector-only noise and show which lexical, entity, scope, or graph signals confirmed a result
-- **Compile actionable knowledge** — Raw conversations become structured wiki pages with priorities, gaps, and suggested next steps
+- **Compile actionable knowledge** — Promoted decisions become an Obsidian wiki: an append-only daily journal plus durable lesson pages that strengthen with evidence
+- **Evolve their own triggers** — The operator loop authors triggers from recurring situations, fires them to recall the right memory, and scores them by whether delivered reports actually cite them
 - **Brief you proactively** — When you start working, relevant context from all sources is already there — you didn't ask for it
 
 ```
@@ -79,8 +80,8 @@ claude auth login   # or: codex login
 npx @jungjaehoon/mama-os init
 mama start
 
-# 3. Open the viewer
-open http://localhost:3847
+# 3. Open the operator board
+open http://localhost:3847/ui
 ```
 
 **Prerequisites:** Node.js >= 22.13.0, one authenticated backend CLI (Claude or Codex), 500MB disk space.
@@ -130,7 +131,14 @@ Agents delegate via `delegate()` with skill injection and automatic retry. Confi
 
 ## Viewer
 
-Web UI at `http://localhost:3847`. PWA-enabled for mobile (add to home screen).
+Web UI at `http://localhost:3847` (redirects to the operator board at `/ui`). PWA-enabled for
+mobile (add to home screen).
+
+**Operator board (`/ui`)** — the primary surface: four agent-published report slots (briefing,
+action required, decisions, pipeline) rendered live over SSE, plus a Triggers tab showing the
+trigger loop's library with an owner veto tray.
+
+**Legacy viewer (`/viewer`)** tabs:
 
 | Tab           | What it shows                                              |
 | ------------- | ---------------------------------------------------------- |


### PR DESCRIPTION
## Summary
Follow-up to #138/#139: the per-package CHANGELOG/README files (which ship inside the npm tarballs and render on the npm package pages) were still at their 0.20.1 / 1.7.0 state.

- **mama-core CHANGELOG**: adds the missing **1.8.0** entry (e5 `query:`/`passage:` prefix scheme fixing the 0.94 anisotropy, prefix-scheme guard + migration 042, re-embed CLI, role threading) and **1.8.1** entry (vectorSearch superseded pre-filter + status-cache sync) — these versions were bumped in July without changelog entries.
- **standalone CHANGELOG**: adds the **0.21.0** operator-runtime entry (trigger loop + success circuit, /ui board, wiki v5, memory promotion, audit dedup, PII history rewrite).
- **standalone README** (npm front page): /ui operator board as the primary surface, trigger loop added to the agent capability list, wiki line updated to the daily+lessons model.

mcp-server / claude-code-plugin / memorybench are untouched (no version change in this release).

Note: the already-published 0.21.0/1.8.1 tarballs carry the previous README; the next patch release picks these up. Docs-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Operator Board at `/ui` with live reports, persistent report slots, and trigger management.
  * Added daily journal and lessons support, scheduled memory promotion, and self-evolving trigger workflows.
  * Improved vector search relevance by prioritizing current information.
  * Added clearer embedding behavior for queries and documents, including support for migrating existing stores.

* **Documentation**
  * Updated Quick Start instructions and clarified the Operator Board and legacy Viewer at `/viewer`.

* **Security**
  * Removed personal information from the public project history and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->