### PR TITLE
fix(connectors): omit undefined optional metadata from slack/trello items

### DIFF
--- a/packages/standalone/src/connectors/slack/index.ts
+++ b/packages/standalone/src/connectors/slack/index.ts
@@ -131,7 +131,9 @@ export class SlackConnector implements IConnector {
               metadata: {
                 channelId,
                 ts: msg.ts as string,
-                threadTs: msg.thread_ts as string | undefined,
+                // Omit when absent: the canonical raw-ref serializer rejects
+                // undefined values ("undefined is not serializable at $.threadTs").
+                ...(msg.thread_ts ? { threadTs: msg.thread_ts as string } : {}),
               },
             });
           }

--- a/packages/standalone/src/connectors/trello/index.ts
+++ b/packages/standalone/src/connectors/trello/index.ts
@@ -44,7 +44,13 @@ export class TrelloConnector implements IConnector {
   /** boardId → (cardId → listName) */
   private lastCardStates: Map<string, Map<string, string>> = new Map();
 
-  private readonly stateFilePath = join(homedir(), '.mama', 'connectors', 'trello', 'trello-state.json');
+  private readonly stateFilePath = join(
+    homedir(),
+    '.mama',
+    'connectors',
+    'trello',
+    'trello-state.json'
+  );
 
   constructor(config: ConnectorConfig) {
     this.config = config;
@@ -57,7 +63,9 @@ export class TrelloConnector implements IConnector {
         for (const [board, cards] of Object.entries(data.lastCardStates ?? {})) {
           this.lastCardStates.set(board, new Map(Object.entries(cards as Record<string, string>)));
         }
-      } catch { /* ignore corrupt state */ }
+      } catch {
+        /* ignore corrupt state */
+      }
     }
   }
 
@@ -194,7 +202,9 @@ export class TrelloConnector implements IConnector {
                   boardId,
                   cardId: card.id,
                   listName: list.name,
-                  prevListName: prevList,
+                  // Omit when absent: the canonical raw-ref serializer rejects
+                  // undefined values ("undefined is not serializable at $.prevListName").
+                  ...(prevList !== undefined ? { prevListName: prevList } : {}),
                   cardName: card.name,
                   members: card.idMembers,
                 },

--- a/packages/standalone/tests/connectors/slack.test.ts
+++ b/packages/standalone/tests/connectors/slack.test.ts
@@ -134,6 +134,28 @@ describe('SlackConnector', () => {
       expect(calls).not.toContain('C003');
     });
 
+    it('omits threadTs from metadata when the message has no thread_ts', async () => {
+      // Regression: undefined metadata values blow up the canonical raw-ref
+      // serializer at poll time ("undefined is not serializable at $.threadTs").
+      mockWebClient.conversations.history.mockResolvedValueOnce({
+        messages: [
+          { ts: '1700000001.000', user: 'U123', text: 'top-level message' },
+          { ts: '1700000002.000', user: 'U123', text: 'reply', thread_ts: '1700000001.000' },
+        ],
+      });
+      const connector = new SlackConnector(
+        makeConfig({ channels: { C001: { role: 'hub', name: 'general' } } })
+      );
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(2);
+      const topLevel = items.find((i) => i.content === 'top-level message');
+      const reply = items.find((i) => i.content === 'reply');
+      expect(topLevel && 'threadTs' in (topLevel.metadata ?? {})).toBe(false);
+      expect(reply?.metadata?.threadTs).toBe('1700000001.000');
+      expect(Object.values(topLevel?.metadata ?? {})).not.toContain(undefined);
+    });
+
     it('skips bot messages', async () => {
       mockWebClient.conversations.history.mockResolvedValueOnce({
         messages: [

--- a/packages/standalone/tests/connectors/trello.test.ts
+++ b/packages/standalone/tests/connectors/trello.test.ts
@@ -161,6 +161,22 @@ describe('TrelloConnector', () => {
       expect(items[1]?.type).toBe('kanban_card');
     });
 
+    it('omits prevListName from metadata on first sight of a card', async () => {
+      // Regression: undefined metadata values blow up the canonical raw-ref
+      // serializer at poll time ("undefined is not serializable at $.prevListName").
+      const lists = [makeTrelloList('list1', 'Todo', [{ id: 'card1', name: 'Task A' }])];
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(lists) })
+      );
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(1);
+      expect('prevListName' in (items[0]?.metadata ?? {})).toBe(false);
+      expect(Object.values(items[0]?.metadata ?? {})).not.toContain(undefined);
+    });
+
     it('sets source to "trello"', async () => {
       const lists = [makeTrelloList('list1', 'Todo', [{ id: 'card1', name: 'Task A' }])];
       vi.stubGlobal(


### PR DESCRIPTION
## Summary
First live polls of the directly-connected slack and trello connectors (enabled today) failed with `CanonicalizeError: undefined is not serializable` — at `$.threadTs` (slack, non-thread messages) and `$.prevListName` (trello, first-seen cards). The canonical raw-ref serializer fails loud on `undefined` by design; the connectors were writing optional fields as undefined values instead of omitting the keys.

- slack: `metadata.threadTs` present only when `msg.thread_ts` exists
- trello: `metadata.prevListName` present only when the card was seen in a different list before
- chatwork polled clean on the same run (no undefined optionals in its payload)

## Test plan
- [x] 2 regression tests: absent field -> key omitted, no undefined values in metadata; present field -> carried
- [x] slack/trello connector suites (52) + typecheck
- [ ] Live after merge: slack/chatwork/trello polls run clean (verified on the deployment where these connectors were enabled today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)