### PR TITLE
fix(memory): korean topic slugs + dual-save dedup

### DIFF
--- a/packages/mama-core/src/memory/api.ts
+++ b/packages/mama-core/src/memory/api.ts
@@ -92,7 +92,9 @@ export function buildDecisionId(topic: string): string {
     .replace(/_+/g, '_')
     .replace(/^_+|_+$/g, '')
     .toLowerCase();
-  const slug = safeTopic || `t${crypto.createHash('sha1').update(topic).digest('hex').slice(0, 8)}`;
+  // sha256 (not sha1) purely to keep SAST scanners quiet - this is an id slug, not crypto.
+  const slug =
+    safeTopic || `t${crypto.createHash('sha256').update(topic).digest('hex').slice(0, 8)}`;
   return `decision_${slug}_${Date.now()}_${crypto.randomUUID().slice(0, 8)}`;
 }
 

--- a/packages/mama-core/src/memory/api.ts
+++ b/packages/mama-core/src/memory/api.ts
@@ -82,9 +82,18 @@ interface SaveMemoryRollbackError extends Error {
   memoryId?: string;
 }
 
-function buildDecisionId(topic: string): string {
-  const safeTopic = topic.replace(/[^a-z0-9_]+/gi, '_').toLowerCase();
-  return `decision_${safeTopic}_${Date.now()}_${crypto.randomUUID().slice(0, 8)}`;
+export function buildDecisionId(topic: string): string {
+  // Non-ASCII topics (Korean etc.) used to collapse into bare underscore runs
+  // ("decision_______<ts>") - unreadable and near-colliding. Collapse the runs
+  // and fall back to a stable topic hash when nothing ASCII survives; the
+  // human-readable topic itself is stored verbatim in the topic column.
+  const safeTopic = topic
+    .replace(/[^a-z0-9_]+/gi, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toLowerCase();
+  const slug = safeTopic || `t${crypto.createHash('sha1').update(topic).digest('hex').slice(0, 8)}`;
+  return `decision_${slug}_${Date.now()}_${crypto.randomUUID().slice(0, 8)}`;
 }
 
 function buildSaveEventReason(toolName: string | null, gatewayCallId: string | null): string {

--- a/packages/mama-core/tests/decision-id-slug.test.ts
+++ b/packages/mama-core/tests/decision-id-slug.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Story SMALLFIX-1: decision id slugs for non-ASCII topics
+ *
+ * Korean-only topics used to collapse into bare underscore runs
+ * ("decision_______<ts>_<rand>") - unreadable and near-colliding. The slug
+ * now collapses runs and falls back to a stable topic hash; the verbatim
+ * topic stays in the topic column.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildDecisionId } from '../src/memory/api.js';
+
+// prettier-ignore
+const koreanTopicKeywords = ['보고_언어_정책', '카나리아 SR 파츠분리', '외주 검수 규칙'];
+
+describe('Story SMALLFIX-1: buildDecisionId slugging', () => {
+  describe('AC #1: ascii topics keep readable slugs', () => {
+    it('collapses separators without losing ascii content', () => {
+      expect(buildDecisionId('database_choice')).toMatch(
+        /^decision_database_choice_\d+_[a-f0-9-]{8}$/
+      );
+      expect(buildDecisionId('API contract!! v2')).toMatch(/^decision_api_contract_v2_\d+_/);
+    });
+  });
+
+  describe('AC #2: non-ascii topics fall back to a stable hash, never underscore runs', () => {
+    it.each(koreanTopicKeywords)('slugs: %s', (topic) => {
+      const id = buildDecisionId(topic);
+      expect(id).not.toMatch(/__/);
+      expect(id).not.toMatch(/^decision__/);
+    });
+
+    it('pure-korean topic gets a deterministic hash slug', () => {
+      const a = buildDecisionId(koreanTopicKeywords[0]);
+      const b = buildDecisionId(koreanTopicKeywords[0]);
+      const slugA = a.split('_')[1];
+      const slugB = b.split('_')[1];
+      expect(slugA).toBe(slugB);
+      expect(slugA).toMatch(/^t[a-f0-9]{8}$/);
+    });
+
+    it('mixed topics keep the ascii part', () => {
+      const id = buildDecisionId(koreanTopicKeywords[1] + '_KMS2019_v2');
+      expect(id).toContain('sr');
+      expect(id).toContain('kms2019');
+      expect(id).not.toMatch(/__/);
+    });
+  });
+});

--- a/packages/standalone/src/gateways/message-router.ts
+++ b/packages/standalone/src/gateways/message-router.ts
@@ -196,8 +196,18 @@ function stripGatewayDecorations(text: string): string {
  * the reasoning header) - the extractor safety net then skips to avoid the
  * dual-save duplicate proven live on 2026-07-17.
  */
-export function agentSavedInTurn(response: string): boolean {
-  return /\u{1F527} mama_save\b/u.test(response);
+export function agentSavedInTurn(response: string | null | undefined): boolean {
+  if (!response) {
+    return false;
+  }
+  // Only the reasoning header (first '||...||' line) counts - a prose mention
+  // of the marker in the body must not suppress the extractor safety net.
+  const newline = response.indexOf('\n');
+  const headerLine = newline === -1 ? response : response.slice(0, newline);
+  if (!headerLine.startsWith('||')) {
+    return false;
+  }
+  return /\u{1F527} mama_save\b/u.test(headerLine);
 }
 
 /**

--- a/packages/standalone/src/gateways/message-router.ts
+++ b/packages/standalone/src/gateways/message-router.ts
@@ -192,6 +192,15 @@ function stripGatewayDecorations(text: string): string {
 }
 
 /**
+ * True when the agent persisted memory during THIS turn (gateway mama_save in
+ * the reasoning header) - the extractor safety net then skips to avoid the
+ * dual-save duplicate proven live on 2026-07-17.
+ */
+export function agentSavedInTurn(response: string): boolean {
+  return /\u{1F527} mama_save\b/u.test(response);
+}
+
+/**
  * Check if message contains sensitive configuration request
  */
 function containsSensitiveRequest(text: string): boolean {
@@ -928,8 +937,17 @@ This protects your credentials from being exposed in chat logs.`;
         this.logFrontdoorActivity(message, message.text, response, Date.now() - conductorStart);
       }
 
-      // Auto-extract facts from conversation (fire-and-forget, non-blocking)
-      if (response && message.text) {
+      // Auto-extract facts from conversation (fire-and-forget, non-blocking).
+      // Dual-save dedup: when the agent ALREADY persisted memory during this
+      // turn (gateway mama_save in the reasoning header), the extractor safety
+      // net would save the same instruction twice (proven live 2026-07-17:
+      // decision_* + mem_* duplicates for one directive). The in-turn save is
+      // the agent's judgment; the net exists for turns where it did not act.
+      const agentSavedThisTurn = agentSavedInTurn(response);
+      if (agentSavedThisTurn) {
+        logger.info('[memory-agent] extraction skipped - agent saved in-turn (dual-save dedup)');
+      }
+      if (response && message.text && !agentSavedThisTurn) {
         const rawAssistantText = stripGatewayDecorations(response);
         void (async () => {
           try {

--- a/packages/standalone/tests/gateways/message-router-turn-save.test.ts
+++ b/packages/standalone/tests/gateways/message-router-turn-save.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Story SMALLFIX-2: dual-save dedup predicate
+ *
+ * When the agent already persisted memory during the turn (gateway mama_save
+ * visible in the reasoning header), the extractor safety net must skip -
+ * one owner directive produced BOTH decision_* and mem_* records live.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { agentSavedInTurn } from '../../src/gateways/message-router.js';
+
+describe('Story SMALLFIX-2: agentSavedInTurn', () => {
+  it('detects a mama_save in the reasoning header', () => {
+    expect(agentSavedInTurn('||📚 Memory | 🔧 mama_save | ⏱️ 2 turns||\nsaved ok')).toBe(true);
+    expect(agentSavedInTurn('||🔧 kagemusha_tasks, 🔧 mama_save | ⏱️ 3 turns||\nreport')).toBe(
+      true
+    );
+  });
+
+  it('does not trigger on other tools or plain mentions', () => {
+    expect(agentSavedInTurn('||🔧 mama_search | ⏱️ 1 turns||\nanswer')).toBe(false);
+    expect(agentSavedInTurn('the mama_save tool exists')).toBe(false);
+    expect(agentSavedInTurn('plain answer')).toBe(false);
+  });
+});

--- a/packages/standalone/tests/gateways/message-router-turn-save.test.ts
+++ b/packages/standalone/tests/gateways/message-router-turn-save.test.ts
@@ -10,16 +10,42 @@ import { describe, expect, it } from 'vitest';
 import { agentSavedInTurn } from '../../src/gateways/message-router.js';
 
 describe('Story SMALLFIX-2: agentSavedInTurn', () => {
-  it('detects a mama_save in the reasoning header', () => {
-    expect(agentSavedInTurn('||📚 Memory | 🔧 mama_save | ⏱️ 2 turns||\nsaved ok')).toBe(true);
-    expect(agentSavedInTurn('||🔧 kagemusha_tasks, 🔧 mama_save | ⏱️ 3 turns||\nreport')).toBe(
-      true
-    );
+  describe('AC #1: mama_save in the reasoning header suppresses the extractor', () => {
+    it('detects a mama_save in the reasoning header', () => {
+      expect(agentSavedInTurn('||📚 Memory | 🔧 mama_save | ⏱️ 2 turns||\nsaved ok')).toBe(true);
+      expect(agentSavedInTurn('||🔧 kagemusha_tasks, 🔧 mama_save | ⏱️ 3 turns||\nreport')).toBe(
+        true
+      );
+    });
+
+    it('detects a header-only response without a body', () => {
+      expect(agentSavedInTurn('||🔧 mama_save | ⏱️ 1 turns||')).toBe(true);
+    });
   });
 
-  it('does not trigger on other tools or plain mentions', () => {
-    expect(agentSavedInTurn('||🔧 mama_search | ⏱️ 1 turns||\nanswer')).toBe(false);
-    expect(agentSavedInTurn('the mama_save tool exists')).toBe(false);
-    expect(agentSavedInTurn('plain answer')).toBe(false);
+  describe('AC #2: other tools, prose mentions, and body markers never suppress', () => {
+    it('does not trigger on other tools or plain mentions', () => {
+      expect(agentSavedInTurn('||🔧 mama_search | ⏱️ 1 turns||\nanswer')).toBe(false);
+      expect(agentSavedInTurn('the mama_save tool exists')).toBe(false);
+      expect(agentSavedInTurn('plain answer')).toBe(false);
+    });
+
+    it('ignores a marker mentioned in the body below the header', () => {
+      expect(
+        agentSavedInTurn('||🔧 mama_search | ⏱️ 1 turns||\nI could run 🔧 mama_save for you')
+      ).toBe(false);
+    });
+
+    it('does not partial-match longer tool names', () => {
+      expect(agentSavedInTurn('||🔧 mama_save_draft | ⏱️ 1 turns||\nx')).toBe(false);
+    });
+  });
+
+  describe('AC #3: falsy or headerless responses are safe no-ops', () => {
+    it('returns false for null/undefined/empty', () => {
+      expect(agentSavedInTurn(null)).toBe(false);
+      expect(agentSavedInTurn(undefined)).toBe(false);
+      expect(agentSavedInTurn('')).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
Two live-proven small repairs from yesterday's owner-console G2 observations:

1. **Korean topic slugs**: buildDecisionId collapsed non-ascii topics into bare underscore runs (`decision_______<ts>`) - recurred twice in production. Runs are collapsed and a stable sha1-8 hash slugs pure-non-ascii topics; the verbatim topic stays in the topic column.
2. **Dual-save dedup**: one owner directive produced BOTH a direct `decision_*` (owner-console mama_save) and an extractor-path `mem_*` record. The extractor safety net now skips (loudly) when the reasoning header shows the agent already ran mama_save this turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Decision identifiers now generate clearer, more consistent labels for topics, including those containing non-ASCII characters.
  * Added support for stable identifiers when topics contain no readable ASCII characters.

* **Bug Fixes**
  * Prevented duplicate memory saves when information has already been saved during the current interaction.
  * Improved handling of mixed-language topics to avoid empty or malformed identifier segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->