### PR TITLE
docs(release): v0.23.0 prep - changelog backfill + doc-consistency audit fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,57 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.23.0] / mama-core [1.9.0] / mama-os [0.23.0] - 2026-07-18
+
+### Added — Owner console (PR #153, Stage 0+1)
+
+- **`owner_console` role with trust-conditional escalation** — granted per
+  message ONLY when telegram + `allowed_chats` locked + 1:1 private DM all
+  hold; groups never escalate; a static sourceMapping to owner_console is
+  downgraded at runtime and flagged MAJOR by the code audit. `allowed_chats`
+  is now the owner trust anchor (documented in the security guide).
+- **Artifact hub tools** — `board_read` and `audit_findings_read` let the
+  owner console answer status questions from operational artifacts instead of
+  stale memory; `report_request` routes owner intent into the REAL report
+  machinery (fire-and-forget on the operator lane, consume-the-hour semantics).
+- **Report context carry** — the last delivered full report persists (0600,
+  atomic) and is injected into owner-console turns, so the chat agent knows
+  what its own system last reported.
+- **Owner directive persistence** — directives stated in owner chat are
+  detected and saved as memory with imperative-form Korean patterns
+  (config-externalizable keywords).
+- **`workerRun` primitive + `operator` global lane** — briefed fresh-session
+  lane runs for host code; all operator work (reports + workers) serializes
+  away from the chat lane. Per-run state moved off instance fields (RunScope).
+- **Role-filtered tool advertising** — each role's prompt advertises exactly
+  the tools it can execute (advertised set == executable set, tested).
+
+### Security — PR #153
+
+- **Memory-write secret inviolability** — `mama_save`/`mama_update`/
+  `mama_add`/`mama_ingest` refuse secret-shaped content (API keys, bot
+  tokens, credentials) with `secret_material_refused`; shape-based scanner
+  with a fail-closed recursion depth cap; patterns assembled at runtime so no
+  secret shapes exist at rest.
+- **Forwarded-message provenance** — telegram forwards are wrapped as
+  untrusted content with a trusted gateway metadata flag (in-band markers are
+  never a trust boundary); the extractor and sensitive-wall strip gated on
+  that flag.
+- **Sensitive-config wall + tripwires** — sensitive config questions from
+  non-owner surfaces are walled with record-only telemetry
+  (observability-over-restriction; no incident-pipeline pollution).
+- **Config roles hygiene** — additive default-role merge at load + prune-at-
+  save (canonical compare) in both config-manager and graph-api paths, so
+  persisted roles neither disable new defaults nor freeze old ones.
+
+### Fixed — PR #154 (live-proven small repairs)
+
+- **Korean topic slugs** — `buildDecisionId` collapses underscore runs and
+  falls back to a stable topic hash for pure-non-ASCII topics (was
+  `decision_______<ts>` unreadable/near-colliding ids).
+- **Dual-save dedup** — when the chat agent already persisted memory in a turn
+  (gateway `mama_save` in the reasoning header), the extractor safety net
+  skips instead of writing a duplicate record.
 
 ### Added — Stage 2: workorder ownership (trigger-loop → operator transfer)
 
@@ -38,6 +88,17 @@ All notable changes to this project will be documented in this file.
   declare kagemusha as read-only project-task truth vs the native ledger, and
   `kagemusha_tasks` results carry a status-vocabulary annotation (no more
   "blocked tasks are missing" hallucinated contradictions).
+
+### Upgrade notes
+
+- `MAMA_STAGE2_WORKORDERS` unset = `off` = **zero behavior change**; a
+  malformed value **fails the boot** (no-fallback by design). Briefs are
+  seeded to `~/.mama/briefs/` only when the flag is `shadow|on`.
+- The `operator_tasks` table is migrated in place on first boot (guarded
+  copy-swap inside a transaction; idempotent across the daemon's two DB
+  connections).
+- Users who previously saved API keys/tokens into memory will now see
+  `secret_material_refused` — intentional (secrets never enter memory).
 
 ## [0.22.1] / mama-core [1.8.1] / mama-os [0.22.1] - 2026-07-17
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,10 +151,10 @@ pnpm vitest run tests/commands/
 
 ### Hook Performance
 
-- **UserPromptSubmit:** Target <1200ms (~150ms actual with HTTP embedding server; only active hook)
-- **PreToolUse/PostToolUse:** Disabled (scripts retained for future use)
-- **Token budget:** 40 tokens (teaser format for UserPromptSubmit)
-- **HTTP Embedding Server:** Port 3847, model stays in memory for fast embedding requests
+- **Active hooks (plugin.json):** SessionStart, PreToolUse (matcher: Read), PostToolUse (matchers: Write/Edit), PreCompact. UserPromptSubmit is NOT wired.
+- **Timing:** PreToolUse/PostToolUse 5s timeout, SessionStart 15s, PreCompact 10s; keep hook work well under those budgets
+- **Token budget:** teaser format (~40 tokens) for frequent hooks
+- **HTTP Embedding Server:** Port 3849 (3847 is the API/UI port), model stays in memory for fast embedding requests
 
 ### MCP Tool Schema
 
