### PR TITLE
fix(agent): boundary repair round — shared executor, tool lockdown, per-call state, stateless reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- Persona-lane agents (operator reports, chat) no longer fail with "Task ledger/Report publisher/... not configured" — the daemon persona now shares the boot-wired gateway executor (root fix for the dual-executor wiring class).
+- Main-persona CLI sessions no longer expose Claude Code native built-in tools; gateway tools are the only surface (`MAMA_PERSONA_NATIVE_TOOLS=1` re-enables).
+- System prompt for spawned/continued runs is now deterministic per call on BOTH backends (claude spawn, codex thread-start developer-instructions) — previously any lane's new process could inherit the last caller's prompt.
+- Operator report envelopes now budget the full multi-turn run (`MAMA_REPORT_WALL_SECONDS`, default 900s, min 60, max 1800); runs whose envelope expires mid-run abort loudly (operator lane) or log loudly (chat) instead of silently losing every end-of-run write.
+- Operator reports run STATELESS (fresh session per run) — the previous continuous session accumulated gather context until runs outlived their envelope (measured 146s→521s growth). The heavy message gather is delta-anchored at the last successful report (`report-schedule-state.json`).
+- Concurrent lanes can no longer cross-route prompts or wipe each other's pending tool results (per-call session routing replaces shared setSessionId mutation).
+- The memory agent shares the boot executor and the boot MAMA API instance (no second API/adapter stack against the same DB).
+
 ## [0.21.0] / mama-core [1.8.1] / mama-os [0.21.0] - 2026-07-12
 
 ### Added

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,5 +1,26 @@
 # TODOS
 
+## Deferred from agent-boundary-repair round (2026-07-16)
+
+### Persona migration to the code-act MCP route
+
+- **What:** Move the main persona off text-parsed gateway tools onto the existing code-act MCP route (code-act-server → HostBridge → shared executor).
+- **Why:** Tool contract enforced at the protocol layer kills the tool-hallucination class structurally (Task 2's `--tools ""` mitigates it at the surface level).
+- **Context:** Exposure already exists — multi-agent pm processes use it today. Adoption for the conductor is its own round (prompt/persona rework).
+- **Depends on:** agent-boundary-repair branch merged.
+
+### Codex per-call model/resumeSession + codex report-thread reset
+
+- **What:** Decide deliberately whether codex should honor per-call `model`/`resumeSession` (Task 3 forwards ONLY systemPrompt on purpose — activating the others changes thread lifecycle, codex-mcp-process.ts thread wipe on `resumeSession === false`). Also implement a codex report-thread reset so Task 6's stateless guarantee holds there (freshSession is pool-level only on codex; the internal threadId persists — a loud log marks this today).
+- **Why:** Without it, a codex-backend deployment keeps the immortal report thread Task 6 killed on claude.
+- **Context:** Default deployments run claude; gap is latent, logged loudly.
+
+### Multi-agent pool getSharedProcess lane accumulation audit
+
+- **What:** Measure dashboard-cron/reconcile shared-process session growth over a week; apply the Task-6 stateless pattern if durations grow.
+- **Why:** Same unbounded-session disease the report lane had (146s→521s) may exist in the multi-agent pool lanes.
+- **Context:** `[Lane]`/duration logs in daemon.log are sufficient instrumentation; owner principle "session = cache, not persistence".
+
 ## Deferred from v0.19 Validation Session v1
 
 ### Fixed benchmark test sets for agent_test

--- a/packages/standalone/src/agent/agent-loop.ts
+++ b/packages/standalone/src/agent/agent-loop.ts
@@ -996,6 +996,26 @@ export class AgentLoop {
       console.log(
         `[AgentLoop] [${isCodex ? 'codex' : 'claude'}] ${channelKey} (${sessionLabel(sessionIsNew)})`
       );
+    } else if (options?.freshSession) {
+      // Stateless lanes (operator reports): session context is a cache, not
+      // persistence - every run self-gathers and recalls; carrying prior runs'
+      // gather dumps only grows the context until runs outlive their envelope
+      // (measured 146s -> 521s over 3 days; owner decision 2026-07-16).
+      const cliSessionId = this.sessionPool.resetSession(channelKey);
+      sessionIsNew = true;
+      ownedSession = true;
+      resolvedCliSessionId = cliSessionId;
+      if (isCodex) {
+        // Codex MCP manages threadId internally and ignores external session ids
+        // (codex-mcp-process.ts:366-369) - the pool reset does NOT reset the codex
+        // thread, so the stateless guarantee does not hold there. Loud, not silent.
+        console.log(
+          '[AgentLoop] freshSession is a pool-level reset only on the codex backend - the codex thread persists (see TODO: codex report thread reset)'
+        );
+      }
+      console.log(
+        `[AgentLoop] [${isCodex ? 'codex' : 'claude'}] ${channelKey} (FRESH session - stateless lane)`
+      );
     } else {
       // Fallback: get session from pool (for direct AgentLoop usage)
       // getSession() returns immediately - if busy, we create a new session

--- a/packages/standalone/src/agent/agent-loop.ts
+++ b/packages/standalone/src/agent/agent-loop.ts
@@ -1024,6 +1024,7 @@ export class AgentLoop {
         );
       }
 
+      let perCallSystemPrompt: string;
       if (options?.systemPrompt) {
         // Skip gateway tools if already embedded in systemPrompt (e.g. by MessageRouter)
         const alreadyHasTools =
@@ -1089,12 +1090,14 @@ export class AgentLoop {
           );
         }
 
+        perCallSystemPrompt = effectivePrompt;
         console.log(
-          `[AgentLoop] Setting systemPrompt: ${effectivePrompt.length} chars (base: ${options.systemPrompt.length}, tools: ${gatewayToolsPrompt.length})`
+          `[AgentLoop] Prepared systemPrompt for this call: ${effectivePrompt.length} chars ` +
+            `(base: ${options.systemPrompt.length}, tools: ${gatewayToolsPrompt.length})`
         );
-        this.agent.setSystemPrompt(effectivePrompt);
       } else {
-        console.log(`[AgentLoop] No systemPrompt in options, using default`);
+        perCallSystemPrompt = this.defaultSystemPrompt;
+        console.log(`[AgentLoop] No systemPrompt in options - using spawn default for this call`);
       }
 
       // Reset StopContinuation state for this channel to prevent leaking
