### PR TITLE
feat(ui): dark mode, SSE status chip, and slot freshness (M9-1)

### DIFF
--- a/packages/standalone/tests/ui/client-sse.test.ts
+++ b/packages/standalone/tests/ui/client-sse.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { connectReportSse } from '../../ui/src/api/client';
+
+type Listener = (event: Event) => void;
+
+class FakeEventSource {
+  static instance: FakeEventSource | null = null;
+  readonly listeners = new Map<string, Listener[]>();
+  readonly close = vi.fn();
+
+  constructor(readonly url: string) {
+    FakeEventSource.instance = this;
+  }
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
+    const callback = listener as Listener;
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), callback]);
+  }
+
+  emit(type: string, event = new Event(type)): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+describe('connectReportSse', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    FakeEventSource.instance = null;
+  });
+
+  it('wires open and down callbacks and closes the stream', () => {
+    vi.stubGlobal('EventSource', FakeEventSource);
+    const onOpen = vi.fn();
+    const onDown = vi.fn();
+
+    const disconnect = connectReportSse({ onUpdate: vi.fn(), onOpen, onDown });
+    const source = FakeEventSource.instance;
+    expect(source?.url).toBe('/api/report/events');
+
+    source?.emit('open');
+    source?.emit('error');
+    disconnect();
+
+    expect(onOpen).toHaveBeenCalledOnce();
+    expect(onDown).toHaveBeenCalledOnce();
+    expect(source?.close).toHaveBeenCalledOnce();
+  });
+
+  it('reports error-to-open recovery in order on repeated reconnects', () => {
+    vi.stubGlobal('EventSource', FakeEventSource);
+    const callbackOrder: string[] = [];
+
+    connectReportSse({
+      onUpdate: vi.fn(),
+      onOpen: () => callbackOrder.push('open'),
+      onDown: () => callbackOrder.push('down'),
+    });
+    const source = FakeEventSource.instance;
+
+    source?.emit('error');
+    source?.emit('open');
+    source?.emit('error');
+    source?.emit('open');
+
+    expect(callbackOrder).toEqual(['down', 'open', 'down', 'open']);
+  });
+});

--- a/packages/standalone/tests/ui/theme-init.test.ts
+++ b/packages/standalone/tests/ui/theme-init.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(new URL('../../ui/public/theme-init.js', import.meta.url), 'utf8');
+
+function runThemeInit(options: {
+  stored?: string | null;
+  prefersDark?: boolean;
+  storageThrows?: boolean;
+}): string | null {
+  let theme: string | null = null;
+  const matchMedia = () => ({ matches: options.prefersDark ?? false });
+  const context = {
+    localStorage: {
+      getItem: () => {
+        if (options.storageThrows) {
+          throw new Error('storage blocked');
+        }
+        return options.stored ?? null;
+      },
+    },
+    window: { matchMedia },
+    document: {
+      documentElement: {
+        setAttribute: (name: string, value: string) => {
+          if (name === 'data-theme') {
+            theme = value;
+          }
+        },
+      },
+    },
+  };
+
+  runInNewContext(source, context);
+  return theme;
+}
+
+describe('theme-init.js', () => {
+  it('uses a valid stored theme before the system preference', () => {
+    expect(runThemeInit({ stored: 'light', prefersDark: true })).toBe('light');
+  });
+
+  it('uses the system preference when no valid theme is stored', () => {
+    expect(runThemeInit({ stored: null, prefersDark: true })).toBe('dark');
+    expect(runThemeInit({ stored: 'system', prefersDark: false })).toBe('light');
+  });
+
+  it('uses the system preference when storage access throws', () => {
+    expect(runThemeInit({ storageThrows: true, prefersDark: true })).toBe('dark');
+  });
+});