@@ -164,9 +164,11 @@ All tools follow standard MCP patterns:
 - Error handling with typed error codes
 - Result format: `{ success: boolean, data?: any, error?: string }`
 
-**Scope-aware tools:** `save_decision`, `recall_decision`, `suggest_decision`, `list_decisions`, `ingest_conversation` accept optional `scopes` parameter (`[{kind: 'project'|'user'|'channel'|'global', id: string}]`) for memory isolation per project/channel.
+**Advertised MCP tools (packages/mcp-server/src/server.js):** `save`, `search`, `update`, `search_decisions_and_contracts`, `case_timeline_range` (`load_checkpoint` remains as an unadvertised compatibility alias).
 
-**Temporal tracking:** `save_decision` and `ingest_conversation` accept optional `event_date` (ISO 8601 YYYY-MM-DD) for recording when events occurred vs. when saved.
+**Scope-aware:** save/search accept optional `scopes` (`[{kind: 'project'|'user'|'channel'|'global', id: string}]`) for memory isolation per project/channel.
+
+**Temporal tracking:** `save` accepts optional `event_date` (ISO 8601 YYYY-MM-DD) for recording when events occurred vs. when saved.
 
 ## Release & Deployment
 
@@ -183,7 +185,11 @@ git commit -m "chore(release): bump mama-os to vX.Y.Z"
 git tag vX.Y.Z
 git push origin main --tags
 
-# 3. Create GitHub Release (triggers GitHub Actions auto-publish)
+# 3. Create GitHub Release (cosmetic - the TAG PUSH above is what triggers
+#    .github/workflows/publish.yml; see docs/development/release-process.md,
+#    the authoritative flow. If the release touches mama-core, publish
+#    mama-core FIRST: publish.yml rewrites workspace:* deps to ^<repo core
+#    version>, so an unpublished core version breaks every user install.)
 gh release create vX.Y.Z --title "vX.Y.Z" --notes "See CHANGELOG.md"
 
 # 4. Verify
@@ -266,6 +272,33 @@ Once saved:
 - Config schema changes
 - Important function signature changes
 - Architecture pattern decisions
+
+## Operator Runtime & Owner Console (v0.23)
+
+The MAMA OS daemon runs an OPERATOR identity alongside chat:
+
+- **Lanes:** chat runs on the `main` global lane; ALL operator work (scheduled
+  reports + workers) serializes on the separate `operator` global lane
+  (`SOURCE_GLOBAL_LANES`, agent-loop.ts) so long runs never block owner replies.
+- **Owner console:** `owner_console` role resolves ONLY via trust-conditional
+  escalation - telegram + `telegram.allowed_chats` locked + 1:1 private DM
+  (RoleManager). `allowed_chats` is therefore the OWNER TRUST ANCHOR: every
+  allowlisted chat's private DM gets the owner surface. Static sourceMapping to
+  owner_console is downgraded at runtime and flagged by the code audit.
+- **Artifact hub tools:** `board_read`, `audit_findings_read`, `report_request`
+  (fire-and-forget into the real report machinery), `workorder_request` /
+  `workorder_status` (Stage 2).
+- **workerRun** (src/operator/worker-run.ts): briefed FRESH lane run - host-code
+  callers only, never from inside an active lane run (deadlock seal).
+- **Stage 2 workorder pipeline** (`MAMA_STAGE2_WORKORDERS=off|shadow|on`, default
+  off = legacy persona runs): publishers enqueue occurrence-keyed workorders into
+  the TaskLedger (`operator_tasks`, kind='system' rows, host-managed); a single
+  unconditional consumer claims serially and runs briefed workerRuns; briefs live
+  in `~/.mama/briefs/brief-<kind>.md` (seeded on boot, user edits win). `shadow`
+  dual-runs the BOARD only against a capture store. Malformed flag values fail
+  the boot (no-fallback).
+- **Memory-write secret filter:** `mama_save`/`mama_update`/`mama_add`/
+  `mama_ingest` REFUSE secret-shaped content (`secret_material_refused`).
 
 ## Connector Framework (v0.17)
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ MAMA OS has full system access via the backend CLI — so security is foundation
 - **Intrusion detection & response** — Honeypot traps → immediate IP ban (15min). Auth failures → auto-ban after 5 attempts. Tarpit delays for suspicious IPs.
 - **Agent permission tiers** — Tier 1 gets full runtime tools, Tier 2 can write scoped
   memory, and Tier 3 stays strictly read-only. Each agent gets only the tools it needs.
