### PR TITLE
feat(operator): native task ledger + gateway tools (M8 Phase 0)

### DIFF
--- a/packages/standalone/src/agent/code-act/host-bridge.ts
+++ b/packages/standalone/src/agent/code-act/host-bridge.ts
@@ -670,7 +670,12 @@ const TOOL_REGISTRY: ToolMeta[] = [
       { name: 'status', type: 'string', required: false },
       { name: 'priority', type: 'string', required: false },
       { name: 'assignee', type: 'string', required: false },
-      { name: 'deadline', type: 'string', required: false },
+      {
+        name: 'deadline',
+        type: 'string | null',
+        required: false,
+        description: 'YYYY-MM-DD, or null to clear',
+      },
       { name: 'latest_event', type: 'string', required: false },
       { name: 'confirmed', type: 'boolean', required: false },
     ],

--- a/packages/standalone/src/agent/code-act/host-bridge.ts
+++ b/packages/standalone/src/agent/code-act/host-bridge.ts
@@ -622,6 +622,51 @@ const TOOL_REGISTRY: ToolMeta[] = [
       '{ messages: Array<{ id: number; channel: string; author: string; content: string; timestamp: string }> }',
     category: 'memory',
   },
+  {
+    name: 'task_list',
+    description:
+      'List native task-ledger work items (order: deadline asc nulls-last, then priority).',
+    params: [
+      { name: 'status', type: 'string', required: false },
+      { name: 'channel', type: 'string', required: false },
+      { name: 'search', type: 'string', required: false },
+      { name: 'limit', type: 'number', required: false },
+    ],
+    returnType: '{ tasks: object[] }',
+    category: 'memory',
+  },
+  {
+    name: 'task_create',
+    description: 'Create a task-ledger item; duplicate (source_channel, source_event_id) upserts.',
+    params: [
+      { name: 'title', type: 'string', required: true },
+      { name: 'status', type: 'string', required: false },
+      { name: 'priority', type: 'string', required: false },
+      { name: 'assignee', type: 'string', required: false },
+      { name: 'deadline', type: 'string', required: false, description: 'YYYY-MM-DD' },
+      { name: 'source_channel', type: 'string', required: false },
+      { name: 'source_event_id', type: 'string', required: false },
+      { name: 'latest_event', type: 'string', required: false },
+    ],
+    returnType: '{ task: object }',
+    category: 'memory',
+  },
+  {
+    name: 'task_update',
+    description: 'Update a task-ledger item by id.',
+    params: [
+      { name: 'id', type: 'number', required: true },
+      { name: 'title', type: 'string', required: false },
+      { name: 'status', type: 'string', required: false },
+      { name: 'priority', type: 'string', required: false },
+      { name: 'assignee', type: 'string', required: false },
+      { name: 'deadline', type: 'string', required: false },
+      { name: 'latest_event', type: 'string', required: false },
+      { name: 'confirmed', type: 'boolean', required: false },
+    ],
+    returnType: '{ task: object }',
+    category: 'memory',
+  },
 ];
 
 /** Read-only tool names for Tier 3 (strictest) */
@@ -643,6 +688,8 @@ export const READ_ONLY_TOOLS = new Set([
   'kagemusha_entities',
   'kagemusha_tasks',
   'kagemusha_messages',
+  // Native task ledger reads: the pipeline projection's source of truth.
+  'task_list',
 ]);
 
 /** Memory-write tools additionally allowed for Tier 2 */
