### PR TITLE
fix(operator): populate normalized_tool_name at the gateway logging site

### DIFF
--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -1670,6 +1670,8 @@ export class GatewayToolExecutor {
         agent_version: 0,
         type: 'gateway_tool_call',
         input_summary: toolName,
+        tool_name: toolName,
+        normalized_tool_name: toolName,
         duration_ms: durationMs,
         execution_status: executionStatus,
         trigger_reason: 'gateway_tool_executor',

--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -422,8 +422,8 @@ This saves resources. Only publish when there is genuinely new information to re
       // the dashboard agent's gateway_tool_call activity, notes from the
       // operator ledger. Observe, never block.
       const reconcileLedger = toolExecutor.getTaskLedger();
-      // gateway_tool_call rows carry the tool name in input_summary (verified
-      // live 2026-07-12; normalized_tool_name is empty on this path).
+      // gateway_tool_call rows now populate normalized_tool_name at the logging
+      // site; the input_summary fallback covers rows written before that fix.
       const traceToolList = OBLIGATED_TOOLS.map((t) => `'${t}'`).join(',');
       const verifierDeps = {
         getSlots: () => apiServer.reportStore.getAllSorted(),
@@ -445,7 +445,7 @@ This saves resources. Only publish when there is genuinely new information to re
             .prepare(
               `SELECT COUNT(*) AS n FROM agent_activity
                WHERE type = 'gateway_tool_call' AND agent_id = 'dashboard-agent'
-                 AND id > ? AND input_summary IN (${traceToolList})`
+                 AND id > ? AND (normalized_tool_name IN (${traceToolList}) OR input_summary IN (${traceToolList}))`
             )
             .get(maxId) as { n: number };
           return row.n;

--- a/packages/standalone/src/db/agent-store.ts
+++ b/packages/standalone/src/db/agent-store.ts
@@ -300,6 +300,8 @@ export interface ActivityRow {
   requested_scopes: string | null;
   envelope_scopes_snapshot: string | null;
   scope_mismatch: number;
+  tool_name: string | null;
+  normalized_tool_name: string | null;
   created_at: string;
 }
 

--- a/packages/standalone/src/db/agent-store.ts
+++ b/packages/standalone/src/db/agent-store.ts
@@ -11,6 +11,7 @@ import { applyAgentMetricsResponseAverageMigration } from './migrations/agent-me
 import { applyAgentActivityValidationColumnsMigration } from './migrations/agent-activity-validation-columns.js';
 import { applyAgentActivityEnvelopeColumnsMigration } from './migrations/agent-activity-envelope-hash.js';
 import { applyAgentActivityGatewayCallIdMigration } from './migrations/agent-activity-gateway-call-id.js';
+import { applyAgentActivityToolNameMigration } from './migrations/agent-activity-tool-name.js';
 import { applyEnvelopeTablesMigration } from './migrations/envelope-tables.js';
 
 type DB = SQLiteDatabase;
@@ -46,6 +47,7 @@ export function initAgentTables(db: SQLiteDatabase): void {
   applyAgentActivityValidationColumnsMigration(db);
   applyAgentActivityEnvelopeColumnsMigration(db);
   applyAgentActivityGatewayCallIdMigration(db);
+  applyAgentActivityToolNameMigration(db);
   applyEnvelopeTablesMigration(db);
 }
 
@@ -253,6 +255,9 @@ export function compareVersionMetrics(
 // ── Activity Types ─────────────────────────────────────────────────────────
 
 export interface LogActivityInput {
+  /** Gateway tool name for gateway_tool_call rows (queryable, unlike input_summary). */
+  tool_name?: string;
+  normalized_tool_name?: string;
   agent_id: string;
   agent_version: number;
   type: string;
@@ -324,9 +329,10 @@ export function logActivity(db: DB, input: LogActivityInput): ActivityRow {
     INSERT INTO agent_activity (
       agent_id, agent_version, type, input_summary, output_summary, tokens_used,
       tools_called, duration_ms, score, details, error_message, run_id, execution_status, trigger_reason,
-      envelope_hash, gateway_call_id, requested_scopes, envelope_scopes_snapshot, scope_mismatch
+      envelope_hash, gateway_call_id, requested_scopes, envelope_scopes_snapshot, scope_mismatch,
+      tool_name, normalized_tool_name
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
   const result = stmt.run(
     input.agent_id,
@@ -347,7 +353,9 @@ export function logActivity(db: DB, input: LogActivityInput): ActivityRow {
     input.gatewayCallId ?? null,
     input.requestedScopes ? JSON.stringify(input.requestedScopes) : null,
     input.envelopeScopesSnapshot ? JSON.stringify(input.envelopeScopesSnapshot) : null,
-    Number(Boolean(input.scopeMismatch))
+    Number(Boolean(input.scopeMismatch)),
+    input.tool_name ?? null,
+    input.normalized_tool_name ?? null
   );
   return db
     .prepare('SELECT * FROM agent_activity WHERE id = ?')

--- a/packages/standalone/src/db/migrations/agent-activity-tool-name.ts
+++ b/packages/standalone/src/db/migrations/agent-activity-tool-name.ts
@@ -1,0 +1,27 @@
+import type { SQLiteDatabase } from '../../sqlite.js';
+
+/**
+ * M8: gateway_tool_call rows carry a queryable tool name (the reconcile
+ * verifier matches obligated tools against it). CREATE TABLE IF NOT EXISTS is
+ * a no-op on existing tables, so this must be an explicit guarded ALTER.
+ */
+export function applyAgentActivityToolNameMigration(db: SQLiteDatabase): void {
+  const tableExists = db
+    .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'agent_activity'")
+    .get() as { 1: number } | undefined;
+
+  if (!tableExists) {
+    return;
+  }
+
+  const columns = (
+    db.prepare('PRAGMA table_info(agent_activity)').all() as Array<{ name: string }>
+  ).map((column) => column.name);
+
+  if (!columns.includes('tool_name')) {
+    db.exec('ALTER TABLE agent_activity ADD COLUMN tool_name TEXT');
+  }
+  if (!columns.includes('normalized_tool_name')) {
+    db.exec('ALTER TABLE agent_activity ADD COLUMN normalized_tool_name TEXT');
+  }
+}


### PR DESCRIPTION
Follow-up to #144's review feedback: matching `input_summary` is fragile. This is the proper fix:

- `logActivity` accepts `tool_name`/`normalized_tool_name`; the `gateway_tool_call` logging site populates both
- the reconcile verifier matches `normalized_tool_name` with an `input_summary` fallback for rows written before this fix
- **guarded ALTER TABLE migration** for the two columns: they existed only in the live DB (their original migration left the tree with vNext); fresh installs and test DBs lacked them, which is exactly what failed the first attempt's pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity records now include explicit gateway tool names for clearer tracking and reporting.
  * Existing activity databases are automatically updated to support the new tool-name fields.

* **Bug Fixes**
  * Board reconciliation now recognizes tool-call records created with both current and legacy logging formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->