@@ -1154,6 +1157,7 @@ export class AgentLoop {
           piResult = await this.agent.prompt(promptText, callbacks, {
             model: options?.model,
             resumeSession: shouldResume,
+            systemPrompt: perCallSystemPrompt,
           });
           // Emit prompt latency metric
           this.onMetric?.('prompt_latency_ms', Date.now() - promptStart, {
@@ -1195,6 +1199,7 @@ export class AgentLoop {
             piResult = await this.agent.prompt(promptText, callbacks, {
               model: options?.model,
               resumeSession: false, // Force new session
+              systemPrompt: perCallSystemPrompt,
             });
             // Prepend reset notice so user knows context was lost
             if (isPromptTooLong && piResult.response) {

--- a/packages/standalone/src/agent/agent-loop.ts
+++ b/packages/standalone/src/agent/agent-loop.ts
@@ -990,7 +990,9 @@ export class AgentLoop {
     };
 
     if (options?.cliSessionId) {
-      this.agent.setSessionId(options.cliSessionId);
+      // Session routing travels per prompt() call via resolvedCliSessionId - no
+      // shared-adapter mutation (setSessionId re-pointed channelKey/currentProcess
+      // across awaits, cross-wiring concurrent lanes).
       console.log(
         `[AgentLoop] [${isCodex ? 'codex' : 'claude'}] ${channelKey} (${sessionLabel(sessionIsNew)})`
       );
@@ -1004,7 +1006,7 @@ export class AgentLoop {
       sessionIsNew = isNew;
       ownedSession = true;
       resolvedCliSessionId = cliSessionId;
-      this.agent.setSessionId(cliSessionId);
+      // Per-call routing via resolvedCliSessionId - no shared-adapter mutation.
       console.log(
         `[AgentLoop] [${isCodex ? 'codex' : 'claude'}] ${channelKey} (${sessionLabel(isNew)})`
       );
@@ -1183,6 +1185,7 @@ export class AgentLoop {
             model: options?.model,
             resumeSession: shouldResume,
             systemPrompt: perCallSystemPrompt,
+            sessionId: resolvedCliSessionId ?? undefined,
           });
           // Emit prompt latency metric
           this.onMetric?.('prompt_latency_ms', Date.now() - promptStart, {
@@ -1218,13 +1221,16 @@ export class AgentLoop {
 
             // Reset session in pool so it creates a new one
             const newSessionId = this.sessionPool.resetSession(channelKey);
-            this.agent.setSessionId(newSessionId);
+            // Per-call routing: hand the new id to this prompt() and update the
+            // resolved id so later turns follow it - no shared-adapter mutation.
+            resolvedCliSessionId = newSessionId;
 
             // Retry with new session (--session-id instead of --resume)
             piResult = await this.agent.prompt(promptText, callbacks, {
               model: options?.model,
               resumeSession: false, // Force new session
               systemPrompt: perCallSystemPrompt,
+              sessionId: newSessionId,
             });
             // Prepend reset notice so user knows context was lost
             if (isPromptTooLong && piResult.response) {

--- a/packages/standalone/src/agent/agent-loop.ts
+++ b/packages/standalone/src/agent/agent-loop.ts
@@ -619,10 +619,14 @@ export class AgentLoop {
         JSON.stringify(this.toolsConfig.mcp)
     );
 
-    this.mcpExecutor = new GatewayToolExecutor(executorOptions);
-    if (this.disallowedTools?.length) {
-      this.mcpExecutor.setDisallowedGatewayTools(this.disallowedTools);
-    }
+    // Root fix (2026-07-16): the daemon persona shares the boot-wired executor so
+    // every dependency wiring (task ledger, report publisher, event bus, gateways,
+    // wiki, obsidian, ...) reaches persona lanes by construction. Constructing a
+    // second instance here is allowed ONLY for deliberately isolated loops
+    // (memory agent, mama run CLI) that own their dep set.
+    this.mcpExecutor = options.executor ?? new GatewayToolExecutor(executorOptions);
+    // Persona tool blocks are per-call policy, not executor state - a shared
+    // executor must never inherit one caller's blocks (see buildToolExecutionContext).
     this.maxTurns = options.maxTurns ?? DEFAULT_MAX_TURNS;
     this.model = options.model!;
     this.onTurn = options.onTurn;
@@ -705,7 +709,19 @@ export class AgentLoop {
   }
 
   private buildToolExecutionContext(options?: AgentLoopOptions): AgentToolExecutionContext | null {
-    return buildAgentToolExecutionContext(options);
+    const base = buildAgentToolExecutionContext(options);
+    if (!base) return null; // no context fields - out-of-scope loops keep today's semantics
+    return {
+      ...base,
+      // Persona blocks are per-call policy - never executor instance state.
+      disallowedGatewayTools: this.disallowedTools,
+      // Never let persona calls inherit the code-act route's fallback identity.
+      // 'conductor' matches the existing delegation-routing fallback
+      // (gateway-tool-executor.ts:653) so attribution is unchanged.
+      // (Persona lanes always pass source/channelId, so base is non-null for them
+      // and the disallowed list travels on every persona run.)
+      agentId: base.agentId || 'conductor',
+    };
   }
 
   /**

--- a/packages/standalone/src/agent/agent-loop.ts
+++ b/packages/standalone/src/agent/agent-loop.ts
@@ -715,7 +715,9 @@ export class AgentLoop {
 
   private buildToolExecutionContext(options?: AgentLoopOptions): AgentToolExecutionContext | null {
     const base = buildAgentToolExecutionContext(options);
-    if (!base) return null; // no context fields - out-of-scope loops keep today's semantics
+    if (!base) {
+      return null; // no context fields - out-of-scope loops keep today's semantics
+    }
     return {
       ...base,
       // Persona blocks are per-call policy - never executor instance state.

--- a/packages/standalone/src/agent/agent-loop.ts
+++ b/packages/standalone/src/agent/agent-loop.ts
@@ -18,6 +18,7 @@ import { PersistentCLIAdapter } from './persistent-cli-adapter.js';
 import { CodexRuntimeProcess } from '../multi-agent/runtime-process.js';
 import type { IModelRunner } from './model-runner.js';
 import { GatewayToolExecutor } from './gateway-tool-executor.js';
+import { envelopeExpired } from '../envelope/run-guard.js';
 import { ToolRegistry } from './tool-registry.js';
 import {
   CodeActSandbox,
@@ -1114,6 +1115,30 @@ export class AgentLoop {
 
       while (turn < this.maxTurns) {
         turn++;
+
+        // A run whose envelope is (about to be) expired cannot commit ANY write -
+        // every gateway call from here on is denied '[expired]' (enforcer.ts:73).
+        if (options?.envelope && envelopeExpired(options.envelope, Date.now(), 30_000)) {
+          const envId = String(
+            (options.envelope as { instance_id?: string }).instance_id ?? 'unknown'
+          );
+          if (options?.source === 'operator') {
+            // Non-interactive lane: abort loudly now instead of burning doomed turns.
+            // The trigger loop keeps its digest buffer and retries next cadence.
+            throw new AgentError(
+              `Envelope ${envId} expired mid-run at turn ${turn}; aborting doomed run`,
+              'ENVELOPE_EXPIRED',
+              undefined,
+              false
+            );
+          }
+          // Interactive lanes (chat): never abort a live conversation - deliver the
+          // text; individual writes will be denied loudly by the enforcer as today.
+          console.error(
+            `[AgentLoop] envelope ${envId} expired mid-run (turn ${turn}, source ${options?.source ?? 'unknown'}); ` +
+              `subsequent gateway writes will be denied`
+          );
+        }
 
         // Emergency brake: prevent infinite loops
         if (turn >= EMERGENCY_MAX_TURNS) {

--- a/packages/standalone/src/agent/agent-loop.ts
+++ b/packages/standalone/src/agent/agent-loop.ts
@@ -606,6 +606,10 @@ export class AgentLoop {
         useGatewayTools: useGatewayMode,
         // Structurally disallow specific tools (e.g., Bash/Read for restricted agents)
         disallowedTools: options.disallowedTools,
+        // Native built-ins cross with text-parsed gateway calls (hallucinated
+        // ToolSearch/Agent, native gathering that bypasses report verification).
+        // Callers opt in per loop; agent-loop-init locks down the main persona.
+        tools: options.builtinTools,
         // Pass configured timeout (default in PersistentCLI: 120s — too short for complex tasks)
         requestTimeout: options.timeoutMs,
       });

--- a/packages/standalone/src/agent/codex-mcp-process.ts
+++ b/packages/standalone/src/agent/codex-mcp-process.ts
@@ -243,7 +243,7 @@ export class CodexMCPProcess extends EventEmitter {
   async prompt(
     content: string,
     callbacks?: PromptCallbacks,
-    options?: { model?: string; resumeSession?: boolean }
+    options?: { model?: string; resumeSession?: boolean; systemPrompt?: string }
   ): Promise<PromptResult> {
     // Ensure process is running (retry once on failure)
     if (this.state === 'dead') {
@@ -303,8 +303,9 @@ export class CodexMCPProcess extends EventEmitter {
         if (this.options.sandbox) {
           args.sandbox = this.options.sandbox;
         }
-        if (this.options.systemPrompt) {
-          args['developer-instructions'] = this.options.systemPrompt;
+        const effectiveSystemPrompt = options?.systemPrompt ?? this.options.systemPrompt;
+        if (effectiveSystemPrompt) {
+          args['developer-instructions'] = effectiveSystemPrompt;
         }
         if (this.options.compactPrompt) {
           args['compact-prompt'] = this.options.compactPrompt;

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -162,6 +162,8 @@ type ActiveGatewayExecutionContext = {
   gatewayCallId?: string;
   parentToolName?: string;
   backgroundTasks?: GatewayToolExecutionContext['backgroundTasks'];
+  /** Per-call gateway tool blocks (e.g. OS-agent must delegate instead). */
+  disallowedGatewayTools?: string[];
 };
 
 type ScopeAuditFields = {
@@ -594,6 +596,7 @@ export class GatewayToolExecutor {
       modelRunId: executionContext?.modelRunId ?? null,
       gatewayCallId: executionContext?.gatewayCallId,
       backgroundTasks: executionContext?.backgroundTasks,
+      disallowedGatewayTools: executionContext?.disallowedGatewayTools,
     };
   }
 
@@ -631,6 +634,8 @@ export class GatewayToolExecutor {
       gatewayCallId: active.gatewayCallId ?? fallback.gatewayCallId,
       parentToolName: active.parentToolName ?? fallback.parentToolName,
       backgroundTasks: active.backgroundTasks ?? fallback.backgroundTasks,
+      // Never merged from fallback - blocks are strictly per-call.
+      disallowedGatewayTools: active.disallowedGatewayTools,
     };
   }
 
@@ -1740,8 +1745,10 @@ export class GatewayToolExecutor {
       );
     }
 
-    // Check structurally disallowed tools (e.g., OS agent can't use sub-agent tools)
-    if (this.disallowedGatewayTools.has(toolName)) {
+    // Structurally disallowed tools are per-call policy carried by the execution
+    // context (a shared executor serves many agents with different blocks).
+    const activeDisallowed = this.getExecutionState()?.disallowedGatewayTools;
+    if (activeDisallowed?.includes(toolName) || this.disallowedGatewayTools.has(toolName)) {
       return {
         success: false,
         error: `Tool "${toolName}" is not available. Use delegate() to assign this work to the appropriate sub-agent.`,

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -898,6 +898,12 @@ export class GatewayToolExecutor {
     this.contextCompileService = service;
   }
 
+  /** Wire the shared MAMA API built at boot (initMamaCore) so the executor never
+   *  lazily constructs a second API/adapter stack against the same DB. */
+  setMamaApi(api: MAMAApiInterface): void {
+    this.mamaApi = api;
+  }
+
   /**
    * Initialize the MAMA API by importing from mcp-server package
    * Called lazily on first tool execution if not provided in constructor

--- a/packages/standalone/src/agent/model-runner.ts
+++ b/packages/standalone/src/agent/model-runner.ts
@@ -35,6 +35,13 @@ export interface PromptOptions {
   allowedTools?: string[];
   disallowedTools?: string[];
   systemPrompt?: string;
+  /**
+   * Pool ROUTING key (SessionPool id) for THIS call, NOT the CLI --session-id.
+   * The pool spawns processes with its own randomUUID() so the CLI never
+   * reloads disk history. Routes this prompt to this session's process
+   * without mutating shared adapter state.
+   */
+  sessionId?: string;
 }
 
 // ─── Metrics ─────────────────────────────────────────────────────────────────

--- a/packages/standalone/src/agent/model-runner.ts
+++ b/packages/standalone/src/agent/model-runner.ts
@@ -34,6 +34,7 @@ export interface PromptOptions {
   resumeSession?: boolean;
   allowedTools?: string[];
   disallowedTools?: string[];
+  systemPrompt?: string;
 }
 
 // ─── Metrics ─────────────────────────────────────────────────────────────────

--- a/packages/standalone/src/agent/persistent-cli-adapter.ts
+++ b/packages/standalone/src/agent/persistent-cli-adapter.ts
@@ -80,6 +80,7 @@ export class PersistentCLIAdapter implements IModelRunner {
       resumeSession?: boolean;
       allowedTools?: string[];
       disallowedTools?: string[];
+      systemPrompt?: string;
     }
   ): Promise<PromptResult> {
     // Get or create process for this channel
@@ -88,7 +89,7 @@ export class PersistentCLIAdapter implements IModelRunner {
     // leading to "Prompt is too long" errors when accumulated context exceeds the window.
     this.currentProcess = await this.processPool.getProcess(this.channelKey, {
       model: options?.model || this.options.model,
-      systemPrompt: this.options.systemPrompt,
+      systemPrompt: options?.systemPrompt ?? this.options.systemPrompt,
       dangerouslySkipPermissions: this.options.dangerouslySkipPermissions,
       useGatewayTools: this.options.useGatewayTools,
       allowedTools: options?.allowedTools || this.options.allowedTools,
@@ -218,6 +219,8 @@ export class PersistentCLIAdapter implements IModelRunner {
    *
    * IMPORTANT: This only affects new processes. Existing processes keep their prompt.
    * To apply a new system prompt, call resetSession() after setSystemPrompt().
+   *
+   * @deprecated - mutates shared spawn state; pass systemPrompt per prompt() call
    */
   setSystemPrompt(prompt: string): void {
     this.options.systemPrompt = prompt;

--- a/packages/standalone/src/agent/persistent-cli-adapter.ts
+++ b/packages/standalone/src/agent/persistent-cli-adapter.ts
@@ -81,13 +81,20 @@ export class PersistentCLIAdapter implements IModelRunner {
       allowedTools?: string[];
       disallowedTools?: string[];
       systemPrompt?: string;
+      // Pool ROUTING key (SessionPool id) for THIS call, NOT the CLI --session-id.
+      // The pool spawns processes with its own randomUUID() (persistent-cli-process.ts:1028)
+      // so the CLI never reloads disk history. Routes this prompt without mutating
+      // shared adapter state.
+      sessionId?: string;
     }
   ): Promise<PromptResult> {
     // Get or create process for this channel
-    // NOTE: Do NOT pass sessionId here. The pool generates fresh randomUUID() for --session-id.
-    // Passing the SessionPool UUID would cause Claude CLI to reload disk history on process restart,
-    // leading to "Prompt is too long" errors when accumulated context exceeds the window.
-    this.currentProcess = await this.processPool.getProcess(this.channelKey, {
+    // NOTE: Do NOT pass sessionId to the process opts. The pool generates fresh randomUUID()
+    // for --session-id. Passing the SessionPool UUID would cause Claude CLI to reload disk
+    // history on process restart, leading to "Prompt is too long" errors when accumulated
+    // context exceeds the window. options.sessionId is the pool ROUTING key only.
+    const channelKey = options?.sessionId ?? this.channelKey;
+    const proc = await this.processPool.getProcess(channelKey, {
       model: options?.model || this.options.model,
       systemPrompt: options?.systemPrompt ?? this.options.systemPrompt,
       dangerouslySkipPermissions: this.options.dangerouslySkipPermissions,
@@ -96,12 +103,17 @@ export class PersistentCLIAdapter implements IModelRunner {
       disallowedTools: options?.disallowedTools || this.options.disallowedTools,
       env: { MAMA_HOOK_FEATURES: 'rules,agents' },
     });
+    // Keep the legacy accessor pointing at the most recent process, but NEVER
+    // dereference this.currentProcess inside prompt() - concurrent calls race it.
+    this.currentProcess = proc;
 
-    // Check if we have pending tool results to send first
-    if (this.pendingToolResults.size > 0) {
+    // Pending tool results belong to the legacy single-channel path; only flush
+    // them when this call routes to that same channel - flushing them into an
+    // arbitrary per-call session would misdeliver them.
+    if (channelKey === this.channelKey && this.pendingToolResults.size > 0) {
       // Verify the process is still alive before sending stale tool results
       // If the process was replaced (e.g., crashed and restarted), pending results are invalid
-      if (!this.currentProcess.isAlive()) {
+      if (!proc.isAlive()) {
         console.warn(
           `[PersistentAdapter] Process not alive, discarding ${this.pendingToolResults.size} pending tool results`
         );
@@ -111,7 +123,7 @@ export class PersistentCLIAdapter implements IModelRunner {
         for (const [toolUseId, { result, isError }] of this.pendingToolResults) {
           try {
             console.log(`[PersistentAdapter] Sending pending tool_result: ${toolUseId}`);
-            await this.currentProcess.sendToolResult(toolUseId, result, isError);
+            await proc.sendToolResult(toolUseId, result, isError);
           } catch (err) {
             console.error(`[PersistentAdapter] Failed to send tool_result ${toolUseId}:`, err);
           }
@@ -125,7 +137,7 @@ export class PersistentCLIAdapter implements IModelRunner {
     this._requestCount++;
     this._lastRequestAt = startTime;
     try {
-      const result = await this.currentProcess.sendMessage(content, callbacks);
+      const result = await proc.sendMessage(content, callbacks);
       this._totalLatencyMs += Date.now() - startTime;
 
       // Track tool use blocks for potential tool result sending
@@ -204,6 +216,8 @@ export class PersistentCLIAdapter implements IModelRunner {
    * Note: This creates a new channel key, effectively switching channels.
    * The old process is kept alive for potential reuse.
    * Callers should use resetSession() if the old process is no longer needed to avoid orphan processes.
+   *
+   * @deprecated - per-call sessionId via prompt() options; this mutates shared adapter state
    */
   setSessionId(sessionId: string): void {
     this.options.sessionId = sessionId;

--- a/packages/standalone/src/agent/types.ts
+++ b/packages/standalone/src/agent/types.ts
@@ -1000,6 +1000,14 @@ export interface AgentLoopOptions {
   cliSessionId?: string;
 
   /**
+   * Start this run on a brand-new pool session (stateless lane). Used by the
+   * operator report lane: session context is a cache, not persistence - every
+   * run self-gathers and recalls, so carrying prior runs' gather dumps only
+   * grows the context until runs outlive their envelope TTL.
+   */
+  freshSession?: boolean;
+
+  /**
    * Skip permission prompts for CLI tool execution
    * WARNING: Security risk - enables autonomous tool execution without user approval
    * @default false

--- a/packages/standalone/src/agent/types.ts
+++ b/packages/standalone/src/agent/types.ts
@@ -1161,7 +1161,8 @@ export type AgentErrorCode =
   | 'NETWORK_ERROR'
   | 'TOOL_ERROR'
   | 'UNKNOWN_TOOL'
-  | 'INVALID_RESPONSE';
+  | 'INVALID_RESPONSE'
+  | 'ENVELOPE_EXPIRED';
 
 /**
  * Custom error class for agent loop errors

--- a/packages/standalone/src/agent/types.ts
+++ b/packages/standalone/src/agent/types.ts
@@ -1047,6 +1047,13 @@ export interface AgentLoopOptions {
   disallowedTools?: string[];
 
   /**
+   * Native Claude Code built-in tool surface (--tools value). Pass-through to
+   * the PersistentCLIAdapter; '' disables all built-ins so gateway tools are the
+   * only surface. Consumed only by the claude backend; a no-op on codex-mcp.
+   */
+  builtinTools?: string;
+
+  /**
    * Enable Code-Act mode: LLM writes JS code blocks instead of tool_call blocks
    * Multiple tools composed in a single QuickJS sandbox execution
    * @default false

--- a/packages/standalone/src/agent/types.ts
+++ b/packages/standalone/src/agent/types.ts
@@ -13,6 +13,7 @@ import type { RoleConfig } from '../cli/config/types.js';
 import type { Envelope } from '../envelope/types.js';
 import type { WikiPublishAdapter } from '../wiki-artifacts/wiki-publish-adapter.js';
 import type { ContextCompileService } from './context-compile-service.js';
+import type { GatewayToolExecutor } from './gateway-tool-executor.js';
 import type {
   AppendToolTraceInput,
   BeginModelRunInput,
@@ -130,6 +131,8 @@ export type GatewayToolExecutionContext = {
   modelRunId?: string | null;
   gatewayCallId?: string;
   backgroundTasks?: BackgroundTaskRegistry;
+  /** Per-call gateway tool blocks (e.g. OS-agent must delegate instead). */
+  disallowedGatewayTools?: string[];
 };
 
 // ============================================================================
@@ -1075,6 +1078,15 @@ export interface AgentLoopOptions {
    * Called at key emission points: prompt latency, tool execution, errors
    */
   onMetric?: (name: string, value: number, labels?: Record<string, string>) => void;
+
+  /**
+   * Boot-wired GatewayToolExecutor to share. When provided, AgentLoop uses it
+   * and constructs nothing - every dependency wiring (task ledger, report
+   * publisher, event bus, gateways, wiki, obsidian, ...) reaches persona lanes
+   * by construction. Omit ONLY for deliberately isolated loops (memory agent,
+   * `mama run` CLI) that own their own dep set.
+   */
+  executor?: GatewayToolExecutor;
 }
 
 /**

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -1165,9 +1165,13 @@ export async function runAgentLoop(
             envelopeBootstrap.envelopeAuthority && envelopeBootstrap.metadata.issuance !== 'off'
               ? async () => {
                   const projectId = resolveReactiveProjectRoot(config, process.env);
+                  // A report run is multi-turn (each turn may take up to agent_ms).
+                  // The TTL must cover the RUN, not one request - otherwise every
+                  // long gather structurally outlives its envelope and all
+                  // end-of-run writes die '[expired]' (9 observed pre-fix).
                   const wallSeconds = Math.min(
-                    Math.max(Math.floor((config.timeouts?.agent_ms ?? 300_000) / 1000), 1),
-                    300
+                    Math.max(Number(process.env.MAMA_REPORT_WALL_SECONDS) || 900, 60),
+                    1800
                   );
                   return envelopeBootstrap.envelopeAuthority!.buildAndPersist({
                     agent_id: 'operator-report',

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -21,7 +21,11 @@ import { killProcessesOnPorts, killAllMamaDaemons, killAllMamaWatchdogs } from '
 import { OAuthManager } from '../../auth/index.js';
 import { GatewayToolExecutor } from '../../agent/gateway-tool-executor.js';
 import { createContextCompileService } from '../../agent/context-compile-service.js';
-import type { AgentContext, GatewayToolExecutionContext } from '../../agent/types.js';
+import type {
+  AgentContext,
+  GatewayToolExecutionContext,
+  MAMAApiInterface,
+} from '../../agent/types.js';
 import { SessionStore, MessageRouter, initChannelHistory } from '../../gateways/index.js';
 import { createGraphHandler } from '../../api/graph-api.js';
 import type { CodeActExecutionContext, GraphHandlerOptions } from '../../api/graph-api-types.js';
@@ -631,6 +635,11 @@ export async function runAgentLoop(
   // ── Phase 3: MAMA Core API ────────────────────────────────────────────────
 
   const { mamaApi, mamaApiClient, connectorExtractionFn } = await initMamaCore(config);
+  // Wire the boot MAMA API onto the shared executor so it never lazily builds a
+  // SECOND API/adapter stack against the same DB (initializeMAMAApi). This also
+  // lets the memory agent fold into the shared executor (Task 7) instead of
+  // carrying its own private instance just for this API.
+  toolExecutor.setMamaApi(mamaApi as MAMAApiInterface);
 
   // getAdapter is still used directly in this file for DB queries after initDB has run
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -661,7 +670,8 @@ export async function runAgentLoop(
     mamaApi,
     mamaApiClient,
     messageRouter,
-    agentLoopBackend
+    agentLoopBackend,
+    toolExecutor
   );
 
   // ── Phase 5: Graph Handler + Embedding ────────────────────────────────────

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -621,6 +621,7 @@ export async function runAgentLoop(
     db,
     metricsStore,
     agentLoopBackend,
+    toolExecutor,
     {
       ...options,
       envelopeIssuanceMode: envelopeBootstrap.metadata.issuance,

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -1209,6 +1209,11 @@ export async function runAgentLoop(
                 sessionKey: OPERATOR_REPORT_SESSION_KEY,
                 source: 'operator',
                 channelId: 'report',
+                // Stateless report lane: each run starts on a fresh session so the
+                // continuous session no longer accumulates every run's gather dumps
+                // (measured 146s -> 521s growth over 3 days). Continuity comes from
+                // the storage layer (self-gather + mama_recall + report store).
+                freshSession: true,
                 ...(envelope ? { envelope } : {}),
               }
             );
@@ -1223,10 +1228,12 @@ export async function runAgentLoop(
         // M2.3: the scheduled full report self-gathers via the persona agent's gateway tools
         // (the Kagemusha lesson: a reporter with tools has substance; a window summary alone
         // reports "quiet" whenever polling is between batches).
-        fullReportSelfGather: [
+        fullReportSelfGather: ({ lastSuccessIso }: { lastSuccessIso: string | null }) => [
           'kagemusha_overview() for room/task/message counts',
           'kagemusha_tasks({}) for the open task board, plus kagemusha_tasks({ status: "review" }) for items awaiting review (status values must be real board statuses like pending/in_progress/review - invented labels match nothing)',
-          'kagemusha_entities({ activeOnly: true }) for active channels, then kagemusha_messages({ channelId }) on the busiest 2-3 (since defaults to the last 7 days; pass an ISO-8601 timestamp like since: "2026-07-09T00:00:00Z" to narrow it - never a phrase like "24h ago")',
+          lastSuccessIso
+            ? `kagemusha_entities({ activeOnly: true }) for active channels, then kagemusha_messages({ channelId, since: "${lastSuccessIso}" }) on the busiest 2-3 - since is the last successful report; do NOT widen it`
+            : 'kagemusha_entities({ activeOnly: true }) for active channels, then kagemusha_messages({ channelId }) on the busiest 2-3 (since defaults to the last 7 days; pass an ISO-8601 timestamp like since: "2026-07-09T00:00:00Z" to narrow it - never a phrase like "24h ago")',
           'mama_recall(query) for memory relevant to what you find',
           'schedule_upcoming({ days: 14 }) for upcoming calendar events -- cross-check task deadlines against them',
         ],

--- a/packages/standalone/src/cli/runtime/agent-loop-init.ts
+++ b/packages/standalone/src/cli/runtime/agent-loop-init.ts
@@ -131,6 +131,15 @@ export function initMainAgentLoop(
       useCodeAct: options?.osAgentMode ? false : useCodeAct,
       toolsConfig: config.agent.tools, // Gateway + MCP hybrid mode
       disallowedTools: osAgentDisallowed,
+      // Gateway tools are the ONLY tool surface for the daemon persona
+      // (owner decision D2, 2026-07-16). MAMA_PERSONA_NATIVE_TOOLS=1 re-enables.
+      // NOTE: consumed only by the claude PersistentCLIAdapter branch - on a
+      // codex-mcp backend this option is a no-op (log below keeps that loud).
+      builtinTools:
+        process.env.MAMA_PERSONA_NATIVE_TOOLS === '1' ||
+        process.env.MAMA_PERSONA_NATIVE_TOOLS?.toLowerCase() === 'true'
+          ? undefined
+          : '',
       // Root fix (2026-07-16): share the boot-wired executor so every dependency
       // wiring reaches the persona lane by construction (no second private twin).
       executor: toolExecutor,
@@ -205,6 +214,11 @@ export function initMainAgentLoop(
     },
     undefined
   );
+  if (runtimeBackend !== 'claude') {
+    console.log(
+      '[agent-loop-init] builtinTools lockdown is a no-op on the codex backend (native-tool surface is claude CLI only)'
+    );
+  }
   console.log('✓ Lane-based concurrency enabled (reasoning collection)');
 
   // Build reasoning header for Discord

--- a/packages/standalone/src/cli/runtime/agent-loop-init.ts
+++ b/packages/standalone/src/cli/runtime/agent-loop-init.ts
@@ -21,6 +21,7 @@ import { join } from 'node:path';
 import type { MAMAConfig } from '../config/types.js';
 import type { OAuthManager } from '../../auth/index.js';
 import { AgentLoop } from '../../agent/index.js';
+import type { GatewayToolExecutor } from '../../agent/index.js';
 import type {
   AgentLoopOptions,
   ContentBlock as AgentContentBlock,
@@ -61,6 +62,7 @@ export function initMainAgentLoop(
   db: SQLiteDatabase,
   metricsStore: MetricsStore | null,
   runtimeBackend: 'claude' | 'codex-mcp',
+  toolExecutor: GatewayToolExecutor,
   options?: {
     osAgentMode?: boolean;
     envelopeIssuanceMode?: EnvelopeIssuanceMode;
@@ -129,6 +131,9 @@ export function initMainAgentLoop(
       useCodeAct: options?.osAgentMode ? false : useCodeAct,
       toolsConfig: config.agent.tools, // Gateway + MCP hybrid mode
       disallowedTools: osAgentDisallowed,
+      // Root fix (2026-07-16): share the boot-wired executor so every dependency
+      // wiring reaches the persona lane by construction (no second private twin).
+      executor: toolExecutor,
       useLanes: true, // Enable lane-based concurrency for Discord
       // SECURITY MODEL: MAMA OS is a headless daemon — no TTY for interactive permission prompts.
       // Permission enforcement is handled by MAMA's own RoleManager layer:
@@ -198,14 +203,7 @@ export function initMainAgentLoop(
         metricsStore?.record({ name, value, labels });
       },
     },
-    undefined,
-    {
-      mamaDbPath: config.database.path.replace(/^~/, homedir()),
-      envelopeIssuanceMode: options?.envelopeIssuanceMode ?? 'off',
-      metricsStore,
-      contextCompileService: options?.contextCompileService,
-      wikiPublishAdapter: options?.wikiPublishAdapter,
-    }
+    undefined
   );
   console.log('✓ Lane-based concurrency enabled (reasoning collection)');
 

--- a/packages/standalone/src/cli/runtime/gateway-init.ts
+++ b/packages/standalone/src/cli/runtime/gateway-init.ts
@@ -124,12 +124,14 @@ export async function initGateways(
           discordGateway!.sendFile(channelId, imagePath, caption),
       };
 
+      // Root fix (2026-07-16): agentLoop now shares the boot-wired toolExecutor,
+      // so this single call wires discord_send onto the shared instance for BOTH
+      // the persona lane and the multi-agent/code-act lanes - no second call needed.
       agentLoop.setDiscordGateway(gatewayInterface);
 
       // Wire gateway tool executor to multi-agent handler
       const multiAgentDiscord = discordGateway.getMultiAgentHandler();
       if (multiAgentDiscord) {
-        toolExecutor.setDiscordGateway(gatewayInterface);
         multiAgentDiscord.setGatewayToolExecutor(toolExecutor);
         // Wire delegate dependencies so code-act sandbox can call delegate()
         toolExecutor.setAgentProcessManager(multiAgentDiscord.getProcessManager());

--- a/packages/standalone/src/cli/runtime/memory-agent-init.ts
+++ b/packages/standalone/src/cli/runtime/memory-agent-init.ts
@@ -22,7 +22,8 @@ import type { MAMAConfig } from '../config/types.js';
 import { expandPath } from '../config/config-manager.js';
 import type { OAuthManager } from '../../auth/index.js';
 import { AgentLoop } from '../../agent/index.js';
-import type { AgentContext, MAMAApiInterface } from '../../agent/types.js';
+import type { GatewayToolExecutor } from '../../agent/gateway-tool-executor.js';
+import type { AgentContext } from '../../agent/types.js';
 import type { MessageRouter } from '../../gateways/message-router.js';
 import type { MemoryAgentProcessManagerLike } from '../../gateways/message-router.js';
 import {
@@ -50,11 +51,16 @@ export interface MemoryAgentInitResult {
 export async function initMemoryAgent(
   oauthManager: OAuthManager,
   config: MAMAConfig,
-  mamaApi: MAMAApiShape,
+  // Task 7: the memory agent no longer carries a private executor built around
+  // this mamaApi - it shares the boot executor (already wired via setMamaApi),
+  // so the positional arg is retained for the call signature but unused here.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _mamaApi: MAMAApiShape,
   mamaApiClient: MamaApiClient,
   messageRouter: MessageRouter,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _runtimeBackend: string
+  _runtimeBackend: string,
+  toolExecutor: GatewayToolExecutor
 ): Promise<MemoryAgentInitResult> {
   // getAdapter is used directly for DB queries after initDB has run
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -96,21 +102,23 @@ export async function initMemoryAgent(
     const memoryModel =
       memoryAgentConfig?.model ||
       (memoryBackend === 'claude' ? 'claude-sonnet-4-6' : config.agent.model);
-    memoryAgentLoop = new AgentLoop(
-      oauthManager,
-      {
-        systemPrompt: memoryPersona,
-        model: memoryModel,
-        maxTurns: 3,
-        backend: memoryBackend,
-        toolsConfig: {
-          gateway: ['mama_search', 'mama_save'],
-          mcp: [],
-        },
+    memoryAgentLoop = new AgentLoop(oauthManager, {
+      systemPrompt: memoryPersona,
+      model: memoryModel,
+      maxTurns: 3,
+      backend: memoryBackend,
+      toolsConfig: {
+        gateway: ['mama_search', 'mama_save'],
+        mcp: [],
       },
-      undefined,
-      { mamaApi: mamaApi as MAMAApiInterface }
-    );
+      // Fold into the boot-wired shared executor (Task 7): the private twin
+      // existed ONLY to carry the initMamaCore mamaApi (now on the shared
+      // executor via setMamaApi), while the shared executor otherwise lazily
+      // built a second API/adapter stack against the same DB. The memory
+      // agent's tool restriction lives in toolsConfig + per-call context, not
+      // executor instance state, so sharing is safe (Task 1 per-call model).
+      executor: toolExecutor,
+    });
     memoryAgentLoop.setSessionKey('memory-agent:shared');
     let memoryBootstrapDelivered = false;
     let memoryBootstrapLock: Promise<void> | null = null;

--- a/packages/standalone/src/envelope/run-guard.ts
+++ b/packages/standalone/src/envelope/run-guard.ts
@@ -1,0 +1,19 @@
+import { parseEnvelopeExpiresAt } from './expiry.js';
+
+/**
+ * True when the envelope cannot authorize the work still ahead of it.
+ * marginMs treats "expires within the margin" as expired, so a run stops
+ * BEFORE burning a turn whose writes are already doomed. Unparseable
+ * expires_at counts as expired: never proceed on a malformed authority bound.
+ */
+export function envelopeExpired(
+  envelope: { expires_at: string },
+  now: number = Date.now(),
+  marginMs = 0
+): boolean {
+  try {
+    return parseEnvelopeExpiresAt(envelope.expires_at) <= now + marginMs;
+  } catch {
+    return true;
+  }
+}

--- a/packages/standalone/src/multi-agent/runtime-process.ts
+++ b/packages/standalone/src/multi-agent/runtime-process.ts
@@ -76,16 +76,24 @@ export class CodexRuntimeProcess extends EventEmitter implements AgentRuntimePro
   async prompt(
     content: string,
     callbacks?: ClaudePromptCallbacks,
-    _options?: PromptOptions
+    options?: PromptOptions
   ): Promise<ClaudePromptResult> {
-    return this.sendMessage(content, callbacks);
+    // Narrowed on purpose: only systemPrompt is per-call plumbing (Task 3).
+    // model/resumeSession stay inert on codex - activating them is a separate,
+    // deliberate change (they alter thread lifecycle, codex-mcp-process.ts:261-266).
+    return this.sendMessage(
+      content,
+      callbacks,
+      options?.systemPrompt !== undefined ? { systemPrompt: options.systemPrompt } : undefined
+    );
   }
 
   // ─── AgentRuntimeProcess.sendMessage() ─────────────────────────────────
 
   async sendMessage(
     content: string,
-    callbacks?: ClaudePromptCallbacks
+    callbacks?: ClaudePromptCallbacks,
+    options?: { systemPrompt?: string }
   ): Promise<ClaudePromptResult> {
     if (this.state === 'dead') {
       throw new Error('Process is dead');
@@ -107,7 +115,11 @@ export class CodexRuntimeProcess extends EventEmitter implements AgentRuntimePro
           }
         : undefined;
 
-      const result = await this.wrapper.prompt(content, codexCallbacks);
+      const result = await this.wrapper.prompt(
+        content,
+        codexCallbacks,
+        options?.systemPrompt !== undefined ? { systemPrompt: options.systemPrompt } : undefined
+      );
 
       const normalized: ClaudePromptResult = {
         response: result.response,

--- a/packages/standalone/src/operator/operator-trigger-loop.ts
+++ b/packages/standalone/src/operator/operator-trigger-loop.ts
@@ -68,8 +68,12 @@ export interface TriggerLoopDeps {
   output?: Pick<OutputSink, 'send'>;
   /** Scheduled full-report cadence (real: ReportScheduler). Absent -> full leg off (M2). */
   reportScheduler?: ReportSchedule;
-  /** M2.3: tool-call instructions for the FULL report so the agent self-gathers context. */
-  fullReportSelfGather?: string[];
+  /**
+   * M2.3: tool-call instructions for the FULL report so the agent self-gathers context.
+   * A provider form receives the last successful report's anchor so the heavy gather
+   * can scope its delta (`since=<lastSuccessIso>`); it is resolved AT FIRE TIME.
+   */
+  fullReportSelfGather?: string[] | ((ctx: { lastSuccessIso: string | null }) => string[]);
   /**
    * M8: board-reconcile feed. Invoked after commit with connector-qualified
    * channelKey ("<connector>:<channelId>") and bounded delta excerpt lines
@@ -122,7 +126,16 @@ export class OperatorTriggerLoop {
     };
     this.digest = new SituationReporter({ recordTriggerUse });
     this.fullReporter = new SituationReporter({
-      selfGatherLines: deps.fullReportSelfGather,
+      // Wrap a provider into a zero-arg closure resolved AT FIRE TIME (buildPrompt
+      // calls it): the delta anchor is the last SUCCESSFUL full report, so a run
+      // that failed never widens the next window (defer, never drop).
+      selfGatherLines:
+        typeof deps.fullReportSelfGather === 'function'
+          ? () =>
+              (deps.fullReportSelfGather as (ctx: { lastSuccessIso: string | null }) => string[])({
+                lastSuccessIso: deps.reportScheduler?.loadLastSuccess() ?? null,
+              })
+          : (deps.fullReportSelfGather ?? []),
       boardPublishLines: deps.fullReportBoardLines,
       recordTriggerUse,
     });
@@ -258,8 +271,18 @@ export class OperatorTriggerLoop {
     if (output && reportScheduler) {
       const { fire, hourKey } = reportScheduler.shouldFire(new Date());
       if (fire) {
+        // Anchor = FIRE time, captured BEFORE the run: anchoring at completion would
+        // leave a gap (messages arriving while the run executes fall after the gather
+        // but before a completion-time anchor). Overlap is tolerable; gaps are not.
+        const firedAtIso = new Date().toISOString();
         fullReported = await this.fullReporter.report(reportAsk, output, 'full');
         reportScheduler.markFired(hourKey); // reached only if report() did not throw (sent OR agent-suppressed)
+        if (fullReported) {
+          // ONLY a delivered report advances the delta anchor. A NOTHING-suppressed
+          // report or a Task-4 ENVELOPE_EXPIRED abort must NOT advance it, so the
+          // next report's window still covers everything this run missed.
+          reportScheduler.markSuccess(firedAtIso);
+        }
         log(
           `[trigger-loop] tick ${tick}: full report ${fullReported ? 'SENT' : 'suppressed by agent'} (${hourKey})`
         );

--- a/packages/standalone/src/operator/report-scheduler.ts
+++ b/packages/standalone/src/operator/report-scheduler.ts
@@ -17,12 +17,20 @@ import { dirname, join } from 'node:path';
 export interface ReportSchedule {
   shouldFire(now: Date): { fire: boolean; hourKey: string };
   markFired(hourKey: string): void;
+  /** Anchor timestamp (ISO) of the last SUCCESSFUL full report, for delta-scoped gathers. */
+  loadLastSuccess(): string | null;
+  /** Persist the anchor after a full report is delivered (failures must never advance it). */
+  markSuccess(iso: string): void;
 }
 
 /** Persist/restore the last-fired hour key (so a restart within the same hour does not re-send). */
 export interface ReportScheduleStore {
   load(): string | null;
   save(hourKey: string): void;
+  /** Anchor timestamp (ISO) of the last SUCCESSFUL full report; null before the first one. */
+  loadLastSuccess(): string | null;
+  /** Persist the success anchor (read-modify-write so it never clobbers the fired-hour key). */
+  markSuccess(iso: string): void;
 }
 
 /** Local-time "YYYY-MM-DD:HH" bucket. Two ticks in the same local hour share a key. */
@@ -70,6 +78,16 @@ export class ReportScheduler implements ReportSchedule {
     this.lastFiredHourKey = hourKey;
     this.store.save(hourKey);
   }
+
+  /** Anchor of the last SUCCESSFUL full report (delegates to the store). */
+  loadLastSuccess(): string | null {
+    return this.store.loadLastSuccess();
+  }
+
+  /** Persist the success anchor (delegates to the store; called ONLY on a delivered report). */
+  markSuccess(iso: string): void {
+    this.store.markSuccess(iso);
+  }
 }
 
 /** File-backed store under ~/.mama - mirrors ConnectorDeltaRepo's atomic cursor file. */
@@ -80,22 +98,53 @@ export class FileReportScheduleStore implements ReportScheduleStore {
     this.path = path;
   }
 
-  load(): string | null {
+  /** Read-parse the whole state object (throws on corrupt - no-fallback). Empty file -> {}. */
+  private readState(): { lastFiredHourKey?: unknown; lastSuccessIso?: unknown } {
     if (!existsSync(this.path)) {
-      return null;
+      return {};
     }
     const parsed: unknown = JSON.parse(readFileSync(this.path, 'utf8')); // throws on corrupt (no-fallback)
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
       throw new Error(`corrupt report-schedule state (not an object): ${this.path}`);
     }
-    const key = (parsed as { lastFiredHourKey?: unknown }).lastFiredHourKey;
+    return parsed as { lastFiredHourKey?: unknown; lastSuccessIso?: unknown };
+  }
+
+  /** Atomic full-object write (tmp+rename) - callers do read-modify-write to preserve sibling fields. */
+  private writeState(state: { lastFiredHourKey?: string; lastSuccessIso?: string }): void {
+    mkdirSync(dirname(this.path), { recursive: true });
+    const tmp = join(dirname(this.path), `.report-schedule.${process.pid}.tmp`);
+    writeFileSync(tmp, JSON.stringify(state), 'utf8');
+    renameSync(tmp, this.path); // atomic replace
+  }
+
+  load(): string | null {
+    const key = this.readState().lastFiredHourKey;
     return typeof key === 'string' ? key : null;
   }
 
   save(hourKey: string): void {
-    mkdirSync(dirname(this.path), { recursive: true });
-    const tmp = join(dirname(this.path), `.report-schedule.${process.pid}.tmp`);
-    writeFileSync(tmp, JSON.stringify({ lastFiredHourKey: hourKey }), 'utf8');
-    renameSync(tmp, this.path); // atomic replace
+    // Read-modify-write: markFired must NOT clobber the success anchor.
+    const state = this.readState();
+    this.writeState({
+      lastFiredHourKey: hourKey,
+      ...(typeof state.lastSuccessIso === 'string' ? { lastSuccessIso: state.lastSuccessIso } : {}),
+    });
+  }
+
+  loadLastSuccess(): string | null {
+    const iso = this.readState().lastSuccessIso;
+    return typeof iso === 'string' ? iso : null;
+  }
+
+  markSuccess(iso: string): void {
+    // Read-modify-write: advancing the anchor must NOT clobber the fired-hour key.
+    const state = this.readState();
+    this.writeState({
+      ...(typeof state.lastFiredHourKey === 'string'
+        ? { lastFiredHourKey: state.lastFiredHourKey }
+        : {}),
+      lastSuccessIso: iso,
+    });
   }
 }

--- a/packages/standalone/src/operator/report-scheduler.ts
+++ b/packages/standalone/src/operator/report-scheduler.ts
@@ -98,14 +98,32 @@ export class FileReportScheduleStore implements ReportScheduleStore {
     this.path = path;
   }
 
-  /** Read-parse the whole state object (throws on corrupt or zero-byte file - no-fallback). MISSING file -> {}. */
+  /**
+   * Read-parse the whole state object. MISSING file -> {} (silent, as today). A corrupt/empty
+   * or non-object state file is disposable bookkeeping: rather than throw and permanently break
+   * the report leg, reset LOUDLY and return {}. Worst case after a reset is one duplicate report
+   * plus a wide gather window - both self-heal on the next successful report.
+   */
   private readState(): { lastFiredHourKey?: unknown; lastSuccessIso?: unknown } {
     if (!existsSync(this.path)) {
       return {};
     }
-    const parsed: unknown = JSON.parse(readFileSync(this.path, 'utf8')); // throws on corrupt (no-fallback)
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(this.path, 'utf8'));
+    } catch (error) {
+      console.error(
+        '[report-scheduler] state file corrupt or unreadable - resetting schedule state:',
+        error
+      );
+      return {};
+    }
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-      throw new Error(`corrupt report-schedule state (not an object): ${this.path}`);
+      console.error(
+        '[report-scheduler] state file corrupt or unreadable - resetting schedule state:',
+        `not a plain object: ${this.path}`
+      );
+      return {};
     }
     return parsed as { lastFiredHourKey?: unknown; lastSuccessIso?: unknown };
   }

--- a/packages/standalone/src/operator/report-scheduler.ts
+++ b/packages/standalone/src/operator/report-scheduler.ts
@@ -98,7 +98,7 @@ export class FileReportScheduleStore implements ReportScheduleStore {
     this.path = path;
   }
 
-  /** Read-parse the whole state object (throws on corrupt - no-fallback). Empty file -> {}. */
+  /** Read-parse the whole state object (throws on corrupt or zero-byte file - no-fallback). MISSING file -> {}. */
   private readState(): { lastFiredHourKey?: unknown; lastSuccessIso?: unknown } {
     if (!existsSync(this.path)) {
       return {};

--- a/packages/standalone/src/operator/situation-report.ts
+++ b/packages/standalone/src/operator/situation-report.ts
@@ -227,13 +227,17 @@ export class SituationReporter {
       ([topic, content]) => `- ${topic}: ${content}`
     );
 
-    // Resolve the gather lines BEFORE the length guard: a zero-arg PROVIDER's
-    // `.length` is its arity (0), so guarding on the raw opts value would compile
+    // Resolve the gather lines only for the FULL report - the digest framing never renders
+    // them, so a zero-arg PROVIDER must not be invoked (it may do real gather work) just to
+    // build a digest prompt. The guard below stays anchored on the RESOLVED array: a zero-arg
+    // provider's `.length` is its arity (0), so guarding on the raw opts value would compile
     // cleanly and silently drop the ENTIRE gather block on every production report.
     const gatherLines =
-      typeof this.opts.selfGatherLines === 'function'
-        ? this.opts.selfGatherLines()
-        : (this.opts.selfGatherLines ?? []);
+      mode === 'full'
+        ? typeof this.opts.selfGatherLines === 'function'
+          ? this.opts.selfGatherLines()
+          : (this.opts.selfGatherLines ?? [])
+        : [];
 
     // M2.1 posture: the full report is a DUTY report (always arrives - a quiet window is
     // reported as quiet, the aliveness signal owners rely on); the digest defaults to briefing

--- a/packages/standalone/src/operator/situation-report.ts
+++ b/packages/standalone/src/operator/situation-report.ts
@@ -61,8 +61,12 @@ export interface SituationReporterOptions {
    * (and which deleted its deterministic report builder for low quality). The lines
    * are injected from the runtime wiring (which knows the daemon's toolset); this
    * module stays generic. Digest mode never uses them (frequent + must stay light).
+   *
+   * A zero-arg provider is resolved at fire time (buildPrompt runs per report),
+   * so runtime wiring can inject freshly anchored gather lines (e.g. a delta
+   * `since=<last successful report>`) without rebuilding the reporter.
    */
-  selfGatherLines?: string[];
+  selfGatherLines?: string[] | (() => string[]);
   /**
    * Kagemusha dual-output mechanism: lines instructing the FULL report run to also
    * publish the operator board slots (report_publish) before writing the text
@@ -223,6 +227,14 @@ export class SituationReporter {
       ([topic, content]) => `- ${topic}: ${content}`
     );
 
+    // Resolve the gather lines BEFORE the length guard: a zero-arg PROVIDER's
+    // `.length` is its arity (0), so guarding on the raw opts value would compile
+    // cleanly and silently drop the ENTIRE gather block on every production report.
+    const gatherLines =
+      typeof this.opts.selfGatherLines === 'function'
+        ? this.opts.selfGatherLines()
+        : (this.opts.selfGatherLines ?? []);
+
     // M2.1 posture: the full report is a DUTY report (always arrives - a quiet window is
     // reported as quiet, the aliveness signal owners rely on); the digest defaults to briefing
     // and keeps NOTHING only for pure noise.
@@ -238,7 +250,7 @@ export class SituationReporter {
             "Structure the report with these sections (render the headings in the owner's language;",
             'omit a section only when it is truly empty):',
             '1) Key situation  2) Action required  3) Decisions needed  4) Pipeline  5) Next actions',
-            ...(this.opts.selfGatherLines && this.opts.selfGatherLines.length > 0
+            ...(gatherLines.length > 0
               ? [
                   '',
                   'Before writing, ACTIVELY gather current context by CALLING your gateway tools.',
@@ -248,7 +260,7 @@ export class SituationReporter {
                   '{"name": "kagemusha_tasks", "input": {"status": "in_progress"}}',
                   '```',
                   'Gather with these gateway tool calls:',
-                  ...this.opts.selfGatherLines.map((line) => `- ${line}`),
+                  ...gatherLines.map((line) => `- ${line}`),
                   'These gateway tools are NOT native or deferred CLI tools: ToolSearch cannot',
                   'load them and will find nothing. Invoke them ONLY as fenced tool_call JSON',
                   'blocks in your reply text - do not search for them, and do not fall back to',

--- a/packages/standalone/tests/agent/envelope-run-guard.test.ts
+++ b/packages/standalone/tests/agent/envelope-run-guard.test.ts
@@ -1,68 +1,69 @@
 import { describe, it, expect } from 'vitest';
 import { envelopeExpired } from '../../src/envelope/run-guard.js';
-
-describe('envelopeExpired', () => {
-  const base = Date.parse('2026-07-16T00:00:00Z');
-  const env = { expires_at: '2026-07-16T00:05:00Z' };
-
-  it('false while valid', () => {
-    expect(envelopeExpired(env, base)).toBe(false);
-  });
-
-  it('true once expires_at has passed', () => {
-    expect(envelopeExpired(env, base + 5 * 60_000 + 1)).toBe(true);
-  });
-
-  it('true within the safety margin before expiry', () => {
-    expect(envelopeExpired(env, base + 5 * 60_000 - 10_000, 30_000)).toBe(true);
-  });
-
-  it('treats unparseable expires_at as expired (fail loud, never permissive)', () => {
-    expect(envelopeExpired({ expires_at: 'not-a-timestamp' }, base)).toBe(true);
-  });
-});
-
 import { AgentLoop } from '../../src/agent/agent-loop.js';
 
-describe('runWithContent envelope guard', () => {
-  const expiredEnvelope = { expires_at: '2020-01-01T00:00:00Z', instance_id: 'env-test' };
+describe('Story BOUNDARY-4: envelope run guard', () => {
+  describe('envelopeExpired', () => {
+    const base = Date.parse('2026-07-16T00:00:00Z');
+    const env = { expires_at: '2026-07-16T00:05:00Z' };
 
-  const makeLoop = (): AgentLoop => {
-    const loop = new AgentLoop({} as never, { toolsConfig: { gateway: ['*'], mcp: [] } });
-    (loop as unknown as { agent: unknown }).agent = {
-      // usage is REQUIRED: agent-loop.ts:1271 reads response.usage.input_tokens
-      // unconditionally - omitting it TypeErrors the chat-lane test.
-      prompt: async () => ({
-        response: 'hi',
-        toolUseBlocks: [],
-        usage: { input_tokens: 0, output_tokens: 0 },
-      }),
-    };
-    return loop;
-  };
+    it('false while valid', () => {
+      expect(envelopeExpired(env, base)).toBe(false);
+    });
 
-  // modelRunId is REQUIRED in the options: shouldBeginModelRun (agent-loop.ts:1497)
-  // is true for gateway mode without one, and beginRuntimeModelRun would then hit
-  // initializeMAMAApi -> initDB() against the developer's REAL default DB
-  // (~/.claude/mama-memory.db). Passing a modelRunId short-circuits that path.
-  it('aborts an operator-lane run with ENVELOPE_EXPIRED', async () => {
-    await expect(
-      makeLoop().runWithContent([{ type: 'text', text: 'gather' }], {
-        source: 'operator',
-        channelId: 'report',
-        modelRunId: 'test-run',
-        envelope: expiredEnvelope as never,
-      })
-    ).rejects.toMatchObject({ code: 'ENVELOPE_EXPIRED' });
+    it('true once expires_at has passed', () => {
+      expect(envelopeExpired(env, base + 5 * 60_000 + 1)).toBe(true);
+    });
+
+    it('true within the safety margin before expiry', () => {
+      expect(envelopeExpired(env, base + 5 * 60_000 - 10_000, 30_000)).toBe(true);
+    });
+
+    it('treats unparseable expires_at as expired (fail loud, never permissive)', () => {
+      expect(envelopeExpired({ expires_at: 'not-a-timestamp' }, base)).toBe(true);
+    });
   });
 
-  it('does NOT abort an interactive chat run (logs loudly instead)', async () => {
-    const result = await makeLoop().runWithContent([{ type: 'text', text: 'hi' }], {
-      source: 'telegram',
-      channelId: 'chat-1',
-      modelRunId: 'test-run',
-      envelope: expiredEnvelope as never,
+  describe('runWithContent envelope guard', () => {
+    const expiredEnvelope = { expires_at: '2020-01-01T00:00:00Z', instance_id: 'env-test' };
+
+    const makeLoop = (): AgentLoop => {
+      const loop = new AgentLoop({} as never, { toolsConfig: { gateway: ['*'], mcp: [] } });
+      (loop as unknown as { agent: unknown }).agent = {
+        // usage is REQUIRED: agent-loop.ts:1271 reads response.usage.input_tokens
+        // unconditionally - omitting it TypeErrors the chat-lane test.
+        prompt: async () => ({
+          response: 'hi',
+          toolUseBlocks: [],
+          usage: { input_tokens: 0, output_tokens: 0 },
+        }),
+      };
+      return loop;
+    };
+
+    // modelRunId is REQUIRED in the options: shouldBeginModelRun (agent-loop.ts:1497)
+    // is true for gateway mode without one, and beginRuntimeModelRun would then hit
+    // initializeMAMAApi -> initDB() against the developer's REAL default DB
+    // (~/.claude/mama-memory.db). Passing a modelRunId short-circuits that path.
+    it('aborts an operator-lane run with ENVELOPE_EXPIRED', async () => {
+      await expect(
+        makeLoop().runWithContent([{ type: 'text', text: 'gather' }], {
+          source: 'operator',
+          channelId: 'report',
+          modelRunId: 'test-run',
+          envelope: expiredEnvelope as never,
+        })
+      ).rejects.toMatchObject({ code: 'ENVELOPE_EXPIRED' });
     });
-    expect(result.response).toBe('hi');
+
+    it('does NOT abort an interactive chat run (logs loudly instead)', async () => {
+      const result = await makeLoop().runWithContent([{ type: 'text', text: 'hi' }], {
+        source: 'telegram',
+        channelId: 'chat-1',
+        modelRunId: 'test-run',
+        envelope: expiredEnvelope as never,
+      });
+      expect(result.response).toBe('hi');
+    });
   });
 });

--- a/packages/standalone/tests/agent/envelope-run-guard.test.ts
+++ b/packages/standalone/tests/agent/envelope-run-guard.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { envelopeExpired } from '../../src/envelope/run-guard.js';
+
+describe('envelopeExpired', () => {
+  const base = Date.parse('2026-07-16T00:00:00Z');
+  const env = { expires_at: '2026-07-16T00:05:00Z' };
+
+  it('false while valid', () => {
+    expect(envelopeExpired(env, base)).toBe(false);
+  });
+
+  it('true once expires_at has passed', () => {
+    expect(envelopeExpired(env, base + 5 * 60_000 + 1)).toBe(true);
+  });
+
+  it('true within the safety margin before expiry', () => {
+    expect(envelopeExpired(env, base + 5 * 60_000 - 10_000, 30_000)).toBe(true);
+  });
+
+  it('treats unparseable expires_at as expired (fail loud, never permissive)', () => {
+    expect(envelopeExpired({ expires_at: 'not-a-timestamp' }, base)).toBe(true);
+  });
+});
+
+import { AgentLoop } from '../../src/agent/agent-loop.js';
+
+describe('runWithContent envelope guard', () => {
+  const expiredEnvelope = { expires_at: '2020-01-01T00:00:00Z', instance_id: 'env-test' };
+
+  const makeLoop = (): AgentLoop => {
+    const loop = new AgentLoop({} as never, { toolsConfig: { gateway: ['*'], mcp: [] } });
+    (loop as unknown as { agent: unknown }).agent = {
+      setSessionId: () => {},
+      // usage is REQUIRED: agent-loop.ts:1271 reads response.usage.input_tokens
+      // unconditionally - omitting it TypeErrors the chat-lane test.
+      prompt: async () => ({
+        response: 'hi',
+        toolUseBlocks: [],
+        usage: { input_tokens: 0, output_tokens: 0 },
+      }),
+    };
+    return loop;
+  };
+
+  // modelRunId is REQUIRED in the options: shouldBeginModelRun (agent-loop.ts:1497)
+  // is true for gateway mode without one, and beginRuntimeModelRun would then hit
+  // initializeMAMAApi -> initDB() against the developer's REAL default DB
+  // (~/.claude/mama-memory.db). Passing a modelRunId short-circuits that path.
+  it('aborts an operator-lane run with ENVELOPE_EXPIRED', async () => {
+    await expect(
+      makeLoop().runWithContent([{ type: 'text', text: 'gather' }], {
+        source: 'operator',
+        channelId: 'report',
+        modelRunId: 'test-run',
+        envelope: expiredEnvelope as never,
+      })
+    ).rejects.toMatchObject({ code: 'ENVELOPE_EXPIRED' });
+  });
+
+  it('does NOT abort an interactive chat run (logs loudly instead)', async () => {
+    const result = await makeLoop().runWithContent([{ type: 'text', text: 'hi' }], {
+      source: 'telegram',
+      channelId: 'chat-1',
+      modelRunId: 'test-run',
+      envelope: expiredEnvelope as never,
+    });
+    expect(result.response).toBe('hi');
+  });
+});

--- a/packages/standalone/tests/agent/envelope-run-guard.test.ts
+++ b/packages/standalone/tests/agent/envelope-run-guard.test.ts
@@ -3,7 +3,7 @@ import { envelopeExpired } from '../../src/envelope/run-guard.js';
 import { AgentLoop } from '../../src/agent/agent-loop.js';
 
 describe('Story BOUNDARY-4: envelope run guard', () => {
-  describe('envelopeExpired', () => {
+  describe('AC #1: envelopeExpired is fail-closed with margin support', () => {
     const base = Date.parse('2026-07-16T00:00:00Z');
     const env = { expires_at: '2026-07-16T00:05:00Z' };
 
@@ -24,7 +24,7 @@ describe('Story BOUNDARY-4: envelope run guard', () => {
     });
   });
 
-  describe('runWithContent envelope guard', () => {
+  describe('AC #2: expired envelopes abort operator runs and never abort chat', () => {
     const expiredEnvelope = { expires_at: '2020-01-01T00:00:00Z', instance_id: 'env-test' };
 
     const makeLoop = (): AgentLoop => {

--- a/packages/standalone/tests/agent/envelope-run-guard.test.ts
+++ b/packages/standalone/tests/agent/envelope-run-guard.test.ts
@@ -30,7 +30,6 @@ describe('runWithContent envelope guard', () => {
   const makeLoop = (): AgentLoop => {
     const loop = new AgentLoop({} as never, { toolsConfig: { gateway: ['*'], mcp: [] } });
     (loop as unknown as { agent: unknown }).agent = {
-      setSessionId: () => {},
       // usage is REQUIRED: agent-loop.ts:1271 reads response.usage.input_tokens
       // unconditionally - omitting it TypeErrors the chat-lane test.
       prompt: async () => ({

--- a/packages/standalone/tests/agent/fresh-session.test.ts
+++ b/packages/standalone/tests/agent/fresh-session.test.ts
@@ -1,37 +1,39 @@
 import { describe, it, expect, vi } from 'vitest';
 import { AgentLoop } from '../../src/agent/agent-loop.js';
 
-describe('freshSession option (stateless lanes)', () => {
-  it('resets the pool session instead of reusing it', async () => {
-    const loop = new AgentLoop({} as never, { toolsConfig: { gateway: ['*'], mcp: [] } });
-    const resetSession = vi.fn().mockReturnValue('fresh-id');
-    const getSession = vi
-      .fn()
-      .mockReturnValue({ sessionId: 'stale-id', isNew: false, busy: false });
-    (loop as unknown as { sessionPool: unknown }).sessionPool = {
-      resetSession,
-      getSession,
-      releaseSession: () => {},
-      // Called unconditionally after every turn (agent-loop.ts:1293-1297) -
-      // omitting it makes a CORRECT implementation fail this test.
-      updateTokens: () => ({ totalTokens: 0, nearThreshold: false }),
-    };
-    (loop as unknown as { agent: unknown }).agent = {
-      prompt: vi.fn().mockResolvedValue({
-        response: 'ok',
-        toolUseBlocks: [],
-        usage: { input_tokens: 0, output_tokens: 0 },
-      }),
-    };
+describe('Story BOUNDARY-6: stateless reports/anchor', () => {
+  describe('freshSession option (stateless lanes)', () => {
+    it('resets the pool session instead of reusing it', async () => {
+      const loop = new AgentLoop({} as never, { toolsConfig: { gateway: ['*'], mcp: [] } });
+      const resetSession = vi.fn().mockReturnValue('fresh-id');
+      const getSession = vi
+        .fn()
+        .mockReturnValue({ sessionId: 'stale-id', isNew: false, busy: false });
+      (loop as unknown as { sessionPool: unknown }).sessionPool = {
+        resetSession,
+        getSession,
+        releaseSession: () => {},
+        // Called unconditionally after every turn (agent-loop.ts:1293-1297) -
+        // omitting it makes a CORRECT implementation fail this test.
+        updateTokens: () => ({ totalTokens: 0, nearThreshold: false }),
+      };
+      (loop as unknown as { agent: unknown }).agent = {
+        prompt: vi.fn().mockResolvedValue({
+          response: 'ok',
+          toolUseBlocks: [],
+          usage: { input_tokens: 0, output_tokens: 0 },
+        }),
+      };
 
-    await loop.runWithContent([{ type: 'text', text: 'report' }], {
-      source: 'operator',
-      channelId: 'report',
-      modelRunId: 'test-run',
-      freshSession: true,
+      await loop.runWithContent([{ type: 'text', text: 'report' }], {
+        source: 'operator',
+        channelId: 'report',
+        modelRunId: 'test-run',
+        freshSession: true,
+      });
+
+      expect(resetSession).toHaveBeenCalledTimes(1);
+      expect(getSession).not.toHaveBeenCalled();
     });
-
-    expect(resetSession).toHaveBeenCalledTimes(1);
-    expect(getSession).not.toHaveBeenCalled();
   });
 });

--- a/packages/standalone/tests/agent/fresh-session.test.ts
+++ b/packages/standalone/tests/agent/fresh-session.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AgentLoop } from '../../src/agent/agent-loop.js';
+
+describe('freshSession option (stateless lanes)', () => {
+  it('resets the pool session instead of reusing it', async () => {
+    const loop = new AgentLoop({} as never, { toolsConfig: { gateway: ['*'], mcp: [] } });
+    const resetSession = vi.fn().mockReturnValue('fresh-id');
+    const getSession = vi
+      .fn()
+      .mockReturnValue({ sessionId: 'stale-id', isNew: false, busy: false });
+    (loop as unknown as { sessionPool: unknown }).sessionPool = {
+      resetSession,
+      getSession,
+      releaseSession: () => {},
+      // Called unconditionally after every turn (agent-loop.ts:1293-1297) -
+      // omitting it makes a CORRECT implementation fail this test.
+      updateTokens: () => ({ totalTokens: 0, nearThreshold: false }),
+    };
+    (loop as unknown as { agent: unknown }).agent = {
+      setSessionId: () => {},
+      prompt: vi.fn().mockResolvedValue({
+        response: 'ok',
+        toolUseBlocks: [],
+        usage: { input_tokens: 0, output_tokens: 0 },
+      }),
+    };
+
+    await loop.runWithContent([{ type: 'text', text: 'report' }], {
+      source: 'operator',
+      channelId: 'report',
+      modelRunId: 'test-run',
+      freshSession: true,
+    });
+
+    expect(resetSession).toHaveBeenCalledTimes(1);
+    expect(getSession).not.toHaveBeenCalled();
+  });
+});

--- a/packages/standalone/tests/agent/fresh-session.test.ts
+++ b/packages/standalone/tests/agent/fresh-session.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { AgentLoop } from '../../src/agent/agent-loop.js';
 
 describe('Story BOUNDARY-6: stateless reports/anchor', () => {
-  describe('freshSession option (stateless lanes)', () => {
+  describe('AC #1: freshSession resets the pool session instead of reusing it', () => {
     it('resets the pool session instead of reusing it', async () => {
       const loop = new AgentLoop({} as never, { toolsConfig: { gateway: ['*'], mcp: [] } });
       const resetSession = vi.fn().mockReturnValue('fresh-id');

--- a/packages/standalone/tests/agent/fresh-session.test.ts
+++ b/packages/standalone/tests/agent/fresh-session.test.ts
@@ -17,7 +17,6 @@ describe('freshSession option (stateless lanes)', () => {
       updateTokens: () => ({ totalTokens: 0, nearThreshold: false }),
     };
     (loop as unknown as { agent: unknown }).agent = {
-      setSessionId: () => {},
       prompt: vi.fn().mockResolvedValue({
         response: 'ok',
         toolUseBlocks: [],

--- a/packages/standalone/tests/agent/per-call-session-routing.test.ts
+++ b/packages/standalone/tests/agent/per-call-session-routing.test.ts
@@ -10,36 +10,40 @@ const makeProcess = () => ({
   }),
 });
 
-describe('per-call session routing (no shared mutation)', () => {
-  it('routes concurrent prompts to their own sessions without cross-talk', async () => {
-    const adapter = new PersistentCLIAdapter({ sessionId: 'constructor-key' });
-    const processes = new Map<string, ReturnType<typeof makeProcess>>();
-    const getProcess = vi.fn(async (key: string) => {
-      if (!processes.has(key)) processes.set(key, makeProcess());
-      return processes.get(key)!;
+describe('Story BOUNDARY-5: per-call session routing', () => {
+  describe('per-call session routing (no shared mutation)', () => {
+    it('routes concurrent prompts to their own sessions without cross-talk', async () => {
+      const adapter = new PersistentCLIAdapter({ sessionId: 'constructor-key' });
+      const processes = new Map<string, ReturnType<typeof makeProcess>>();
+      const getProcess = vi.fn(async (key: string) => {
+        if (!processes.has(key)) {
+          processes.set(key, makeProcess());
+        }
+        return processes.get(key)!;
+      });
+      (adapter as unknown as { processPool: { getProcess: unknown } }).processPool = {
+        getProcess,
+      };
+
+      await Promise.all([
+        adapter.prompt('for-A', undefined, { sessionId: 'session-A' }),
+        adapter.prompt('for-B', undefined, { sessionId: 'session-B' }),
+      ]);
+
+      expect(processes.get('session-A')!.sendMessage).toHaveBeenCalledWith('for-A', undefined);
+      expect(processes.get('session-B')!.sendMessage).toHaveBeenCalledWith('for-B', undefined);
+      // Shared adapter state must be untouched by per-call routing.
+      expect(adapter.getOptions().sessionId).toBe('constructor-key');
     });
-    (adapter as unknown as { processPool: { getProcess: unknown } }).processPool = {
-      getProcess,
-    };
 
-    await Promise.all([
-      adapter.prompt('for-A', undefined, { sessionId: 'session-A' }),
-      adapter.prompt('for-B', undefined, { sessionId: 'session-B' }),
-    ]);
-
-    expect(processes.get('session-A')!.sendMessage).toHaveBeenCalledWith('for-A', undefined);
-    expect(processes.get('session-B')!.sendMessage).toHaveBeenCalledWith('for-B', undefined);
-    // Shared adapter state must be untouched by per-call routing.
-    expect(adapter.getOptions().sessionId).toBe('constructor-key');
-  });
-
-  it('falls back to the constructor channel key when no per-call sessionId given', async () => {
-    const adapter = new PersistentCLIAdapter({ sessionId: 'constructor-key' });
-    const getProcess = vi.fn().mockResolvedValue(makeProcess());
-    (adapter as unknown as { processPool: { getProcess: unknown } }).processPool = {
-      getProcess,
-    };
-    await adapter.prompt('hello');
-    expect(getProcess).toHaveBeenCalledWith('constructor-key', expect.any(Object));
+    it('falls back to the constructor channel key when no per-call sessionId given', async () => {
+      const adapter = new PersistentCLIAdapter({ sessionId: 'constructor-key' });
+      const getProcess = vi.fn().mockResolvedValue(makeProcess());
+      (adapter as unknown as { processPool: { getProcess: unknown } }).processPool = {
+        getProcess,
+      };
+      await adapter.prompt('hello');
+      expect(getProcess).toHaveBeenCalledWith('constructor-key', expect.any(Object));
+    });
   });
 });

--- a/packages/standalone/tests/agent/per-call-session-routing.test.ts
+++ b/packages/standalone/tests/agent/per-call-session-routing.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PersistentCLIAdapter } from '../../src/agent/persistent-cli-adapter.js';
+
+const makeProcess = () => ({
+  isAlive: () => true,
+  sendMessage: vi.fn().mockResolvedValue({
+    response: 'ok',
+    toolUseBlocks: [],
+    usage: { input_tokens: 0, output_tokens: 0 },
+  }),
+});
+
+describe('per-call session routing (no shared mutation)', () => {
+  it('routes concurrent prompts to their own sessions without cross-talk', async () => {
+    const adapter = new PersistentCLIAdapter({ sessionId: 'constructor-key' });
+    const processes = new Map<string, ReturnType<typeof makeProcess>>();
+    const getProcess = vi.fn(async (key: string) => {
+      if (!processes.has(key)) processes.set(key, makeProcess());
+      return processes.get(key)!;
+    });
+    (adapter as unknown as { processPool: { getProcess: unknown } }).processPool = {
+      getProcess,
+    };
+
+    await Promise.all([
+      adapter.prompt('for-A', undefined, { sessionId: 'session-A' } as never),
+      adapter.prompt('for-B', undefined, { sessionId: 'session-B' } as never),
+    ]);
+
+    expect(processes.get('session-A')!.sendMessage).toHaveBeenCalledWith('for-A', undefined);
+    expect(processes.get('session-B')!.sendMessage).toHaveBeenCalledWith('for-B', undefined);
+    // Shared adapter state must be untouched by per-call routing.
+    expect(adapter.getOptions().sessionId).toBe('constructor-key');
+  });
+
+  it('falls back to the constructor channel key when no per-call sessionId given', async () => {
+    const adapter = new PersistentCLIAdapter({ sessionId: 'constructor-key' });
+    const getProcess = vi.fn().mockResolvedValue(makeProcess());
+    (adapter as unknown as { processPool: { getProcess: unknown } }).processPool = {
+      getProcess,
+    };
+    await adapter.prompt('hello');
+    expect(getProcess).toHaveBeenCalledWith('constructor-key', expect.any(Object));
+  });
+});

--- a/packages/standalone/tests/agent/per-call-session-routing.test.ts
+++ b/packages/standalone/tests/agent/per-call-session-routing.test.ts
@@ -11,7 +11,7 @@ const makeProcess = () => ({
 });
 
 describe('Story BOUNDARY-5: per-call session routing', () => {
-  describe('per-call session routing (no shared mutation)', () => {
+  describe('AC #1: sessionId routes each call to its own process without shared mutation', () => {
     it('routes concurrent prompts to their own sessions without cross-talk', async () => {
       const adapter = new PersistentCLIAdapter({ sessionId: 'constructor-key' });
       const processes = new Map<string, ReturnType<typeof makeProcess>>();

--- a/packages/standalone/tests/agent/per-call-session-routing.test.ts
+++ b/packages/standalone/tests/agent/per-call-session-routing.test.ts
@@ -23,8 +23,8 @@ describe('per-call session routing (no shared mutation)', () => {
     };
 
     await Promise.all([
-      adapter.prompt('for-A', undefined, { sessionId: 'session-A' } as never),
-      adapter.prompt('for-B', undefined, { sessionId: 'session-B' } as never),
+      adapter.prompt('for-A', undefined, { sessionId: 'session-A' }),
+      adapter.prompt('for-B', undefined, { sessionId: 'session-B' }),
     ]);
 
     expect(processes.get('session-A')!.sendMessage).toHaveBeenCalledWith('for-A', undefined);

--- a/packages/standalone/tests/agent/per-call-system-prompt.test.ts
+++ b/packages/standalone/tests/agent/per-call-system-prompt.test.ts
@@ -1,0 +1,43 @@
+// packages/standalone/tests/agent/per-call-system-prompt.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { PersistentCLIAdapter } from '../../src/agent/persistent-cli-adapter.js';
+
+const stubPool = (adapter: PersistentCLIAdapter) => {
+  const getProcess = vi.fn().mockResolvedValue({
+    isAlive: () => true,
+    sendMessage: vi.fn().mockResolvedValue({ response: 'ok', toolUseBlocks: [] }),
+  });
+  (adapter as unknown as { processPool: { getProcess: unknown } }).processPool = {
+    getProcess,
+  };
+  return getProcess;
+};
+
+describe('per-call system prompt (no shared mutation)', () => {
+  it('routes options.systemPrompt to getProcess for this call only', async () => {
+    const adapter = new PersistentCLIAdapter({ systemPrompt: 'SPAWN-DEFAULT' });
+    const getProcess = stubPool(adapter);
+
+    await adapter.prompt('hello', undefined, {
+      systemPrompt: 'PER-CALL-PROMPT',
+    });
+
+    expect(getProcess).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ systemPrompt: 'PER-CALL-PROMPT' })
+    );
+    expect(adapter.getOptions().systemPrompt).toBe('SPAWN-DEFAULT');
+  });
+
+  it('falls back to the constructor systemPrompt when no per-call value given', async () => {
+    const adapter = new PersistentCLIAdapter({ systemPrompt: 'SPAWN-DEFAULT' });
+    const getProcess = stubPool(adapter);
+
+    await adapter.prompt('hello');
+
+    expect(getProcess).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ systemPrompt: 'SPAWN-DEFAULT' })
+    );
+  });
+});

--- a/packages/standalone/tests/agent/per-call-system-prompt.test.ts
+++ b/packages/standalone/tests/agent/per-call-system-prompt.test.ts
@@ -13,31 +13,33 @@ const stubPool = (adapter: PersistentCLIAdapter) => {
   return getProcess;
 };
 
-describe('per-call system prompt (no shared mutation)', () => {
-  it('routes options.systemPrompt to getProcess for this call only', async () => {
-    const adapter = new PersistentCLIAdapter({ systemPrompt: 'SPAWN-DEFAULT' });
-    const getProcess = stubPool(adapter);
+describe('Story BOUNDARY-3: per-call system prompt', () => {
+  describe('per-call system prompt (no shared mutation)', () => {
+    it('routes options.systemPrompt to getProcess for this call only', async () => {
+      const adapter = new PersistentCLIAdapter({ systemPrompt: 'SPAWN-DEFAULT' });
+      const getProcess = stubPool(adapter);
 
-    await adapter.prompt('hello', undefined, {
-      systemPrompt: 'PER-CALL-PROMPT',
+      await adapter.prompt('hello', undefined, {
+        systemPrompt: 'PER-CALL-PROMPT',
+      });
+
+      expect(getProcess).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ systemPrompt: 'PER-CALL-PROMPT' })
+      );
+      expect(adapter.getOptions().systemPrompt).toBe('SPAWN-DEFAULT');
     });
 
-    expect(getProcess).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({ systemPrompt: 'PER-CALL-PROMPT' })
-    );
-    expect(adapter.getOptions().systemPrompt).toBe('SPAWN-DEFAULT');
-  });
+    it('falls back to the constructor systemPrompt when no per-call value given', async () => {
+      const adapter = new PersistentCLIAdapter({ systemPrompt: 'SPAWN-DEFAULT' });
+      const getProcess = stubPool(adapter);
 
-  it('falls back to the constructor systemPrompt when no per-call value given', async () => {
-    const adapter = new PersistentCLIAdapter({ systemPrompt: 'SPAWN-DEFAULT' });
-    const getProcess = stubPool(adapter);
+      await adapter.prompt('hello');
 
-    await adapter.prompt('hello');
-
-    expect(getProcess).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({ systemPrompt: 'SPAWN-DEFAULT' })
-    );
+      expect(getProcess).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ systemPrompt: 'SPAWN-DEFAULT' })
+      );
+    });
   });
 });

--- a/packages/standalone/tests/agent/per-call-system-prompt.test.ts
+++ b/packages/standalone/tests/agent/per-call-system-prompt.test.ts
@@ -14,7 +14,7 @@ const stubPool = (adapter: PersistentCLIAdapter) => {
 };
 
 describe('Story BOUNDARY-3: per-call system prompt', () => {
-  describe('per-call system prompt (no shared mutation)', () => {
+  describe('AC #1: systemPrompt travels per prompt() call without mutating shared adapter state', () => {
     it('routes options.systemPrompt to getProcess for this call only', async () => {
       const adapter = new PersistentCLIAdapter({ systemPrompt: 'SPAWN-DEFAULT' });
       const getProcess = stubPool(adapter);

--- a/packages/standalone/tests/agent/persona-native-tools.test.ts
+++ b/packages/standalone/tests/agent/persona-native-tools.test.ts
@@ -9,21 +9,23 @@ const adapterOptions = (loop: AgentLoop): { tools?: string } =>
     }
   ).persistentCLI.getOptions();
 
-describe('persona native tool lockdown (builtinTools pass-through)', () => {
-  it('passes builtinTools through to the CLI adapter as the --tools value', () => {
-    const loop = new AgentLoop({} as never, {
-      backend: 'claude',
-      toolsConfig: { gateway: ['*'], mcp: [] },
-      builtinTools: '',
+describe('Story BOUNDARY-2: persona native tool lockdown', () => {
+  describe('persona native tool lockdown (builtinTools pass-through)', () => {
+    it('passes builtinTools through to the CLI adapter as the --tools value', () => {
+      const loop = new AgentLoop({} as never, {
+        backend: 'claude',
+        toolsConfig: { gateway: ['*'], mcp: [] },
+        builtinTools: '',
+      });
+      expect(adapterOptions(loop).tools).toBe('');
     });
-    expect(adapterOptions(loop).tools).toBe('');
-  });
 
-  it('leaves native tools untouched when builtinTools is not set', () => {
-    const loop = new AgentLoop({} as never, {
-      backend: 'claude',
-      toolsConfig: { gateway: ['*'], mcp: [] },
+    it('leaves native tools untouched when builtinTools is not set', () => {
+      const loop = new AgentLoop({} as never, {
+        backend: 'claude',
+        toolsConfig: { gateway: ['*'], mcp: [] },
+      });
+      expect(adapterOptions(loop).tools).toBeUndefined();
     });
-    expect(adapterOptions(loop).tools).toBeUndefined();
   });
 });

--- a/packages/standalone/tests/agent/persona-native-tools.test.ts
+++ b/packages/standalone/tests/agent/persona-native-tools.test.ts
@@ -1,0 +1,29 @@
+// packages/standalone/tests/agent/persona-native-tools.test.ts
+import { describe, it, expect } from 'vitest';
+import { AgentLoop } from '../../src/agent/agent-loop.js';
+
+const adapterOptions = (loop: AgentLoop): { tools?: string } =>
+  (
+    loop as unknown as {
+      persistentCLI: { getOptions(): { tools?: string } };
+    }
+  ).persistentCLI.getOptions();
+
+describe('persona native tool lockdown (builtinTools pass-through)', () => {
+  it('passes builtinTools through to the CLI adapter as the --tools value', () => {
+    const loop = new AgentLoop({} as never, {
+      backend: 'claude',
+      toolsConfig: { gateway: ['*'], mcp: [] },
+      builtinTools: '',
+    });
+    expect(adapterOptions(loop).tools).toBe('');
+  });
+
+  it('leaves native tools untouched when builtinTools is not set', () => {
+    const loop = new AgentLoop({} as never, {
+      backend: 'claude',
+      toolsConfig: { gateway: ['*'], mcp: [] },
+    });
+    expect(adapterOptions(loop).tools).toBeUndefined();
+  });
+});

--- a/packages/standalone/tests/agent/persona-native-tools.test.ts
+++ b/packages/standalone/tests/agent/persona-native-tools.test.ts
@@ -10,7 +10,7 @@ const adapterOptions = (loop: AgentLoop): { tools?: string } =>
   ).persistentCLI.getOptions();
 
 describe('Story BOUNDARY-2: persona native tool lockdown', () => {
-  describe('persona native tool lockdown (builtinTools pass-through)', () => {
+  describe('AC #1: builtinTools option controls the CLI --tools surface', () => {
     it('passes builtinTools through to the CLI adapter as the --tools value', () => {
       const loop = new AgentLoop({} as never, {
         backend: 'claude',

--- a/packages/standalone/tests/agent/shared-executor.test.ts
+++ b/packages/standalone/tests/agent/shared-executor.test.ts
@@ -6,7 +6,7 @@ const loopExecutor = (loop: AgentLoop): unknown =>
   (loop as unknown as { mcpExecutor: unknown }).mcpExecutor;
 
 describe('Story BOUNDARY-1: shared gateway executor', () => {
-  describe('shared gateway executor (root fix for dual-wiring)', () => {
+  describe('AC #1: persona loop uses the injected boot-wired executor and per-call tool blocks', () => {
     it('uses the injected executor instead of constructing its own', () => {
       const shared = new GatewayToolExecutor({});
       const loop = new AgentLoop({} as never, {

--- a/packages/standalone/tests/agent/shared-executor.test.ts
+++ b/packages/standalone/tests/agent/shared-executor.test.ts
@@ -5,66 +5,68 @@ import { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
 const loopExecutor = (loop: AgentLoop): unknown =>
   (loop as unknown as { mcpExecutor: unknown }).mcpExecutor;
 
-describe('shared gateway executor (root fix for dual-wiring)', () => {
-  it('uses the injected executor instead of constructing its own', () => {
-    const shared = new GatewayToolExecutor({});
-    const loop = new AgentLoop({} as never, {
-      toolsConfig: { gateway: ['*'], mcp: [] },
-      executor: shared,
+describe('Story BOUNDARY-1: shared gateway executor', () => {
+  describe('shared gateway executor (root fix for dual-wiring)', () => {
+    it('uses the injected executor instead of constructing its own', () => {
+      const shared = new GatewayToolExecutor({});
+      const loop = new AgentLoop({} as never, {
+        toolsConfig: { gateway: ['*'], mcp: [] },
+        executor: shared,
+      });
+      expect(loopExecutor(loop)).toBe(shared);
     });
-    expect(loopExecutor(loop)).toBe(shared);
-  });
 
-  it('boot wiring on the shared executor is visible to the persona loop', () => {
-    const shared = new GatewayToolExecutor({});
-    const loop = new AgentLoop({} as never, {
-      toolsConfig: { gateway: ['*'], mcp: [] },
-      executor: shared,
+    it('boot wiring on the shared executor is visible to the persona loop', () => {
+      const shared = new GatewayToolExecutor({});
+      const loop = new AgentLoop({} as never, {
+        toolsConfig: { gateway: ['*'], mcp: [] },
+        executor: shared,
+      });
+      const fakeLedger = { list: () => [] } as never;
+      shared.setTaskLedger(fakeLedger); // simulates start.ts:1067
+      expect((loopExecutor(loop) as { getTaskLedger(): unknown }).getTaskLedger()).toBe(fakeLedger);
     });
-    const fakeLedger = { list: () => [] } as never;
-    shared.setTaskLedger(fakeLedger); // simulates start.ts:1067
-    expect((loopExecutor(loop) as { getTaskLedger(): unknown }).getTaskLedger()).toBe(fakeLedger);
-  });
 
-  it('still constructs its own executor when none injected (memory agent / mama run)', () => {
-    const loop = new AgentLoop({} as never, { toolsConfig: { gateway: ['*'], mcp: [] } });
-    expect(loopExecutor(loop)).toBeInstanceOf(GatewayToolExecutor);
-  });
-
-  it('does NOT mutate instance-level disallowed tools on an injected executor', () => {
-    const shared = new GatewayToolExecutor({});
-    new AgentLoop({} as never, {
-      toolsConfig: { gateway: ['*'], mcp: [] },
-      executor: shared,
-      disallowedTools: ['report_publish'],
+    it('still constructs its own executor when none injected (memory agent / mama run)', () => {
+      const loop = new AgentLoop({} as never, { toolsConfig: { gateway: ['*'], mcp: [] } });
+      expect(loopExecutor(loop)).toBeInstanceOf(GatewayToolExecutor);
     });
-    // Instance-level set would leak the persona's blocks to dashboard-agent/code-act
-    // callers of the shared executor. The list must flow per-call instead.
-    expect(
-      (shared as unknown as { disallowedGatewayTools: Set<string> }).disallowedGatewayTools.size
-    ).toBe(0);
-  });
 
-  it('DENIES a tool via per-call context (end-to-end through normalize+merge)', async () => {
-    // Regression guard for the silent-drop hazard: normalizeExecutionContext and
-    // mergeWithFallbackExecutionContext are explicit-field whitelists - if either
-    // drops disallowedGatewayTools, enforcement dies silently. This test fails then.
-    const shared = new GatewayToolExecutor({});
-    const result = await shared.execute(
-      'report_publish',
-      { slots: {} } as never,
-      { disallowedGatewayTools: ['report_publish'] } as never
-    );
-    expect(result).toMatchObject({
-      success: false,
-      error: expect.stringContaining('not available'),
+    it('does NOT mutate instance-level disallowed tools on an injected executor', () => {
+      const shared = new GatewayToolExecutor({});
+      new AgentLoop({} as never, {
+        toolsConfig: { gateway: ['*'], mcp: [] },
+        executor: shared,
+        disallowedTools: ['report_publish'],
+      });
+      // Instance-level set would leak the persona's blocks to dashboard-agent/code-act
+      // callers of the shared executor. The list must flow per-call instead.
+      expect(
+        (shared as unknown as { disallowedGatewayTools: Set<string> }).disallowedGatewayTools.size
+      ).toBe(0);
     });
-  });
 
-  it('setMamaApi wires the API onto an already-constructed executor', () => {
-    const shared = new GatewayToolExecutor({});
-    const fakeApi = { marker: 'initMamaCore-instance' } as never;
-    (shared as unknown as { setMamaApi(api: unknown): void }).setMamaApi(fakeApi);
-    expect((shared as unknown as { mamaApi: unknown }).mamaApi).toBe(fakeApi);
+    it('DENIES a tool via per-call context (end-to-end through normalize+merge)', async () => {
+      // Regression guard for the silent-drop hazard: normalizeExecutionContext and
+      // mergeWithFallbackExecutionContext are explicit-field whitelists - if either
+      // drops disallowedGatewayTools, enforcement dies silently. This test fails then.
+      const shared = new GatewayToolExecutor({});
+      const result = await shared.execute(
+        'report_publish',
+        { slots: {} } as never,
+        { disallowedGatewayTools: ['report_publish'] } as never
+      );
+      expect(result).toMatchObject({
+        success: false,
+        error: expect.stringContaining('not available'),
+      });
+    });
+
+    it('setMamaApi wires the API onto an already-constructed executor', () => {
+      const shared = new GatewayToolExecutor({});
+      const fakeApi = { marker: 'initMamaCore-instance' } as never;
+      (shared as unknown as { setMamaApi(api: unknown): void }).setMamaApi(fakeApi);
+      expect((shared as unknown as { mamaApi: unknown }).mamaApi).toBe(fakeApi);
+    });
   });
 });

--- a/packages/standalone/tests/agent/shared-executor.test.ts
+++ b/packages/standalone/tests/agent/shared-executor.test.ts
@@ -60,4 +60,11 @@ describe('shared gateway executor (root fix for dual-wiring)', () => {
       error: expect.stringContaining('not available'),
     });
   });
+
+  it('setMamaApi wires the API onto an already-constructed executor', () => {
+    const shared = new GatewayToolExecutor({});
+    const fakeApi = { marker: 'initMamaCore-instance' } as never;
+    (shared as unknown as { setMamaApi(api: unknown): void }).setMamaApi(fakeApi);
+    expect((shared as unknown as { mamaApi: unknown }).mamaApi).toBe(fakeApi);
+  });
 });

--- a/packages/standalone/tests/agent/shared-executor.test.ts
+++ b/packages/standalone/tests/agent/shared-executor.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { AgentLoop } from '../../src/agent/agent-loop.js';
+import { GatewayToolExecutor } from '../../src/agent/gateway-tool-executor.js';
+
+const loopExecutor = (loop: AgentLoop): unknown =>
+  (loop as unknown as { mcpExecutor: unknown }).mcpExecutor;
+
+describe('shared gateway executor (root fix for dual-wiring)', () => {
+  it('uses the injected executor instead of constructing its own', () => {
+    const shared = new GatewayToolExecutor({});
+    const loop = new AgentLoop({} as never, {
+      toolsConfig: { gateway: ['*'], mcp: [] },
+      executor: shared,
+    });
+    expect(loopExecutor(loop)).toBe(shared);
+  });
+
+  it('boot wiring on the shared executor is visible to the persona loop', () => {
+    const shared = new GatewayToolExecutor({});
+    const loop = new AgentLoop({} as never, {
+      toolsConfig: { gateway: ['*'], mcp: [] },
+      executor: shared,
+    });
+    const fakeLedger = { list: () => [] } as never;
+    shared.setTaskLedger(fakeLedger); // simulates start.ts:1067
+    expect((loopExecutor(loop) as { getTaskLedger(): unknown }).getTaskLedger()).toBe(fakeLedger);
+  });
+
+  it('still constructs its own executor when none injected (memory agent / mama run)', () => {
+    const loop = new AgentLoop({} as never, { toolsConfig: { gateway: ['*'], mcp: [] } });
+    expect(loopExecutor(loop)).toBeInstanceOf(GatewayToolExecutor);
+  });
+
+  it('does NOT mutate instance-level disallowed tools on an injected executor', () => {
+    const shared = new GatewayToolExecutor({});
+    new AgentLoop({} as never, {
+      toolsConfig: { gateway: ['*'], mcp: [] },
+      executor: shared,
+      disallowedTools: ['report_publish'],
+    });
+    // Instance-level set would leak the persona's blocks to dashboard-agent/code-act
+    // callers of the shared executor. The list must flow per-call instead.
+    expect(
+      (shared as unknown as { disallowedGatewayTools: Set<string> }).disallowedGatewayTools.size
+    ).toBe(0);
+  });
+
+  it('DENIES a tool via per-call context (end-to-end through normalize+merge)', async () => {
+    // Regression guard for the silent-drop hazard: normalizeExecutionContext and
+    // mergeWithFallbackExecutionContext are explicit-field whitelists - if either
+    // drops disallowedGatewayTools, enforcement dies silently. This test fails then.
+    const shared = new GatewayToolExecutor({});
+    const result = await shared.execute(
+      'report_publish',
+      { slots: {} } as never,
+      { disallowedGatewayTools: ['report_publish'] } as never
+    );
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining('not available'),
+    });
+  });
+});

--- a/packages/standalone/tests/cli/runtime/agent-loop-init-envelope-options.test.ts
+++ b/packages/standalone/tests/cli/runtime/agent-loop-init-envelope-options.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { AgentLoop } from '../../../src/agent/index.js';
+import { AgentLoop, GatewayToolExecutor } from '../../../src/agent/index.js';
 import type { AgentContext, AgentLoopOptions, ContentBlock } from '../../../src/agent/types.js';
 import type { MAMAConfig } from '../../../src/cli/config/types.js';
 import type { OAuthManager } from '../../../src/auth/index.js';
@@ -99,7 +99,8 @@ describe('Story M1R: initMainAgentLoop envelope options', () => {
         { getToken: vi.fn() } as unknown as OAuthManager,
         {} as SQLiteDatabase,
         null as MetricsStore | null,
-        'claude'
+        'claude',
+        new GatewayToolExecutor({})
       );
       const options = createOptions();
 
@@ -114,7 +115,8 @@ describe('Story M1R: initMainAgentLoop envelope options', () => {
         { getToken: vi.fn() } as unknown as OAuthManager,
         {} as SQLiteDatabase,
         null as MetricsStore | null,
-        'claude'
+        'claude',
+        new GatewayToolExecutor({})
       );
       const content: ContentBlock[] = [{ type: 'text', text: 'hello' }];
       const options = createOptions();

--- a/packages/standalone/tests/operator/operator-trigger-loop.test.ts
+++ b/packages/standalone/tests/operator/operator-trigger-loop.test.ts
@@ -9,11 +9,22 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import Database, { type SQLiteDatabase } from '../../src/sqlite.js';
 import { TriggerRegistry } from '../../src/operator/trigger-registry.js';
 import { OperatorTriggerLoop, type TickResult } from '../../src/operator/operator-trigger-loop.js';
-import type { OperatorChannelEvent, OperatorMemoryPort } from '../../src/operator/operator-interfaces.js';
+import type {
+  OperatorChannelEvent,
+  OperatorMemoryPort,
+} from '../../src/operator/operator-interfaces.js';
 import type { CreateTriggerInput } from '../../src/operator/trigger-types.js';
 
 function ev(id: number, channelId: string, content: string): OperatorChannelEvent {
-  return { id, channel: 'slack', channelId, userId: 'u1', role: 'user', content, createdAt: id * 100 };
+  return {
+    id,
+    channel: 'slack',
+    channelId,
+    userId: 'u1',
+    role: 'user',
+    content,
+    createdAt: id * 100,
+  };
 }
 
 function seedTrigger(reg: TriggerRegistry, id = 'tr1', keyword = 'report'): void {
@@ -73,7 +84,13 @@ describe('OperatorTriggerLoop', () => {
       registry: reg,
       askAgent: async () => '[]', // author proposes nothing by default
       review: async () => ({ action: 'kept' as const }),
-      config: { tickMs: 60_000, drainLimit: 50, authorEveryNTicks: 3, reviewEveryNTicks: 5, authorWindowSize: 10 },
+      config: {
+        tickMs: 60_000,
+        drainLimit: 50,
+        authorEveryNTicks: 3,
+        reviewEveryNTicks: 5,
+        authorWindowSize: 10,
+      },
       log: (line) => logs.push(line),
       ...over,
     });
@@ -104,7 +121,16 @@ describe('OperatorTriggerLoop', () => {
         },
       ])
     );
-    const loop = makeLoop({ askAgent, config: { tickMs: 1000, drainLimit: 50, authorEveryNTicks: 2, reviewEveryNTicks: 99, authorWindowSize: 10 } });
+    const loop = makeLoop({
+      askAgent,
+      config: {
+        tickMs: 1000,
+        drainLimit: 50,
+        authorEveryNTicks: 2,
+        reviewEveryNTicks: 99,
+        authorWindowSize: 10,
+      },
+    });
     delta.queue = [ev(1, 'ch-a', 'zzz again')];
     await loop.tick(); // tick 1: no author
     expect(askAgent).not.toHaveBeenCalled();
@@ -118,7 +144,16 @@ describe('OperatorTriggerLoop', () => {
     seedTrigger(reg, 'fired-one', 'report');
     seedTrigger(reg, 'silent-one', 'zzz');
     const review = vi.fn(async () => ({ action: 'retired' as const, reason: 'noisy' }));
-    const loop = makeLoop({ review, config: { tickMs: 1000, drainLimit: 50, authorEveryNTicks: 99, reviewEveryNTicks: 2, authorWindowSize: 10 } });
+    const loop = makeLoop({
+      review,
+      config: {
+        tickMs: 1000,
+        drainLimit: 50,
+        authorEveryNTicks: 99,
+        reviewEveryNTicks: 2,
+        authorWindowSize: 10,
+      },
+    });
     delta.queue = [ev(1, 'ch-a', 'the report is late')]; // fires 'fired-one' only
     await loop.tick();
     await loop.tick(); // review tick
@@ -137,7 +172,14 @@ describe('OperatorTriggerLoop', () => {
     const loop = makeLoop({
       askAgent,
       output: { send },
-      config: { tickMs: 1000, drainLimit: 50, authorEveryNTicks: 99, reviewEveryNTicks: 99, authorWindowSize: 10, reportEveryNTicks: 2 },
+      config: {
+        tickMs: 1000,
+        drainLimit: 50,
+        authorEveryNTicks: 99,
+        reviewEveryNTicks: 99,
+        authorWindowSize: 10,
+        reportEveryNTicks: 2,
+      },
     });
     delta.queue = [ev(1, 'ch-a', 'the report is late')];
     await loop.tick(); // fire buffered
@@ -196,14 +238,21 @@ describe('OperatorTriggerLoop', () => {
     const loop = makeLoop({
       askAgent,
       output: { send },
-      config: { tickMs: 1000, drainLimit: 50, authorEveryNTicks: 99, reviewEveryNTicks: 99, authorWindowSize: 10, reportEveryNTicks: 2 },
+      config: {
+        tickMs: 1000,
+        drainLimit: 50,
+        authorEveryNTicks: 99,
+        reviewEveryNTicks: 99,
+        authorWindowSize: 10,
+        reportEveryNTicks: 2,
+      },
     });
     delta.queue = [ev(1, 'ch-a', 'the report is late'), ev(2, 'ch-b', 'unrelated chatter')];
-    await loop.tick();            // tick 1: fire on ch-a; window buffers ch-a + ch-b
+    await loop.tick(); // tick 1: fire on ch-a; window buffers ch-a + ch-b
     const r2 = await loop.tick(); // tick 2: digest
     expect(r2.reported).toBe(true);
     const digestPrompt = captured.find((p) => p.includes('Fire activity'))!;
-    expect(digestPrompt).toContain('ch-b');             // a NON-firing channel is in the window
+    expect(digestPrompt).toContain('ch-b'); // a NON-firing channel is in the window
     expect(digestPrompt).toContain('unrelated chatter');
     expect(digestPrompt).toContain('ch-a');
   });
@@ -211,13 +260,25 @@ describe('OperatorTriggerLoop', () => {
   it('scheduled full report: fires at a configured hour even with no trigger fires, marks the hour (M2)', async () => {
     const send = vi.fn(async () => {});
     const markFired = vi.fn();
+    const markSuccess = vi.fn();
     const askAgent = vi.fn(async () => 'FULL REPORT text');
-    const scheduler = { shouldFire: () => ({ fire: true, hourKey: '2026-07-09:08' }), markFired };
+    const scheduler = {
+      shouldFire: () => ({ fire: true, hourKey: '2026-07-09:08' }),
+      markFired,
+      loadLastSuccess: () => null,
+      markSuccess,
+    };
     const loop = makeLoop({
       askAgent,
       output: { send },
       reportScheduler: scheduler,
-      config: { tickMs: 1000, drainLimit: 50, authorEveryNTicks: 99, reviewEveryNTicks: 99, authorWindowSize: 10 },
+      config: {
+        tickMs: 1000,
+        drainLimit: 50,
+        authorEveryNTicks: 99,
+        reviewEveryNTicks: 99,
+        authorWindowSize: 10,
+      },
     });
     delta.queue = [ev(1, 'ch-a', 'some chatter'), ev(2, 'ch-b', 'more chatter')]; // window only, no trigger seeded
     const r = await loop.tick();
@@ -225,6 +286,9 @@ describe('OperatorTriggerLoop', () => {
     expect(r.fullReported).toBe(true);
     expect(send).toHaveBeenCalledWith('FULL REPORT text');
     expect(markFired).toHaveBeenCalledWith('2026-07-09:08');
+    // A DELIVERED report advances the delta anchor (fire-time ISO timestamp).
+    expect(markSuccess).toHaveBeenCalledTimes(1);
+    expect(markSuccess.mock.calls[0][0]).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
   it('reports route through the persona agent (reportAsk) while authoring stays on askAgent (M2.2)', async () => {
@@ -233,13 +297,25 @@ describe('OperatorTriggerLoop', () => {
     const askAgent = vi.fn(async () => '[]'); // author/review path (bare CLI in prod)
     const reportAsk = vi.fn(async () => 'persona-composed report');
     const markFired = vi.fn();
-    const scheduler = { shouldFire: () => ({ fire: true, hourKey: 'k' }), markFired };
+    const scheduler = {
+      shouldFire: () => ({ fire: true, hourKey: 'k' }),
+      markFired,
+      loadLastSuccess: () => null,
+      markSuccess: vi.fn(),
+    };
     const loop = makeLoop({
       askAgent,
       reportAsk,
       output: { send },
       reportScheduler: scheduler,
-      config: { tickMs: 1000, drainLimit: 50, authorEveryNTicks: 1, reviewEveryNTicks: 99, authorWindowSize: 10, reportEveryNTicks: 1 },
+      config: {
+        tickMs: 1000,
+        drainLimit: 50,
+        authorEveryNTicks: 1,
+        reviewEveryNTicks: 99,
+        authorWindowSize: 10,
+        reportEveryNTicks: 1,
+      },
     });
     delta.queue = [ev(1, 'ch-a', 'the report is late')];
     const r = await loop.tick();
@@ -256,12 +332,23 @@ describe('OperatorTriggerLoop', () => {
     const send = vi.fn(async () => {});
     const markFired = vi.fn();
     const askAgent = vi.fn(async () => 'Scheduled report: quiet window.');
-    const scheduler = { shouldFire: () => ({ fire: true, hourKey: '2026-07-09:13' }), markFired };
+    const scheduler = {
+      shouldFire: () => ({ fire: true, hourKey: '2026-07-09:13' }),
+      markFired,
+      loadLastSuccess: () => null,
+      markSuccess: vi.fn(),
+    };
     const loop = makeLoop({
       askAgent,
       output: { send },
       reportScheduler: scheduler,
-      config: { tickMs: 1000, drainLimit: 50, authorEveryNTicks: 99, reviewEveryNTicks: 99, authorWindowSize: 10 },
+      config: {
+        tickMs: 1000,
+        drainLimit: 50,
+        authorEveryNTicks: 99,
+        reviewEveryNTicks: 99,
+        authorWindowSize: 10,
+      },
     });
     // NO events drained at all - the buffer is completely empty.
     const r = await loop.tick();
@@ -274,45 +361,86 @@ describe('OperatorTriggerLoop', () => {
   it('scheduled full report: agent NOTHING suppresses the send but still marks the hour (fire once)', async () => {
     const send = vi.fn();
     const markFired = vi.fn();
+    const markSuccess = vi.fn();
     const askAgent = vi.fn(async () => 'NOTHING');
-    const scheduler = { shouldFire: () => ({ fire: true, hourKey: 'k' }), markFired };
+    const scheduler = {
+      shouldFire: () => ({ fire: true, hourKey: 'k' }),
+      markFired,
+      loadLastSuccess: () => null,
+      markSuccess,
+    };
     const loop = makeLoop({
       askAgent,
       output: { send },
       reportScheduler: scheduler,
-      config: { tickMs: 1000, drainLimit: 50, authorEveryNTicks: 99, reviewEveryNTicks: 99, authorWindowSize: 10 },
+      config: {
+        tickMs: 1000,
+        drainLimit: 50,
+        authorEveryNTicks: 99,
+        reviewEveryNTicks: 99,
+        authorWindowSize: 10,
+      },
     });
     delta.queue = [ev(1, 'ch-a', 'chatter')];
     const r = await loop.tick();
     expect(r.fullReported).toBe(false);
     expect(send).not.toHaveBeenCalled();
     expect(markFired).toHaveBeenCalledWith('k');
+    // A NOTHING-suppressed report is NOT delivered -> the anchor must not advance.
+    expect(markSuccess).not.toHaveBeenCalled();
   });
 
   it('scheduled full report: send failure throws (no-fallback), hour NOT marked -> retries', async () => {
-    const send = vi.fn(async () => { throw new Error('telegram down'); });
+    const send = vi.fn(async () => {
+      throw new Error('telegram down');
+    });
     const markFired = vi.fn();
+    const markSuccess = vi.fn();
     const askAgent = vi.fn(async () => 'FULL');
-    const scheduler = { shouldFire: () => ({ fire: true, hourKey: 'k' }), markFired };
+    const scheduler = {
+      shouldFire: () => ({ fire: true, hourKey: 'k' }),
+      markFired,
+      loadLastSuccess: () => null,
+      markSuccess,
+    };
     const loop = makeLoop({
       askAgent,
       output: { send },
       reportScheduler: scheduler,
-      config: { tickMs: 1000, drainLimit: 50, authorEveryNTicks: 99, reviewEveryNTicks: 99, authorWindowSize: 10 },
+      config: {
+        tickMs: 1000,
+        drainLimit: 50,
+        authorEveryNTicks: 99,
+        reviewEveryNTicks: 99,
+        authorWindowSize: 10,
+      },
     });
     delta.queue = [ev(1, 'ch-a', 'chatter')];
     await expect(loop.tick()).rejects.toThrow('telegram down');
     expect(markFired).not.toHaveBeenCalled();
+    // Send threw before markFired/markSuccess -> the anchor never advances (retry next cadence).
+    expect(markSuccess).not.toHaveBeenCalled();
   });
 
   it('scheduled full report: not a configured hour -> no send, no mark', async () => {
     const send = vi.fn();
     const markFired = vi.fn();
-    const scheduler = { shouldFire: () => ({ fire: false, hourKey: 'k' }), markFired };
+    const scheduler = {
+      shouldFire: () => ({ fire: false, hourKey: 'k' }),
+      markFired,
+      loadLastSuccess: () => null,
+      markSuccess: vi.fn(),
+    };
     const loop = makeLoop({
       output: { send },
       reportScheduler: scheduler,
-      config: { tickMs: 1000, drainLimit: 50, authorEveryNTicks: 99, reviewEveryNTicks: 99, authorWindowSize: 10 },
+      config: {
+        tickMs: 1000,
+        drainLimit: 50,
+        authorEveryNTicks: 99,
+        reviewEveryNTicks: 99,
+        authorWindowSize: 10,
+      },
     });
     delta.queue = [ev(1, 'ch-a', 'chatter')];
     const r = await loop.tick();
@@ -325,7 +453,14 @@ describe('OperatorTriggerLoop', () => {
     vi.useFakeTimers();
     try {
       const loop = makeLoop({
-        config: { tickMs: 60_000, drainLimit: 50, authorEveryNTicks: 99, reviewEveryNTicks: 99, authorWindowSize: 10, nudgeDebounceMs: 15_000 },
+        config: {
+          tickMs: 60_000,
+          drainLimit: 50,
+          authorEveryNTicks: 99,
+          reviewEveryNTicks: 99,
+          authorWindowSize: 10,
+          nudgeDebounceMs: 15_000,
+        },
       });
       const tickSpy = vi.spyOn(loop, 'tick');
       loop.nudge();
@@ -343,7 +478,14 @@ describe('OperatorTriggerLoop', () => {
     vi.useFakeTimers();
     try {
       const loop = makeLoop({
-        config: { tickMs: 60_000, drainLimit: 50, authorEveryNTicks: 99, reviewEveryNTicks: 99, authorWindowSize: 10, nudgeDebounceMs: 15_000 },
+        config: {
+          tickMs: 60_000,
+          drainLimit: 50,
+          authorEveryNTicks: 99,
+          reviewEveryNTicks: 99,
+          authorWindowSize: 10,
+          nudgeDebounceMs: 15_000,
+        },
       });
       const tickSpy = vi.spyOn(loop, 'tick');
       loop.nudge();
@@ -361,13 +503,28 @@ describe('OperatorTriggerLoop', () => {
     vi.useFakeTimers();
     try {
       const loop = makeLoop({
-        config: { tickMs: 60_000, drainLimit: 50, authorEveryNTicks: 99, reviewEveryNTicks: 99, authorWindowSize: 10, nudgeDebounceMs: 5_000 },
+        config: {
+          tickMs: 60_000,
+          drainLimit: 50,
+          authorEveryNTicks: 99,
+          reviewEveryNTicks: 99,
+          authorWindowSize: 10,
+          nudgeDebounceMs: 5_000,
+        },
       });
       // First nudge-driven tick hangs, so `running` stays true across the second nudge window.
       let resolveFirst: () => void = () => {};
       const firstTick = new Promise<TickResult>((res) => {
         resolveFirst = () =>
-          res({ tick: 1, drained: 0, fires: 0, authored: 0, reviewed: 0, reported: false, fullReported: false });
+          res({
+            tick: 1,
+            drained: 0,
+            fires: 0,
+            authored: 0,
+            reviewed: 0,
+            reported: false,
+            fullReported: false,
+          });
       });
       const tickSpy = vi.spyOn(loop, 'tick').mockReturnValueOnce(firstTick);
       loop.nudge();
@@ -387,12 +544,19 @@ describe('OperatorTriggerLoop', () => {
     vi.useFakeTimers();
     try {
       const loop = makeLoop({
-        config: { tickMs: 60_000, drainLimit: 50, authorEveryNTicks: 99, reviewEveryNTicks: 99, authorWindowSize: 10, nudgeDebounceMs: 15_000 },
+        config: {
+          tickMs: 60_000,
+          drainLimit: 50,
+          authorEveryNTicks: 99,
+          reviewEveryNTicks: 99,
+          authorWindowSize: 10,
+          nudgeDebounceMs: 15_000,
+        },
       });
       const tickSpy = vi.spyOn(loop, 'tick');
       const stop = loop.start(); // interval at 60s
-      loop.nudge();              // arm nudge at +15s
-      stop();                    // must clear both the interval AND the pending nudge
+      loop.nudge(); // arm nudge at +15s
+      stop(); // must clear both the interval AND the pending nudge
       await vi.advanceTimersByTimeAsync(15_000 + 60_000);
       expect(tickSpy).not.toHaveBeenCalled();
     } finally {
@@ -408,11 +572,18 @@ describe('OperatorTriggerLoop', () => {
       const forward = () => triggerLoopNudge.current?.();
       forward(); // the initial poll's sink fires before the loop is constructed -> safe no-op
       const loop = makeLoop({
-        config: { tickMs: 60_000, drainLimit: 50, authorEveryNTicks: 99, reviewEveryNTicks: 99, authorWindowSize: 10, nudgeDebounceMs: 15_000 },
+        config: {
+          tickMs: 60_000,
+          drainLimit: 50,
+          authorEveryNTicks: 99,
+          reviewEveryNTicks: 99,
+          authorWindowSize: 10,
+          nudgeDebounceMs: 15_000,
+        },
       });
       const tickSpy = vi.spyOn(loop, 'tick');
       triggerLoopNudge.current = () => loop.nudge(); // gated block binds it after start()
-      forward();                                     // a later poll batch -> reaches loop.nudge()
+      forward(); // a later poll batch -> reaches loop.nudge()
       await vi.advanceTimersByTimeAsync(15_000);
       expect(tickSpy).toHaveBeenCalledTimes(1);
     } finally {

--- a/packages/standalone/tests/operator/report-anchor.test.ts
+++ b/packages/standalone/tests/operator/report-anchor.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { FileReportScheduleStore } from '../../src/operator/report-scheduler.js';
+
+describe('report success anchor', () => {
+  const freshStore = () =>
+    new FileReportScheduleStore(join(mkdtempSync(join(tmpdir(), 'anchor-')), 'state.json'));
+
+  it('starts with no anchor', () => {
+    expect(freshStore().loadLastSuccess()).toBeNull();
+  });
+
+  it('persists the anchor and the REAL fired-hour write path does not clobber it', () => {
+    const path = join(mkdtempSync(join(tmpdir(), 'anchor-')), 'state.json');
+    const a = new FileReportScheduleStore(path);
+    a.markSuccess('2026-07-16T09:00:00.000Z');
+    // save() is the production write path (ReportScheduler.markFired -> store.save,
+    // report-scheduler.ts:69-72). It must read-modify-write, or every full-report
+    // fire wipes the anchor. Real hour-key format is '2026-07-16:09' (hourKeyLocal).
+    a.save('2026-07-16:09');
+    const b = new FileReportScheduleStore(path);
+    expect(b.loadLastSuccess()).toBe('2026-07-16T09:00:00.000Z');
+    expect(b.load()).toBe('2026-07-16:09');
+  });
+});

--- a/packages/standalone/tests/operator/report-anchor.test.ts
+++ b/packages/standalone/tests/operator/report-anchor.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { FileReportScheduleStore } from '../../src/operator/report-scheduler.js';
 
 describe('Story BOUNDARY-6: stateless reports/anchor', () => {
-  describe('report success anchor', () => {
+  describe('AC #1: the success anchor persists and survives the fired-hour write path', () => {
     const freshStore = () =>
       new FileReportScheduleStore(join(mkdtempSync(join(tmpdir(), 'anchor-')), 'state.json'));
 

--- a/packages/standalone/tests/operator/report-anchor.test.ts
+++ b/packages/standalone/tests/operator/report-anchor.test.ts
@@ -4,24 +4,26 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { FileReportScheduleStore } from '../../src/operator/report-scheduler.js';
 
-describe('report success anchor', () => {
-  const freshStore = () =>
-    new FileReportScheduleStore(join(mkdtempSync(join(tmpdir(), 'anchor-')), 'state.json'));
+describe('Story BOUNDARY-6: stateless reports/anchor', () => {
+  describe('report success anchor', () => {
+    const freshStore = () =>
+      new FileReportScheduleStore(join(mkdtempSync(join(tmpdir(), 'anchor-')), 'state.json'));
 
-  it('starts with no anchor', () => {
-    expect(freshStore().loadLastSuccess()).toBeNull();
-  });
+    it('starts with no anchor', () => {
+      expect(freshStore().loadLastSuccess()).toBeNull();
+    });
 
-  it('persists the anchor and the REAL fired-hour write path does not clobber it', () => {
-    const path = join(mkdtempSync(join(tmpdir(), 'anchor-')), 'state.json');
-    const a = new FileReportScheduleStore(path);
-    a.markSuccess('2026-07-16T09:00:00.000Z');
-    // save() is the production write path (ReportScheduler.markFired -> store.save,
-    // report-scheduler.ts:69-72). It must read-modify-write, or every full-report
-    // fire wipes the anchor. Real hour-key format is '2026-07-16:09' (hourKeyLocal).
-    a.save('2026-07-16:09');
-    const b = new FileReportScheduleStore(path);
-    expect(b.loadLastSuccess()).toBe('2026-07-16T09:00:00.000Z');
-    expect(b.load()).toBe('2026-07-16:09');
+    it('persists the anchor and the REAL fired-hour write path does not clobber it', () => {
+      const path = join(mkdtempSync(join(tmpdir(), 'anchor-')), 'state.json');
+      const a = new FileReportScheduleStore(path);
+      a.markSuccess('2026-07-16T09:00:00.000Z');
+      // save() is the production write path (ReportScheduler.markFired -> store.save,
+      // report-scheduler.ts:69-72). It must read-modify-write, or every full-report
+      // fire wipes the anchor. Real hour-key format is '2026-07-16:09' (hourKeyLocal).
+      a.save('2026-07-16:09');
+      const b = new FileReportScheduleStore(path);
+      expect(b.loadLastSuccess()).toBe('2026-07-16T09:00:00.000Z');
+      expect(b.load()).toBe('2026-07-16:09');
+    });
   });
 });

--- a/packages/standalone/tests/operator/report-scheduler.test.ts
+++ b/packages/standalone/tests/operator/report-scheduler.test.ts
@@ -3,7 +3,7 @@
  * Pure local-hour decision + persisted last-fired key (restart-safe, no double-send).
  * No agent, no loop. Ports the Kagemusha tickScheduledReports mechanism (LOCAL hours here).
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -18,7 +18,14 @@ import {
 function memStore(initial: string | null = null): ReportScheduleStore & { saved: string[] } {
   let key = initial;
   const saved: string[] = [];
-  return { saved, load: () => key, save: (k: string) => { key = k; saved.push(k); } };
+  return {
+    saved,
+    load: () => key,
+    save: (k: string) => {
+      key = k;
+      saved.push(k);
+    },
+  };
 }
 
 describe('parseReportHours', () => {
@@ -86,7 +93,10 @@ describe('ReportScheduler.shouldFire', () => {
 describe('FileReportScheduleStore', () => {
   let tmp: string;
   let path: string;
-  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'report-sched-')); path = join(tmp, 'state.json'); });
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'report-sched-'));
+    path = join(tmp, 'state.json');
+  });
   afterEach(() => rmSync(tmp, { recursive: true, force: true }));
 
   it('load() -> null when absent; save/load round-trips; survives a fresh instance (restart)', () => {
@@ -97,8 +107,16 @@ describe('FileReportScheduleStore', () => {
     expect(store.load()).toBe('2026-07-09:08');
     expect(new FileReportScheduleStore(path).load()).toBe('2026-07-09:08');
   });
-  it('corrupt state throws loudly (no-fallback)', () => {
+  it('corrupt state resets LOUDLY instead of throwing (disposable bookkeeping)', () => {
+    // A corrupt schedule-state file must not permanently break the report leg: reset to {}
+    // and log loudly. Worst case after reset is one duplicate report + a wide gather window.
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
     writeFileSync(path, 'not json', 'utf8');
-    expect(() => new FileReportScheduleStore(path).load()).toThrow();
+    expect(new FileReportScheduleStore(path).load()).toBeNull();
+    expect(spy).toHaveBeenCalledWith(
+      '[report-scheduler] state file corrupt or unreadable - resetting schedule state:',
+      expect.anything()
+    );
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

Root-cause repair round for four live boundary defect classes found by 2026-07-16 daemon log analysis (3 days, 62K lines). Plan reviewed through 9 adversarial subagent rounds (38 findings folded, CLEAR at v11); implementation reviewed CLEAR.

### Root causes fixed

1. **Dual-executor wiring class** — the persona AgentLoop constructed a private GatewayToolExecutor that boot wiring never reached (task ledger, report publisher, event bus, slack, wiki, obsidian all persona-invisible → 22 live "not configured" failures). The daemon persona now shares the boot-wired executor; per-caller tool blocks moved into the per-call execution context; the memory agent folds in too (single MAMA API stack).
2. **Native/gateway tool-surface crossing** — persona CLI sessions had both Claude Code built-ins and text-parsed gateway tools (18 hallucinated ToolSearch/Agent calls, 5 unverifiable reports). Main persona now spawns with `--tools ""` (`MAMA_PERSONA_NATIVE_TOOLS=1` re-enables).
3. **Shared adapter mutation races** — setSystemPrompt/setSessionId mutated shared state applied at the next spawn, so any lane's new process could inherit the LAST caller's prompt/session. Both now travel per prompt() call on BOTH backends (codex thread-start developer-instructions preserved via systemPrompt-only narrowing).
4. **Envelope TTL vs run-budget incoherence + immortal report session** — report envelopes carried a single-request TTL (330s) while the report lane's continuous session grew runs 146s→521s until every write died `[expired]` (9 full-run losses). TTL now budgets the run (`MAMA_REPORT_WALL_SECONDS`, default 900s) with a lane-aware margin guard (operator aborts loudly, chat never aborted), and reports run STATELESS per run with the message gather delta-anchored at the last successful report.

### Verification

- Full suite: 3540 passed / typecheck green (all 7 packages)
- Live: daemon restarted on this build, 20-min monitoring window — zero "not configured" / `[expired]` / Unknown-tool / NO-gateway-gather; persona spawns accept `--tools ""`; chat + memory-audit runs completed
- Plan + review trail: `docs/superpowers/plans/2026-07-16-agent-boundary-repair.md` (local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for multiple simultaneous persona and lane executions by preventing session, prompt, and tool-result interference.
  * Shared runtime services now avoid duplicate connections and configuration failures.
  * Operator runs now stop clearly when execution limits expire, while interactive runs remain available.
  * Native tool access can be restricted consistently across persona runs.

* **Improvements**
  * Scheduled full reports now use fresh sessions and gather only changes since the last successfully delivered report.
  * Report execution now handles delivery failures and expiration more predictably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->