--- a/packages/standalone/tests/ui/theme-init.test.ts
+++ b/packages/standalone/tests/ui/theme-init.test.ts
@@ -8,6 +8,7 @@ function runThemeInit(options: {
   stored?: string | null;
   prefersDark?: boolean;
   storageThrows?: boolean;
+  supportsMatchMedia?: boolean;
 }): string | null {
   let theme: string | null = null;
   const matchMedia = () => ({ matches: options.prefersDark ?? false });
@@ -20,7 +21,7 @@ function runThemeInit(options: {
         return options.stored ?? null;
       },
     },
-    window: { matchMedia },
+    window: options.supportsMatchMedia === false ? {} : { matchMedia },
     document: {
       documentElement: {
         setAttribute: (name: string, value: string) => {
@@ -48,5 +49,9 @@ describe('theme-init.js', () => {
 
   it('uses the system preference when storage access throws', () => {
     expect(runThemeInit({ storageThrows: true, prefersDark: true })).toBe('dark');
+  });
+
+  it('falls back to light when matchMedia is unavailable', () => {
+    expect(runThemeInit({ stored: null, supportsMatchMedia: false })).toBe('light');
   });
 });

--- a/packages/standalone/tests/ui/theme.test.ts
+++ b/packages/standalone/tests/ui/theme.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { applyTheme, getStoredTheme, resolveTheme, toggleTheme } from '../../ui/src/lib/theme';
+
+describe('getStoredTheme', () => {
+  it('returns a supported stored theme', () => {
+    expect(getStoredTheme({ getItem: () => 'dark' })).toBe('dark');
+  });
+
+  it('ignores unsupported stored values', () => {
+    expect(getStoredTheme({ getItem: () => 'system' })).toBeNull();
+  });
+
+  it('returns null when storage access throws', () => {
+    expect(
+      getStoredTheme({
+        getItem: () => {
+          throw new Error('storage blocked');
+        },
+      })
+    ).toBeNull();
+  });
+});
+
+describe('resolveTheme', () => {
+  it('prefers the stored theme over the system preference', () => {
+    expect(resolveTheme('light', true)).toBe('light');
+  });
+
+  it('uses the system preference when no theme is stored', () => {
+    expect(resolveTheme(null, true)).toBe('dark');
+    expect(resolveTheme(null, false)).toBe('light');
+  });
+});
+
+describe('applyTheme', () => {
+  it('sets the theme on a supplied root target', () => {
+    const target = { dataset: {} as Record<string, string> };
+
+    applyTheme('dark', target);
+
+    expect(target.dataset.theme).toBe('dark');
+  });
+});
+
+describe('toggleTheme', () => {
+  it('switches between light and dark', () => {
+    expect(toggleTheme('light')).toBe('dark');
+    expect(toggleTheme('dark')).toBe('light');
+  });
+});

--- a/packages/standalone/tests/ui/time.test.ts
+++ b/packages/standalone/tests/ui/time.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { formatRelativeTime, getFreshnessClass } from '../../ui/src/lib/time';
+
+describe('formatRelativeTime', () => {
+  const now = 10_000_000;
+
+  it('returns just now for future and sub-minute timestamps', () => {
+    expect(formatRelativeTime(now, now + 60_000)).toBe('just now');
+    expect(formatRelativeTime(now, now - 59_999)).toBe('just now');
+  });
+
+  it('formats elapsed whole minutes', () => {
+    expect(formatRelativeTime(now, now - 60_000)).toBe('1m ago');
+    expect(formatRelativeTime(now, now - 59 * 60_000)).toBe('59m ago');
+  });
+
+  it('formats elapsed whole hours and days', () => {
+    expect(formatRelativeTime(now, now - 2 * 60 * 60_000)).toBe('2h ago');
+    expect(formatRelativeTime(now, now - 3 * 24 * 60 * 60_000)).toBe('3d ago');
+  });
+});
+
+describe('getFreshnessClass', () => {
+  const now = 24 * 60 * 60_000;
+
+  it('uses the fresh style until one hour old', () => {
+    expect(getFreshnessClass(now, now - (60 * 60_000 - 1))).toBe('bg-agent-light text-agent');
+  });
+
+  it('uses the neutral style from one through six hours old', () => {
+    expect(getFreshnessClass(now, now - 60 * 60_000)).toBe(
+      'bg-surface-secondary text-text-tertiary'
+    );
+    expect(getFreshnessClass(now, now - 6 * 60 * 60_000)).toBe(
+      'bg-surface-secondary text-text-tertiary'
+    );
+  });
+
+  it('uses the warning style after six hours', () => {
+    expect(getFreshnessClass(now, now - (6 * 60 * 60_000 + 1))).toBe(
+      'bg-warning-soft text-warning-text'
+    );
+  });
+});

--- a/packages/standalone/tests/ui/time.test.ts
+++ b/packages/standalone/tests/ui/time.test.ts
@@ -18,6 +18,11 @@ describe('formatRelativeTime', () => {
     expect(formatRelativeTime(now, now - 2 * 60 * 60_000)).toBe('2h ago');
     expect(formatRelativeTime(now, now - 3 * 24 * 60 * 60_000)).toBe('3d ago');
   });
+
+  it('returns unknown for non-finite timestamps', () => {
+    expect(formatRelativeTime(now, Number.NaN)).toBe('unknown');
+    expect(formatRelativeTime(now, Number.POSITIVE_INFINITY)).toBe('unknown');
+  });
 });
 
 describe('getFreshnessClass', () => {
@@ -39,6 +44,13 @@ describe('getFreshnessClass', () => {
   it('uses the warning style after six hours', () => {
     expect(getFreshnessClass(now, now - (6 * 60 * 60_000 + 1))).toBe(
       'bg-warning-soft text-warning-text'
+    );
+  });
+
+  it('uses the neutral style for non-finite timestamps', () => {
+    expect(getFreshnessClass(now, Number.NaN)).toBe('bg-surface-secondary text-text-tertiary');
+    expect(getFreshnessClass(now, Number.NEGATIVE_INFINITY)).toBe(
+      'bg-surface-secondary text-text-tertiary'
     );
   });
 });

--- a/packages/standalone/ui/index.html
+++ b/packages/standalone/ui/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MAMA Operator</title>
+    <script src="/theme-init.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/standalone/ui/public/theme-init.js
+++ b/packages/standalone/ui/public/theme-init.js
@@ -2,6 +2,7 @@
 (function () {
   let theme = null;
   try {
+    // Keep in sync with THEME_STORAGE_KEY in src/lib/theme.ts.
     const stored = localStorage.getItem('mama-ui-theme');
     if (stored === 'light' || stored === 'dark') {
       theme = stored;
@@ -10,7 +11,10 @@
     theme = null;
   }
   if (!theme) {
-    theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    const prefersDark =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches;
+    theme = prefersDark ? 'dark' : 'light';
   }
   document.documentElement.setAttribute('data-theme', theme);
 })();

--- a/packages/standalone/ui/public/theme-init.js
+++ b/packages/standalone/ui/public/theme-init.js
@@ -1,0 +1,16 @@
+/* global localStorage, window, document */
+(function () {
+  let theme = null;
+  try {
+    const stored = localStorage.getItem('mama-ui-theme');
+    if (stored === 'light' || stored === 'dark') {
+      theme = stored;
+    }
+  } catch (_error) {
+    theme = null;
+  }
+  if (!theme) {
+    theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  document.documentElement.setAttribute('data-theme', theme);
+})();

--- a/packages/standalone/ui/src/api/client.ts
+++ b/packages/standalone/ui/src/api/client.ts
@@ -53,6 +53,7 @@ export const api = {
 export function connectReportSse(handlers: {
   onUpdate: (data: unknown) => void;
   onOpen?: () => void;
+  onDown?: () => void;
 }): () => void {
   const es = new EventSource('/api/report/events');
   es.addEventListener('report-update', (ev) => {
@@ -64,6 +65,9 @@ export function connectReportSse(handlers: {
   });
   if (handlers.onOpen) {
     es.addEventListener('open', handlers.onOpen);
+  }
+  if (handlers.onDown) {
+    es.addEventListener('error', handlers.onDown);
   }
   return () => es.close();
 }

--- a/packages/standalone/ui/src/components/Layout.tsx
+++ b/packages/standalone/ui/src/components/Layout.tsx
@@ -5,7 +5,7 @@ export default function Layout() {
   return (
     <div className="flex h-full bg-bg">
       <Sidebar />
-      <main className="flex-1 overflow-y-auto pb-14 md:pb-0">
+      <main className="flex-1 min-w-0 overflow-y-auto pb-14 md:pb-0">
         <Outlet />
       </main>
     </div>

--- a/packages/standalone/ui/src/components/Sidebar.tsx
+++ b/packages/standalone/ui/src/components/Sidebar.tsx
@@ -43,7 +43,10 @@ export default function Sidebar() {
     } catch {
       storedTheme = null;
     }
-    return resolveTheme(storedTheme, window.matchMedia('(prefers-color-scheme: dark)').matches);
+    const prefersDark =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches;
+    return resolveTheme(storedTheme, prefersDark);
   });
 
   const handleThemeToggle = () => {

--- a/packages/standalone/ui/src/components/Sidebar.tsx
+++ b/packages/standalone/ui/src/components/Sidebar.tsx
@@ -1,4 +1,13 @@
+import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
+import {
+  applyTheme,
+  getStoredTheme,
+  resolveTheme,
+  THEME_STORAGE_KEY,
+  toggleTheme,
+  type Theme,
+} from '../lib/theme';
 
 interface NavItem {
   to: string;
@@ -23,6 +32,31 @@ const navItems: NavItem[] = [
 const legacyLinks = [{ href: '/viewer', label: 'Legacy viewer' }];
 
 export default function Sidebar() {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const documentTheme = document.documentElement.dataset.theme;
+    if (documentTheme === 'light' || documentTheme === 'dark') {
+      return documentTheme;
+    }
+    let storedTheme: Theme | null = null;
+    try {
+      storedTheme = getStoredTheme(window.localStorage);
+    } catch {
+      storedTheme = null;
+    }
+    return resolveTheme(storedTheme, window.matchMedia('(prefers-color-scheme: dark)').matches);
+  });
+
+  const handleThemeToggle = () => {
+    const nextTheme = toggleTheme(theme);
+    applyTheme(nextTheme, document.documentElement);
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+    } catch {
+      // The applied theme still works when storage is unavailable.
+    }
+    setTheme(nextTheme);
+  };
+
   const linkClass = ({ isActive }: { isActive: boolean }) =>
     `flex items-center gap-2 px-2 py-1.5 text-[13px] rounded-lg transition-all duration-150 ${
       isActive
@@ -42,7 +76,7 @@ export default function Sidebar() {
         <div className="px-3 pt-3 pb-1">
           <div className="flex items-center gap-2.5 px-2 mb-3">
             <div className="w-7 h-7 rounded-lg bg-agent flex items-center justify-center">
-              <span className="text-white text-xs font-bold">M</span>
+              <span className="text-on-agent text-xs font-bold">M</span>
             </div>
             <span className="text-[14px] font-semibold text-text tracking-tight">
               MAMA Operator
@@ -82,8 +116,36 @@ export default function Sidebar() {
             ))}
           </div>
         </nav>
-        <div className="px-4 py-3">
-          <div className="text-[10px] text-text-tertiary">MAMA Operator (beta)</div>
+        <div className="px-3 py-3 border-t border-sidebar-border">
+          <button
+            type="button"
+            onClick={handleThemeToggle}
+            aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} theme`}
+            className="w-full flex items-center gap-2 px-2 py-1.5 text-[13px] rounded-lg text-text-secondary hover:text-text hover:bg-sidebar-hover transition-colors"
+          >
+            <svg
+              className="w-5 h-5 text-text-tertiary"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={1.5}
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d={
+                  theme === 'dark'
+                    ? 'M12 3v1.5m0 15V21m9-9h-1.5M4.5 12H3m15.364 6.364-1.06-1.06M6.696 6.696l-1.06-1.06m12.728 0-1.06 1.06M6.696 17.304l-1.06 1.06M16.5 12a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0z'
+                    : 'M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z'
+                }
+              />
+            </svg>
+            <span>{theme === 'dark' ? 'Light theme' : 'Dark theme'}</span>
+          </button>
+          <div className="px-2 pt-2 text-[10px] text-text-tertiary">
+            MAMA Operator (beta)
+          </div>
         </div>
       </aside>
 
@@ -107,6 +169,32 @@ export default function Sidebar() {
             )}
           </NavLink>
         ))}
+        <button
+          type="button"
+          onClick={handleThemeToggle}
+          aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} theme`}
+          className="flex flex-col items-center justify-center gap-0.5 py-1.5 text-[10px] text-text-tertiary"
+        >
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d={
+                theme === 'dark'
+                  ? 'M12 3v1.5m0 15V21m9-9h-1.5M4.5 12H3m15.364 6.364-1.06-1.06M6.696 6.696l-1.06-1.06m12.728 0-1.06 1.06M6.696 17.304l-1.06 1.06M16.5 12a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0z'
+                  : 'M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z'
+              }
+            />
+          </svg>
+          <span>Theme</span>
+        </button>
       </nav>
     </>
   );

--- a/packages/standalone/ui/src/components/TriggerRow.tsx
+++ b/packages/standalone/ui/src/components/TriggerRow.tsx
@@ -18,7 +18,7 @@ export default function TriggerRow({
 
   return (
     <div
-      className={`px-4 py-3 border-b border-border last:border-b-0 ${disabled ? 'opacity-60' : ''}`}
+      className={`px-4 py-3 border-b border-border last:border-b-0 ${disabled ? 'opacity-90' : ''}`}
     >
       <div className="flex items-center gap-3">
         <span

--- a/packages/standalone/ui/src/lib/theme.ts
+++ b/packages/standalone/ui/src/lib/theme.ts
@@ -1,0 +1,32 @@
+export const THEME_STORAGE_KEY = 'mama-ui-theme';
+
+export type Theme = 'light' | 'dark';
+
+export interface ThemeStorageReader {
+  getItem(key: string): string | null;
+}
+
+export interface ThemeTarget {
+  dataset: Record<string, string> | DOMStringMap;
+}
+
+export function getStoredTheme(storage: ThemeStorageReader): Theme | null {
+  try {
+    const value = storage.getItem(THEME_STORAGE_KEY);
+    return value === 'light' || value === 'dark' ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveTheme(storedTheme: Theme | null, prefersDark: boolean): Theme {
+  return storedTheme ?? (prefersDark ? 'dark' : 'light');
+}
+
+export function applyTheme(theme: Theme, target: ThemeTarget): void {
+  target.dataset.theme = theme;
+}
+
+export function toggleTheme(theme: Theme): Theme {
+  return theme === 'light' ? 'dark' : 'light';
+}

--- a/packages/standalone/ui/src/lib/time.ts
+++ b/packages/standalone/ui/src/lib/time.ts
@@ -3,6 +3,9 @@ const HOUR_MS = 60 * MINUTE_MS;
 const DAY_MS = 24 * HOUR_MS;
 
 export function getFreshnessClass(now: number, updatedAt: number): string {
+  if (!Number.isFinite(updatedAt)) {
+    return 'bg-surface-secondary text-text-tertiary';
+  }
   const age = Math.max(0, now - updatedAt);
   if (age < HOUR_MS) {
     return 'bg-agent-light text-agent';
@@ -14,6 +17,9 @@ export function getFreshnessClass(now: number, updatedAt: number): string {
 }
 
 export function formatRelativeTime(now: number, then: number): string {
+  if (!Number.isFinite(then)) {
+    return 'unknown';
+  }
   const elapsed = Math.max(0, now - then);
   if (elapsed < MINUTE_MS) {
     return 'just now';

--- a/packages/standalone/ui/src/lib/time.ts
+++ b/packages/standalone/ui/src/lib/time.ts
@@ -1,0 +1,28 @@
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+export function getFreshnessClass(now: number, updatedAt: number): string {
+  const age = Math.max(0, now - updatedAt);
+  if (age < HOUR_MS) {
+    return 'bg-agent-light text-agent';
+  }
+  if (age <= 6 * HOUR_MS) {
+    return 'bg-surface-secondary text-text-tertiary';
+  }
+  return 'bg-warning-soft text-warning-text';
+}
+
+export function formatRelativeTime(now: number, then: number): string {
+  const elapsed = Math.max(0, now - then);
+  if (elapsed < MINUTE_MS) {
+    return 'just now';
+  }
+  if (elapsed < HOUR_MS) {
+    return `${Math.floor(elapsed / MINUTE_MS)}m ago`;
+  }
+  if (elapsed < DAY_MS) {
+    return `${Math.floor(elapsed / HOUR_MS)}h ago`;
+  }
+  return `${Math.floor(elapsed / DAY_MS)}d ago`;
+}

--- a/packages/standalone/ui/src/pages/Board.tsx
+++ b/packages/standalone/ui/src/pages/Board.tsx
@@ -10,8 +10,11 @@ import {
 import { sanitizeReportHtml } from '../api/sanitize';
 import { connectReportSse } from '../api/client';
 import StatCard from '../components/StatCard';
+import { formatRelativeTime, getFreshnessClass } from '../lib/time';
 
-function SlotRenderer({ slot }: { slot: ReportSlot }) {
+type SseStatus = 'live' | 'reconnecting';
+
+function SlotRenderer({ slot, now }: { slot: ReportSlot; now: number }) {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -21,10 +24,17 @@ function SlotRenderer({ slot }: { slot: ReportSlot }) {
 
   return (
     <section
-      className="bg-surface rounded-xl border border-border shadow-[var(--shadow-xs)] p-4"
+      className="min-w-0 bg-surface rounded-xl border border-border shadow-[var(--shadow-xs)] p-4"
       data-slot={slot.slotId}
     >
-      <div ref={ref} />
+      <div className="flex justify-end mb-2">
+        <span
+          className={`text-[10px] font-medium rounded-full px-2 py-0.5 ${getFreshnessClass(now, slot.updatedAt)}`}
+        >
+          {formatRelativeTime(now, slot.updatedAt)}
+        </span>
+      </div>
+      <div ref={ref} className="report-slot-content" />
     </section>
   );
 }
@@ -45,6 +55,8 @@ export default function Board() {
   const [slots, setSlots] = useState<SlotRecord>({});
   const [loading, setLoading] = useState(true);
   const [lastUpdate, setLastUpdate] = useState<number | null>(null);
+  const [sseStatus, setSseStatus] = useState<SseStatus>('reconnecting');
+  const [now, setNow] = useState(() => Date.now());
 
   const load = useCallback(async () => {
     try {
@@ -67,6 +79,11 @@ export default function Board() {
     void load();
   }, [load]);
 
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), 30_000);
+    return () => window.clearInterval(timer);
+  }, []);
+
   // SSE hot-reload; onOpen refetches state missed while disconnected.
   useEffect(() => {
     const disconnect = connectReportSse({
@@ -75,8 +92,10 @@ export default function Board() {
         setLastUpdate(Date.now());
       },
       onOpen: () => {
+        setSseStatus('live');
         void load();
       },
+      onDown: () => setSseStatus('reconnecting'),
     });
     return disconnect;
   }, [load]);
@@ -90,17 +109,24 @@ export default function Board() {
   const ordered = orderSlots(slots);
 
   return (
-    <div className="flex flex-col h-full">
-      <div className="flex items-center justify-between px-4 py-3 border-b border-border flex-shrink-0 bg-surface">
-        <div className="flex items-center gap-3">
+    <div className="flex flex-col h-full min-w-0">
+      <div className="flex items-center justify-between gap-2 px-4 py-3 border-b border-border flex-shrink-0 bg-surface">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
           <h1 className="text-base font-semibold text-text">Operator Board</h1>
+          <span
+            role="status"
+            aria-live="polite"
+            className={`text-[10px] font-semibold tracking-wide rounded-full px-2 py-0.5 ${
+              sseStatus === 'live'
+                ? 'bg-success-soft text-success-text'
+                : 'bg-warning-soft text-warning-text'
+            }`}
+          >
+            {sseStatus === 'live' ? 'LIVE' : 'RECONNECTING'}
+          </span>
           {lastUpdate && (
-            <span className="text-[10px] text-text-tertiary">
-              {new Date(lastUpdate).toLocaleTimeString(undefined, {
-                hour: '2-digit',
-                minute: '2-digit',
-              })}{' '}
-              updated
+            <span className="text-[10px] text-text-tertiary whitespace-nowrap">
+              updated {formatRelativeTime(now, lastUpdate)}
             </span>
           )}
         </div>
@@ -113,7 +139,7 @@ export default function Board() {
       </div>
 
       <div className="flex-1 overflow-y-auto">
-        <div className="p-4 max-w-4xl mx-auto">
+        <div className="p-4 max-w-4xl min-w-0 mx-auto">
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
             <StatCard label="Active triggers" value={summary?.triggers.active ?? '-'} />
             <StatCard label="Total fires" value={summary?.triggers.fired ?? '-'} />
@@ -138,7 +164,7 @@ export default function Board() {
           ) : (
             <div className="space-y-3">
               {ordered.map((slot) => (
-                <SlotRenderer key={slot.slotId} slot={slot} />
+                <SlotRenderer key={slot.slotId} slot={slot} now={now} />
               ))}
             </div>
           )}

--- a/packages/standalone/ui/src/styles/global.css
+++ b/packages/standalone/ui/src/styles/global.css
@@ -18,6 +18,7 @@
   --color-agent: #6366f1;
   --color-agent-hover: #4f46e5;
   --color-agent-light: #eef2ff;
+  --color-on-agent: #ffffff;
 
   --color-text: #1a1a1a;
   --color-text-secondary: #616161;
@@ -27,8 +28,51 @@
   --color-success: #047b5d;
   --color-warning: #ffb800;
   --color-danger: #d72c0d;
+  --color-success-soft: #e7f5f0;
+  --color-success-text: #04664e;
+  --color-warning-soft: #fff4d6;
+  --color-warning-text: #805c00;
 
   --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+:root {
+  color-scheme: light;
+}
+
+:root[data-theme='dark'] {
+  color-scheme: dark;
+
+  --color-bg: #141414;
+  --color-surface: #1e1e1e;
+  --color-surface-hover: #292929;
+  --color-surface-selected: #303030;
+  --color-surface-secondary: #292929;
+
+  --color-sidebar: #191919;
+  --color-sidebar-hover: #282828;
+  --color-sidebar-active: #303030;
+  --color-sidebar-border: #343434;
+
+  --color-agent: #a5b4fc;
+  --color-agent-hover: #c7d2fe;
+  --color-agent-light: #2b315a;
+  --color-on-agent: #1a1a3a;
+
+  --color-text: #f5f5f5;
+  --color-text-secondary: #c4c4c4;
+  --color-text-tertiary: #9b9b9b;
+  --color-border: #3a3a3a;
+
+  --color-success: #5ee0b3;
+  --color-warning: #ffd166;
+  --color-danger: #ff8f7a;
+  --color-success-soft: #173b30;
+  --color-success-text: #7ce8c3;
+  --color-warning-soft: #4a3814;
+  --color-warning-text: #ffdb7d;
+
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.35);
 }
 
 html,
@@ -40,6 +84,7 @@ body,
 body {
   background-color: var(--color-bg);
   color: var(--color-text);
+  overflow-x: hidden;
 }
 
 /* -- Board slot vocabulary -----------------------------------------------
@@ -106,7 +151,7 @@ body {
   background: color-mix(in srgb, var(--color-danger) 12%, transparent);
 }
 .badge-warning {
-  color: color-mix(in srgb, var(--color-warning) 70%, black);
+  color: var(--color-warning-text);
   background: color-mix(in srgb, var(--color-warning) 16%, transparent);
 }
 .badge-info {
@@ -146,8 +191,16 @@ body {
 
 .report-table {
   width: 100%;
+  min-width: 640px;
   border-collapse: collapse;
   font-size: 12px;
+}
+
+.report-slot-content {
+  max-width: 100%;
+  min-width: 0;
+  overflow-x: auto;
+  overflow-wrap: anywhere;
 }
 .report-table th {
   text-align: left;


### PR DESCRIPTION
First phase of the M9 UI improvement round (owner-approved proposal). Implemented by Codex gpt-5.6 (high) under a supervisor loop: Codex plan -> supervisor gate -> Codex implement -> adversarial Codex review (7 P2 findings, all fixed) -> independent verification.

## Changes
- **Dark mode**: pre-paint theme bootstrap via CSP-safe external script (`theme-init.js`), `data-theme` on `<html>`, localStorage persistence (`mama-ui-theme`), `prefers-color-scheme` fallback, `color-scheme` declarations. Full dark token override set in `global.css` including new `--color-on-agent` / soft tokens; reviewer-verified >= 4.5:1 contrast for all badge/tag/stat/chip classes in both themes.
- **Theme toggles**: sidebar footer + mobile bottom nav, aria-labels, existing icons untouched.
- **Board status strip**: LIVE / RECONNECTING SSE chip (`role=status`, `aria-live=polite`), relative "updated Xm ago" header time.
- **Slot freshness chips**: per-slot age chip (<1h / 1-6h / >6h tones) on a 30s tick, pure `lib/time.ts`.
- **Mobile overflow**: `.report-slot-content` scroll containment, `min-w-0` chain, `.report-table` min-width; no page-level horizontal scroll at 375px.
- **Tests** (24): theme resolution, theme-init evaluated in a node VM, relative-time + freshness boundary cases, SSE error->reopen recovery.

## Verification
- `pnpm --dir packages/standalone/ui run bundle` clean (tsc + vite)
- `pnpm vitest run tests/ui/` 5 files, 24 tests green
- ASCII + no-hex-in-TSX audits clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added light and dark themes with system-preference detection and saved theme selection.
  * Added theme toggle controls to desktop and mobile navigation.
  * Added live connection status indicators, showing when the board is reconnecting.
  * Added relative update times and freshness styling for report slots.
  * Improved report layout behavior on narrow screens and long content.

* **Bug Fixes**
  * Improved layout sizing, disabled-row visibility, and warning text contrast.
  * Added safer handling for connection interruptions and persisted theme access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->