### PR TITLE
fix(operator): worker system prompt forces text-gateway path (shadow-gate §8.2)

### DIFF
--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -1159,7 +1159,14 @@ export async function runAgentLoop(
       noticeOwner: (summary) => messageRouter.enqueueOperatorNotice(summary),
       opsAlarm,
       runOptionsFor: async (wo) => {
-        const runOptions: Record<string, unknown> = {};
+        // Worker prompt forces the TEXT-gateway tool path (shadow-gate §8.2:
+        // the spawn-default persona prompt routes tools through code-act,
+        // where per-run envelope/capture overrides cannot reach).
+        const { buildWorkerSystemPrompt } = await import('../../operator/worker-run.js');
+        const { getGatewayToolsPrompt } = await import('../../agent/agent-loop.js');
+        const runOptions: Record<string, unknown> = {
+          systemPrompt: buildWorkerSystemPrompt(getGatewayToolsPrompt()),
+        };
         if (stage2Flag === 'shadow') {
           // Shadow ≡ board only. A non-board order here (e.g. enqueued at
           // 'on' before a rollback) would run LIVE with no capture seam

--- a/packages/standalone/src/operator/worker-run.ts
+++ b/packages/standalone/src/operator/worker-run.ts
@@ -58,6 +58,26 @@ export interface WorkerRunInput {
 
 const KIND_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
 
+/**
+ * Worker-specific system prompt (shadow-gate finding §8.2): the spawn-default
+ * persona prompt carries code-act sandbox instructions, so worker tool calls
+ * went through POST /api/code-act - a server-side surface the per-run
+ * execution-context seam (envelope, capture override) cannot reach. A custom
+ * systemPrompt REPLACES the persona layers entirely (agent-loop.ts:484-486),
+ * so workers advertise ONLY the text-gateway tool syntax and every call flows
+ * through the in-process path where the seam works.
+ */
+export function buildWorkerSystemPrompt(gatewayToolsPrompt: string): string {
+  return [
+    'You are a MAMA OS system worker. You execute exactly ONE work order and stop.',
+    'Follow the brief in the user message. Call tools ONLY via the tool_call JSON',
+    'blocks documented below - no other execution mechanism exists in this session.',
+    'Do not ask questions; finish with the exact final line your brief specifies.',
+    '',
+    gatewayToolsPrompt.trim(),
+  ].join('\n');
+}
+
 export function buildWorkerSessionKey(kind: string): string {
   return `operator:worker:${kind}`;
 }

--- a/packages/standalone/tests/operator/worker-run.test.ts
+++ b/packages/standalone/tests/operator/worker-run.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   buildWorkerSessionKey,
+  buildWorkerSystemPrompt,
   workerRun,
   type WorkerRunner,
 } from '../../src/operator/worker-run.js';
@@ -124,5 +125,18 @@ describe('Story S2-T4: workerRun runOptions merge order', () => {
     expect(captured.source).toBe('operator');
     expect(captured.channelId).toBe('worker:board');
     expect(captured.freshSession).toBe(true);
+  });
+});
+
+/**
+ * Story S2 shadow-gate §8.2: worker system prompt forces the text-gateway path.
+ */
+describe('Story S2-§8.2: buildWorkerSystemPrompt', () => {
+  it('carries the gateway tools doc and excludes code-act instructions', () => {
+    const prompt = buildWorkerSystemPrompt('# Gateway Tools\n\nCall tools via JSON block: ...');
+    expect(prompt).toContain('# Gateway Tools');
+    expect(prompt).toContain('ONE work order');
+    expect(prompt).not.toMatch(/code-?act/i);
+    expect(prompt).not.toMatch(/sandbox/i);
   });
 });


### PR DESCRIPTION
Shadow observation found worker runs executing tools via POST /api/code-act (spawn-default persona prompt includes the code-act sandbox), where per-run envelope + capture overrides cannot reach. Workers now get a purpose-built system prompt (worker preamble + gateway tools doc, no code-act section) - a custom systemPrompt replaces the persona layers entirely, forcing the in-process text-gateway path where the whole Stage-2 seam works.

Verified: typecheck + operator suites green. Live re-verification on the next 30-min board slot after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)