+- **Owner-console trust model (v0.22+)** — Telegram inbound requires an explicit `allowed_chats`
+  allowlist (boot warns loudly when open); the `owner_console` role is granted only in an
+  allowlisted chat's 1:1 DM, memory writes refuse secret-shaped content, and forwarded/third-party
+  text is wrapped as untrusted before it reaches any prompt.
 - **Fail-safe shutdown** — When an intrusion cannot be contained, MAMA shuts down gracefully rather than operating compromised.
 
 See the full [Security Guide](docs/guides/security.md) for Cloudflare Zero Trust setup, token authentication, threat scenarios, and Code-Act sandbox isolation.
@@ -247,9 +251,9 @@ open-source components.
 
 | Package                                          | Version | Description                                           |
 | ------------------------------------------------ | ------- | ----------------------------------------------------- |
-| [@jungjaehoon/mama-os](packages/standalone/)     | 0.22.1  | Always-on runtime, envelopes, connectors, worker APIs |
+| [@jungjaehoon/mama-os](packages/standalone/)     | 0.23.0  | Always-on runtime, envelopes, connectors, worker APIs |
 | [@jungjaehoon/mama-server](packages/mcp-server/) | 1.14.0  | MCP server for Claude Desktop/Code and any MCP client |
-| [@jungjaehoon/mama-core](packages/mama-core/)    | 1.8.1   | Core memory, provenance, raw refs, graph, embeddings  |
+| [@jungjaehoon/mama-core](packages/mama-core/)    | 1.9.0   | Core memory, provenance, raw refs, graph, embeddings  |
 | [mama plugin](packages/claude-code-plugin/)      | 1.10.0  | Claude Code plugin (marketplace)                      |
 | [memorybench](packages/memorybench/)             | 1.0.0   | Memory retrieval benchmarking framework               |
 
@@ -327,17 +331,18 @@ that selects, rejects, and explains evidence before a worker writes memory or co
 
 ## Roadmap
 
-| Phase    | Version | Focus                                                                                                                                                                                                                                                                                |
-| -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Done** | v0.15   | Search quality overhaul, FTS5, evolution engine (58% -> 88%)                                                                                                                                                                                                                         |
-| **Done** | v0.16   | `event_date` API, tool-use answer, memory agent v5 (88% -> 93%)                                                                                                                                                                                                                      |
-| **Done** | v0.17   | Connector framework (15 connectors), truth-first 3-pass extraction                                                                                                                                                                                                                   |
-| **Done** | v0.18   | Output layer: knowledge agents, viewer redesign, security hardening                                                                                                                                                                                                                  |
-| **Done** | v0.19   | Agent-management foundation: viewer-aware frontdoor, validation UI, activity telemetry, conductor isolation                                                                                                                                                                          |
-| **Done** | v0.20.1 | M1-M6 runtime foundation plus Context Compile V0: envelopes, model/tool trace ledger, raw/situation/graph worker APIs, strict search diagnostics, append-only `context_packets`, `context_compile`, and downstream `context_packet_id` provenance                                    |
-| **Now**  | v0.21   | The operator runtime: self-evolving trigger loop with a citation success circuit, `/ui` operator board (four live report slots + trigger library), task-truth from the real task ledger, wiki v5 daily journal + lessons, scheduled memory promotion, self-auditing with alert dedup |
-|          | Later   | Cross-language retrieval hardening, domain extraction templates, cross-worker packet analytics, and team-scoped context review workflows                                                                                                                                             |
-|          | v1.0    | Team mode: shared scoped knowledge graph for organizations. General release                                                                                                                                                                                                          |
+| Phase    | Version | Focus                                                                                                                                                                                                                                                                                                                                                     |
+| -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Done** | v0.15   | Search quality overhaul, FTS5, evolution engine (58% -> 88%)                                                                                                                                                                                                                                                                                              |
+| **Done** | v0.16   | `event_date` API, tool-use answer, memory agent v5 (88% -> 93%)                                                                                                                                                                                                                                                                                           |
+| **Done** | v0.17   | Connector framework (15 connectors), truth-first 3-pass extraction                                                                                                                                                                                                                                                                                        |
+| **Done** | v0.18   | Output layer: knowledge agents, viewer redesign, security hardening                                                                                                                                                                                                                                                                                       |
+| **Done** | v0.19   | Agent-management foundation: viewer-aware frontdoor, validation UI, activity telemetry, conductor isolation                                                                                                                                                                                                                                               |
+| **Done** | v0.20.1 | M1-M6 runtime foundation plus Context Compile V0: envelopes, model/tool trace ledger, raw/situation/graph worker APIs, strict search diagnostics, append-only `context_packets`, `context_compile`, and downstream `context_packet_id` provenance                                                                                                         |
+| **Done** | v0.21   | The operator runtime: self-evolving trigger loop with a citation success circuit, `/ui` operator board (four live report slots + trigger library), task-truth from the real task ledger, wiki v5 daily journal + lessons, scheduled memory promotion, self-auditing with alert dedup                                                                      |
+| **Now**  | v0.23   | The owner console + workorder ownership: trust-conditional `owner_console` role (telegram allowlist DM), artifact-hub tools (board/audit/workorder status, on-demand reports), memory-write secret filter, untrusted-content provenance, and the Stage-2 durable workorder pipeline (flag-gated) that moves board/wiki/memory runs onto the operator lane |
+|          | Later   | Cross-language retrieval hardening, domain extraction templates, cross-worker packet analytics, and team-scoped context review workflows                                                                                                                                                                                                                  |
+|          | v1.0    | Team mode: shared scoped knowledge graph for organizations. General release                                                                                                                                                                                                                                                                               |
 
 ## Development
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -63,3 +63,9 @@
 - **Cons:** 의존성이 많아서 추출이 복잡 (agent context, retry, skills, raw store, sessions DB, process manager, history injection)
 - **Context:** v0.19 validation 구현 시 리팩토링 없이 sessionService.recordRun() 호출만 추가하기로 결정. 별도 브랜치에서 진행.
 - **Depends on:** validation_session v1 완료
