### PR TITLE
feat(ui): native Tasks page + operator tasks API (M9-2)

### DIFF
--- a/packages/standalone/src/api/index.ts
+++ b/packages/standalone/src/api/index.ts
@@ -197,7 +197,7 @@ export function createApiServer(options: ApiServerOptions): ApiServer {
     const origin = req.headers.origin;
     if (origin && /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) {
       res.setHeader('Access-Control-Allow-Origin', origin);
-      res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+      res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');
       res.setHeader(
         'Access-Control-Allow-Headers',
         'Content-Type, Authorization, x-mama-envelope-hash, x-mama-model-run-id'

--- a/packages/standalone/src/api/operator-tasks-handler.ts
+++ b/packages/standalone/src/api/operator-tasks-handler.ts
@@ -1,0 +1,183 @@
+import type { Express, Request, Response } from 'express';
+import { requireAuth } from './auth-middleware.js';
+import {
+  TASK_PRIORITIES,
+  TASK_STATUSES,
+  type TaskLedger,
+  type TaskPriority,
+  type TaskRecord,
+  type TaskStatus,
+  type UpdateTaskInput,
+} from '../operator/task-ledger.js';
+
+export interface OperatorTaskRouteDeps {
+  getTaskLedger: () => TaskLedger | null;
+}
+
+const ALLOWED_PATCH_FIELDS = new Set(['status', 'priority', 'assignee', 'due_date', 'confirmed']);
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function serializeTask(task: TaskRecord) {
+  return {
+    id: task.id,
+    title: task.title,
+    status: task.status,
+    priority: task.priority,
+    assignee: task.assignee,
+    due_date: task.deadlineIso,
+    source_channel: task.sourceChannel,
+    latest_event: task.latestEvent,
+    auto_created: task.autoCreated,
+    confirmed: task.confirmed,
+    created_at: task.createdAt,
+    updated_at: task.updatedAt,
+  };
+}
+
+function isValidDate(value: string): boolean {
+  if (!ISO_DATE_PATTERN.test(value)) return false;
+  const [year, month, day] = value.split('-').map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day
+  );
+}
+
+function readStringQuery(value: unknown, field: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string') {
+    throw new Error(`${field} must be a string`);
+  }
+  return value;
+}
+
+function readLimit(value: unknown): number {
+  if (value === undefined) return 50;
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) {
+    throw new Error('limit must be an integer from 1 to 200');
+  }
+  const limit = Number(value);
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 200) {
+    throw new Error('limit must be an integer from 1 to 200');
+  }
+  return limit;
+}
+
+function validatePatchBody(body: unknown): UpdateTaskInput {
+  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+    throw new Error('body must be a non-empty object');
+  }
+  const input = body as Record<string, unknown>;
+  const keys = Object.keys(input);
+  if (keys.length === 0) {
+    throw new Error('body must be a non-empty object');
+  }
+  const unknownFields = keys.filter((key) => !ALLOWED_PATCH_FIELDS.has(key));
+  if (unknownFields.length > 0) {
+    throw new Error(`unknown fields: ${unknownFields.join(', ')}`);
+  }
+
+  const patch: UpdateTaskInput = {};
+  if ('status' in input) {
+    if (typeof input.status !== 'string' || !TASK_STATUSES.includes(input.status as TaskStatus)) {
+      throw new Error(`status must be one of ${TASK_STATUSES.join('|')}`);
+    }
+    patch.status = input.status as TaskStatus;
+  }
+  if ('priority' in input) {
+    if (
+      typeof input.priority !== 'string' ||
+      !TASK_PRIORITIES.includes(input.priority as TaskPriority)
+    ) {
+      throw new Error(`priority must be one of ${TASK_PRIORITIES.join('|')}`);
+    }
+    patch.priority = input.priority as TaskPriority;
+  }
+  if ('assignee' in input) {
+    if (input.assignee !== null && typeof input.assignee !== 'string') {
+      throw new Error('assignee must be a string or null');
+    }
+    patch.assignee = input.assignee === null ? null : input.assignee.trim();
+  }
+  if ('due_date' in input) {
+    if (input.due_date !== null && typeof input.due_date !== 'string') {
+      throw new Error('due_date must be a YYYY-MM-DD date or null');
+    }
+    if (typeof input.due_date === 'string' && !isValidDate(input.due_date)) {
+      throw new Error('due_date must be a real YYYY-MM-DD calendar date or null');
+    }
+    patch.deadline = input.due_date;
+  }
+  if ('confirmed' in input) {
+    if (typeof input.confirmed !== 'boolean') {
+      throw new Error('confirmed must be a boolean');
+    }
+    patch.confirmed = input.confirmed;
+  }
+  return patch;
+}
+
+function getLedgerOr503(deps: OperatorTaskRouteDeps, res: Response): TaskLedger | null {
+  const ledger = deps.getTaskLedger();
+  if (!ledger) {
+    res.status(503).json({ error: 'task ledger unavailable' });
+    return null;
+  }
+  return ledger;
+}
+
+export function registerOperatorTaskRoutes(app: Express, deps: OperatorTaskRouteDeps): void {
+  app.get('/api/operator/tasks', requireAuth, (req: Request, res: Response) => {
+    const ledger = getLedgerOr503(deps, res);
+    if (!ledger) return;
+
+    try {
+      const status = readStringQuery(req.query.status, 'status');
+      if (status !== undefined && !TASK_STATUSES.includes(status as TaskStatus)) {
+        res.status(400).json({
+          error: `status must be one of ${TASK_STATUSES.join('|')}`,
+        });
+        return;
+      }
+      const sourceChannel = readStringQuery(req.query.source_channel, 'source_channel');
+      const limit = readLimit(req.query.limit);
+      const tasks = ledger.list({
+        status: status as TaskStatus | undefined,
+        channel: sourceChannel,
+        limit,
+        order: 'deadline_priority',
+      });
+      res.json({ tasks: tasks.map(serializeTask) });
+    } catch (error) {
+      res.status(400).json({ error: error instanceof Error ? error.message : String(error) });
+    }
+  });
+
+  app.patch('/api/operator/tasks/:id', requireAuth, (req: Request, res: Response) => {
+    const ledger = getLedgerOr503(deps, res);
+    if (!ledger) return;
+
+    const rawId = req.params.id;
+    if (typeof rawId !== 'string' || !/^[1-9]\d*$/.test(rawId)) {
+      res.status(400).json({ error: 'id must be a positive base-10 integer' });
+      return;
+    }
+    const id = Number(rawId);
+    if (!Number.isSafeInteger(id)) {
+      res.status(400).json({ error: 'id must be a positive base-10 integer' });
+      return;
+    }
+    if (!ledger.getById(id)) {
+      res.status(404).json({ error: 'task not found' });
+      return;
+    }
+
+    try {
+      const patch = validatePatchBody(req.body);
+      const task = ledger.update(id, patch);
+      res.json({ ok: true, task: serializeTask(task) });
+    } catch (error) {
+      res.status(400).json({ error: error instanceof Error ? error.message : String(error) });
+    }
+  });
+}

