### PR TITLE
fix(operator): per-run envelopes for workorder worker runs (live shadow-gate finding)

### DIFF
--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -1158,7 +1158,8 @@ export async function runAgentLoop(
       loadBrief: (kind) => loadBrief(kind),
       noticeOwner: (summary) => messageRouter.enqueueOperatorNotice(summary),
       opsAlarm,
-      runOptionsFor: (wo) => {
+      runOptionsFor: async (wo) => {
+        const runOptions: Record<string, unknown> = {};
         if (stage2Flag === 'shadow') {
           // Shadow ≡ board only. A non-board order here (e.g. enqueued at
           // 'on' before a rollback) would run LIVE with no capture seam
@@ -1172,9 +1173,47 @@ export async function runAgentLoop(
           if (!shadowCapture) {
             throw new Error('[stage2] shadow capture publisher missing - refusing live publish');
           }
-          return { reportPublisherOverride: shadowCapture.publisher };
+          runOptions.reportPublisherOverride = shadowCapture.publisher;
         }
-        return undefined;
+        // Per-run scoped envelope (live-gate finding, 2026-07-18): gateway
+        // 'model_tool' executions are envelope-gated, and workerRun is a new
+        // caller class with no issuer - without this, every worker tool call
+        // (incl. report_publish) dies 'envelope_missing'. Mirrors the report
+        // lane's issuance (createPersonaReportAsk wiring below); issuance
+        // failure rejects -> failWorkOrder (no envelope-less fallback run).
+        if (envelopeBootstrap.envelopeAuthority && envelopeBootstrap.metadata.issuance !== 'off') {
+          const projectId = resolveReactiveProjectRoot(config, process.env);
+          const wallSeconds = Math.min(
+            Math.max(Number(process.env.MAMA_REPORT_WALL_SECONDS) || 900, 60),
+            1800
+          );
+          runOptions.envelope = await envelopeBootstrap.envelopeAuthority.buildAndPersist({
+            agent_id: `workorder-${wo.workKind}`,
+            instance_id: randomUUID(),
+            // 'watch' = daemon-internal issuing source (closed EnvelopeSource
+            // union; enforcement authorizes on scope, never on source).
+            source: 'watch',
+            channel_id: `worker:${wo.workKind}`,
+            trigger_context: { user_text: `<stage2 workorder ${wo.workKind}#${wo.id}>` },
+            scope: {
+              project_refs: [{ kind: 'project' as const, id: projectId }],
+              raw_connectors: codeActRawConnectors,
+              memory_scopes: resolveCodeActMemoryScopes(
+                deriveMemoryScopes({
+                  source: 'operator',
+                  channelId: `worker:${wo.workKind}`,
+                  projectId,
+                }),
+                getAdapter()
+              ),
+              allowed_destinations: [],
+            },
+            tier: 2,
+            budget: { wall_seconds: wallSeconds },
+            expires_at: new Date(Date.now() + wallSeconds * 1000 + 30_000).toISOString(),
+          });
+        }
+        return Object.keys(runOptions).length > 0 ? runOptions : undefined;
       },
       onEvent: (event) => {
         // Telemetry replacement for executeValidatedRun's task_start/complete

--- a/packages/standalone/src/operator/workorder-consumer.ts
+++ b/packages/standalone/src/operator/workorder-consumer.ts
@@ -70,11 +70,16 @@ export interface WorkOrderConsumerDeps {
   /** Telemetry seam (agent_activity / eventBus) - optional. */
   onEvent?: (event: WorkOrderConsumerEvent) => void;
   /**
-   * Per-order extra run options (Stage-2 shadow: the board capture-publisher
-   * override). A THROW here fails the order loudly - at shadow, a missing
-   * capture publisher must never fall through to a live publish (plan T4 AC).
+   * Per-order extra run options (Stage-2: per-run envelope issuance + the
+   * shadow capture-publisher override). May be async - envelope issuance
+   * persists to the DB. A THROW/REJECT here fails the order loudly - at
+   * shadow, a missing capture publisher must never fall through to a live
+   * publish (plan T4 AC), and a run without an envelope would have every
+   * model_tool call denied 'envelope_missing'.
    */
-  runOptionsFor?: (wo: WorkOrderRecord) => Record<string, unknown> | undefined;
+  runOptionsFor?: (
+    wo: WorkOrderRecord
+  ) => Record<string, unknown> | undefined | Promise<Record<string, unknown> | undefined>;
   log?: (line: string) => void;
   tickMs?: number;
   now?: () => number;
@@ -215,13 +220,15 @@ export class WorkOrderConsumer {
 
     let response: string;
     try {
+      // Inside the try: a runOptionsFor throw/reject (shadow capture publisher
+      // missing, envelope issuance failure) fails the order instead of running
+      // with the live publisher / without an envelope.
+      const runOptions = await this.deps.runOptionsFor?.(wo);
       response = await workerRun(this.deps.runner, {
         kind: wo.workKind,
         brief,
         input: JSON.stringify(wo.payload),
-        // Inside the try: a runOptionsFor throw (e.g. shadow capture publisher
-        // missing) fails the order instead of running with the live publisher.
-        runOptions: this.deps.runOptionsFor?.(wo),
+        runOptions,
       });
     } catch (err) {
       this.handleFailure(wo, errMessage(err));


### PR DESCRIPTION
First live shadow cycle: the board worker's `report_publish` was denied `envelope_missing` — workerRun is a new caller class with no envelope issuer (owner chat = reactive router issuance; report lane = createPersonaReportAsk issuance; workers had none).

Fix mirrors the report-lane per-run scoped issuance for each workorder run (source 'watch', tier 2, no send surface, report-wall TTL), threaded through an async `runOptionsFor` whose rejection fails the order through the existing retry/alarm policy — never an envelope-less fallback run.

Verified: typecheck + operator suites green (224). Live re-verification on next 30-min board slot after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-run execution envelopes for eligible work orders, including project, connector, memory, expiration, and execution-time details.
  * Added configurable envelope validity periods, with safe limits and a default duration.

* **Bug Fixes**
  * Improved handling of asynchronous run configuration.
  * Configuration failures now follow the standard work-order failure handling process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->