+
+### 문서 부채 (2026-07-18 릴리즈 감사에서 이연 - 3렌즈 감사 결과)
+
+- **What:** v0.23 릴리즈 차단분은 수정 완료. 이연분: developer-playbook.md(2025-11 스냅숏 - mama-plugin 경로/384차원/구 툴명/데드 링크), deployment-architecture.md("4 packages", 워크플로 이름 불일치), docs/guides/deployment.md(e5-small 기본값), testing.md("134 tests"), code-standards.md(구 트리), hooks.md(384차원 예시 + SessionStart/PreCompact 미문서), code-act-sandbox.md + security.md Code-Act 섹션의 샌드박스 툴 표(host-bridge TOOL_REGISTRY와 불일치), reference/api.md에 operator task 라우트 3종 추가, configuration-options.md에 MAMA_TRIGGER_LOOP\* 패밀리/MAMA_BOARD_RECONCILE 행, AGENTS.md 전면 재생성(GitHub Packages/wave-swarm 중심 등 5+ 거짓), entity-substrate-runbook.md 포트 라벨.
+- **At-cutover (Stage 2 on 전환 시 함께):** README/standalone README/mama-os.md/package-structure.md의 "상주 타이머 인격 런" 기술을 워크오더 파이프라인 기술로 전환.
+- **Why:** 오늘 기준 거짓인 사용자 대면 사실층은 v0.23 준비 PR에서 수정했고, 나머지는 저빈도 개발 문서라 릴리즈 비차단 판정.

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -1,6 +1,6 @@
 # Package Structure
 
-MAMA uses a four-package monorepo architecture with shared core modules to eliminate code duplication and enable independent package updates.
+MAMA uses a multi-package monorepo (mama-core, mcp-server, standalone/mama-os, claude-code-plugin, memorybench) with shared core modules to eliminate code duplication and enable independent package updates.
 
 ## Architecture Overview
 