--- a/packages/standalone/src/api/operator-tasks-handler.ts
+++ b/packages/standalone/src/api/operator-tasks-handler.ts
@@ -35,7 +35,9 @@ function serializeTask(task: TaskRecord) {
 }
 
 function isValidDate(value: string): boolean {
-  if (!ISO_DATE_PATTERN.test(value)) return false;
+  if (!ISO_DATE_PATTERN.test(value)) {
+    return false;
+  }
   const [year, month, day] = value.split('-').map(Number);
   const date = new Date(Date.UTC(year, month - 1, day));
   return (

--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -31,6 +31,7 @@ import type { SQLiteDatabase } from '../../sqlite.js';
 import { buildMemoryAgentDashboardPayload } from '../../memory/memory-agent-dashboard.js';
 import type { ApiServer } from '../../api/index.js';
 import { createUploadRouter } from '../../api/upload-handler.js';
+import { registerOperatorTaskRoutes } from '../../api/operator-tasks-handler.js';
 import { requireAuth, isAuthenticated, logUnauthorizedAttempt } from '../../api/auth-middleware.js';
 import type { OAuthManager } from '../../auth/index.js';
 import type { DiscordGateway } from '../../gateways/discord.js';
@@ -253,6 +254,10 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
 
   // Wire EventBus to tool executor for agent_notices tool
   toolExecutor.setAgentEventBus(eventBus);
+
+  registerOperatorTaskRoutes(apiServer.app, {
+    getTaskLedger: () => toolExecutor.getTaskLedger(),
+  });
 
   const hasEnabledAgentConfig = (agentId: string): boolean => {
     const agentConfig = config.multi_agent?.agents?.[agentId];

--- a/packages/standalone/src/operator/task-ledger.ts
+++ b/packages/standalone/src/operator/task-ledger.ts
@@ -68,7 +68,7 @@ export interface CreateTaskInput {
 export interface UpdateTaskInput {
   status?: TaskStatus;
   priority?: TaskPriority;
-  assignee?: string;
+  assignee?: string | null;
   deadline?: string | null;
   latest_event?: string;
   confirmed?: boolean;
@@ -115,7 +115,15 @@ function assertEnum(value: string, allowed: readonly string[], field: string): v
 }
 
 function assertIsoDate(value: string, field: string): void {
-  if (!ISO_DATE_PATTERN.test(value) || isoToEpochMs(value) === null) {
+  const match = ISO_DATE_PATTERN.exec(value);
+  if (!match) {
+    throw new Error(`${field} must be an ISO date (YYYY-MM-DD), got: ${value}`);
+  }
+  const [year, month, day] = value.split('-').map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  const isRoundTrip =
+    date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day;
+  if (!isRoundTrip) {
     throw new Error(`${field} must be an ISO date (YYYY-MM-DD), got: ${value}`);
   }
 }

--- a/packages/standalone/tests/api/operator-tasks-handler.test.ts
+++ b/packages/standalone/tests/api/operator-tasks-handler.test.ts
@@ -1,0 +1,364 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import express from 'express';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { registerOperatorTaskRoutes } from '../../src/api/operator-tasks-handler.js';
+import { TaskLedger } from '../../src/operator/task-ledger.js';
+import Database, { type SQLiteDatabase } from '../../src/sqlite.js';
+
+interface InProcessResponse {
+  status: number;
+  body: unknown;
+}
+
+class InProcessRequest implements PromiseLike<InProcessResponse> {
+  private body: unknown;
+  private headers: Record<string, string> = {};
+
+  constructor(
+    private app: express.Express,
+    private method: 'get' | 'patch',
+    private url: string
+  ) {}
+
+  send(body: unknown): this {
+    this.body = body;
+    return this;
+  }
+
+  set(name: string, value: string): this {
+    this.headers[name.toLowerCase()] = value;
+    return this;
+  }
+
+  then<TResult1 = InProcessResponse, TResult2 = never>(
+    onfulfilled?: ((value: InProcessResponse) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): PromiseLike<TResult1 | TResult2> {
+    return this.run().then(onfulfilled, onrejected);
+  }
+
+  private async run(): Promise<InProcessResponse> {
+    const parsed = new URL(this.url, 'http://localhost');
+    const routePath = this.method === 'patch' ? '/api/operator/tasks/:id' : '/api/operator/tasks';
+    const router = (this.app as express.Express & { router: { stack: RouteLayer[] } }).router;
+    const route = router.stack.find(
+      (layer) => layer.route?.path === routePath && layer.route.methods[this.method]
+    )?.route;
+    if (!route) throw new Error(`route not registered: ${this.method} ${routePath}`);
+
+    const query = Object.fromEntries(parsed.searchParams.entries());
+    const params =
+      this.method === 'patch'
+        ? { id: decodeURIComponent(parsed.pathname.slice('/api/operator/tasks/'.length)) }
+        : {};
+    const req = {
+      method: this.method.toUpperCase(),
+      url: `${parsed.pathname}${parsed.search}`,
+      originalUrl: `${parsed.pathname}${parsed.search}`,
+      path: parsed.pathname,
+      headers: this.headers,
+      socket: { remoteAddress: '127.0.0.1' },
+      query,
+      params,
+      body: this.body,
+    };
+
+    return new Promise((resolve, reject) => {
+      let status = 200;
+      let settled = false;
+      const finish = (body: unknown) => {
+        if (!settled) {
+          settled = true;
+          resolve({ status, body });
+        }
+      };
+      const res = {
+        status(code: number) {
+          status = code;
+          return this;
+        },
+        json(body: unknown) {
+          finish(body);
+          return this;
+        },
+        end() {
+          finish(undefined);
+          return this;
+        },
+      };
+      const runLayer = (index: number, error?: unknown) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        const layer = route.stack[index];
+        if (!layer) {
+          finish(undefined);
+          return;
+        }
+        try {
+          const result = layer.handle(req, res, (nextError?: unknown) =>
+            runLayer(index + 1, nextError)
+          );
+          if (result instanceof Promise) result.catch(reject);
+        } catch (caught) {
+          reject(caught);
+        }
+      };
+      runLayer(0);
+    });
+  }
+}
+
+interface RouteLayer {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{
+      handle: (req: unknown, res: unknown, next: (error?: unknown) => void) => unknown;
+    }>;
+  };
+}
+
+function request(app: express.Express) {
+  return {
+    get: (url: string) => new InProcessRequest(app, 'get', url),
+    patch: (url: string) => new InProcessRequest(app, 'patch', url),
+  };
+}
+
+describe('Operator tasks API', () => {
+  let app: express.Express;
+  let db: SQLiteDatabase;
+  let dir: string;
+  let ledger: TaskLedger;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'operator-tasks-api-'));
+    db = new Database(join(dir, 'operator.db'));
+    ledger = new TaskLedger(db);
+    app = express();
+    app.use(express.json());
+    registerOperatorTaskRoutes(app, { getTaskLedger: () => ledger });
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns at most 50 tasks in deadline and priority order by default', async () => {
+    ledger.create({ title: 'no deadline', priority: 'high' });
+    ledger.create({ title: 'later', deadline: '2026-08-01', priority: 'low' });
+    ledger.create({ title: 'sooner normal', deadline: '2026-07-15', priority: 'normal' });
+    ledger.create({ title: 'sooner high', deadline: '2026-07-15', priority: 'high' });
+    for (let index = 0; index < 48; index += 1) {
+      ledger.create({ title: `filler ${index}` });
+    }
+
+    const response = await request(app).get('/api/operator/tasks');
+
+    expect(response.status).toBe(200);
+    expect(response.body.tasks).toHaveLength(50);
+    expect(response.body.tasks.slice(0, 3).map((task: { title: string }) => task.title)).toEqual([
+      'sooner high',
+      'sooner normal',
+      'later',
+    ]);
+  });
+
+  it('combines status, source_channel, and limit filters', async () => {
+    ledger.create({
+      title: 'matching one',
+      status: 'review',
+      source_channel: 'synthetic:channel-a',
+      deadline: '2026-07-15',
+    });
+    ledger.create({
+      title: 'matching two',
+      status: 'review',
+      source_channel: 'synthetic:channel-a',
+      deadline: '2026-07-16',
+    });
+    ledger.create({
+      title: 'wrong status',
+      status: 'pending',
+      source_channel: 'synthetic:channel-a',
+    });
+    ledger.create({
+      title: 'wrong channel',
+      status: 'review',
+      source_channel: 'synthetic:channel-b',
+    });
+
+    const response = await request(app).get(
+      '/api/operator/tasks?status=review&source_channel=synthetic%3Achannel-a&limit=1'
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.tasks.map((task: { title: string }) => task.title)).toEqual([
+      'matching one',
+    ]);
+  });
+
+  it('serializes only the documented wire fields', async () => {
+    const created = ledger.create({
+      title: 'Review release candidate',
+      status: 'review',
+      priority: 'high',
+      assignee: 'worker-a',
+      deadline: '2026-07-15',
+      source_channel: 'synthetic:channel-a',
+      source_event_id: 'event-1',
+      latest_event: 'Candidate submitted',
+    });
+
+    const response = await request(app).get('/api/operator/tasks');
+
+    expect(response.status).toBe(200);
+    expect(response.body.tasks[0]).toEqual({
+      id: created.id,
+      title: 'Review release candidate',
+      status: 'review',
+      priority: 'high',
+      assignee: 'worker-a',
+      due_date: '2026-07-15',
+      source_channel: 'synthetic:channel-a',
+      latest_event: 'Candidate submitted',
+      auto_created: true,
+      confirmed: false,
+      created_at: created.createdAt,
+      updated_at: created.updatedAt,
+    });
+    expect(response.body.tasks[0]).not.toHaveProperty('source_event_id');
+    expect(response.body.tasks[0]).not.toHaveProperty('deadline');
+  });
+
+  it.each([
+    ['/api/operator/tasks?status=unknown', 'status'],
+    ['/api/operator/tasks?limit=0', 'limit'],
+    ['/api/operator/tasks?limit=201', 'limit'],
+    ['/api/operator/tasks?limit=1.5', 'limit'],
+    ['/api/operator/tasks?limit=text', 'limit'],
+  ])('rejects invalid query %s', async (url, expectedField) => {
+    const response = await request(app).get(url);
+    expect(response.status).toBe(400);
+    expect(response.body.error).toContain(expectedField);
+  });
+
+  it('updates every allowed field and persists the external due_date mapping', async () => {
+    const created = ledger.create({ title: 'Owner task' });
+
+    const response = await request(app).patch(`/api/operator/tasks/${created.id}`).send({
+      status: 'in_progress',
+      priority: 'high',
+      assignee: 'worker-b',
+      due_date: '2026-07-20',
+      confirmed: true,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+    expect(response.body.task).toMatchObject({
+      id: created.id,
+      status: 'in_progress',
+      priority: 'high',
+      assignee: 'worker-b',
+      due_date: '2026-07-20',
+      confirmed: true,
+    });
+    expect(ledger.getById(created.id)).toMatchObject({
+      status: 'in_progress',
+      priority: 'high',
+      assignee: 'worker-b',
+      deadlineIso: '2026-07-20',
+      confirmed: true,
+    });
+  });
+
+  it('clears due_date and assignee with null', async () => {
+    const created = ledger.create({
+      title: 'Clear fields',
+      assignee: 'worker-a',
+      deadline: '2026-07-20',
+    });
+
+    const response = await request(app)
+      .patch(`/api/operator/tasks/${created.id}`)
+      .send({ assignee: null, due_date: null });
+
+    expect(response.status).toBe(200);
+    expect(response.body.task.assignee).toBeNull();
+    expect(response.body.task.due_date).toBeNull();
+    expect(ledger.getById(created.id)?.assignee).toBeNull();
+    expect(ledger.getById(created.id)?.deadlineIso).toBeNull();
+  });
+
+  it('approves with confirmed only and preserves status and priority', async () => {
+    const created = ledger.create({ title: 'Approve task', status: 'review', priority: 'low' });
+
+    const response = await request(app)
+      .patch(`/api/operator/tasks/${created.id}`)
+      .send({ confirmed: true });
+
+    expect(response.status).toBe(200);
+    expect(response.body.task).toMatchObject({
+      confirmed: true,
+      status: 'review',
+      priority: 'low',
+    });
+  });
+
+  it('rejects malformed IDs and returns 404 for an absent task', async () => {
+    for (const id of ['0', '-1', '1.5', 'abc', '01x']) {
+      const response = await request(app)
+        .patch(`/api/operator/tasks/${id}`)
+        .send({ confirmed: true });
+      expect(response.status).toBe(400);
+    }
+    const missing = await request(app).patch('/api/operator/tasks/9999').send({ confirmed: true });
+    expect(missing.status).toBe(404);
+  });
+
+  it.each([
+    [undefined, 'body'],
+    [{}, 'body'],
+    [{ title: 'not allowed' }, 'unknown'],
+    [{ status: 'unknown' }, 'status'],
+    [{ priority: 'urgent' }, 'priority'],
+    [{ assignee: 123 }, 'assignee'],
+    [{ due_date: '2026-02-30' }, 'due_date'],
+    [{ due_date: 123 }, 'due_date'],
+    [{ confirmed: 'yes' }, 'confirmed'],
+    [[], 'body'],
+    ['not an object', 'body'],
+  ])('rejects invalid patch body %#', async (body, expectedField) => {
+    const created = ledger.create({ title: 'Validation target' });
+    const response = await request(app).patch(`/api/operator/tasks/${created.id}`).send(body);
+    expect(response.status).toBe(400);
+    expect(response.body.error).toContain(expectedField);
+  });
+
+  it('returns 503 when the shared ledger is unavailable', async () => {
+    const unavailableApp = express();
+    unavailableApp.use(express.json());
+    registerOperatorTaskRoutes(unavailableApp, { getTaskLedger: () => null });
+
+    const getResponse = await request(unavailableApp).get('/api/operator/tasks');
+    const patchResponse = await request(unavailableApp)
+      .patch('/api/operator/tasks/1')
+      .send({ confirmed: true });
+
+    expect(getResponse.status).toBe(503);
+    expect(getResponse.body).toEqual({ error: 'task ledger unavailable' });
+    expect(patchResponse.status).toBe(503);
+  });
+
+  it('requires authentication for tunnel-style requests', async () => {
+    const response = await request(app).get('/api/operator/tasks').set('cf-ray', 'synthetic-ray');
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/packages/standalone/tests/operator/task-ledger.test.ts
+++ b/packages/standalone/tests/operator/task-ledger.test.ts
@@ -34,6 +34,7 @@ describe('TaskLedger', () => {
     expect(() => ledger.create({ title: '  ' })).toThrow(/title/);
     expect(() => ledger.create({ title: 'x', deadline: 'next friday' })).toThrow(/ISO date/);
     expect(() => ledger.create({ title: 'x', deadline: '2026-13-99' })).toThrow(/ISO date/);
+    expect(() => ledger.create({ title: 'x', deadline: '2026-02-30' })).toThrow(/ISO date/);
   });
 
   it('maps ISO deadline to UTC-midnight epoch ms for the OperatorTask interface', () => {
@@ -88,6 +89,12 @@ describe('TaskLedger', () => {
     const cleared = ledger.update(t.id, { deadline: null });
     expect(cleared.deadlineIso).toBeNull();
     expect(cleared.deadline).toBeNull();
+  });
+
+  it('assignee can be cleared with null', () => {
+    const t = ledger.create({ title: 'x', assignee: 'worker-a' });
+    const cleared = ledger.update(t.id, { assignee: null });
+    expect(cleared.assignee).toBeNull();
   });
 
   it('deadline_priority ordering: deadline asc nulls last, then priority, LIMIT after order', () => {

--- a/packages/standalone/tests/ui/task-cache.test.ts
+++ b/packages/standalone/tests/ui/task-cache.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import type { OperatorTask } from '../../ui/src/api/client';
+import { updateTaskCache } from '../../ui/src/lib/task-cache';
+
+function task(id: number, status: OperatorTask['status']): OperatorTask {
+  return {
+    id,
+    title: `Task ${id}`,
+    status,
+    priority: 'normal',
+    assignee: null,
+    due_date: null,
+    source_channel: null,
+    latest_event: null,
+    auto_created: false,
+    confirmed: true,
+    created_at: 1,
+    updated_at: 2,
+  };
+}
+
+describe('updateTaskCache', () => {
+  it('moves an updated task between status caches and replaces it in the all cache', () => {
+    const pendingTask = task(1, 'pending');
+    const otherPendingTask = task(2, 'pending');
+    const updatedTask = { ...pendingTask, status: 'done' as const, updated_at: 3 };
+
+    expect(updateTaskCache({ tasks: [pendingTask, otherPendingTask] }, null, updatedTask)).toEqual({
+      tasks: [updatedTask, otherPendingTask],
+    });
+    expect(
+      updateTaskCache({ tasks: [pendingTask, otherPendingTask] }, 'pending', updatedTask)
+    ).toEqual({
+      tasks: [otherPendingTask],
+    });
+    expect(updateTaskCache({ tasks: [] }, 'done', updatedTask)).toEqual({
+      tasks: [updatedTask],
+    });
+  });
+
+  it('does not insert an updated task into an unrelated populated status cache', () => {
+    const reviewTask = task(2, 'review');
+
+    expect(updateTaskCache({ tasks: [reviewTask] }, 'review', task(1, 'done'))).toEqual({
+      tasks: [reviewTask],
+    });
+  });
+});

--- a/packages/standalone/tests/ui/task-links.test.ts
+++ b/packages/standalone/tests/ui/task-links.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+import { linkifyTaskReferences, segmentTaskReferences } from '../../ui/src/lib/task-links';
+
+abstract class FakeNode {
+  abstract readonly nodeType: number;
+  parentElement: FakeElement | null = null;
+  childNodes: FakeNode[] = [];
+
+  constructor(readonly ownerDocument: FakeDocument) {}
+
+  append(node: FakeNode): void {
+    node.parentElement = this instanceof FakeElement ? this : this.parentElement;
+    this.childNodes.push(node);
+  }
+
+  replaceWith(replacement: FakeNode): void {
+    if (!this.parentElement) throw new Error('Cannot replace a detached node');
+    const index = this.parentElement.childNodes.indexOf(this);
+    const replacements = replacement.nodeType === 11 ? replacement.childNodes : [replacement];
+    for (const node of replacements) node.parentElement = this.parentElement;
+    this.parentElement.childNodes.splice(index, 1, ...replacements);
+  }
+}
+
+class FakeText extends FakeNode {
+  readonly nodeType = 3;
+
+  constructor(
+    ownerDocument: FakeDocument,
+    public data: string
+  ) {
+    super(ownerDocument);
+  }
+}
+
+class FakeElement extends FakeNode {
+  readonly nodeType = 1;
+  readonly attributes = new Map<string, string>();
+
+  constructor(
+    ownerDocument: FakeDocument,
+    readonly tagName: string
+  ) {
+    super(ownerDocument);
+  }
+
+  set href(value: string) {
+    this.setAttribute('href', value);
+  }
+
+  set className(value: string) {
+    this.setAttribute('class', value);
+  }
+
+  set textContent(value: string) {
+    this.childNodes = [];
+    this.append(this.ownerDocument.createTextNode(value));
+  }
+
+  hasAttribute(name: string): boolean {
+    return this.attributes.has(name);
+  }
+
+  removeAttribute(name: string): void {
+    this.attributes.delete(name);
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+}
+
+class FakeFragment extends FakeNode {
+  readonly nodeType = 11;
+}
+
+class FakeDocument {
+  createDocumentFragment(): FakeFragment {
+    return new FakeFragment(this);
+  }
+
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(this, tagName.toUpperCase());
+  }
+
+  createTextNode(data: string): FakeText {
+    return new FakeText(this, data);
+  }
+}
+
+function element(document: FakeDocument, tagName: string, ...children: FakeNode[]): FakeElement {
+  const result = document.createElement(tagName);
+  for (const child of children) result.append(child);
+  return result;
+}
+
+function escapeText(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+function serialize(node: FakeNode): string {
+  if (node instanceof FakeText) return escapeText(node.data);
+  const children = node.childNodes.map(serialize).join('');
+  if (!(node instanceof FakeElement)) return children;
+  const attributes = [...node.attributes].map(([name, value]) => ` ${name}="${value}"`).join('');
+  return `<${node.tagName.toLowerCase()}${attributes}>${children}</${node.tagName.toLowerCase()}>`;
+}
+
+function linkify(root: FakeElement): void {
+  linkifyTaskReferences(root as unknown as HTMLElement);
+}
+
+describe('segmentTaskReferences', () => {
+  it('segments one task reference', () => {
+    expect(segmentTaskReferences('Review #12 today')).toEqual([
+      { type: 'text', value: 'Review ' },
+      { type: 'task', value: '#12', taskId: '12' },
+      { type: 'text', value: ' today' },
+    ]);
+  });
+
+  it('segments multiple task references and adjacent punctuation', () => {
+    expect(segmentTaskReferences('#1, then (#23).')).toEqual([
+      { type: 'task', value: '#1', taskId: '1' },
+      { type: 'text', value: ', then (' },
+      { type: 'task', value: '#23', taskId: '23' },
+      { type: 'text', value: ').' },
+    ]);
+  });
+
+  it('preserves text when there are no numeric references', () => {
+    expect(segmentTaskReferences('No references here')).toEqual([
+      { type: 'text', value: 'No references here' },
+    ]);
+  });
+
+  it('does not segment non-numeric hashtags', () => {
+    expect(segmentTaskReferences('Keep #release and #12x intact')).toEqual([
+      { type: 'text', value: 'Keep #release and #12x intact' },
+    ]);
+  });
+});
+
+describe('linkifyTaskReferences', () => {
+  it('keeps hostile markup as text while linking task references', () => {
+    const document = new FakeDocument();
+    const root = element(
+      document,
+      'div',
+      document.createTextNode('<img src=x onerror=alert(1)> Review #7')
+    );
+
+    linkify(root);
+
+    expect(serialize(root)).toBe(
+      '<div>&lt;img src=x onerror=alert(1)&gt; Review <a href="/ui/tasks#task-7" data-task-id="7" class="task-reference-link">#7</a></div>'
+    );
+  });
+
+  it('removes attacker-authored task ids and adds only generated link metadata', () => {
+    const document = new FakeDocument();
+    const hostile = element(document, 'span', document.createTextNode('Open #12'));
+    hostile.setAttribute('data-task-id', '999');
+    const root = element(document, 'div', hostile);
+
+    linkify(root);
+
+    expect(serialize(root)).toBe(
+      '<div><span>Open <a href="/ui/tasks#task-12" data-task-id="12" class="task-reference-link">#12</a></span></div>'
+    );
+  });
+
+  it('skips existing links, code, and preformatted content', () => {
+    const document = new FakeDocument();
+    const root = element(
+      document,
+      'div',
+      element(document, 'a', document.createTextNode('#1')),
+      element(document, 'code', document.createTextNode('#2')),
+      element(document, 'pre', document.createTextNode('#3')),
+      document.createTextNode(' #4')
+    );
+
+    linkify(root);
+
+    expect(serialize(root)).toBe(
+      '<div><a>#1</a><code>#2</code><pre>#3</pre> <a href="/ui/tasks#task-4" data-task-id="4" class="task-reference-link">#4</a></div>'
+    );
+  });
+});

--- a/packages/standalone/tests/ui/task-mutation-state.test.ts
+++ b/packages/standalone/tests/ui/task-mutation-state.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import {
+  finishTaskMutation,
+  startTaskMutation,
+  type TaskMutationState,
+} from '../../ui/src/lib/task-mutation-state';
+
+describe('task mutation state', () => {
+  it('tracks concurrent pending mutations by task id', () => {
+    let state: TaskMutationState = new Map();
+
+    state = startTaskMutation(state, 1);
+    state = startTaskMutation(state, 2);
+    state = finishTaskMutation(state, 1);
+
+    expect(state.get(1)).toBeUndefined();
+    expect(state.get(2)).toEqual({ pending: true });
+  });
+
+  it('keeps an error associated with only the failed task', () => {
+    let state: TaskMutationState = new Map();
+
+    state = startTaskMutation(state, 1);
+    state = startTaskMutation(state, 2);
+    state = finishTaskMutation(state, 1, 'Task update failed');
+
+    expect(state.get(1)).toEqual({ pending: false, error: 'Task update failed' });
+    expect(state.get(2)).toEqual({ pending: true });
+  });
+});

--- a/packages/standalone/tests/ui/task-scroll.test.ts
+++ b/packages/standalone/tests/ui/task-scroll.test.ts
@@ -1,0 +1,22 @@
+import { scrollTaskHashIntoView } from '../../ui/src/lib/task-scroll';
+
+describe('scrollTaskHashIntoView', () => {
+  it('scrolls a task hash only once after the target becomes available', () => {
+    const scrollIntoView = vi.fn();
+    const findTarget = vi
+      .fn<(id: string) => { scrollIntoView: (options: ScrollIntoViewOptions) => void } | null>()
+      .mockReturnValueOnce(null)
+      .mockReturnValue({ scrollIntoView });
+
+    let scrolledHash: string | null = null;
+    scrolledHash = scrollTaskHashIntoView('#task-7', scrolledHash, findTarget);
+    scrolledHash = scrollTaskHashIntoView('#task-7', scrolledHash, findTarget);
+    scrolledHash = scrollTaskHashIntoView('#task-7', scrolledHash, findTarget);
+
+    expect(scrolledHash).toBe('#task-7');
+    expect(findTarget).toHaveBeenCalledTimes(2);
+    expect(findTarget).toHaveBeenCalledWith('task-7');
+    expect(scrollIntoView).toHaveBeenCalledOnce();
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'center' });
+  });
+});

--- a/packages/standalone/tests/ui/time.test.ts
+++ b/packages/standalone/tests/ui/time.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatRelativeTime, getFreshnessClass } from '../../ui/src/lib/time';
+import { formatDday, formatRelativeTime, getFreshnessClass } from '../../ui/src/lib/time';
 
 describe('formatRelativeTime', () => {
   const now = 10_000_000;
@@ -52,5 +52,28 @@ describe('getFreshnessClass', () => {
     expect(getFreshnessClass(now, Number.NEGATIVE_INFINITY)).toBe(
       'bg-surface-secondary text-text-tertiary'
     );
+  });
+});
+
+describe('formatDday', () => {
+  const localNoon = new Date(2026, 6, 12, 12).getTime();
+
+  it('returns a dash without a due date and for invalid dates', () => {
+    expect(formatDday(localNoon, null)).toBe('-');
+    expect(formatDday(localNoon, '2026-02-30')).toBe('-');
+    expect(formatDday(localNoon, 'not-a-date')).toBe('-');
+  });
+
+  it('formats today, future, and overdue dates', () => {
+    expect(formatDday(localNoon, '2026-07-12')).toBe('D-day');
+    expect(formatDday(localNoon, '2026-07-15')).toBe('D-3');
+    expect(formatDday(localNoon, '2026-07-10')).toBe('D+2');
+  });
+
+  it('handles month and year boundaries with UTC calendar arithmetic', () => {
+    const yearEnd = new Date(2026, 11, 31, 23, 30).getTime();
+    expect(formatDday(yearEnd, '2027-01-01')).toBe('D-1');
+    const monthStart = new Date(2026, 7, 1, 0, 30).getTime();
+    expect(formatDday(monthStart, '2026-07-31')).toBe('D+1');
   });
 });

--- a/packages/standalone/ui/src/App.tsx
+++ b/packages/standalone/ui/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route } from 'react-router-dom';
 import Layout from './components/Layout';
 import Board from './pages/Board';
 import Triggers from './pages/Triggers';
+import Tasks from './pages/Tasks';
 
 export default function App() {
   return (
@@ -9,6 +10,7 @@ export default function App() {
       <Route element={<Layout />}>
         <Route index element={<Board />} />
         <Route path="triggers" element={<Triggers />} />
+        <Route path="tasks" element={<Tasks />} />
       </Route>
     </Routes>
   );

--- a/packages/standalone/ui/src/api/client.ts
+++ b/packages/standalone/ui/src/api/client.ts
@@ -23,6 +23,33 @@ export interface TriggerRow {
   disabledReason: string | null;
 }
 
+export type TaskStatus = 'pending' | 'in_progress' | 'review' | 'blocked' | 'done' | 'cancelled';
+
+export type TaskPriority = 'high' | 'normal' | 'low';
+
+export interface OperatorTask {
+  id: number;
+  title: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  assignee: string | null;
+  due_date: string | null;
+  source_channel: string | null;
+  latest_event: string | null;
+  auto_created: boolean;
+  confirmed: boolean;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface TaskPatch {
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  assignee?: string | null;
+  due_date?: string | null;
+  confirmed?: boolean;
+}
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
   const res = await fetch(path, {
     headers: { 'content-type': 'application/json' },
@@ -38,6 +65,18 @@ export const api = {
   getReport: () => request<{ slots: ReportSlot[] }>('/api/report'),
   getOperatorSummary: () => request<OperatorSummary>('/api/operator/summary'),
   listTriggers: () => request<{ triggers: TriggerRow[] }>('/api/operator/triggers'),
+  listTasks: (filters: { status?: TaskStatus; source_channel?: string; limit?: number } = {}) => {
+    const params = new URLSearchParams();
+    if (filters.status) params.set('status', filters.status);
+    if (filters.source_channel) params.set('source_channel', filters.source_channel);
+    params.set('limit', String(filters.limit ?? 50));
+    return request<{ tasks: OperatorTask[] }>(`/api/operator/tasks?${params.toString()}`);
+  },
+  updateTask: (id: number, patch: TaskPatch) =>
+    request<{ ok: true; task: OperatorTask }>(`/api/operator/tasks/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(patch),
+    }),
   disableTrigger: async (id: string, reason: string): Promise<void> => {
     await request<{ ok: boolean }>(`/api/operator/triggers/${encodeURIComponent(id)}/disable`, {
       method: 'POST',

--- a/packages/standalone/ui/src/components/Sidebar.tsx
+++ b/packages/standalone/ui/src/components/Sidebar.tsx
@@ -27,6 +27,11 @@ const navItems: NavItem[] = [
     label: 'Triggers',
     d: 'M13 10V3L4 14h7v7l9-11h-7z',
   },
+  {
+    to: '/tasks',
+    label: 'Tasks',
+    d: 'M9 11l3 3L22 4M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11',
+  },
 ];
 
 const legacyLinks = [{ href: '/viewer', label: 'Legacy viewer' }];
@@ -146,9 +151,7 @@ export default function Sidebar() {
             </svg>
             <span>{theme === 'dark' ? 'Light theme' : 'Dark theme'}</span>
           </button>
-          <div className="px-2 pt-2 text-[10px] text-text-tertiary">
-            MAMA Operator (beta)
-          </div>
+          <div className="px-2 pt-2 text-[10px] text-text-tertiary">MAMA Operator (beta)</div>
         </div>
       </aside>
 

--- a/packages/standalone/ui/src/components/TaskRow.tsx
+++ b/packages/standalone/ui/src/components/TaskRow.tsx
@@ -1,0 +1,118 @@
+import type { OperatorTask, TaskPatch, TaskStatus } from '../api/client';
+import { formatDday, formatRelativeTime } from '../lib/time';
+
+const TASK_STATUSES: TaskStatus[] = [
+  'pending',
+  'in_progress',
+  'review',
+  'blocked',
+  'done',
+  'cancelled',
+];
+
+const STATUS_CLASSES: Record<TaskStatus, string> = {
+  pending: 'bg-surface-secondary text-text-secondary',
+  in_progress: 'bg-agent-light text-agent-hover dark:text-agent',
+  review: 'bg-warning-soft text-warning-text',
+  blocked: 'bg-warning-soft text-warning-text',
+  done: 'bg-success-soft text-success-text',
+  cancelled: 'bg-surface-secondary text-text-secondary dark:text-text-tertiary',
+};
+
+const PRIORITY_CLASSES = {
+  high: 'bg-warning-soft text-warning-text',
+  normal: 'bg-surface-secondary text-text-secondary',
+  low: 'bg-surface-secondary text-text-secondary dark:text-text-tertiary',
+};
+
+interface TaskRowProps {
+  task: OperatorTask;
+  now: number;
+  pending: boolean;
+  error?: string;
+  onPatch: (task: OperatorTask, patch: TaskPatch) => void;
+}
+
+function statusLabel(status: TaskStatus): string {
+  return status.replace('_', ' ');
+}
+
+export default function TaskRow({ task, now, pending, error, onPatch }: TaskRowProps) {
+  const unconfirmed = task.auto_created && !task.confirmed;
+
+  return (
+    <tr id={`task-${task.id}`} className="scroll-mt-4 border-b border-border last:border-0">
+      <td className="px-3 py-3 text-xs font-medium text-text-secondary dark:text-text-tertiary whitespace-nowrap">
+        #{task.id}
+      </td>
+      <td className="px-3 py-3 min-w-56">
+        <div className="text-sm font-medium text-text">{task.title}</div>
+        {unconfirmed && (
+          <div className="mt-0.5 text-[11px] font-medium text-warning-text">(unconfirmed)</div>
+        )}
+        {task.latest_event && (
+          <div className="mt-1 max-w-80 truncate text-[11px] text-text-secondary dark:text-text-tertiary">
+            {task.latest_event}
+          </div>
+        )}
+      </td>
+      <td className="px-3 py-3 whitespace-nowrap">
+        <select
+          aria-label={`Status for task ${task.id}`}
+          value={task.status}
+          disabled={pending}
+          onChange={(event) => onPatch(task, { status: event.target.value as TaskStatus })}
+          className={`rounded-full border-0 px-2 py-1 text-xs font-medium disabled:opacity-50 ${STATUS_CLASSES[task.status]}`}
+        >
+          {TASK_STATUSES.map((status) => (
+            <option key={status} value={status}>
+              {statusLabel(status)}
+            </option>
+          ))}
+        </select>
+      </td>
+      <td className="px-3 py-3 whitespace-nowrap">
+        <span
+          className={`rounded-full px-2 py-1 text-xs font-medium ${PRIORITY_CLASSES[task.priority]}`}
+        >
+          {task.priority}
+        </span>
+      </td>
+      <td className="px-3 py-3 text-xs text-text-secondary whitespace-nowrap">
+        {task.assignee || 'unassigned'}
+      </td>
+      <td className="px-3 py-3 text-xs text-text-secondary whitespace-nowrap">
+        <div>{task.due_date || '-'}</div>
+        <div className="text-[11px] text-text-secondary dark:text-text-tertiary">
+          {formatDday(now, task.due_date)}
+        </div>
+      </td>
+      <td className="px-3 py-3 max-w-48 truncate text-xs text-text-secondary">
+        {task.source_channel || '-'}
+      </td>
+      <td className="px-3 py-3 text-xs text-text-secondary dark:text-text-tertiary whitespace-nowrap">
+        {formatRelativeTime(now, task.updated_at)}
+      </td>
+      <td className="px-3 py-3 whitespace-nowrap">
+        {unconfirmed && (
+          <button
+            type="button"
+            disabled={pending}
+            onClick={() => onPatch(task, { confirmed: true })}
+            className="rounded-lg bg-agent-hover px-2.5 py-1.5 text-xs font-medium text-on-agent hover:bg-agent-hover dark:bg-agent disabled:opacity-50"
+          >
+            {pending ? 'Saving...' : 'Approve'}
+          </button>
+        )}
+        {error && (
+          <div
+            role="alert"
+            className="mt-1 max-w-48 whitespace-normal text-[11px] text-warning-text"
+          >
+            {error}
+          </div>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/packages/standalone/ui/src/lib/task-cache.ts
+++ b/packages/standalone/ui/src/lib/task-cache.ts
@@ -1,0 +1,25 @@
+import type { OperatorTask, TaskStatus } from '../api/client';
+
+export interface OperatorTasksCache {
+  tasks: OperatorTask[];
+}
+
+export function updateTaskCache(
+  cached: OperatorTasksCache,
+  status: TaskStatus | null,
+  updated: OperatorTask
+): OperatorTasksCache {
+  const existingIndex = cached.tasks.findIndex((task) => task.id === updated.id);
+  const matchesFilter = status === null || status === updated.status;
+
+  if (!matchesFilter) {
+    return existingIndex === -1
+      ? cached
+      : { tasks: cached.tasks.filter((task) => task.id !== updated.id) };
+  }
+
+  if (existingIndex === -1) return { tasks: [updated, ...cached.tasks] };
+  return {
+    tasks: cached.tasks.map((task) => (task.id === updated.id ? updated : task)),
+  };
+}

--- a/packages/standalone/ui/src/lib/task-links.ts
+++ b/packages/standalone/ui/src/lib/task-links.ts
@@ -1,0 +1,61 @@
+export type TaskReferenceSegment =
+  | { type: 'text'; value: string }
+  | { type: 'task'; value: string; taskId: string };
+
+const TASK_REFERENCE_PATTERN = /#(\d+)(?![A-Za-z0-9_])/g;
+
+export function segmentTaskReferences(text: string): TaskReferenceSegment[] {
+  const segments: TaskReferenceSegment[] = [];
+  let cursor = 0;
+  for (const match of text.matchAll(TASK_REFERENCE_PATTERN)) {
+    const index = match.index;
+    if (index > cursor) {
+      segments.push({ type: 'text', value: text.slice(cursor, index) });
+    }
+    segments.push({ type: 'task', value: match[0], taskId: match[1] });
+    cursor = index + match[0].length;
+  }
+  if (cursor < text.length || segments.length === 0) {
+    segments.push({ type: 'text', value: text.slice(cursor) });
+  }
+  return segments;
+}
+
+export function linkifyTaskReferences(root: HTMLElement): void {
+  const document = root.ownerDocument;
+  const textNodes: Text[] = [];
+
+  const collectTextNodes = (node: Node): void => {
+    if (node.nodeType === 1) {
+      const element = node as Element;
+      element.removeAttribute('data-task-id');
+      if (['A', 'CODE', 'PRE'].includes(element.tagName.toUpperCase())) return;
+    }
+    if (node.nodeType === 3) {
+      textNodes.push(node as Text);
+      return;
+    }
+    for (const child of Array.from(node.childNodes)) collectTextNodes(child);
+  };
+
+  collectTextNodes(root);
+
+  for (const textNode of textNodes) {
+    const segments = segmentTaskReferences(textNode.data);
+    if (!segments.some((segment) => segment.type === 'task')) continue;
+    const fragment = document.createDocumentFragment();
+    for (const segment of segments) {
+      if (segment.type === 'text') {
+        fragment.append(document.createTextNode(segment.value));
+        continue;
+      }
+      const anchor = document.createElement('a');
+      anchor.href = `/ui/tasks#task-${segment.taskId}`;
+      anchor.setAttribute('data-task-id', segment.taskId);
+      anchor.className = 'task-reference-link';
+      anchor.textContent = segment.value;
+      fragment.append(anchor);
+    }
+    textNode.replaceWith(fragment);
+  }
+}

--- a/packages/standalone/ui/src/lib/task-mutation-state.ts
+++ b/packages/standalone/ui/src/lib/task-mutation-state.ts
@@ -1,0 +1,26 @@
+export interface TaskMutationStatus {
+  pending: boolean;
+  error?: string;
+}
+
+export type TaskMutationState = Map<number, TaskMutationStatus>;
+
+export function startTaskMutation(state: TaskMutationState, taskId: number): TaskMutationState {
+  const next = new Map(state);
+  next.set(taskId, { pending: true });
+  return next;
+}
+
+export function finishTaskMutation(
+  state: TaskMutationState,
+  taskId: number,
+  error?: string
+): TaskMutationState {
+  const next = new Map(state);
+  if (error) {
+    next.set(taskId, { pending: false, error });
+  } else {
+    next.delete(taskId);
+  }
+  return next;
+}

--- a/packages/standalone/ui/src/lib/task-scroll.ts
+++ b/packages/standalone/ui/src/lib/task-scroll.ts
@@ -1,0 +1,21 @@
+interface ScrollTarget {
+  scrollIntoView: (options: ScrollIntoViewOptions) => void;
+}
+
+export function scrollTaskHashIntoView(
+  hash: string,
+  scrolledHash: string | null,
+  findTarget: (id: string) => ScrollTarget | null
+): string | null {
+  if (!hash.startsWith('#task-') || scrolledHash === hash) {
+    return scrolledHash;
+  }
+
+  const target = findTarget(hash.slice(1));
+  if (!target) {
+    return scrolledHash;
+  }
+
+  target.scrollIntoView({ block: 'center' });
+  return hash;
+}

--- a/packages/standalone/ui/src/lib/time.ts
+++ b/packages/standalone/ui/src/lib/time.ts
@@ -32,3 +32,24 @@ export function formatRelativeTime(now: number, then: number): string {
   }
   return `${Math.floor(elapsed / DAY_MS)}d ago`;
 }
+
+export function formatDday(now: number, dueDate: string | null): string {
+  if (!dueDate || !/^\d{4}-\d{2}-\d{2}$/.test(dueDate) || !Number.isFinite(now)) {
+    return '-';
+  }
+  const [year, month, day] = dueDate.split('-').map(Number);
+  const dueUtc = Date.UTC(year, month - 1, day);
+  const due = new Date(dueUtc);
+  if (
+    due.getUTCFullYear() !== year ||
+    due.getUTCMonth() !== month - 1 ||
+    due.getUTCDate() !== day
+  ) {
+    return '-';
+  }
+  const current = new Date(now);
+  const todayUtc = Date.UTC(current.getFullYear(), current.getMonth(), current.getDate());
+  const days = Math.round((dueUtc - todayUtc) / DAY_MS);
+  if (days === 0) return 'D-day';
+  return days > 0 ? `D-${days}` : `D+${Math.abs(days)}`;
+}

--- a/packages/standalone/ui/src/pages/Board.tsx
+++ b/packages/standalone/ui/src/pages/Board.tsx
@@ -16,10 +16,11 @@ function SlotRenderer({ slot, now }: { slot: ReportSlot; now: number }) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!ref.current) return;
-    ref.current.innerHTML = sanitizeReportHtml(slot.html);
+    const element = ref.current;
+    if (!element) return;
+    element.innerHTML = sanitizeReportHtml(slot.html);
     if (slot.slotId !== 'pipeline') return;
-    linkifyTaskReferences(ref.current);
+    linkifyTaskReferences(element);
     const handleClick = (event: MouseEvent) => {
       if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
         return;
@@ -31,8 +32,8 @@ function SlotRenderer({ slot, now }: { slot: ReportSlot; now: number }) {
       event.preventDefault();
       navigate(`/tasks#task-${taskId}`);
     };
-    ref.current.addEventListener('click', handleClick);
-    return () => ref.current?.removeEventListener('click', handleClick);
+    element.addEventListener('click', handleClick);
+    return () => element.removeEventListener('click', handleClick);
   }, [navigate, slot.html, slot.slotId]);
 
   return (

--- a/packages/standalone/ui/src/pages/Board.tsx
+++ b/packages/standalone/ui/src/pages/Board.tsx
@@ -1,26 +1,39 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 import { api } from '../api/client';
-import {
-  mergeReportEvent,
-  orderSlots,
-  type ReportSlot,
-  type SlotRecord,
-} from '../api/report';
+import { mergeReportEvent, orderSlots, type ReportSlot, type SlotRecord } from '../api/report';
 import { sanitizeReportHtml } from '../api/sanitize';
 import { connectReportSse } from '../api/client';
 import StatCard from '../components/StatCard';
 import { formatRelativeTime, getFreshnessClass } from '../lib/time';
+import { linkifyTaskReferences } from '../lib/task-links';
 
 type SseStatus = 'live' | 'reconnecting';
 
 function SlotRenderer({ slot, now }: { slot: ReportSlot; now: number }) {
   const ref = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (!ref.current) return;
     ref.current.innerHTML = sanitizeReportHtml(slot.html);
-  }, [slot.html]);
+    if (slot.slotId !== 'pipeline') return;
+    linkifyTaskReferences(ref.current);
+    const handleClick = (event: MouseEvent) => {
+      if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+        return;
+      }
+      const target =
+        event.target instanceof Element ? event.target.closest('[data-task-id]') : null;
+      const taskId = target instanceof HTMLElement ? target.dataset.taskId : undefined;
+      if (!taskId || !/^\d+$/.test(taskId)) return;
+      event.preventDefault();
+      navigate(`/tasks#task-${taskId}`);
+    };
+    ref.current.addEventListener('click', handleClick);
+    return () => ref.current?.removeEventListener('click', handleClick);
+  }, [navigate, slot.html, slot.slotId]);
 
   return (
     <section
@@ -44,8 +57,8 @@ function EmptyState() {
     <div className="flex flex-col items-center justify-center h-full text-center px-6 py-16">
       <h2 className="text-lg font-semibold text-text mb-2">No reports published yet</h2>
       <p className="text-sm text-text-secondary max-w-md">
-        Slots appear here once an agent publishes them via report_publish. The heartbeat
-        briefing or the dashboard agent fills the first slot.
+        Slots appear here once an agent publishes them via report_publish. The heartbeat briefing or
+        the dashboard agent fills the first slot.
       </p>
     </div>
   );
@@ -143,11 +156,7 @@ export default function Board() {
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
             <StatCard label="Active triggers" value={summary?.triggers.active ?? '-'} />
             <StatCard label="Total fires" value={summary?.triggers.fired ?? '-'} />
-            <StatCard
-              label="Succeeded"
-              value={summary?.triggers.succeeded ?? '-'}
-              tone="success"
-            />
+            <StatCard label="Succeeded" value={summary?.triggers.succeeded ?? '-'} tone="success" />
             <StatCard
               label="Failed"
               value={summary?.triggers.failed ?? '-'}

--- a/packages/standalone/ui/src/pages/Tasks.tsx
+++ b/packages/standalone/ui/src/pages/Tasks.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api, type OperatorTask, type TaskPatch, type TaskStatus } from '../api/client';
 import TaskRow from '../components/TaskRow';
 import { updateTaskCache, type OperatorTasksCache } from '../lib/task-cache';
+import { scrollTaskHashIntoView } from '../lib/task-scroll';
 import {
   finishTaskMutation,
   startTaskMutation,
@@ -29,6 +30,7 @@ export default function Tasks() {
   const [now, setNow] = useState(() => Date.now());
   const [mutationStates, setMutationStates] = useState<TaskMutationState>(() => new Map());
   const queryClient = useQueryClient();
+  const scrolledHashRef = useRef<string | null>(null);
   const query = useQuery({
     queryKey: ['operatorTasks', selectedStatus],
     queryFn: () => api.listTasks({ status: selectedStatus ?? undefined, limit: 50 }),
@@ -44,7 +46,9 @@ export default function Tasks() {
         queryKey: ['operatorTasks'],
       });
       for (const [queryKey, cached] of cachedQueries) {
-        if (!cached) continue;
+        if (!cached) {
+          continue;
+        }
         const status = queryKey[1] as TaskStatus | null;
         queryClient.setQueryData(queryKey, updateTaskCache(cached, status, updated));
       }
@@ -63,9 +67,14 @@ export default function Tasks() {
   }, []);
 
   useEffect(() => {
-    if (!query.data?.tasks.length || !window.location.hash.startsWith('#task-')) return;
-    const target = document.getElementById(window.location.hash.slice(1));
-    target?.scrollIntoView({ block: 'center' });
+    if (!query.data?.tasks.length) {
+      return;
+    }
+    scrolledHashRef.current = scrollTaskHashIntoView(
+      window.location.hash,
+      scrolledHashRef.current,
+      (id) => document.getElementById(id)
+    );
   }, [query.data]);
 
   const patchTask = (task: OperatorTask, patch: TaskPatch) => {

--- a/packages/standalone/ui/src/pages/Tasks.tsx
+++ b/packages/standalone/ui/src/pages/Tasks.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api, type OperatorTask, type TaskPatch, type TaskStatus } from '../api/client';
+import TaskRow from '../components/TaskRow';
+import { updateTaskCache, type OperatorTasksCache } from '../lib/task-cache';
+import {
+  finishTaskMutation,
+  startTaskMutation,
+  type TaskMutationState,
+} from '../lib/task-mutation-state';
+
+const STATUS_FILTERS: Array<{ value: TaskStatus | null; label: string }> = [
+  { value: null, label: 'All' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'in_progress', label: 'In progress' },
+  { value: 'review', label: 'Review' },
+  { value: 'blocked', label: 'Blocked' },
+  { value: 'done', label: 'Done' },
+  { value: 'cancelled', label: 'Cancelled' },
+];
+
+interface MutationInput {
+  task: OperatorTask;
+  patch: TaskPatch;
+}
+
+export default function Tasks() {
+  const [selectedStatus, setSelectedStatus] = useState<TaskStatus | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+  const [mutationStates, setMutationStates] = useState<TaskMutationState>(() => new Map());
+  const queryClient = useQueryClient();
+  const query = useQuery({
+    queryKey: ['operatorTasks', selectedStatus],
+    queryFn: () => api.listTasks({ status: selectedStatus ?? undefined, limit: 50 }),
+    refetchInterval: 30_000,
+  });
+  const mutation = useMutation({
+    mutationFn: ({ task, patch }: MutationInput) => api.updateTask(task.id, patch),
+    onMutate: ({ task }) => {
+      setMutationStates((current) => startTaskMutation(current, task.id));
+    },
+    onSuccess: ({ task: updated }, { task }) => {
+      const cachedQueries = queryClient.getQueriesData<OperatorTasksCache>({
+        queryKey: ['operatorTasks'],
+      });
+      for (const [queryKey, cached] of cachedQueries) {
+        if (!cached) continue;
+        const status = queryKey[1] as TaskStatus | null;
+        queryClient.setQueryData(queryKey, updateTaskCache(cached, status, updated));
+      }
+      setMutationStates((current) => finishTaskMutation(current, task.id));
+      void queryClient.invalidateQueries({ queryKey: ['operatorTasks'] });
+    },
+    onError: (error, { task }) => {
+      const message = error instanceof Error ? error.message : 'Task update failed';
+      setMutationStates((current) => finishTaskMutation(current, task.id, message));
+    },
+  });
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), 30_000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  useEffect(() => {
+    if (!query.data?.tasks.length || !window.location.hash.startsWith('#task-')) return;
+    const target = document.getElementById(window.location.hash.slice(1));
+    target?.scrollIntoView({ block: 'center' });
+  }, [query.data]);
+
+  const patchTask = (task: OperatorTask, patch: TaskPatch) => {
+    mutation.mutate({ task, patch });
+  };
+
+  return (
+    <div className="flex min-h-full min-w-0 flex-col">
+      <header className="border-b border-border bg-surface px-4 py-4">
+        <h1 className="text-base font-semibold text-text">Tasks</h1>
+        <p className="mt-1 text-xs text-text-secondary">
+          Native operator ledger ordered by due date and priority.
+        </p>
+      </header>
+
+      <div className="flex-1 p-4">
+        <div className="mx-auto max-w-6xl">
+          <div className="mb-4 flex flex-wrap gap-2" aria-label="Filter tasks by status">
+            {STATUS_FILTERS.map((filter) => {
+              const active = selectedStatus === filter.value;
+              return (
+                <button
+                  key={filter.label}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => setSelectedStatus(filter.value)}
+                  className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                    active
+                      ? 'bg-agent-hover text-on-agent dark:bg-agent'
+                      : 'bg-surface text-text-secondary hover:bg-surface-hover'
+                  }`}
+                >
+                  {filter.label}
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="overflow-hidden rounded-xl border border-border bg-surface shadow-[var(--shadow-xs)]">
+            {query.isPending ? (
+              <div className="px-4 py-16 text-center text-sm text-text-tertiary">
+                Loading tasks...
+              </div>
+            ) : query.isError ? (
+              <div className="px-4 py-16 text-center text-sm text-warning-text">
+                {query.error instanceof Error ? query.error.message : 'Unable to load tasks'}
+              </div>
+            ) : query.data.tasks.length === 0 ? (
+              <div className="px-4 py-16 text-center">
+                <div className="text-sm font-medium text-text">No tasks found</div>
+                <div className="mt-1 text-xs text-text-tertiary">
+                  Try another status filter or wait for the ledger to update.
+                </div>
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="task-table">
+                  <thead>
+                    <tr>
+                      <th>ID</th>
+                      <th>Task</th>
+                      <th>Status</th>
+                      <th>Priority</th>
+                      <th>Assignee</th>
+                      <th>Due</th>
+                      <th>Source</th>
+                      <th>Updated</th>
+                      <th>Action</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {query.data.tasks.map((task) => {
+                      const mutationState = mutationStates.get(task.id);
+                      return (
+                        <TaskRow
+                          key={task.id}
+                          task={task}
+                          now={now}
+                          pending={mutationState?.pending === true}
+                          error={mutationState?.error}
+                          onPatch={patchTask}
+                        />
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/standalone/ui/src/styles/global.css
+++ b/packages/standalone/ui/src/styles/global.css
@@ -1,5 +1,7 @@
 @import 'tailwindcss';
 
+@custom-variant dark (&:where([data-theme='dark'], [data-theme='dark'] *));
+
 /* MAMA Operator theme tokens -- components must consume ONLY these tokens,
  * never hardcoded hex in TSX (learning: mama-dual-color-system).
  * Brand alignment with the legacy palette is a one-token swap on --color-agent. */
@@ -216,4 +218,40 @@ body {
 }
 .report-table tr:last-child td {
   border-bottom: none;
+}
+
+.task-table {
+  width: 100%;
+  min-width: 1040px;
+  border-collapse: collapse;
+}
+
+.task-table th {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface-secondary);
+  color: var(--color-text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  text-align: left;
+  white-space: nowrap;
+}
+
+:root[data-theme='dark'] .task-table th {
+  color: var(--color-text-tertiary);
+}
+
+.task-reference-link {
+  color: var(--color-agent-hover);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+:root[data-theme='dark'] .task-reference-link {
+  color: var(--color-agent);
+}
+
+.task-reference-link:hover {
+  color: var(--color-agent-hover);
 }


### PR DESCRIPTION
Second phase of the M9 UI round. Codex gpt-5.6 (high) worker under supervisor loop: Codex plan (7 spec corrections, all adopted) -> gate -> implement -> adversarial Codex review (4 P2s, all fixed) -> independent verification.

## Backend
- `GET /api/operator/tasks`: status / source_channel / limit (1..200, default 50) filters, deadline_priority ordering, snake_case wire contract mapping ledger `deadline` to `due_date`
- `PATCH /api/operator/tasks/:id`: allows `status|priority|assignee|due_date|confirmed`, rejects unknown fields, round-trip calendar date validation, positive safe-int id guard, 404/400/503 paths
- Shared `TaskLedger` via `toolExecutor.getTaskLedger()` lazy accessor (single connection, routes never close it); `requireAuth` on both; CORS gains PATCH
- Reviewer-verified: bound SQLite params, no field smuggling, wiring order safe

## UI
- New `/tasks` page + sidebar entry: table (#id, title, status badge, priority, assignee, D-day, source, updated), status filter chips, inline status dropdown with per-task pending/error state (concurrent-safe), status-keyed react-query cache reconciliation
- Approve button on `auto_created && !confirmed` tasks -- PATCHes `confirmed: true` only (matches board "(unconfirmed)" marker semantics)
- Board pipeline slot `#id` references linkified into `/tasks` deep links, post-sanitize, text nodes only, skips `a`/`code`/`pre` (reviewer-verified no XSS vector)
- WCAG AA contrast fixes for small light-theme text; dark theme preserved

## Verification
- UI bundle + standalone typecheck clean
- 80 tests green (route handler on temp sqlite via in-process express stack, ledger validation, hostile-markup linkify DOM tests, D-day/DST boundaries)
- ASCII + no-hex-in-TSX audits clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)