@@ -658,6 +705,9 @@ export const MEMORY_WRITE_TOOLS = new Set([
   // the code-act sandbox never injects the function and every run silently
   // degrades to the wiki_publish fallback.
   'obsidian',
+  // Native task ledger writes: reconcile runs maintain work items (M8).
+  'task_create',
+  'task_update',
 ]);
 
 export class HostBridge {

--- a/packages/standalone/src/agent/code-act/host-bridge.ts
+++ b/packages/standalone/src/agent/code-act/host-bridge.ts
@@ -652,6 +652,16 @@ const TOOL_REGISTRY: ToolMeta[] = [
     category: 'memory',
   },
   {
+    name: 'contract_no_update',
+    description: 'Record that a reconcile run judged nothing affected (scoped, verifiable).',
+    params: [
+      { name: 'reason', type: 'string', required: true },
+      { name: 'scope', type: 'string', required: true },
+    ],
+    returnType: '{ note: { id: number } }',
+    category: 'memory',
+  },
+  {
     name: 'task_update',
     description: 'Update a task-ledger item by id.',
     params: [
@@ -708,6 +718,7 @@ export const MEMORY_WRITE_TOOLS = new Set([
   // Native task ledger writes: reconcile runs maintain work items (M8).
   'task_create',
   'task_update',
+  'contract_no_update',
 ]);
 
 export class HostBridge {

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -514,6 +514,9 @@ export class GatewayToolExecutor {
   setTaskLedger(ledger: import('../operator/task-ledger.js').TaskLedger): void {
     this.taskLedger = ledger;
   }
+  getTaskLedger(): import('../operator/task-ledger.js').TaskLedger | null {
+    return this.taskLedger;
+  }
   private agentEventBus: AgentEventBus | null = null;
   setAgentEventBus(bus: AgentEventBus): void {
     this.agentEventBus = bus;

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -510,6 +510,10 @@ export class GatewayToolExecutor {
     this.obsidianVaultPath = vaultPath;
     this.obsidianVaultName = vaultName ?? null;
   }
+  private taskLedger: import('../operator/task-ledger.js').TaskLedger | null = null;
+  setTaskLedger(ledger: import('../operator/task-ledger.js').TaskLedger): void {
+    this.taskLedger = ledger;
+  }
   private agentEventBus: AgentEventBus | null = null;
   setAgentEventBus(bus: AgentEventBus): void {
     this.agentEventBus = bus;
@@ -2290,6 +2294,57 @@ export class GatewayToolExecutor {
             );
           }
           return { success: true, messages: queryMessages(msgInput) };
+        }
+        case 'task_list': {
+          if (!this.taskLedger) {
+            return { success: false, error: 'Task ledger not configured' } as GatewayToolResult;
+          }
+          const listInput = input as {
+            status?: string;
+            channel?: string;
+            search?: string;
+            limit?: number;
+            order?: string;
+          };
+          return {
+            success: true,
+            tasks: this.taskLedger.list({
+              status: listInput.status as never,
+              channel: listInput.channel,
+              search: listInput.search,
+              limit: listInput.limit,
+              order: (listInput.order as never) ?? 'deadline_priority',
+            }),
+          };
+        }
+        case 'task_create': {
+          if (!this.taskLedger) {
+            return { success: false, error: 'Task ledger not configured' } as GatewayToolResult;
+          }
+          return {
+            success: true,
+            task: this.taskLedger.create(input as never),
+          };
+        }
+        case 'task_update': {
+          if (!this.taskLedger) {
+            return { success: false, error: 'Task ledger not configured' } as GatewayToolResult;
+          }
+          const { id: rawId, ...patch } = input as { id: unknown } & Record<string, unknown>;
+          // Agents routinely pass "12"; coerce, reject non-numeric with a typed error.
+          const id = typeof rawId === 'string' ? Number(rawId.trim()) : (rawId as number);
+          if (!Number.isInteger(id) || id <= 0) {
+            throw new AgentError(
+              `task_update requires a numeric id, got: ${String(rawId)}`,
+              'TOOL_ERROR',
+              undefined,
+              false
+            );
+          }
+          return {
+            success: true,
+            task: this.taskLedger.update(id, patch as never),
+          };
         }
         case 'agent_notices': {
           const rawLimit = Number((input as { limit?: number }).limit);

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -2346,6 +2346,21 @@ export class GatewayToolExecutor {
             task: this.taskLedger.update(id, patch as never),
           };
         }
+        case 'contract_no_update': {
+          if (!this.taskLedger) {
+            return { success: false, error: 'Task ledger not configured' } as GatewayToolResult;
+          }
+          const { reason, scope } = input as { reason?: string; scope?: string };
+          if (!reason || !scope) {
+            throw new AgentError(
+              'contract_no_update requires both reason and scope',
+              'TOOL_ERROR',
+              undefined,
+              false
+            );
+          }
+          return { success: true, note: this.taskLedger.recordNoUpdate(scope, reason) };
+        }
         case 'agent_notices': {
           const rawLimit = Number((input as { limit?: number }).limit);
           const limit = Number.isFinite(rawLimit)

--- a/packages/standalone/src/agent/gateway-tools.md
+++ b/packages/standalone/src/agent/gateway-tools.md
@@ -62,12 +62,15 @@ Call tools via JSON block:
 
 ## OS Monitoring (viewer-only)
 
-- **report_publish**(slots: { briefing?: html, alerts?: html, activity?: html, pipeline?: html }) — Update dashboard report slots with HTML content. Each slot is a section of the dashboard that you write as HTML.
+- **report_publish**(slots: { briefing?: html, action_required?: html, decisions?: html, pipeline?: html } -- partial maps allowed; only the given slots are updated) — Update dashboard report slots with HTML content. Each slot is a section of the dashboard that you write as HTML.
 - **wiki_publish**(pages: [{path, title, type, content, confidence?, sourceIds?, sourceRefs?}]) — Publish compiled wiki pages to Obsidian vault. Each page becomes a markdown file with YAML frontmatter.
 - **obsidian**(command, args?) — Execute Obsidian CLI command on the wiki vault. Search, read, create, append, move, delete pages, manage tags and backlinks.
 - **os_list_bots**() — List configured bot platforms and status
 - **os_restart_bot**() — Restart a bot platform
 - **os_stop_bot**() — Stop a bot platform
+- **task_list**(status? (pending|in_progress|review|blocked|done|cancelled), channel?, search?, limit?, order? ('deadline_priority'|'updated')) — List operator work items from the native task ledger. Canonical board order: deadline asc (nulls last), then priority high>normal>low.
+- **task_create**(title (required), status?, priority? (high|normal|low), assignee?, deadline? (YYYY-MM-DD), source_channel? ("<connector>:<channelId>"), source_event_id?, latest_event?, confirmed?) — Create a work item in the native task ledger. Duplicate (source_channel, source_event_id) UPSERTS the existing row instead of duplicating it.
+- **task_update**(id (required), title?, status?, priority?, assignee?, deadline? (YYYY-MM-DD or null to clear), latest_event?, confirmed?) — Update a work item in the native task ledger by id.
 - **agent_activity**(agent_id, limit?) — Get recent agent activity rows and sync the viewer to that agent activity tab so you and the user inspect the same logs.
 - **agent_compare**(agent_id, version_a, version_b) — Compare metrics between two versions of an agent (Before/After)
 

--- a/packages/standalone/src/agent/gateway-tools.md
+++ b/packages/standalone/src/agent/gateway-tools.md
@@ -71,6 +71,7 @@ Call tools via JSON block:
 - **task_list**(status? (pending|in_progress|review|blocked|done|cancelled), channel?, search?, limit?, order? ('deadline_priority'|'updated')) — List operator work items from the native task ledger. Canonical board order: deadline asc (nulls last), then priority high>normal>low.
 - **task_create**(title (required), status?, priority? (high|normal|low), assignee?, deadline? (YYYY-MM-DD), source_channel? ("<connector>:<channelId>"), source_event_id?, latest_event?, confirmed?) — Create a work item in the native task ledger. Duplicate (source_channel, source_event_id) UPSERTS the existing row instead of duplicating it.
 - **task_update**(id (required), title?, status?, priority?, assignee?, deadline? (YYYY-MM-DD or null to clear), latest_event?, confirmed?) — Update a work item in the native task ledger by id.
+- **contract_no_update**(reason (required), scope (required, e.g. "reconcile:slack:C001")) — Record that a reconcile run judged NOTHING on the board or ledger affected. Silence becomes a verifiable judgment.
 - **agent_activity**(agent_id, limit?) — Get recent agent activity rows and sync the viewer to that agent activity tab so you and the user inspect the same logs.
 - **agent_compare**(agent_id, version_a, version_b) — Compare metrics between two versions of an agent (Before/After)
 

--- a/packages/standalone/src/agent/tool-registry.ts
+++ b/packages/standalone/src/agent/tool-registry.ts
@@ -334,6 +334,13 @@ register({
   params:
     'id (required), title?, status?, priority?, assignee?, deadline? (YYYY-MM-DD or null to clear), latest_event?, confirmed?',
 });
+register({
+  name: 'contract_no_update',
+  description:
+    'Record that a reconcile run judged NOTHING on the board or ledger affected. Silence becomes a verifiable judgment.',
+  category: 'os_monitoring',
+  params: 'reason (required), scope (required, e.g. "reconcile:slack:C001")',
+});
 
 // System tools
 register({

--- a/packages/standalone/src/agent/tool-registry.ts
+++ b/packages/standalone/src/agent/tool-registry.ts
@@ -90,7 +90,8 @@ register({
   description:
     'Update dashboard report slots with HTML content. Each slot is a section of the dashboard that you write as HTML.',
   category: 'os_monitoring',
-  params: 'slots: { briefing?: html, alerts?: html, activity?: html, pipeline?: html }',
+  params:
+    'slots: { briefing?: html, action_required?: html, decisions?: html, pipeline?: html } -- partial maps allowed; only the given slots are updated',
 });
 register({
   name: 'wiki_publish',
@@ -307,6 +308,31 @@ register({
   description: 'Read raw messages from a specific channel (follow entities -> tasks -> messages)',
   category: 'business_data',
   params: 'channelId (required), since?, limit?, search?',
+});
+
+// Native task ledger (M8): operator-owned work items projected onto the board
+register({
+  name: 'task_list',
+  description:
+    'List operator work items from the native task ledger. Canonical board order: deadline asc (nulls last), then priority high>normal>low.',
+  category: 'os_monitoring',
+  params:
+    "status? (pending|in_progress|review|blocked|done|cancelled), channel?, search?, limit?, order? ('deadline_priority'|'updated')",
+});
+register({
+  name: 'task_create',
+  description:
+    'Create a work item in the native task ledger. Duplicate (source_channel, source_event_id) UPSERTS the existing row instead of duplicating it.',
+  category: 'os_monitoring',
+  params:
+    'title (required), status?, priority? (high|normal|low), assignee?, deadline? (YYYY-MM-DD), source_channel? ("<connector>:<channelId>"), source_event_id?, latest_event?, confirmed?',
+});
+register({
+  name: 'task_update',
+  description: 'Update a work item in the native task ledger by id.',
+  category: 'os_monitoring',
+  params:
+    'id (required), title?, status?, priority?, assignee?, deadline? (YYYY-MM-DD or null to clear), latest_event?, confirmed?',
 });
 
 // System tools

--- a/packages/standalone/src/agent/types.ts
+++ b/packages/standalone/src/agent/types.ts
@@ -773,6 +773,7 @@ export type GatewayToolName =
   | 'task_list'
   | 'task_create'
   | 'task_update'
+  | 'contract_no_update'
   // System tools
   | 'agent_notices'
   // Agent management tools (Managed Agents pattern)

--- a/packages/standalone/src/agent/types.ts
+++ b/packages/standalone/src/agent/types.ts
@@ -769,6 +769,10 @@ export type GatewayToolName =
   | 'kagemusha_entities'
   | 'kagemusha_tasks'
   | 'kagemusha_messages'
+  // Native task ledger (M8: operator-owned work items)
+  | 'task_list'
+  | 'task_create'
+  | 'task_update'
   // System tools
   | 'agent_notices'
   // Agent management tools (Managed Agents pattern)

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -26,7 +26,8 @@ import { SessionStore, MessageRouter, initChannelHistory } from '../../gateways/
 import { createGraphHandler } from '../../api/graph-api.js';
 import type { CodeActExecutionContext, GraphHandlerOptions } from '../../api/graph-api-types.js';
 import Database from '../../sqlite.js';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
 import { minimatch } from 'minimatch';
 import { UICommandQueue } from '../../api/ui-command-handler.js';
 import { initAgentTables, getLatestVersion, createAgentVersion } from '../../db/agent-store.js';
@@ -87,6 +88,9 @@ const CODE_ACT_MUTATION_TOOLS = new Set([
   'mama_ingest',
   'report_publish',
   'wiki_publish',
+  'task_create',
+  'task_update',
+  'contract_no_update',
 ]);
 
 function isTruthyEnvValue(value: string | undefined): boolean {
@@ -1045,6 +1049,32 @@ export async function runAgentLoop(
   // and point it at the loop once it exists. Null until then -> nudge no-ops (no loop = nothing to
   // wake), which preserves today's behavior when MAMA_TRIGGER_LOOP is unset.
   const triggerLoopNudge: { current: (() => void) | null } = { current: null };
+  // M8: board-reconcile feed. The trigger loop is built BEFORE the event bus
+  // exists (initApiServer), so it emits through this mutable sink (same
+  // pattern as triggerLoopNudge above).
+  const channelDeltaSink: { current: ((channelKey: string, lines: string[]) => void) | null } = {
+    current: null,
+  };
+
+  // Operator DB + native task ledger (M8): wired UNCONDITIONALLY -- the task
+  // tools are standard gateway tools and must work even when the trigger loop
+  // is off (review finding on #142). Single handle, closed once at shutdown.
+  const operatorDbPath = expandPath('~/.mama/operator/triggers.db');
+  mkdirSync(dirname(operatorDbPath), { recursive: true });
+  const operatorDb = new Database(operatorDbPath);
+  {
+    const { TaskLedger } = await import('../../operator/task-ledger.js');
+    toolExecutor.setTaskLedger(new TaskLedger(operatorDb));
+  }
+  gateways.push({
+    stop: async () => {
+      try {
+        operatorDb.close();
+      } catch {
+        /* already closed */
+      }
+    },
+  });
   const { rawStoreForApi, enabledConnectorNames, connectorSchedulerStop } = await initConnectors(
     connectorExtractionFn,
     { nudge: () => triggerLoopNudge.current?.() }
@@ -1077,8 +1107,6 @@ export async function runAgentLoop(
       const { createMamaMemoryPort } = await import('../../operator/mama-memory-port.js');
       const { askAgentCLI } = await import('../../operator/trigger-author.js');
       const { reviewTriggerCLI } = await import('../../operator/trigger-review.js');
-      const { mkdirSync } = await import('node:fs');
-      const { dirname } = await import('node:path');
       const { ReportScheduler, FileReportScheduleStore, parseReportHours } =
         await import('../../operator/report-scheduler.js');
       const { createPersonaReportAsk, OPERATOR_REPORT_SESSION_KEY } =
@@ -1086,14 +1114,7 @@ export async function runAgentLoop(
       const { OPERATOR_FULL_REPORT_TAG } = await import('../../operator/situation-report.js');
       const { buildBoardPublishLines } = await import('../../operator/board-slot-instructions.js');
 
-      const triggerDbPath = expandPath('~/.mama/operator/triggers.db');
-      mkdirSync(dirname(triggerDbPath), { recursive: true });
-      const operatorDb = new Database(triggerDbPath);
       const triggerRegistry = new TriggerRegistry(operatorDb);
-      // Native task ledger (M8) shares the operator DB handle; the handle owner
-      // (the shutdown hook below) closes it once -- stores have no close().
-      const { TaskLedger } = await import('../../operator/task-ledger.js');
-      toolExecutor.setTaskLedger(new TaskLedger(operatorDb));
       // Owner-report leg (M1.5): destination chat comes from env (~/.mama/start.sh),
       // never source. No chat configured or no telegram gateway -> loop stays read-only.
       const reportChatId = process.env.MAMA_TRIGGER_LOOP_REPORT_CHAT || '';
@@ -1120,6 +1141,7 @@ export async function runAgentLoop(
         ),
         memory: createMamaMemoryPort(),
         registry: triggerRegistry,
+        onChannelDelta: (channelKey, lines) => channelDeltaSink.current?.(channelKey, lines),
         askAgent: askAgentCLI,
         // M2.2: reports go through the daemon's persona agent (system prompt, pinned model,
         // session lanes) instead of the bare CLI - report tone comes from generation inputs.
@@ -1227,8 +1249,8 @@ export async function runAgentLoop(
         stop: async () => {
           triggerLoopNudge.current = null;
           stopTriggerLoop();
-          // Close the operator triggers.db handle (PR #119 review: was leaked on shutdown).
-          triggerRegistry.close();
+          // The shared operator DB handle is closed by the unconditional stop
+          // hook above (single owner); nothing to close here.
         },
       });
       console.log('✓ Trigger loop enabled (MAMA_TRIGGER_LOOP=1, read-only surface mode)');
@@ -1256,6 +1278,9 @@ export async function runAgentLoop(
     envelopeAuthority: envelopeBootstrap.envelopeAuthority,
     contextCompileService,
   });
+
+  channelDeltaSink.current = (channelKey, lines) =>
+    eventBus.emit({ type: 'operator:channel-delta', channelKey, lines });
 
   await registerApiRoutes({
     config,

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -1062,9 +1062,13 @@ export async function runAgentLoop(
   const operatorDbPath = expandPath('~/.mama/operator/triggers.db');
   mkdirSync(dirname(operatorDbPath), { recursive: true });
   const operatorDb = new Database(operatorDbPath);
-  {
+  try {
     const { TaskLedger } = await import('../../operator/task-ledger.js');
     toolExecutor.setTaskLedger(new TaskLedger(operatorDb));
+  } catch (err) {
+    // Fail loud, but do not leak the handle on a failed boot.
+    operatorDb.close();
+    throw err;
   }
   gateways.push({
     stop: async () => {

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -1088,7 +1088,12 @@ export async function runAgentLoop(
 
       const triggerDbPath = expandPath('~/.mama/operator/triggers.db');
       mkdirSync(dirname(triggerDbPath), { recursive: true });
-      const triggerRegistry = new TriggerRegistry(new Database(triggerDbPath));
+      const operatorDb = new Database(triggerDbPath);
+      const triggerRegistry = new TriggerRegistry(operatorDb);
+      // Native task ledger (M8) shares the operator DB handle; the handle owner
+      // (the shutdown hook below) closes it once -- stores have no close().
+      const { TaskLedger } = await import('../../operator/task-ledger.js');
+      toolExecutor.setTaskLedger(new TaskLedger(operatorDb));
       // Owner-report leg (M1.5): destination chat comes from env (~/.mama/start.sh),
       // never source. No chat configured or no telegram gateway -> loop stays read-only.
       const reportChatId = process.env.MAMA_TRIGGER_LOOP_REPORT_CHAT || '';

--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -377,16 +377,21 @@ This saves resources. Only publish when there is genuinely new information to re
       }
     };
 
-    // Serialize ALL dashboard runs (boot, interval, manual) on one chain -- the shared
-    // agent process rejects concurrent requests, so unserialized triggers raced into
-    // 'Process is busy' errors (same pattern as CronWorker's executionQueue).
-    let dashboardRunChain: Promise<void> = Promise.resolve();
-    const runDashboardAgent = (opts?: { force?: boolean }): Promise<void> => {
-      // Trailing catch keeps one failed link from poisoning every future run:
-      // a rejected chain would silently skip all subsequent .then() links.
-      dashboardRunChain = dashboardRunChain.then(() => doDashboardRun(opts)).catch(() => {});
-      return dashboardRunChain;
+    // ONE board-writer queue: dashboard cron, manual refresh, AND reconcile runs
+    // all serialize here -- the shared agent process rejects concurrent requests
+    // ('Process is busy' class). Per-job rejection propagates to the caller
+    // while the chain itself survives (M8 review: a caller must be able to
+    // distinguish its own job's failure).
+    let boardWriterChain: Promise<void> = Promise.resolve();
+    const boardWriterQueue = {
+      push(job: () => Promise<void>): Promise<void> {
+        const jobPromise = boardWriterChain.then(job);
+        boardWriterChain = jobPromise.catch(() => {});
+        return jobPromise;
+      },
     };
+    const runDashboardAgent = (opts?: { force?: boolean }): Promise<void> =>
+      boardWriterQueue.push(() => doDashboardRun(opts)).catch(() => {});
 
     // First run after 10s (let connectors poll first), then every 30 min
     setTimeout(runDashboardAgent, 10_000);
@@ -397,6 +402,59 @@ This saves resources. Only publish when there is genuinely new information to re
       runDashboardAgent({ force: true }).catch(() => {});
       res.json({ ok: true, message: 'Dashboard agent triggered (forced refresh)' });
     });
+
+    // -- M8 board reconcile leg (freshness layer; default OFF, opt-in like
+    // MAMA_TRIGGER_LOOP). The trigger loop emits operator:channel-delta after
+    // committing its cursor; the 30-min cron above remains the repair pass.
+    if (process.env.MAMA_BOARD_RECONCILE === '1') {
+      const { buildReconcilePrompt, ReconcileScheduler } =
+        await import('../../operator/board-reconcile.js');
+      const kagemushaContext =
+        (process.env.MAMA_RECONCILE_TASK_CONTEXT ?? 'native') === 'kagemusha';
+      const reconcileScheduler = new ReconcileScheduler({
+        debounceMs: Number(process.env.MAMA_RECONCILE_DEBOUNCE_MS) || undefined,
+        maxWaitMs: Number(process.env.MAMA_RECONCILE_MAX_WAIT_MS) || undefined,
+        globalMaxPerHour: Number(process.env.MAMA_RECONCILE_MAX_PER_HOUR) || undefined,
+        log: (line) => console.log(line),
+        run: (channelKey, deltaLines) =>
+          boardWriterQueue.push(async () => {
+            const prompt = buildReconcilePrompt({
+              channelKey,
+              deltaLines,
+              todayIso: new Date().toISOString().slice(0, 10),
+              kagemushaContext,
+            });
+            await executeValidatedRun('dashboard-agent', prompt, {
+              requestTimeout: 300_000,
+            });
+            console.log(`[reconcile] run complete channel=${channelKey}`);
+          }),
+      });
+      eventBus.on('operator:channel-delta', (event) => {
+        if (event.type === 'operator:channel-delta') {
+          reconcileScheduler.enqueue(event.channelKey, event.lines);
+        }
+      });
+
+      // Manual reconcile: lines from the body, or the caller must supply them
+      // (no silent alternate data path -- M8 review #17).
+      apiServer.app.post('/api/operator/reconcile', requireAuth, (req, res) => {
+        const { channelKey, lines } = (req.body ?? {}) as {
+          channelKey?: string;
+          lines?: string[];
+        };
+        if (!channelKey || !Array.isArray(lines) || lines.length === 0) {
+          res.status(400).json({
+            ok: false,
+            error: 'channelKey and non-empty lines[] are required',
+          });
+          return;
+        }
+        reconcileScheduler.enqueue(channelKey, lines);
+        res.json({ ok: true, message: 'Reconcile queued (async; runs after debounce)' });
+      });
+      console.log('[reconcile] Board reconcile leg enabled (MAMA_BOARD_RECONCILE=1)');
+    }
   } else {
     routesLogger.debug('[Dashboard Agent] Skipped; dashboard-agent is not configured');
   }

--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -409,8 +409,43 @@ This saves resources. Only publish when there is genuinely new information to re
     if (process.env.MAMA_BOARD_RECONCILE === '1') {
       const { buildReconcilePrompt, ReconcileScheduler } =
         await import('../../operator/board-reconcile.js');
+      const { captureSnapshot, verifyAfterRun, OBLIGATED_TOOLS } =
+        await import('../../operator/action-verifier.js');
       const kagemushaContext =
         (process.env.MAMA_RECONCILE_TASK_CONTEXT ?? 'native') === 'kagemusha';
+
+      // Verifier deps (M8 Phase 2): run-bound signals only -- trace rows from
+      // the dashboard agent's gateway_tool_call activity, notes from the
+      // operator ledger. Observe, never block.
+      const reconcileLedger = toolExecutor.getTaskLedger();
+      const traceToolList = OBLIGATED_TOOLS.map((t) => `'${t}'`).join(',');
+      const verifierDeps = {
+        getSlots: () => apiServer.reportStore.getAllSorted(),
+        getLedgerHash: () => reconcileLedger?.payloadHash() ?? '',
+        getScopedNoteMaxId: (scope: string) => reconcileLedger?.maxNoUpdateId(scope) ?? 0,
+        getTraceMaxId: () => {
+          if (!sessionsDb) return 0;
+          const row = sessionsDb
+            .prepare(
+              `SELECT MAX(id) AS max_id FROM agent_activity
+               WHERE type = 'gateway_tool_call' AND agent_id = 'dashboard-agent'`
+            )
+            .get() as { max_id: number | null };
+          return row.max_id ?? 0;
+        },
+        countObligatedTraceRowsSince: (maxId: number) => {
+          if (!sessionsDb) return 0;
+          const row = sessionsDb
+            .prepare(
+              `SELECT COUNT(*) AS n FROM agent_activity
+               WHERE type = 'gateway_tool_call' AND agent_id = 'dashboard-agent'
+                 AND id > ? AND normalized_tool_name IN (${traceToolList})`
+            )
+            .get(maxId) as { n: number };
+          return row.n;
+        },
+      };
+
       const reconcileScheduler = new ReconcileScheduler({
         debounceMs: Number(process.env.MAMA_RECONCILE_DEBOUNCE_MS) || undefined,
         maxWaitMs: Number(process.env.MAMA_RECONCILE_MAX_WAIT_MS) || undefined,
@@ -418,6 +453,8 @@ This saves resources. Only publish when there is genuinely new information to re
         log: (line) => console.log(line),
         run: (channelKey, deltaLines) =>
           boardWriterQueue.push(async () => {
+            const scope = `reconcile:${channelKey}`;
+            const before = captureSnapshot(verifierDeps, scope);
             const prompt = buildReconcilePrompt({
               channelKey,
               deltaLines,
@@ -427,7 +464,35 @@ This saves resources. Only publish when there is genuinely new information to re
             await executeValidatedRun('dashboard-agent', prompt, {
               requestTimeout: 300_000,
             });
-            console.log(`[reconcile] run complete channel=${channelKey}`);
+            const verdict = verifyAfterRun(verifierDeps, before, scope);
+            const outcome = verdict.verified ? 'reconcile_verified' : 'reconcile_unverified';
+            console.log(
+              `[reconcile] ${outcome} channel=${channelKey}${verdict.effects.length > 0 ? ` (${verdict.effects.join('; ')})` : ''}`
+            );
+            try {
+              if (sessionsDb) {
+                logActivity(sessionsDb, {
+                  agent_id: 'dashboard-agent',
+                  agent_version: 0,
+                  type: outcome,
+                  input_summary: `reconcile ${channelKey}`,
+                  output_summary: verdict.effects.join('; '),
+                  execution_status: 'completed',
+                  trigger_reason: 'reconcile',
+                });
+              }
+            } catch {
+              /* telemetry only */
+            }
+            if (!verdict.verified) {
+              // Loud, never blocking (observability over restriction).
+              eventBus.emit({
+                type: 'agent:action',
+                agent: 'Dashboard Agent',
+                action: 'reconcile_unverified',
+                target: channelKey,
+              });
+            }
           }),
       });
       eventBus.on('operator:channel-delta', (event) => {

--- a/packages/standalone/src/multi-agent/agent-event-bus.ts
+++ b/packages/standalone/src/multi-agent/agent-event-bus.ts
@@ -9,6 +9,7 @@ export type AgentEvent =
   | { type: 'memory:saved'; topic: string; project?: string }
   | { type: 'extraction:completed'; projects: string[] }
   | { type: 'memory:promoted'; saved: number }
+  | { type: 'operator:channel-delta'; channelKey: string; lines: string[] }
   | { type: 'wiki:compiled'; pages: string[] }
   | { type: 'dashboard:refresh' }
   | { type: 'agent:action'; agent: string; action: string; target: string };

--- a/packages/standalone/src/operator/action-verifier.ts
+++ b/packages/standalone/src/operator/action-verifier.ts
@@ -1,0 +1,105 @@
+/**
+ * OperatorActionVerifier (M8 Phase 2) - verifies that a reconcile run actually
+ * performed its obligated action. Ports Kagemusha's ContractActionVerifier
+ * snapshot-diff mechanism, strengthened per plan review: signals must be BOUND
+ * to the run, not to unrelated board activity.
+ *
+ * Verified iff, after the run:
+ *  (a) a NEW gateway tool-call trace row exists (rowid past the snapshot)
+ *      whose normalized tool name is one of the obligated tools, or
+ *  (b) a NEW no-update note exists with EXACTLY this run's scope.
+ * Slot/ledger hash deltas are recorded as evidence detail only -- another
+ * writer may have moved them (the board-writer queue makes in-queue runs
+ * non-concurrent, which closes the remaining race).
+ *
+ * Observe, never block: the caller records the outcome and emits a notice;
+ * an unverified run is a loud signal, not a rejection.
+ */
+
+import { createHash } from 'node:crypto';
+
+export const OBLIGATED_TOOLS = [
+  'report_publish',
+  'task_create',
+  'task_update',
+  'contract_no_update',
+] as const;
+
+export interface VerifierDeps {
+  /** Current report slots (id -> html). */
+  getSlots: () => Array<{ slotId: string; html: string }>;
+  /** Stable hash of the task ledger payload. */
+  getLedgerHash: () => string;
+  /** Max no-update note id for a scope (0 when none). */
+  getScopedNoteMaxId: (scope: string) => number;
+  /**
+   * Count of gateway tool-call trace rows past a rowid whose normalized tool
+   * name is in OBLIGATED_TOOLS (bound to the reconcile agent).
+   */
+  countObligatedTraceRowsSince: (maxId: number) => number;
+  /** Max gateway trace rowid right now (0 when none). */
+  getTraceMaxId: () => number;
+}
+
+export interface ActionSnapshot {
+  slotHashes: Record<string, string>;
+  ledgerHash: string;
+  scopedNoteMaxId: number;
+  traceMaxId: number;
+}
+
+export interface VerifyResult {
+  verified: boolean;
+  /** Human-readable evidence lines for the activity record. */
+  effects: string[];
+}
+
+export function captureSnapshot(deps: VerifierDeps, scope: string): ActionSnapshot {
+  const slotHashes: Record<string, string> = {};
+  for (const slot of deps.getSlots()) {
+    slotHashes[slot.slotId] = createHash('sha256').update(slot.html).digest('hex');
+  }
+  return {
+    slotHashes,
+    ledgerHash: deps.getLedgerHash(),
+    scopedNoteMaxId: deps.getScopedNoteMaxId(scope),
+    traceMaxId: deps.getTraceMaxId(),
+  };
+}
+
+export function verifyAfterRun(
+  deps: VerifierDeps,
+  before: ActionSnapshot,
+  scope: string
+): VerifyResult {
+  const effects: string[] = [];
+  let verified = false;
+
+  // (a) run-bound signal: obligated gateway tool traces past the snapshot.
+  const obligatedTraces = deps.countObligatedTraceRowsSince(before.traceMaxId);
+  if (obligatedTraces > 0) {
+    verified = true;
+    effects.push(`obligated tool traces: ${obligatedTraces}`);
+  }
+
+  // (b) run-bound signal: a new no-update note with EXACTLY this scope.
+  const noteMaxNow = deps.getScopedNoteMaxId(scope);
+  if (noteMaxNow > before.scopedNoteMaxId) {
+    verified = true;
+    effects.push(`no-update note recorded (scope=${scope})`);
+  }
+
+  // Evidence detail only (NOT sufficient alone -- see module doc).
+  const after = captureSnapshot(deps, scope);
+  const changedSlots = Object.keys({ ...before.slotHashes, ...after.slotHashes }).filter(
+    (id) => before.slotHashes[id] !== after.slotHashes[id]
+  );
+  if (changedSlots.length > 0) {
+    effects.push(`slots changed: ${changedSlots.join(', ')}`);
+  }
+  if (after.ledgerHash !== before.ledgerHash) {
+    effects.push('task ledger changed');
+  }
+
+  return { verified, effects };
+}

--- a/packages/standalone/src/operator/board-reconcile.ts
+++ b/packages/standalone/src/operator/board-reconcile.ts
@@ -1,0 +1,192 @@
+/**
+ * board-reconcile - the delta -> taskboard reconcile contract (M8 Phase 1).
+ *
+ * Ports Kagemusha's taskboard reconcile mechanism (agent-awareness.ts
+ * buildTaskboardReconcilePrompt / runTaskboardReconcile): when a channel delta
+ * arrives, the AGENT judges which board slots are affected and MUST either act
+ * (partial report_publish / task_create / task_update) or record a
+ * contract_no_update note. The system only debounces, budgets, and serializes;
+ * every judgment is the agent's (agent-first).
+ *
+ * Freshness-layer semantics: the 30-minute dashboard cron remains the
+ * repair/catch-up pass. Over-budget work is DEFERRED (channel stays dirty with
+ * its pending lines), never silently dropped; a crash loses at most one
+ * debounce window, which the next cron repairs.
+ */
+
+export interface ReconcilePromptInput {
+  /** "<connector>:<channelId>" - connector-qualified, collision-free. */
+  channelKey: string;
+  channelLabel?: string;
+  deltaLines: string[];
+  todayIso: string;
+  /** Also read kagemusha_tasks as judgment CONTEXT (never the projection source). */
+  kagemushaContext?: boolean;
+}
+
+/** The prompt MUST begin with this token so the persona's RECONCILE RUN mode engages. */
+export const RECONCILE_RUN_TOKEN = 'RECONCILE RUN';
+
+export function buildReconcilePrompt(input: ReconcilePromptInput): string {
+  const label = input.channelLabel ?? input.channelKey;
+  const scope = `reconcile:${input.channelKey}`;
+  return [
+    `${RECONCILE_RUN_TOKEN} for channel ${label} (${input.channelKey}). Today is ${input.todayIso}.`,
+    'New messages arrived in this channel. Reconcile the operator board and the task ledger',
+    'against them. Plan (execute in order):',
+    '1. Read the delta lines below.',
+    `2. task_list() for existing work items${input.kagemushaContext ? ' and kagemusha_tasks() as extra CONTEXT (the native ledger stays the projection source)' : ''}.`,
+    '3. Judge which slots are affected (briefing / action_required / decisions / pipeline).',
+    '4. You MUST call at least ONE of: report_publish with ONLY the affected slots,',
+    '   task_create, or task_update -- when the delta concerns work that ALREADY has a',
+    '   task row (match by title or source in step 2), task_update that row instead of',
+    '   creating a near-duplicate, and pass source_channel plus source_event_id from the',
+    '   delta header so retries upsert. If NOTHING on the board or ledger is affected,',
+    `   you MUST call contract_no_update({reason, scope: "${scope}"}) instead.`,
+    '5. Finish with exactly one line: RECONCILED <comma-separated slots or none>.',
+    '',
+    'Constraints: do not rewrite unaffected slots; no mama_save; no follow-up questions.',
+    '',
+    `<latest-delta channel="${input.channelKey}">`,
+    ...input.deltaLines,
+    '</latest-delta>',
+  ].join('\n');
+}
+
+export interface ReconcileSchedulerOptions {
+  /** Trailing-edge debounce per channel. */
+  debounceMs?: number;
+  /** A continuously-busy channel still fires by this bound (anti-starvation). */
+  maxWaitMs?: number;
+  /** GLOBAL budget across all channels (sliding hour). Over-budget defers, never drops. */
+  globalMaxPerHour?: number;
+  /** Bounded pending lines kept per channel while deferred. */
+  maxPendingLines?: number;
+  run: (channelKey: string, deltaLines: string[]) => Promise<void>;
+  log: (line: string) => void;
+  now?: () => number;
+}
+
+interface ChannelState {
+  pendingLines: string[];
+  debounceTimer: ReturnType<typeof setTimeout> | null;
+  firstEnqueuedAt: number | null;
+}
+
+export class ReconcileScheduler {
+  private readonly debounceMs: number;
+  private readonly maxWaitMs: number;
+  private readonly globalMaxPerHour: number;
+  private readonly maxPendingLines: number;
+  private readonly run: ReconcileSchedulerOptions['run'];
+  private readonly log: ReconcileSchedulerOptions['log'];
+  private readonly now: () => number;
+
+  private channels = new Map<string, ChannelState>();
+  private runTimestamps: number[] = [];
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  private stopped = false;
+
+  constructor(opts: ReconcileSchedulerOptions) {
+    this.debounceMs = opts.debounceMs ?? 180_000;
+    this.maxWaitMs = opts.maxWaitMs ?? 600_000;
+    this.globalMaxPerHour = opts.globalMaxPerHour ?? 12;
+    this.maxPendingLines = opts.maxPendingLines ?? 30;
+    this.run = opts.run;
+    this.log = opts.log;
+    this.now = opts.now ?? Date.now;
+  }
+
+  enqueue(channelKey: string, lines: string[]): void {
+    if (this.stopped) return;
+    const state = this.channels.get(channelKey) ?? {
+      pendingLines: [],
+      debounceTimer: null,
+      firstEnqueuedAt: null,
+    };
+    state.pendingLines = [...state.pendingLines, ...lines].slice(-this.maxPendingLines);
+    if (state.firstEnqueuedAt === null) state.firstEnqueuedAt = this.now();
+    this.channels.set(channelKey, state);
+
+    if (state.debounceTimer) clearTimeout(state.debounceTimer);
+    // Trailing debounce with a max-wait bound: continuous traffic cannot
+    // starve the channel past maxWaitMs since its first pending event.
+    const sinceFirst = this.now() - state.firstEnqueuedAt;
+    const delay = Math.max(0, Math.min(this.debounceMs, this.maxWaitMs - sinceFirst));
+    const timer = setTimeout(() => {
+      state.debounceTimer = null;
+      void this.fire(channelKey);
+    }, delay);
+    timer.unref?.();
+    state.debounceTimer = timer;
+  }
+
+  /** Channels currently holding deferred/pending work (for observability). */
+  dirtyChannels(): string[] {
+    return [...this.channels.entries()]
+      .filter(([, s]) => s.pendingLines.length > 0)
+      .map(([k]) => k);
+  }
+
+  stop(): void {
+    this.stopped = true;
+    for (const state of this.channels.values()) {
+      if (state.debounceTimer) clearTimeout(state.debounceTimer);
+      state.debounceTimer = null;
+    }
+    if (this.retryTimer) clearTimeout(this.retryTimer);
+    this.retryTimer = null;
+  }
+
+  private budgetAvailable(): boolean {
+    const cutoff = this.now() - 3_600_000;
+    this.runTimestamps = this.runTimestamps.filter((t) => t > cutoff);
+    return this.runTimestamps.length < this.globalMaxPerHour;
+  }
+
+  private scheduleRetry(): void {
+    if (this.retryTimer || this.stopped) return;
+    const timer = setTimeout(() => {
+      this.retryTimer = null;
+      const dirty = this.dirtyChannels();
+      for (const key of dirty) {
+        const state = this.channels.get(key);
+        if (state && !state.debounceTimer) void this.fire(key);
+      }
+    }, 60_000);
+    timer.unref?.();
+    this.retryTimer = timer;
+  }
+
+  private async fire(channelKey: string): Promise<void> {
+    if (this.stopped) return;
+    const state = this.channels.get(channelKey);
+    if (!state || state.pendingLines.length === 0) return;
+
+    if (!this.budgetAvailable()) {
+      // DEFER, never drop: the channel stays dirty and retries when budget frees.
+      this.log(
+        `[reconcile] global budget exhausted (${this.globalMaxPerHour}/h); deferring ${channelKey} (${state.pendingLines.length} lines kept)`
+      );
+      this.scheduleRetry();
+      return;
+    }
+
+    const lines = state.pendingLines;
+    state.pendingLines = [];
+    state.firstEnqueuedAt = null;
+    this.runTimestamps.push(this.now());
+
+    try {
+      await this.run(channelKey, lines);
+    } catch (err) {
+      // Run failure keeps the channel dirty for retry; the scheduler survives.
+      state.pendingLines = [...lines, ...state.pendingLines].slice(-this.maxPendingLines);
+      if (state.firstEnqueuedAt === null) state.firstEnqueuedAt = this.now();
+      this.log(
+        `[reconcile] run failed for ${channelKey}: ${err instanceof Error ? err.message : String(err)}; kept dirty for retry`
+      );
+      this.scheduleRetry();
+    }
+  }
+}

--- a/packages/standalone/src/operator/operator-trigger-loop.ts
+++ b/packages/standalone/src/operator/operator-trigger-loop.ts
@@ -70,6 +70,13 @@ export interface TriggerLoopDeps {
   reportScheduler?: ReportSchedule;
   /** M2.3: tool-call instructions for the FULL report so the agent self-gathers context. */
   fullReportSelfGather?: string[];
+  /**
+   * M8: board-reconcile feed. Invoked after commit with connector-qualified
+   * channelKey ("<connector>:<channelId>") and bounded delta excerpt lines
+   * (each carrying the event id so reconcile task writes can pass
+   * source_event_id). Absent -> no reconcile leg.
+   */
+  onChannelDelta?: (channelKey: string, lines: string[]) => void;
   /** Kagemusha dual output: FULL report also publishes the operator board slots. */
   fullReportBoardLines?: string[];
   config: TriggerLoopConfig;
@@ -166,6 +173,32 @@ export class OperatorTriggerLoop {
       }
     }
     delta.commit(events);
+
+    // M8: feed the board-reconcile leg AFTER commit (the loop's cursor is
+    // authoritative; reconcile is a freshness layer repaired by the 30-min cron).
+    if (this.deps.onChannelDelta && events.length > 0) {
+      const byChannel = new Map<string, OperatorChannelEvent[]>();
+      for (const event of events) {
+        const key = `${event.channel}:${event.channelId}`;
+        const bucket = byChannel.get(key) ?? [];
+        bucket.push(event);
+        byChannel.set(key, bucket);
+      }
+      for (const [channelKey, channelEvents] of byChannel) {
+        const lines = channelEvents
+          .slice(-10)
+          .map(
+            (e) => `- [id:${e.eventIndexId ?? e.id}] ${e.userId}: ${e.content.trim().slice(0, 200)}`
+          );
+        try {
+          this.deps.onChannelDelta(channelKey, lines);
+        } catch (err) {
+          log(
+            `[trigger-loop] onChannelDelta failed for ${channelKey}: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
+    }
 
     // Feed the drained window into the report accumulators (bounded per-channel) and keep the
     // author window. The digest reports on ALL channels seen, not only the ones that fired.

--- a/packages/standalone/src/operator/task-ledger.ts
+++ b/packages/standalone/src/operator/task-ledger.ts
@@ -1,0 +1,335 @@
+/**
+ * TaskLedger - the operator-owned native work-item ledger (M8 Task 0.1).
+ *
+ * Ports the SHAPE of Kagemusha's proven task store (11 columns: id/title/status/
+ * priority/deadline/source/auto_created/confirmed/timestamps) plus `assignee`
+ * and an idempotency key. Implements the pre-existing `TaskSource` interface
+ * (operator-interfaces.ts) so the board projects ONE task model, not two.
+ *
+ * Reconcile runs create/update rows through the task_create/task_update gateway
+ * tools; the pipeline board slot is a projection of `list({order:
+ * 'deadline_priority'})`. The AGENT makes every judgment about what becomes a
+ * task; this store only persists.
+ *
+ * Schema-extension note: CREATE TABLE IF NOT EXISTS is a no-op on existing
+ * tables. Any post-ship column addition needs an explicit ALTER TABLE guarded
+ * by a PRAGMA table_info check, added to runMigration().
+ *
+ * The db handle is SHARED with TriggerRegistry and owned by the caller
+ * (start.ts opens and closes it once) - deliberately no close() here.
+ */
+
+import { createHash } from 'node:crypto';
+import type { SQLiteDatabase } from '../sqlite.js';
+import type { OperatorTask, TaskSource } from './operator-interfaces.js';
+
+export const TASK_STATUSES = [
+  'pending',
+  'in_progress',
+  'review',
+  'blocked',
+  'done',
+  'cancelled',
+] as const;
+export type TaskStatus = (typeof TASK_STATUSES)[number];
+
+export const TASK_PRIORITIES = ['high', 'normal', 'low'] as const;
+export type TaskPriority = (typeof TASK_PRIORITIES)[number];
+
+/** Extended record: satisfies OperatorTask (numeric deadline) and carries the ISO original. */
+export interface TaskRecord extends OperatorTask {
+  status: TaskStatus;
+  priority: TaskPriority;
+  /** ISO YYYY-MM-DD as stored; `deadline` (OperatorTask) is its UTC-midnight epoch ms. */
+  deadlineIso: string | null;
+  assignee: string | null;
+  sourceChannel: string | null;
+  sourceEventId: string | null;
+  latestEvent: string | null;
+  autoCreated: boolean;
+  confirmed: boolean;
+}
+
+export interface CreateTaskInput {
+  title: string;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  assignee?: string;
+  /** ISO YYYY-MM-DD */
+  deadline?: string;
+  /** channelKey: "<connector>:<channelId>" */
+  source_channel?: string;
+  /** Idempotency key from the connector event; duplicate (channel, event) UPSERTS. */
+  source_event_id?: string;
+  latest_event?: string;
+  confirmed?: boolean;
+}
+
+export interface UpdateTaskInput {
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  assignee?: string;
+  deadline?: string | null;
+  latest_event?: string;
+  confirmed?: boolean;
+  title?: string;
+}
+
+export interface ListTasksFilter {
+  status?: TaskStatus;
+  channel?: string;
+  search?: string;
+  limit?: number;
+  /** 'deadline_priority' = deadline asc NULLS LAST, then high>normal>low, then id. */
+  order?: 'deadline_priority' | 'updated';
+}
+
+interface TaskRow {
+  id: number;
+  title: string;
+  status: string;
+  priority: string;
+  assignee: string | null;
+  deadline: string | null;
+  source_channel: string | null;
+  source_event_id: string | null;
+  latest_event: string | null;
+  auto_created: number;
+  confirmed: number;
+  created_at: number;
+  updated_at: number;
+}
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function isoToEpochMs(iso: string | null): number | null {
+  if (!iso) return null;
+  const ms = Date.parse(`${iso}T00:00:00Z`);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+function assertIsoDate(value: string, field: string): void {
+  if (!ISO_DATE_PATTERN.test(value) || isoToEpochMs(value) === null) {
+    throw new Error(`${field} must be an ISO date (YYYY-MM-DD), got: ${value}`);
+  }
+}
+
+function rowToRecord(row: TaskRow): TaskRecord {
+  return {
+    id: row.id,
+    title: row.title,
+    status: row.status as TaskStatus,
+    priority: row.priority as TaskPriority,
+    deadline: isoToEpochMs(row.deadline),
+    deadlineIso: row.deadline,
+    assignee: row.assignee,
+    sourceChannel: row.source_channel,
+    sourceEventId: row.source_event_id,
+    latestEvent: row.latest_event,
+    autoCreated: row.auto_created === 1,
+    confirmed: row.confirmed === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export class TaskLedger implements TaskSource {
+  private db: SQLiteDatabase;
+
+  constructor(db: SQLiteDatabase) {
+    this.db = db;
+    this.runMigration();
+  }
+
+  private runMigration(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS operator_tasks (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending'
+          CHECK (status IN ('pending','in_progress','review','blocked','done','cancelled')),
+        priority TEXT NOT NULL DEFAULT 'normal' CHECK (priority IN ('high','normal','low')),
+        assignee TEXT,
+        deadline TEXT,
+        source_channel TEXT,
+        source_event_id TEXT,
+        latest_event TEXT,
+        auto_created INTEGER NOT NULL DEFAULT 1,
+        confirmed INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_operator_tasks_source
+        ON operator_tasks(source_channel, source_event_id)
+        WHERE source_event_id IS NOT NULL;
+      CREATE INDEX IF NOT EXISTS idx_operator_tasks_status ON operator_tasks(status);
+      CREATE INDEX IF NOT EXISTS idx_operator_tasks_deadline ON operator_tasks(deadline);
+
+      CREATE TABLE IF NOT EXISTS operator_no_update_notes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        scope TEXT NOT NULL,
+        reason TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_operator_no_update_scope
+        ON operator_no_update_notes(scope, id);
+    `);
+  }
+
+  /** TaskSource conformance: open items in canonical board order. */
+  getTasks(): OperatorTask[] {
+    return this.list({ order: 'deadline_priority' });
+  }
+
+  list(filter: ListTasksFilter = {}): TaskRecord[] {
+    const where: string[] = [];
+    const params: unknown[] = [];
+    if (filter.status) {
+      where.push('status = ?');
+      params.push(filter.status);
+    }
+    if (filter.channel) {
+      where.push('source_channel = ?');
+      params.push(filter.channel);
+    }
+    if (filter.search) {
+      where.push('(title LIKE ? OR latest_event LIKE ? OR assignee LIKE ?)');
+      const like = `%${filter.search}%`;
+      params.push(like, like, like);
+    }
+    const order =
+      filter.order === 'updated'
+        ? 'updated_at DESC, id DESC'
+        : // deadline asc NULLS LAST, then priority high>normal>low, then id.
+          // LIMIT applies AFTER ordering so the true top-N is returned.
+          `CASE WHEN deadline IS NULL THEN 1 ELSE 0 END ASC, deadline ASC,
+           CASE priority WHEN 'high' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END ASC, id ASC`;
+    const limit = Math.max(1, Math.min(200, Math.floor(filter.limit ?? 50)));
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM operator_tasks
+         ${where.length > 0 ? `WHERE ${where.join(' AND ')}` : ''}
+         ORDER BY ${order}
+         LIMIT ?`
+      )
+      .all(...params, limit) as TaskRow[];
+    return rows.map(rowToRecord);
+  }
+
+  getById(id: number): TaskRecord | null {
+    const row = this.db.prepare(`SELECT * FROM operator_tasks WHERE id = ?`).get(id) as
+      | TaskRow
+      | undefined;
+    return row ? rowToRecord(row) : null;
+  }
+
+  /**
+   * Create a task. Idempotent under at-least-once delivery: a duplicate
+   * (source_channel, source_event_id) UPSERTS - the existing row gets the new
+   * latest_event (and title stays) instead of a near-duplicate row appearing.
+   */
+  create(input: CreateTaskInput): TaskRecord {
+    if (!input.title || input.title.trim() === '') {
+      throw new Error('task title must be a non-empty string');
+    }
+    if (input.deadline !== undefined) assertIsoDate(input.deadline, 'deadline');
+    const now = Date.now();
+
+    if (input.source_channel && input.source_event_id) {
+      const existing = this.db
+        .prepare(`SELECT * FROM operator_tasks WHERE source_channel = ? AND source_event_id = ?`)
+        .get(input.source_channel, input.source_event_id) as TaskRow | undefined;
+      if (existing) {
+        return this.update(existing.id, {
+          ...(input.latest_event !== undefined ? { latest_event: input.latest_event } : {}),
+        });
+      }
+    }
+
+    const result = this.db
+      .prepare(
+        `INSERT INTO operator_tasks
+           (title, status, priority, assignee, deadline, source_channel, source_event_id,
+            latest_event, auto_created, confirmed, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        input.title.trim(),
+        input.status ?? 'pending',
+        input.priority ?? 'normal',
+        input.assignee ?? null,
+        input.deadline ?? null,
+        input.source_channel ?? null,
+        input.source_event_id ?? null,
+        input.latest_event ?? null,
+        1,
+        input.confirmed ? 1 : 0,
+        now,
+        now
+      );
+    return this.getById(Number(result.lastInsertRowid))!;
+  }
+
+  update(id: number, patch: UpdateTaskInput): TaskRecord {
+    const existing = this.getById(id);
+    if (!existing) throw new Error(`task_update: no task with id ${id}`);
+    if (patch.deadline !== undefined && patch.deadline !== null) {
+      assertIsoDate(patch.deadline, 'deadline');
+    }
+    if (patch.title !== undefined && patch.title.trim() === '') {
+      throw new Error('task title must be a non-empty string');
+    }
+
+    const sets: string[] = ['updated_at = ?'];
+    const params: unknown[] = [Date.now()];
+    const assign = (column: string, value: unknown) => {
+      sets.push(`${column} = ?`);
+      params.push(value);
+    };
+    if (patch.title !== undefined) assign('title', patch.title.trim());
+    if (patch.status !== undefined) assign('status', patch.status);
+    if (patch.priority !== undefined) assign('priority', patch.priority);
+    if (patch.assignee !== undefined) assign('assignee', patch.assignee);
+    if (patch.deadline !== undefined) assign('deadline', patch.deadline);
+    if (patch.latest_event !== undefined) assign('latest_event', patch.latest_event);
+    if (patch.confirmed !== undefined) assign('confirmed', patch.confirmed ? 1 : 0);
+
+    this.db.prepare(`UPDATE operator_tasks SET ${sets.join(', ')} WHERE id = ?`).run(...params, id);
+    return this.getById(id)!;
+  }
+
+  /** Stable hash over ordered rows - the Phase-2 verifier's ledger snapshot. */
+  payloadHash(): string {
+    const rows = this.db
+      .prepare(
+        `SELECT id, title, status, priority, assignee, deadline, latest_event, confirmed,
+                updated_at
+         FROM operator_tasks ORDER BY id ASC`
+      )
+      .all() as Array<Record<string, unknown>>;
+    return createHash('sha256').update(JSON.stringify(rows)).digest('hex');
+  }
+
+  /** contract_no_update: silence as a verifiable judgment, scoped to one reconcile run. */
+  recordNoUpdate(scope: string, reason: string): { id: number } {
+    if (!scope || !reason) {
+      throw new Error('contract_no_update requires both scope and reason');
+    }
+    const result = this.db
+      .prepare(`INSERT INTO operator_no_update_notes (scope, reason, created_at) VALUES (?, ?, ?)`)
+      .run(scope, reason, Date.now());
+    return { id: Number(result.lastInsertRowid) };
+  }
+
+  /** Max no-update note id, optionally scoped - the verifier's note snapshot. */
+  maxNoUpdateId(scope?: string): number {
+    const row = (
+      scope
+        ? this.db
+            .prepare(`SELECT MAX(id) AS max_id FROM operator_no_update_notes WHERE scope = ?`)
+            .get(scope)
+        : this.db.prepare(`SELECT MAX(id) AS max_id FROM operator_no_update_notes`).get()
+    ) as { max_id: number | null };
+    return row.max_id ?? 0;
+  }
+}

--- a/packages/standalone/src/operator/task-ledger.ts
+++ b/packages/standalone/src/operator/task-ledger.ts
@@ -283,7 +283,9 @@ export class TaskLedger implements TaskSource {
         now,
         now
       );
-    return this.getById(Number(result.lastInsertRowid))!;
+    const created = this.getById(Number(result.lastInsertRowid));
+    if (!created) throw new Error('task_create: inserted row could not be read back');
+    return created;
   }
 
   update(id: number, patch: UpdateTaskInput): TaskRecord {

--- a/packages/standalone/src/operator/task-ledger.ts
+++ b/packages/standalone/src/operator/task-ledger.ts
@@ -108,6 +108,12 @@ function isoToEpochMs(iso: string | null): number | null {
   return Number.isNaN(ms) ? null : ms;
 }
 
+function assertEnum(value: string, allowed: readonly string[], field: string): void {
+  if (!allowed.includes(value)) {
+    throw new Error(`${field} must be one of ${allowed.join('|')}, got: ${value}`);
+  }
+}
+
 function assertIsoDate(value: string, field: string): void {
   if (!ISO_DATE_PATTERN.test(value) || isoToEpochMs(value) === null) {
     throw new Error(`${field} must be an ISO date (YYYY-MM-DD), got: ${value}`);
@@ -204,7 +210,8 @@ export class TaskLedger implements TaskSource {
           // LIMIT applies AFTER ordering so the true top-N is returned.
           `CASE WHEN deadline IS NULL THEN 1 ELSE 0 END ASC, deadline ASC,
            CASE priority WHEN 'high' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END ASC, id ASC`;
-    const limit = Math.max(1, Math.min(200, Math.floor(filter.limit ?? 50)));
+    const rawLimit = Number(filter.limit);
+    const limit = Number.isFinite(rawLimit) ? Math.max(1, Math.min(200, Math.floor(rawLimit))) : 50;
     const rows = this.db
       .prepare(
         `SELECT * FROM operator_tasks
@@ -232,6 +239,8 @@ export class TaskLedger implements TaskSource {
     if (!input.title || input.title.trim() === '') {
       throw new Error('task title must be a non-empty string');
     }
+    if (input.status !== undefined) assertEnum(input.status, TASK_STATUSES, 'status');
+    if (input.priority !== undefined) assertEnum(input.priority, TASK_PRIORITIES, 'priority');
     if (input.deadline !== undefined) assertIsoDate(input.deadline, 'deadline');
     const now = Date.now();
 
@@ -240,7 +249,14 @@ export class TaskLedger implements TaskSource {
         .prepare(`SELECT * FROM operator_tasks WHERE source_channel = ? AND source_event_id = ?`)
         .get(input.source_channel, input.source_event_id) as TaskRow | undefined;
       if (existing) {
+        // Upsert carries every provided field EXCEPT title (the original naming
+        // stays stable across retries; movement and state updates flow through).
         return this.update(existing.id, {
+          ...(input.status !== undefined ? { status: input.status } : {}),
+          ...(input.priority !== undefined ? { priority: input.priority } : {}),
+          ...(input.assignee !== undefined ? { assignee: input.assignee } : {}),
+          ...(input.deadline !== undefined ? { deadline: input.deadline } : {}),
+          ...(input.confirmed !== undefined ? { confirmed: input.confirmed } : {}),
           ...(input.latest_event !== undefined ? { latest_event: input.latest_event } : {}),
         });
       }
@@ -273,6 +289,8 @@ export class TaskLedger implements TaskSource {
   update(id: number, patch: UpdateTaskInput): TaskRecord {
     const existing = this.getById(id);
     if (!existing) throw new Error(`task_update: no task with id ${id}`);
+    if (patch.status !== undefined) assertEnum(patch.status, TASK_STATUSES, 'status');
+    if (patch.priority !== undefined) assertEnum(patch.priority, TASK_PRIORITIES, 'priority');
     if (patch.deadline !== undefined && patch.deadline !== null) {
       assertIsoDate(patch.deadline, 'deadline');
     }

--- a/packages/standalone/tests/agent/task-tools.test.ts
+++ b/packages/standalone/tests/agent/task-tools.test.ts
@@ -1,24 +1,22 @@
 /**
- * Gateway task-ledger tools (M8 Task 0.2): task_list / task_create / task_update
- * executor cases against a REAL in-memory TaskLedger -- proves the mechanism,
- * not substrings. Synthetic data only.
+ * Story M8-P0 -- Gateway task-ledger tools: task_list / task_create /
+ * task_update executor cases against a REAL in-memory TaskLedger and a REAL
+ * GatewayToolExecutor (no internal mocks; the task paths do not use mamaApi).
+ * Synthetic data only.
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
 import { TaskLedger } from '../../src/operator/task-ledger.js';
 import Database from '../../src/sqlite.js';
-import type { MAMAApiInterface } from '../../src/agent/types.js';
 
 function makeExecutor(): { executor: GatewayToolExecutor; ledger: TaskLedger } {
-  const executor = new GatewayToolExecutor({
-    mamaApi: { save: vi.fn() } as unknown as MAMAApiInterface,
-  });
+  const executor = new GatewayToolExecutor();
   const ledger = new TaskLedger(new Database(':memory:'));
   executor.setTaskLedger(ledger);
   return { executor, ledger };
 }
 
-describe('gateway task ledger tools', () => {
+describe('Story M8-P0: native task ledger gateway tools', () => {
   let executor: GatewayToolExecutor;
   let ledger: TaskLedger;
 
@@ -26,66 +24,86 @@ describe('gateway task ledger tools', () => {
     ({ executor, ledger } = makeExecutor());
   });
 
-  it('fails closed when the ledger is not configured', async () => {
-    const bare = new GatewayToolExecutor({
-      mamaApi: { save: vi.fn() } as unknown as MAMAApiInterface,
+  describe('Acceptance Criteria: fail-closed wiring', () => {
+    it('fails closed when the ledger is not configured', async () => {
+      const bare = new GatewayToolExecutor();
+      const result = (await bare.execute('task_list', {})) as { success: boolean; error?: string };
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not configured');
     });
-    const result = (await bare.execute('task_list', {})) as { success: boolean; error?: string };
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('not configured');
   });
 
-  it('task_create -> task_list round-trip in canonical order', async () => {
-    await executor.execute('task_create', { title: 'later', deadline: '2026-09-01' });
-    await executor.execute('task_create', {
-      title: 'sooner',
-      deadline: '2026-07-20',
-      priority: 'high',
-      assignee: 'worker-a',
-      source_channel: 'slack:C001',
+  describe('Acceptance Criteria: create/list round-trip', () => {
+    it('task_create -> task_list round-trip in canonical order', async () => {
+      await executor.execute('task_create', { title: 'later', deadline: '2026-09-01' });
+      await executor.execute('task_create', {
+        title: 'sooner',
+        deadline: '2026-07-20',
+        priority: 'high',
+        assignee: 'worker-a',
+        source_channel: 'slack:C001',
+      });
+      const result = (await executor.execute('task_list', {})) as {
+        success: boolean;
+        tasks: Array<{ title: string; assignee: string | null }>;
+      };
+      expect(result.success).toBe(true);
+      expect(result.tasks.map((t) => t.title)).toEqual(['sooner', 'later']);
+      expect(result.tasks[0]?.assignee).toBe('worker-a');
     });
-    const result = (await executor.execute('task_list', {})) as {
-      success: boolean;
-      tasks: Array<{ title: string; assignee: string | null }>;
-    };
-    expect(result.success).toBe(true);
-    expect(result.tasks.map((t) => t.title)).toEqual(['sooner', 'later']);
-    expect(result.tasks[0]?.assignee).toBe('worker-a');
   });
 
-  it('task_update coerces a string id ("12" pattern) and patches the row', async () => {
-    const created = (await executor.execute('task_create', { title: 'x' })) as {
-      task: { id: number };
-    };
-    const result = (await executor.execute('task_update', {
-      id: String(created.task.id),
-      status: 'in_progress',
-      latest_event: 'started today',
-    })) as { success: boolean; task: { status: string; latestEvent: string } };
-    expect(result.success).toBe(true);
-    expect(result.task.status).toBe('in_progress');
-    expect(result.task.latestEvent).toBe('started today');
+  describe('Acceptance Criteria: update semantics', () => {
+    it('task_update coerces a string id ("12" pattern) and patches the row', async () => {
+      const created = (await executor.execute('task_create', { title: 'x' })) as {
+        task: { id: number };
+      };
+      const result = (await executor.execute('task_update', {
+        id: String(created.task.id),
+        status: 'in_progress',
+        latest_event: 'started today',
+      })) as { success: boolean; task: { status: string; latestEvent: string } };
+      expect(result.success).toBe(true);
+      expect(result.task.status).toBe('in_progress');
+      expect(result.task.latestEvent).toBe('started today');
+    });
+
+    it('task_update rejects a non-numeric id with a typed error', async () => {
+      await expect(executor.execute('task_update', { id: 'abc', status: 'done' })).rejects.toThrow(
+        /numeric id/
+      );
+    });
   });
 
-  it('task_update rejects a non-numeric id with a typed error', async () => {
-    await expect(executor.execute('task_update', { id: 'abc', status: 'done' })).rejects.toThrow(
-      /numeric id/
-    );
+  describe('Acceptance Criteria: idempotent create', () => {
+    it('task_create upserts on duplicate source key through the tool surface', async () => {
+      await executor.execute('task_create', {
+        title: 'review still',
+        source_channel: 'slack:C001',
+        source_event_id: 'ev-9',
+      });
+      await executor.execute('task_create', {
+        title: 'review still v2',
+        source_channel: 'slack:C001',
+        source_event_id: 'ev-9',
+        latest_event: 'resubmitted',
+      });
+      expect(ledger.list({})).toHaveLength(1);
+      expect(ledger.list({})[0]?.latestEvent).toBe('resubmitted');
+    });
   });
 
-  it('task_create upserts on duplicate source key through the tool surface', async () => {
-    await executor.execute('task_create', {
-      title: 'review still',
-      source_channel: 'slack:C001',
-      source_event_id: 'ev-9',
+  describe('Acceptance Criteria: contract_no_update note', () => {
+    it('records a scoped note and rejects missing fields', async () => {
+      const result = (await executor.execute('contract_no_update', {
+        reason: 'greeting only',
+        scope: 'reconcile:slack:C001',
+      })) as { success: boolean; note: { id: number } };
+      expect(result.success).toBe(true);
+      expect(ledger.maxNoUpdateId('reconcile:slack:C001')).toBe(result.note.id);
+      await expect(executor.execute('contract_no_update', { reason: 'x' })).rejects.toThrow(
+        /scope/
+      );
     });
-    await executor.execute('task_create', {
-      title: 'review still v2',
-      source_channel: 'slack:C001',
-      source_event_id: 'ev-9',
-      latest_event: 'resubmitted',
-    });
-    expect(ledger.list({})).toHaveLength(1);
-    expect(ledger.list({})[0]?.latestEvent).toBe('resubmitted');
   });
 });

--- a/packages/standalone/tests/agent/task-tools.test.ts
+++ b/packages/standalone/tests/agent/task-tools.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Gateway task-ledger tools (M8 Task 0.2): task_list / task_create / task_update
+ * executor cases against a REAL in-memory TaskLedger -- proves the mechanism,
+ * not substrings. Synthetic data only.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
+import { TaskLedger } from '../../src/operator/task-ledger.js';
+import Database from '../../src/sqlite.js';
+import type { MAMAApiInterface } from '../../src/agent/types.js';
+
+function makeExecutor(): { executor: GatewayToolExecutor; ledger: TaskLedger } {
+  const executor = new GatewayToolExecutor({
+    mamaApi: { save: vi.fn() } as unknown as MAMAApiInterface,
+  });
+  const ledger = new TaskLedger(new Database(':memory:'));
+  executor.setTaskLedger(ledger);
+  return { executor, ledger };
+}
+
+describe('gateway task ledger tools', () => {
+  let executor: GatewayToolExecutor;
+  let ledger: TaskLedger;
+
+  beforeEach(() => {
+    ({ executor, ledger } = makeExecutor());
+  });
+
+  it('fails closed when the ledger is not configured', async () => {
+    const bare = new GatewayToolExecutor({
+      mamaApi: { save: vi.fn() } as unknown as MAMAApiInterface,
+    });
+    const result = (await bare.execute('task_list', {})) as { success: boolean; error?: string };
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not configured');
+  });
+
+  it('task_create -> task_list round-trip in canonical order', async () => {
+    await executor.execute('task_create', { title: 'later', deadline: '2026-09-01' });
+    await executor.execute('task_create', {
+      title: 'sooner',
+      deadline: '2026-07-20',
+      priority: 'high',
+      assignee: 'worker-a',
+      source_channel: 'slack:C001',
+    });
+    const result = (await executor.execute('task_list', {})) as {
+      success: boolean;
+      tasks: Array<{ title: string; assignee: string | null }>;
+    };
+    expect(result.success).toBe(true);
+    expect(result.tasks.map((t) => t.title)).toEqual(['sooner', 'later']);
+    expect(result.tasks[0]?.assignee).toBe('worker-a');
+  });
+
+  it('task_update coerces a string id ("12" pattern) and patches the row', async () => {
+    const created = (await executor.execute('task_create', { title: 'x' })) as {
+      task: { id: number };
+    };
+    const result = (await executor.execute('task_update', {
+      id: String(created.task.id),
+      status: 'in_progress',
+      latest_event: 'started today',
+    })) as { success: boolean; task: { status: string; latestEvent: string } };
+    expect(result.success).toBe(true);
+    expect(result.task.status).toBe('in_progress');
+    expect(result.task.latestEvent).toBe('started today');
+  });
+
+  it('task_update rejects a non-numeric id with a typed error', async () => {
+    await expect(executor.execute('task_update', { id: 'abc', status: 'done' })).rejects.toThrow(
+      /numeric id/
+    );
+  });
+
+  it('task_create upserts on duplicate source key through the tool surface', async () => {
+    await executor.execute('task_create', {
+      title: 'review still',
+      source_channel: 'slack:C001',
+      source_event_id: 'ev-9',
+    });
+    await executor.execute('task_create', {
+      title: 'review still v2',
+      source_channel: 'slack:C001',
+      source_event_id: 'ev-9',
+      latest_event: 'resubmitted',
+    });
+    expect(ledger.list({})).toHaveLength(1);
+    expect(ledger.list({})[0]?.latestEvent).toBe('resubmitted');
+  });
+});

--- a/packages/standalone/tests/code-act/host-bridge.test.ts
+++ b/packages/standalone/tests/code-act/host-bridge.test.ts
@@ -84,6 +84,18 @@ describe('HostBridge', () => {
       expect(t3Names).not.toContain('Write');
     });
 
+    it('native task ledger: task_list read-only (tiers 2+3), writes tier-2 only', () => {
+      const bridge = new HostBridge(makeExecutor());
+      const t2 = bridge.getAvailableFunctions(2).map((f) => f.name);
+      const t3 = bridge.getAvailableFunctions(3).map((f) => f.name);
+      expect(t2).toContain('task_list');
+      expect(t2).toContain('task_create');
+      expect(t2).toContain('task_update');
+      expect(t3).toContain('task_list');
+      expect(t3).not.toContain('task_create');
+      expect(t3).not.toContain('task_update');
+    });
+
     it('kagemusha query tools are read-only: available at tier 2 AND tier 3', () => {
       // The dashboard agent (tier 2) reads real task lifecycle state through these;
       // they are pure queries against the kagemusha bridge db, so tier 3 gets them too.

--- a/packages/standalone/tests/code-act/integration.test.ts
+++ b/packages/standalone/tests/code-act/integration.test.ts
@@ -146,7 +146,9 @@ describe('Code-Act Integration', () => {
     expect(fullPrompt).toContain('declare function mama_search');
     expect(fullPrompt).toContain('declare function Read');
     expect(fullPrompt).toContain('## Code-Act');
-    expect(fullPrompt.length).toBeLessThan(9000);
+    // Budget raised 9000 -> 9800 for the M8 native task-ledger tools
+    // (task_list/task_create/task_update add ~450 chars of tier-1 type defs).
+    expect(fullPrompt.length).toBeLessThan(9800);
   });
 
   it('Tier 2 sandbox blocks write tools', async () => {

--- a/packages/standalone/tests/code-act/type-definition-generator.test.ts
+++ b/packages/standalone/tests/code-act/type-definition-generator.test.ts
@@ -103,7 +103,8 @@ describe('TypeDefinitionGenerator', () => {
 
     it('stays within token budget for Tier 1', () => {
       const dts = TypeDefinitionGenerator.generate(1);
-      expect(dts.length).toBeLessThan(7200);
+      // Budget raised 7200 -> 8000 for the M8 native task-ledger tools.
+      expect(dts.length).toBeLessThan(8000);
     });
   });
 

--- a/packages/standalone/tests/operator/action-verifier.test.ts
+++ b/packages/standalone/tests/operator/action-verifier.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for OperatorActionVerifier (M8 Phase 2): every signal class is
+ * run-bound -- unrelated activity must NOT verify. Synthetic data only.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  captureSnapshot,
+  verifyAfterRun,
+  type VerifierDeps,
+} from '../../src/operator/action-verifier.js';
+
+function makeDeps(overrides: Partial<VerifierDeps> = {}): VerifierDeps & {
+  state: {
+    slots: Array<{ slotId: string; html: string }>;
+    ledger: string;
+    notes: Map<string, number>;
+    traceMax: number;
+    obligatedSince: number;
+  };
+} {
+  const state = {
+    slots: [{ slotId: 'pipeline', html: '<p>v1</p>' }],
+    ledger: 'hash-a',
+    notes: new Map<string, number>(),
+    traceMax: 100,
+    obligatedSince: 0,
+  };
+  return {
+    state,
+    getSlots: () => state.slots,
+    getLedgerHash: () => state.ledger,
+    getScopedNoteMaxId: (scope: string) => state.notes.get(scope) ?? 0,
+    countObligatedTraceRowsSince: () => state.obligatedSince,
+    getTraceMaxId: () => state.traceMax,
+    ...overrides,
+  };
+}
+
+describe('OperatorActionVerifier', () => {
+  const scope = 'reconcile:slack:C001';
+
+  it('verifies on a new obligated gateway trace row', () => {
+    const deps = makeDeps();
+    const before = captureSnapshot(deps, scope);
+    deps.state.obligatedSince = 2; // agent called report_publish + task_update
+    const result = verifyAfterRun(deps, before, scope);
+    expect(result.verified).toBe(true);
+    expect(result.effects.join(' ')).toContain('obligated tool traces: 2');
+  });
+
+  it('verifies on a new no-update note with EXACTLY this scope', () => {
+    const deps = makeDeps();
+    const before = captureSnapshot(deps, scope);
+    deps.state.notes.set(scope, 7);
+    const result = verifyAfterRun(deps, before, scope);
+    expect(result.verified).toBe(true);
+    expect(result.effects.join(' ')).toContain(`scope=${scope}`);
+  });
+
+  it('a note for a FOREIGN scope does NOT verify', () => {
+    const deps = makeDeps();
+    const before = captureSnapshot(deps, scope);
+    deps.state.notes.set('reconcile:chatwork:9', 5);
+    const result = verifyAfterRun(deps, before, scope);
+    expect(result.verified).toBe(false);
+  });
+
+  it('hash-only changes do NOT verify (another writer may have moved them)', () => {
+    const deps = makeDeps();
+    const before = captureSnapshot(deps, scope);
+    deps.state.slots = [{ slotId: 'pipeline', html: '<p>v2</p>' }];
+    deps.state.ledger = 'hash-b';
+    const result = verifyAfterRun(deps, before, scope);
+    expect(result.verified).toBe(false);
+    // ...but the deltas ARE recorded as evidence detail.
+    expect(result.effects.join(' ')).toContain('slots changed: pipeline');
+    expect(result.effects.join(' ')).toContain('task ledger changed');
+  });
+
+  it('a no-op run yields unverified with no effects', () => {
+    const deps = makeDeps();
+    const before = captureSnapshot(deps, scope);
+    const result = verifyAfterRun(deps, before, scope);
+    expect(result.verified).toBe(false);
+    expect(result.effects).toEqual([]);
+  });
+});

--- a/packages/standalone/tests/operator/board-reconcile.test.ts
+++ b/packages/standalone/tests/operator/board-reconcile.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for the board reconcile contract (M8 Phase 1): prompt contract +
+ * scheduler debounce/max-wait/global-budget/deferral semantics. Fake timers;
+ * synthetic data only.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  buildReconcilePrompt,
+  ReconcileScheduler,
+  RECONCILE_RUN_TOKEN,
+} from '../../src/operator/board-reconcile.js';
+
+describe('buildReconcilePrompt', () => {
+  it('begins with the RECONCILE RUN mode token', () => {
+    const prompt = buildReconcilePrompt({
+      channelKey: 'slack:C001',
+      deltaLines: ['- u1: hello'],
+      todayIso: '2026-07-12',
+    });
+    expect(prompt.startsWith(RECONCILE_RUN_TOKEN)).toBe(true);
+  });
+
+  it('carries the obligated-action contract, dedup discipline, and scoped no-update', () => {
+    const prompt = buildReconcilePrompt({
+      channelKey: 'slack:C001',
+      deltaLines: ['- u1: submitted v2'],
+      todayIso: '2026-07-12',
+    });
+    expect(prompt).toContain('report_publish with ONLY the affected slots');
+    expect(prompt).toContain('task_update that row instead of');
+    expect(prompt).toContain('source_event_id');
+    expect(prompt).toContain('contract_no_update({reason, scope: "reconcile:slack:C001"})');
+    expect(prompt).toContain('RECONCILED');
+    expect(prompt).toContain('<latest-delta channel="slack:C001">');
+  });
+
+  it('adds kagemusha context as CONTEXT only when enabled', () => {
+    const base = buildReconcilePrompt({
+      channelKey: 'kakao:room',
+      deltaLines: ['x'],
+      todayIso: '2026-07-12',
+    });
+    expect(base).not.toContain('kagemusha_tasks');
+    const withCtx = buildReconcilePrompt({
+      channelKey: 'kakao:room',
+      deltaLines: ['x'],
+      todayIso: '2026-07-12',
+      kagemushaContext: true,
+    });
+    expect(withCtx).toContain('kagemusha_tasks() as extra CONTEXT');
+    expect(withCtx).toContain('projection source');
+  });
+});
+
+describe('ReconcileScheduler', () => {
+  let run: ReturnType<typeof vi.fn>;
+  let log: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    run = vi.fn().mockResolvedValue(undefined);
+    log = vi.fn();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function make(opts: Partial<ConstructorParameters<typeof ReconcileScheduler>[0]> = {}) {
+    return new ReconcileScheduler({
+      debounceMs: 1000,
+      maxWaitMs: 3000,
+      globalMaxPerHour: 2,
+      run,
+      log,
+      ...opts,
+    });
+  }
+
+  it('coalesces a burst into one run after the debounce', async () => {
+    const s = make();
+    s.enqueue('slack:C1', ['a']);
+    s.enqueue('slack:C1', ['b']);
+    await vi.advanceTimersByTimeAsync(999);
+    expect(run).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(2);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith('slack:C1', ['a', 'b']);
+    s.stop();
+  });
+
+  it('max-wait bounds a continuously-busy channel (no starvation)', async () => {
+    const s = make();
+    // keep re-enqueueing every 500ms; trailing debounce alone would never fire
+    for (let i = 0; i < 10; i++) {
+      s.enqueue('slack:C1', [`m${i}`]);
+      await vi.advanceTimersByTimeAsync(500);
+      if (run.mock.calls.length > 0) break;
+    }
+    expect(run).toHaveBeenCalledTimes(1); // fired by maxWaitMs=3000 bound
+    s.stop();
+  });
+
+  it('over-budget work is DEFERRED with a log line, then retried when budget frees', async () => {
+    const s = make({ globalMaxPerHour: 1, debounceMs: 10 });
+    s.enqueue('slack:C1', ['a']);
+    await vi.advanceTimersByTimeAsync(20);
+    expect(run).toHaveBeenCalledTimes(1);
+
+    s.enqueue('chatwork:9', ['b']);
+    await vi.advanceTimersByTimeAsync(20);
+    expect(run).toHaveBeenCalledTimes(1); // deferred, not run
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('deferring chatwork:9'));
+    expect(s.dirtyChannels()).toContain('chatwork:9');
+
+    // budget window passes -> retry timer picks the dirty channel up
+    await vi.advanceTimersByTimeAsync(3_600_001);
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run).toHaveBeenLastCalledWith('chatwork:9', ['b']);
+    s.stop();
+  });
+
+  it('run failure keeps the channel dirty and the scheduler alive', async () => {
+    run.mockRejectedValueOnce(new Error('agent busy'));
+    const s = make({ debounceMs: 10, globalMaxPerHour: 10 });
+    s.enqueue('slack:C1', ['a']);
+    await vi.advanceTimersByTimeAsync(20);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('kept dirty for retry'));
+    expect(s.dirtyChannels()).toContain('slack:C1');
+    await vi.advanceTimersByTimeAsync(60_001); // retry timer
+    expect(run).toHaveBeenCalledTimes(2);
+    s.stop();
+  });
+
+  it('pending lines are bounded per channel', async () => {
+    const s = make({ debounceMs: 10, maxPendingLines: 3 });
+    s.enqueue('slack:C1', ['1', '2', '3', '4', '5']);
+    await vi.advanceTimersByTimeAsync(20);
+    expect(run).toHaveBeenCalledWith('slack:C1', ['3', '4', '5']);
+    s.stop();
+  });
+
+  it('stop() cancels timers and blocks new work', async () => {
+    const s = make();
+    s.enqueue('slack:C1', ['a']);
+    s.stop();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(run).not.toHaveBeenCalled();
+    s.enqueue('slack:C1', ['b']);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(run).not.toHaveBeenCalled();
+  });
+});

--- a/packages/standalone/tests/operator/task-ledger.test.ts
+++ b/packages/standalone/tests/operator/task-ledger.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for TaskLedger (M8 Task 0.1) - the operator-owned native work-item
+ * ledger. Synthetic data only; in-memory sqlite.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database, { type SQLiteDatabase } from '../../src/sqlite.js';
+import { TaskLedger } from '../../src/operator/task-ledger.js';
+
+describe('TaskLedger', () => {
+  let db: SQLiteDatabase;
+  let ledger: TaskLedger;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    ledger = new TaskLedger(db);
+  });
+
+  it('creates a task with defaults (pending, normal, auto_created, unconfirmed)', () => {
+    const t = ledger.create({ title: 'ship the widget' });
+    expect(t.id).toBeGreaterThan(0);
+    expect(t.status).toBe('pending');
+    expect(t.priority).toBe('normal');
+    expect(t.autoCreated).toBe(true);
+    expect(t.confirmed).toBe(false);
+    expect(t.deadline).toBeNull();
+  });
+
+  it('rejects invalid status and priority via CHECK', () => {
+    expect(() => ledger.create({ title: 'x', status: 'doing' as never })).toThrow();
+    expect(() => ledger.create({ title: 'x', priority: 'urgent' as never })).toThrow();
+  });
+
+  it('rejects empty titles and malformed deadlines', () => {
+    expect(() => ledger.create({ title: '  ' })).toThrow(/title/);
+    expect(() => ledger.create({ title: 'x', deadline: 'next friday' })).toThrow(/ISO date/);
+    expect(() => ledger.create({ title: 'x', deadline: '2026-13-99' })).toThrow(/ISO date/);
+  });
+
+  it('maps ISO deadline to UTC-midnight epoch ms for the OperatorTask interface', () => {
+    const t = ledger.create({ title: 'x', deadline: '2026-07-20' });
+    expect(t.deadlineIso).toBe('2026-07-20');
+    expect(t.deadline).toBe(Date.parse('2026-07-20T00:00:00Z'));
+  });
+
+  it('upserts on duplicate (source_channel, source_event_id) instead of duplicating', () => {
+    const first = ledger.create({
+      title: 'review the still',
+      source_channel: 'slack:C001',
+      source_event_id: 'ev-1',
+      latest_event: 'submitted v1',
+    });
+    const second = ledger.create({
+      title: 'review the still (retry wording)',
+      source_channel: 'slack:C001',
+      source_event_id: 'ev-1',
+      latest_event: 'submitted v2',
+    });
+    expect(second.id).toBe(first.id);
+    expect(second.title).toBe('review the still'); // original title kept
+    expect(second.latestEvent).toBe('submitted v2'); // movement recorded
+    expect(ledger.list({ channel: 'slack:C001' })).toHaveLength(1);
+  });
+
+  it('same event id on a DIFFERENT channel is a distinct task', () => {
+    ledger.create({ title: 'a', source_channel: 'slack:C001', source_event_id: 'ev-1' });
+    ledger.create({ title: 'b', source_channel: 'chatwork:123', source_event_id: 'ev-1' });
+    expect(ledger.list({})).toHaveLength(2);
+  });
+
+  it('update patches fields and bumps updated_at; unknown id throws', () => {
+    const t = ledger.create({ title: 'x' });
+    const updated = ledger.update(t.id, {
+      status: 'in_progress',
+      assignee: 'worker-a',
+      deadline: '2026-08-01',
+      confirmed: true,
+    });
+    expect(updated.status).toBe('in_progress');
+    expect(updated.assignee).toBe('worker-a');
+    expect(updated.deadlineIso).toBe('2026-08-01');
+    expect(updated.confirmed).toBe(true);
+    expect(updated.updatedAt).toBeGreaterThanOrEqual(t.updatedAt);
+    expect(() => ledger.update(9999, { status: 'done' })).toThrow(/no task/);
+  });
+
+  it('deadline can be cleared with null', () => {
+    const t = ledger.create({ title: 'x', deadline: '2026-08-01' });
+    const cleared = ledger.update(t.id, { deadline: null });
+    expect(cleared.deadlineIso).toBeNull();
+    expect(cleared.deadline).toBeNull();
+  });
+
+  it('deadline_priority ordering: deadline asc nulls last, then priority, LIMIT after order', () => {
+    ledger.create({ title: 'no-deadline-high', priority: 'high' });
+    ledger.create({ title: 'late-low', deadline: '2026-09-01', priority: 'low' });
+    ledger.create({ title: 'soon-normal', deadline: '2026-07-15', priority: 'normal' });
+    ledger.create({ title: 'soon-high', deadline: '2026-07-15', priority: 'high' });
+    const top2 = ledger.list({ order: 'deadline_priority', limit: 2 });
+    // The true top-2 by (deadline, priority) - NOT insertion order.
+    expect(top2.map((t) => t.title)).toEqual(['soon-high', 'soon-normal']);
+    const all = ledger.list({ order: 'deadline_priority' });
+    expect(all[all.length - 1]?.title).toBe('no-deadline-high'); // nulls last
+  });
+
+  it('filters: status, channel, search', () => {
+    ledger.create({ title: 'alpha work', status: 'review', source_channel: 'slack:C1' });
+    ledger.create({ title: 'beta work', assignee: 'worker-b' });
+    expect(ledger.list({ status: 'review' })).toHaveLength(1);
+    expect(ledger.list({ channel: 'slack:C1' })).toHaveLength(1);
+    expect(ledger.list({ search: 'worker-b' })).toHaveLength(1);
+    expect(ledger.list({ search: 'alpha' })[0]?.title).toBe('alpha work');
+  });
+
+  it('getTasks() satisfies TaskSource with canonical ordering', () => {
+    ledger.create({ title: 'b', deadline: '2026-08-01' });
+    ledger.create({ title: 'a', deadline: '2026-07-15' });
+    const tasks = ledger.getTasks();
+    expect(tasks[0]?.title).toBe('a');
+    expect(typeof tasks[0]?.deadline).toBe('number'); // OperatorTask numeric contract
+  });
+
+  it('payloadHash changes on mutation and is stable otherwise', () => {
+    const t = ledger.create({ title: 'x' });
+    const h1 = ledger.payloadHash();
+    expect(ledger.payloadHash()).toBe(h1);
+    ledger.update(t.id, { status: 'done' });
+    expect(ledger.payloadHash()).not.toBe(h1);
+  });
+
+  it('no-update notes: record + scoped max id', () => {
+    expect(ledger.maxNoUpdateId()).toBe(0);
+    const a = ledger.recordNoUpdate('reconcile:slack:C1', 'greeting only');
+    ledger.recordNoUpdate('reconcile:chatwork:9', 'bot chatter');
+    expect(ledger.maxNoUpdateId('reconcile:slack:C1')).toBe(a.id);
+    expect(ledger.maxNoUpdateId()).toBeGreaterThan(a.id);
+    expect(() => ledger.recordNoUpdate('', 'x')).toThrow(/scope/);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 0 of the M8 transplant round (gate: plan-eng-review + Codex outside voice, 19 findings integrated; plan doc is local).

A generic MAMA OS install had NO item tracker: `task_list` sat in agent config allowlists but never existed in the gateway registry; the only item-level truth was the personal kagemusha bridge, and mama-core's case substrate has 0 rows.

- **TaskLedger** (`src/operator/task-ledger.ts`): Kagemusha's proven task-store shape + `assignee` + idempotency key. Duplicate `(source_channel, source_event_id)` UPSERTS (at-least-once safe); canonical `deadline_priority` ordering with LIMIT after ordering; implements the pre-existing `TaskSource` interface — one task model, not two. Shares the operator DB handle with TriggerRegistry; deliberately no `close()` (owner closes once).
- **Gateway tools**: `task_list` / `task_create` / `task_update` — type union, registry, executor cases (string-id coercion, fail-closed when unwired), code-act tiers (`task_list` read-only 2+3; writes tier-2 only).
- `operator_no_update_notes` ships in the same migration for Phase 1's `contract_no_update`.
- Drive-by: `report_publish` metadata slot names fixed (was advertising `alerts`/`activity`).
- code-act prompt budget tests raised (9000→9800 / 7200→8000) for the three new tier-1 type defs.

## Test plan
- [x] 13 TaskLedger tests (CRUD, CHECKs, upsert, ordering-with-limit, TaskSource conformance, payloadHash, notes)
- [x] 5 executor mechanism tests against a REAL in-memory ledger (round-trip, coercion, upsert-through-tool, fail-closed)
- [x] Host-bridge tier exposure; full standalone suite (3401 passed); typecheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a native task ledger for storing and managing operator work items.
  - Added tools to list, create, and update tasks, including filtering by status, channel, search term, and ordering.
  - Task creation prevents duplicates for repeated source events.
  - Task updates support status, priority, assignee, deadline, confirmation, and latest-event changes.
  - Task listing is available at supported access tiers, while task creation and updates require elevated access.

- **Bug Fixes**
  - Updated report publishing inputs to support partial dashboard updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->