@@ -88,7 +88,7 @@ All packages depend on `mama-core` using pnpm workspace dependencies (`workspace
 **Dependencies:**
 
 - `@huggingface/transformers` - Local embeddings
-- `node:sqlite` - Built-in SQLite runtime (Node.js 22+)
+- `better-sqlite3` - SQLite runtime (shared across packages)
 - Pure-TS cosine similarity for vector search
 
 **Distribution:** npm (`@jungjaehoon/mama-core`)
@@ -256,10 +256,10 @@ pnpm clean
 
 Each package has independent versioning:
 
-- **mama-core:** 1.8.1 (stable API)
+- **mama-core:** 1.9.0 (stable API)
 - **mama-server:** 1.14.0 (follows MAMA version)
 - **claude-code-plugin:** 1.10.0 (follows MAMA version)
-- **mama-os:** 0.22.1 (standalone agent)
+- **mama-os:** 0.23.0 (standalone agent)
 
 ## Distribution Strategy
 
@@ -311,7 +311,7 @@ npx @jungjaehoon/mama-os
 
 ### 2. Code Reuse
 
-All packages share mama-core to eliminate duplication. The shared runtime lives in mama-core, including the SQLite layer (`node:sqlite`) and embedding stack (`transformers.js`).
+All packages share mama-core to eliminate duplication. The shared runtime lives in mama-core, including the SQLite layer (`better-sqlite3`) and embedding stack (`transformers.js`).
 
 ### 3. Independent Updates
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -20,13 +20,13 @@
 │         │        │            │                   │           │
 │         │        │   ┌────────▼───────────────────┘           │
 │         │        │   │  MCP Server (stdio)        │           │
-│         └────────┴──▶│  4 Tools: save/search/     │           │
-│                      │  update/load_checkpoint    │           │
+│         └────────┴──▶│  5 Tools: save/search/     │           │
+│                      │  update/contracts/timeline │           │
 │                      └──────┬──────────┬──────────┘           │
 │                             │          │                      │
 │            ┌────────────────▼──┐  ┌────▼──────────────────┐   │
 │            │ SQLite + pure-TS  │  │ HTTP Embedding Server │   │
-│            │ cosine similarity │  │ :3847 (model in mem)  │   │
+│            │ cosine similarity │  │ :3849 (model in mem)  │   │
 │            │ mama-memory.db    │  └───────────────────────┘   │
 │            └───────────────────┘                              │
 │                                                               │
@@ -62,13 +62,13 @@
 ### MCP Server
 
 - **Transport:** stdio (local process)
-- **Tools:** 4 (save, search, update, load_checkpoint)
+- **Tools:** 5 advertised (save, search, update, search_decisions_and_contracts, case_timeline_range); `load_checkpoint` kept as an unadvertised compatibility alias
 - **Performance:** <100ms p99 latency
 
 ### Database (SQLite + pure-TS cosine similarity)
 
 - **Decisions table:** topic, decision, reasoning, confidence, outcome, kind, status, summary
-- **Embeddings:** 384-dimensional vectors (multilingual-e5-small, q8) with in-memory cache
+- **Embeddings:** 1024-dimensional vectors (multilingual-e5-large, q8) with in-memory cache
 - **Graph:** supersedes/builds_on/debates/synthesizes edges
 - **Memory scopes:** project/channel/user/global isolation via memory_scopes + memory_scope_bindings
 - **Truth projection:** memory_truth table for recall filtering (preserves history, surfaces current truth)
@@ -77,7 +77,7 @@
 
 ### Embeddings
 
-- **Model:** Xenova/multilingual-e5-small (~113MB, quantized q8)
+- **Model:** Xenova/multilingual-e5-large (~560MB, quantized q8, 1024-dim)
 - **Tier 1:** Transformers.js (ONNX runtime)
 - **Tier 2:** Disabled (fallback to exact match)
 
@@ -107,20 +107,53 @@ CronScheduler ──► CronWorker (Haiku CLI) ──► EventEmitter
                                          Discord  Slack  Viewer
 ```
 
-### Hooks
+### Operator Runtime (MAMA OS)
 
-- **UserPromptSubmit:** Automatic semantic search via HTTP embedding server
-- **PreToolUse:** MCP search + contract-only injection + Reasoning Summary
-- **PostToolUse:** Contract extraction + save guidance with structured reasoning
+The daemon runs an operator identity alongside chat (v0.22-v0.23):
+
+- **Lanes:** chat serializes on the `main` global lane; ALL operator work
+  (scheduled situation reports, workers) serializes on a separate `operator`
+  global lane - long runs never block owner replies.
+- **Trigger loop** (`MAMA_TRIGGER_LOOP=1`): agent-evolved triggers on the live
+  connector stream + scheduled full situation reports (configurable local
+  hours) delivered to the owner channel.
+- **Owner console:** the `owner_console` role resolves ONLY via trust-conditional
+  escalation (telegram + locked `allowed_chats` + 1:1 private DM). It reads
+  operational artifacts (board, audit findings, workorder status) and can issue
+  work (`report_request`, `workorder_request`) - fire-and-forget, host code runs it.
+- **Stage-2 workorder pipeline** (`MAMA_STAGE2_WORKORDERS`, default off):
+  scheduled system runs (board / wiki / memory promotion) convert from direct
+  persona timers into durable, occurrence-keyed workorders in the operator task
+  ledger, consumed serially by one host-code consumer that launches briefed
+  `workerRun`s on the operator lane. Procedure knowledge lives in
+  `~/.mama/briefs/brief-<kind>.md`.
+
+```
+publishers (schedule/boot/REST/events/reconcile)
+    ↓ enqueue (occurrence-keyed, deduped)
+operator_tasks ledger (kind='system')
+    ↓ claim (serial, priority)
+WorkOrderConsumer ──► workerRun(brief + payload) on 'operator' lane
+    ↓ completion hooks (verification, event re-emission)
+board / wiki / memory artifacts
+```
+
+### Hooks (Claude Code plugin)
+
+- **SessionStart:** checkpoint + recent-decision bootstrap into the session
+- **PreToolUse (Read):** related-decision injection when reading matching files
+- **PostToolUse (Write/Edit):** contract extraction + save guidance
+- **PreCompact:** checkpoint safety net before context compaction
+- (UserPromptSubmit is not wired in the current plugin manifest)
 
 ---
 
 ## Data Flow
 
 ```
-User Prompt
+File Read (plugin session)
     ↓
-UserPromptSubmit Hook
+PreToolUse Hook
     ↓
 Semantic Search (Tier 1) or Exact Match (Tier 2)
     ↓

--- a/docs/explanation/data-privacy.md
+++ b/docs/explanation/data-privacy.md
@@ -9,16 +9,19 @@
 ## Core Guarantees
 
 ### 1. 100% Local Processing
+
 - All data stored in `~/.claude/mama-memory.db`
 - No network calls (except initial model download)
 - No telemetry, no tracking, no analytics
 
 ### 2. No Cloud Dependencies
+
 - Embeddings generated locally (Transformers.js)
 - Database is SQLite (file-based)
 - MCP transport is stdio (local process)
 
 ### 3. User Control
+
 - Hooks can be disabled anytime
 - Database can be deleted anytime
 - All operations are manual-first (hooks are optional enhancement)
@@ -30,11 +33,13 @@
 **Location:** `~/.claude/mama-memory.db`
 
 **Contents:**
+
 - Decisions you explicitly save
-- Embeddings (384-dimensional vectors)
+- Embeddings (1024-dimensional vectors)
 - Supersedes graph edges
 
 **NOT stored:**
+
 - Claude Code conversations (never captured)
 - File contents (never captured)
 - User prompts (only used for search, not stored)
@@ -47,7 +52,7 @@
 
 ```bash
 # Downloads from Hugging Face CDN (first run only)
-https://huggingface.co/Xenova/multilingual-e5-small
+https://huggingface.co/Xenova/multilingual-e5-large
 # ~120MB model file
 # Cached locally at ~/.cache/huggingface/
 ```
@@ -59,11 +64,13 @@ https://huggingface.co/Xenova/multilingual-e5-small
 ## Hook Privacy
 
 ### UserPromptSubmit Hook
+
 - **Reads:** User's prompt (from environment variable)
 - **Stores:** Nothing (search only, no logging)
 - **Sends:** Nothing (100% local search)
 
 ### Can be disabled:
+
 ```bash
 export MAMA_DISABLE_HOOKS=true
 ```
@@ -73,6 +80,7 @@ export MAMA_DISABLE_HOOKS=true
 ## Data Ownership
 
 **You own all data:**
+
 - Export: `sqlite3 ~/.claude/mama-memory.db .dump > backup.sql`
 - Delete: `rm ~/.claude/mama-memory.db`
 - Migrate: Copy database file to another machine
@@ -84,17 +92,20 @@ export MAMA_DISABLE_HOOKS=true
 ## Security Considerations
 
 ### Filesystem Permissions
+
 ```bash
 # Database file permissions (user-only read/write)
 chmod 600 ~/.claude/mama-memory.db
 ```
 
 ### No Encryption
+
 - Database is NOT encrypted at rest
 - Relies on OS-level filesystem encryption (FileVault, LUKS, BitLocker)
 - For sensitive decisions, use encrypted filesystem
 
 ### No Authentication
+
 - MCP server is stdio (local process only)
 - No network port, no remote access
 - Only accessible by Claude Code process
@@ -112,11 +123,13 @@ chmod 600 ~/.claude/mama-memory.db
 ## Transparency
 
 **Tier status always visible:**
+
 ```
 🔍 System Status: 🟢 Tier 1 | Full Features Active
 ```
 
 **You always know:**
+
 - What tier is active
 - What features are working
 - What features are degraded
@@ -126,6 +139,7 @@ chmod 600 ~/.claude/mama-memory.db
 ---
 
 **Related:**
+
 - [Architecture Overview](architecture.md)
 - [Configuration Guide](../guides/configuration.md)
 - [Hooks Reference](../reference/hooks.md)

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -10,9 +10,9 @@ MAMA is a pnpm workspace-based monorepo with four packages:
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.22.1  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.23.0  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.14.0  |
-| MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 1.8.1   |
+| MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 1.9.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.10.0  |
 
 ---
@@ -60,9 +60,9 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.22.1          |
+| `packages/standalone/package.json`                       | `version` | 0.23.0          |
 | `packages/mcp-server/package.json`                       | `version` | 1.14.0          |
-| `packages/mama-core/package.json`                        | `version` | 1.8.1           |
+| `packages/mama-core/package.json`                        | `version` | 1.9.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.10.0          |
 | `packages/claude-code-plugin/.claude-plugin/plugin.json` | `version` | 1.10.0          |
 

--- a/docs/guides/gateway-config.md
+++ b/docs/guides/gateway-config.md
@@ -462,9 +462,17 @@ gateways:
 
 **How it works:**
 
-- If `allowed_chats` is empty or not set: Bot responds to anyone
+- If `allowed_chats` is empty or not set: Bot responds to anyone — and startup
+  emits a loud SECURITY WARNING. The owner console is DISABLED in this state.
 - If `allowed_chats` has IDs: Bot only responds to those chat IDs
-- Unauthorized chats are silently ignored
+- Unauthorized chats are dropped with a rate-capped warning in the daemon log
+
+**⚠️ `allowed_chats` is the OWNER TRUST ANCHOR (v0.22+):** any allowlisted
+chat's 1:1 private DM is granted the `owner_console` role — a wide operational
+surface (board/audit/workorder reads, `report_request`/`workorder_request`,
+`mama_save`/`mama_update`, task creation). Only list chats you trust with
+owner-level access. Group/supergroup IDs (negative numbers) never escalate,
+but listing a teammate's private chat gives THAT person the owner console.
 
 ### Example Configurations
 
@@ -491,6 +499,12 @@ gateways:
       - '222222222' # Bob
       - '333333333' # Charlie
 ```
+
+> **Warning:** every ID listed here gets the `owner_console` role in their own
+> 1:1 DM with the bot (see above). A "team bot" allowlist is an OWNER list, not
+> a mere access list — Alice, Bob, and Charlie can each read operational
+> artifacts and write memory. If teammates should chat without owner powers,
+> run a separate bot for them instead of widening this list.
 
 **Public bot (anyone can use):**
 

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -63,6 +63,34 @@ To route alerts to chat, set:
 export MAMA_SECURITY_ALERT_CHANNELS="discord:CHANNEL_ID,slack:C123456"
 ```
 
+## Owner Console Trust Model (v0.22+)
+
+The `owner_console` role is the widest chat surface MAMA grants, and it is
+resolved per message by trust checks — never by static configuration:
+
+- **Escalation conditions (ALL required):** telegram gateway + a non-empty
+  `telegram.allowed_chats` allowlist + the message arrives in an allowlisted
+  chat's **1:1 private DM**. Groups/supergroups never escalate. A static
+  `roles.sourceMapping` entry pointing at `owner_console` is downgraded at
+  runtime and flagged as MAJOR by the deterministic code audit.
+- **`allowed_chats` is therefore the owner trust anchor** — every listed chat's
+  DM gets owner powers (artifact reads: `board_read`, `audit_findings_read`,
+  `workorder_status`; work issuance: `report_request`, `workorder_request`;
+  memory writes: `mama_save`, `mama_update`; task creation). List only chats
+  you trust with owner-level access. An empty allowlist disables the owner
+  console entirely and startup warns loudly that inbound is open.
+- **Memory-write secret filter:** `mama_save` / `mama_update` / `mama_add` /
+  `mama_ingest` REFUSE content matching secret shapes (API keys, bot tokens,
+  long credentials) with `code: secret_material_refused` — secrets never enter
+  memory, even when the owner pastes them. This is a behavior change visible to
+  users who previously saved such content.
+- **Forwarded-message provenance:** telegram forwards and connector-derived
+  third-party text are wrapped in untrusted-content delimiters before reaching
+  any prompt, so injected instructions inside them are treated as data.
+- **Tool advertising is role-filtered:** each role's system prompt advertises
+  only the tools that role can actually execute, so a prompt-injected tool name
+  outside the role's allowlist fails both advertisement and execution.
+
 ## Envelope Threat Model and Posture
 
 M1R covers Reactive runtime issuance, gateway audit logging, and memory-scope

--- a/docs/guides/standalone-troubleshooting.md
+++ b/docs/guides/standalone-troubleshooting.md
@@ -282,14 +282,14 @@ grep -A 5 "slack:" ~/.mama/config.yaml
      telegram:
        enabled: true
        token: '123456789:ABCdefGHI...'
-       allowed_chat_ids:
-         - 987654321 # Your chat ID
+       allowed_chats:
+         - '987654321' # Your chat ID (quoted - compared as a string)
    ```
 
 3. **Get your chat ID:**
    - Message @userinfobot on Telegram
    - Copy your ID
-   - Add to `allowed_chat_ids` in config
+   - Add to `allowed_chats` in config
 
 4. **Check bot token:**
    - Message @BotFather

--- a/docs/index.md
+++ b/docs/index.md
@@ -151,5 +151,5 @@ _Contributing, testing, and development guidelines_
 
 ---
 
-**Status:** MAMA OS v0.21 — Operator runtime: self-evolving trigger loop, `/ui` operator board, wiki v5 daily journal + lessons, scheduled memory promotion
+**Status:** MAMA OS v0.23 — Operator runtime: self-evolving trigger loop, `/ui` operator board, wiki v5 daily journal + lessons, scheduled memory promotion
 **Last Updated:** 2026-07-12

--- a/packages/mama-core/CHANGELOG.md
+++ b/packages/mama-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-07-18
+
+- `buildDecisionId` exported; Korean/non-ASCII topics now produce stable
+  hashed slugs (`decision_t<hash>_...`) instead of bare underscore runs;
+  existing decision ids are untouched.
+
 ## [1.8.1] - 2026-07-12
 
 ### Fixed

--- a/packages/mama-core/package.json
+++ b/packages/mama-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-core",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "MAMA Core - Shared modules for Memory-Augmented MCP Assistant",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/standalone/CHANGELOG.md
+++ b/packages/standalone/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-07-18
+
+The owner-console + workorder-ownership release: trust-conditional
+`owner_console` role (telegram allowlist DM), artifact-hub tools
+(`board_read`/`audit_findings_read`/`report_request`/`workorder_request`/
+`workorder_status`), report context carry, memory-write secret filter,
+forwarded-message provenance, and the flag-gated Stage-2 durable workorder
+pipeline (`MAMA_STAGE2_WORKORDERS`, default off = no behavior change).
+Full details in the repository root CHANGELOG.md.
+
+## [0.22.1] - 2026-07-17
+
+Security-utility round: telegram inbound allowlist warning + drop logging,
+untrusted-content wrapping for connector-derived text, deterministic hourly
+code audit (no LLM loop), security-telemetry purge. Full details in the
+repository root CHANGELOG.md.
+
+## [0.22.0] - 2026-07-16
+
+Operator console groundwork and daemon persona boundary repair. Full details
+in the repository root CHANGELOG.md.
+
 ## [0.21.0] - 2026-07-12
 
 The operator runtime release. Full details in the repository root CHANGELOG.md.

--- a/packages/standalone/README.md
+++ b/packages/standalone/README.md
@@ -63,7 +63,9 @@ MAMA OS has full system access — so security is not optional, it's foundationa
   the fact without exposing prompt bodies or hidden connector payloads.
 - **5-layer prompt injection defense** — Output sanitization, channel trust boundaries, silent mode for unknown sources, bulk extraction limits. Built from a real incident, not theory.
 - **Intrusion detection** — Honeypot traps for scanner probes (`.git`, `.env`, `wp-login.php`), per-IP suspicion scoring, automatic tarpit delays, and IP deny-listing when thresholds are exceeded.
-- **Agent permission tiers** — Tier 1 (full access), Tier 2 (read-only), Tier 3 (scoped read-only). Each agent only gets the tools it needs.
+- **Agent permission tiers** — Tier 1 (full access), Tier 2 (read + memory write), Tier 3 (read-only). Each agent only gets the tools it needs.
+- **Owner console (v0.22+)** — the `owner_console` role is granted ONLY in an allowlisted telegram chat's 1:1 DM (`telegram.allowed_chats` is the trust anchor). It reads operational artifacts (`board_read`, `audit_findings_read`, `workorder_status`) and issues work (`report_request`, `workorder_request`) fire-and-forget; memory writes refuse secret-shaped content.
+- **Stage-2 workorder pipeline (v0.23, flag-gated)** — `MAMA_STAGE2_WORKORDERS=off|shadow|on` converts the scheduled board/wiki/memory-promotion runs into durable, occurrence-keyed workorders consumed serially on the operator lane; briefs live in `~/.mama/briefs/`. Default `off` = unchanged behavior.
 - **Fail-safe shutdown** — When an intrusion cannot be contained, MAMA shuts itself down gracefully rather than operating in a compromised state.
 
 These aren't theoretical protections. The prompt injection defense was built after a real attack where an adversary injected a fake "server failure" message into a monitored channel, causing the AI agent to voluntarily expose system configuration. The IP banning system has blocked actual intrusion attempts in production.

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "description": "MAMA OS - Local AI Runtime. Your scattered knowledge, organized by AI agents that never sleep.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Release-prep for **mama-os 0.23.0 / mama-core 1.9.0** (range v0.22.1..main = PR #153 owner console, #154 small repairs, #155 Stage-2 workorder pipeline), driven by a 3-lens documentation audit (reference/API vs code, architecture docs, release mechanics).

### Changelogs & versions
- Root CHANGELOG: #153/#154 were entirely absent from [Unreleased] (v0.22.1 tag predates #153 — 14 of 16 unreleased commits undocumented). Backfilled + upgrade notes; header finalized.
- `packages/standalone/CHANGELOG.md` ships in the npm tarball but stopped at 0.21.0 → backfilled 0.22.0/0.22.1/0.23.0. mama-core 1.9.0 entry added.
- Version bumps + `sync-versions` (8 files).

### False-fact layer (wrong today, predating these PRs)
- **CLAUDE.md hook section was inverted** (UserPromptSubmit is NOT wired; SessionStart/PreToolUse/PostToolUse/PreCompact are the active set), embedding port 3847→3849, MCP tool names → advertised five, release trigger corrected (tag push; mama-core-first ordering documented).
- architecture.md: e5-large/1024-dim (was e5-small/384), 5 tools, real hooks, **new Operator Runtime section** (lanes, trigger loop, owner console, Stage-2 pipeline).
- data-privacy/package-structure/standalone-README tier semantics corrected.

### Owner-console trust anchor (3 blocking findings, one root cause)
`telegram.allowed_chats` became the owner_console trust anchor in #153 with zero user-facing docs:
- gateway-config.md documents the escalation + warns the team-bot example is an OWNER list
- security.md gains an Owner Console Trust Model section (incl. the `secret_material_refused` behavior change)
- standalone-troubleshooting.md fixed a **non-existent `allowed_chat_ids` key** that left followers' bots open to everyone

### Release order (hard constraint)
`publish.yml` rewrites `workspace:*` → `^<repo core version>`: **tag `mama-core-v1.9.0` and verify npm BEFORE tagging `v0.23.0`**, or mama-os installs break on an unresolvable `^1.9.0`.

Deferred doc debt (legacy dev docs + at-cutover list) recorded in TODOS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)