### PR TITLE
feat: delta-bench temporal-truth eval + mama-core recall repair (57.5%→75%)

### DIFF
--- a/packages/mama-core/src/db-adapter/node-sqlite-adapter.ts
+++ b/packages/mama-core/src/db-adapter/node-sqlite-adapter.ts
@@ -816,6 +816,10 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
       }
 
       this.exec(`
+        CREATE INDEX IF NOT EXISTS idx_decisions_topic
+          ON decisions(topic)
+      `);
+      this.exec(`
         CREATE INDEX IF NOT EXISTS idx_decisions_envelope_hash
           ON decisions(envelope_hash)
       `);

--- a/packages/mama-core/src/mama-api.ts
+++ b/packages/mama-core/src/mama-api.ts
@@ -1609,7 +1609,9 @@ function annotateTopicCurrency<T extends { id?: unknown; topic?: unknown }>(
         rows.map((r) => r.topic).filter((t): t is string => typeof t === 'string' && t.length > 0)
       ),
     ];
-    if (topics.length === 0) return rows;
+    if (topics.length === 0) {
+      return rows;
+    }
     const adapter = getAdapter();
     const placeholders = topics.map(() => '?').join(',');
     // Supersession is scope-isolated (mirrors the save-path same-topic lookup):
@@ -1644,10 +1646,22 @@ function annotateTopicCurrency<T extends { id?: unknown; topic?: unknown }>(
     }
     // created_at mixes epoch seconds, epoch ms, and TEXT datetimes in live DBs.
     const toMs = (v: number | string | null): number => {
-      if (typeof v === 'number' && Number.isFinite(v)) return v > 1e12 ? v : v * 1000;
+      if (typeof v === 'number' && Number.isFinite(v)) {
+        return v > 1e12 ? v : v * 1000;
+      }
       if (typeof v === 'string') {
-        if (/^\d+$/.test(v.trim())) return toMs(Number(v.trim()));
-        const parsed = Date.parse(v.includes('T') ? v : v.trim().replace(' ', 'T') + 'Z');
+        const trimmed = v.trim();
+        if (/^\d+$/.test(trimmed)) {
+          return toMs(Number(trimmed));
+        }
+        // Stamp UTC only when the text carries no timezone marker: appending
+        // 'Z' to a value that already ends in 'Z' or an offset yields NaN, and
+        // a bare T-form datetime would otherwise parse as ambiguous local time.
+        const formatted = trimmed.includes('T') ? trimmed : trimmed.replace(' ', 'T');
+        const hasTz = formatted.endsWith('Z') || /[+-]\d{2}:?\d{2}$/.test(formatted);
+        const parsed = Date.parse(hasTz ? formatted : formatted + 'Z');
+        // Unparseable rows are skipped per-row by the caller (NaN), never
+        // thrown: one legacy bad timestamp must not blank the whole annotation.
         return Number.isFinite(parsed) ? parsed : NaN;
       }
       return NaN;
@@ -1655,7 +1669,9 @@ function annotateTopicCurrency<T extends { id?: unknown; topic?: unknown }>(
     const newestByTopic = new Map<string, { ms: number; id: string }>();
     for (const row of all) {
       const ms = toMs(row.created_at);
-      if (!Number.isFinite(ms)) continue;
+      if (!Number.isFinite(ms)) {
+        continue;
+      }
       const cur = newestByTopic.get(row.topic);
       // Deterministic tiebreak on equal timestamps: higher id wins (ids embed
       // their creation ms, so lexicographic order is stable and monotonic-ish).
@@ -1665,7 +1681,9 @@ function annotateTopicCurrency<T extends { id?: unknown; topic?: unknown }>(
     }
     return rows.map((r) => {
       const newest = typeof r.topic === 'string' ? newestByTopic.get(r.topic) : undefined;
-      if (!newest) return r;
+      if (!newest) {
+        return r;
+      }
       return { ...r, superseded_by_newer: newest.id !== r.id };
     });
   } catch (err) {

--- a/packages/mama-core/src/mama-api.ts
+++ b/packages/mama-core/src/mama-api.ts
@@ -1600,7 +1600,8 @@ async function saveWithTrustedProvenance(
  * the current row is explicitly marked.
  */
 function annotateTopicCurrency<T extends { id?: unknown; topic?: unknown }>(
-  rows: T[]
+  rows: T[],
+  scopes?: Array<{ kind: string; id: string }>
 ): Array<T & { superseded_by_newer?: boolean }> {
   try {
     const topics = [
@@ -1611,9 +1612,36 @@ function annotateTopicCurrency<T extends { id?: unknown; topic?: unknown }>(
     if (topics.length === 0) return rows;
     const adapter = getAdapter();
     const placeholders = topics.map(() => '?').join(',');
-    const all = adapter
-      .prepare(`SELECT id, topic, created_at FROM decisions WHERE topic IN (${placeholders})`)
-      .all(...topics) as Array<{ id: string; topic: string; created_at: number | string | null }>;
+    // Supersession is scope-isolated (mirrors the save-path same-topic lookup):
+    // a newer row for the same topic in ANOTHER project/channel must not mark
+    // this scope's current truth as stale. When the search ran scoped, the
+    // currency comparison is restricted to the same scopes. Rows with an
+    // excluded status (quarantined etc.) never count as "the newer truth".
+    const statusFilter =
+      "AND (d.status IS NULL OR d.status NOT IN ('superseded','quarantined','contradicted','stale'))";
+    type CurrencyRow = { id: string; topic: string; created_at: number | string | null };
+    let all: CurrencyRow[];
+    if (scopes && scopes.length > 0) {
+      const scopePairs = scopes.flatMap((s) => [s.kind, s.id]);
+      const scopePlaceholders = scopes
+        .map(() => '(ms.kind = ? AND ms.external_id = ?)')
+        .join(' OR ');
+      all = adapter
+        .prepare(
+          `SELECT DISTINCT d.id, d.topic, d.created_at
+           FROM decisions d
+           JOIN memory_scope_bindings msb ON msb.memory_id = d.id
+           JOIN memory_scopes ms ON ms.id = msb.scope_id
+           WHERE d.topic IN (${placeholders}) AND (${scopePlaceholders}) ${statusFilter}`
+        )
+        .all(...topics, ...scopePairs) as CurrencyRow[];
+    } else {
+      all = adapter
+        .prepare(
+          `SELECT id, topic, created_at FROM decisions d WHERE topic IN (${placeholders}) ${statusFilter}`
+        )
+        .all(...topics) as CurrencyRow[];
+    }
     // created_at mixes epoch seconds, epoch ms, and TEXT datetimes in live DBs.
     const toMs = (v: number | string | null): number => {
       if (typeof v === 'number' && Number.isFinite(v)) return v > 1e12 ? v : v * 1000;
@@ -1629,7 +1657,11 @@ function annotateTopicCurrency<T extends { id?: unknown; topic?: unknown }>(
       const ms = toMs(row.created_at);
       if (!Number.isFinite(ms)) continue;
       const cur = newestByTopic.get(row.topic);
-      if (!cur || ms > cur.ms) newestByTopic.set(row.topic, { ms, id: row.id });
+      // Deterministic tiebreak on equal timestamps: higher id wins (ids embed
+      // their creation ms, so lexicographic order is stable and monotonic-ish).
+      if (!cur || ms > cur.ms || (ms === cur.ms && row.id > cur.id)) {
+        newestByTopic.set(row.topic, { ms, id: row.id });
+      }
     }
     return rows.map((r) => {
       const newest = typeof r.topic === 'string' ? newestByTopic.get(r.topic) : undefined;
@@ -1850,7 +1882,7 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
 
       return {
         query: userQuestion,
-        results: annotateTopicCurrency(limitedResults),
+        results: annotateTopicCurrency(limitedResults, options.scopes),
         ...diagnosticsResponse,
         meta: {
           count: limitedResults.length,
@@ -1918,7 +1950,7 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
 
       return {
         query: userQuestion,
-        results: annotateTopicCurrency(limitedRows),
+        results: annotateTopicCurrency(limitedRows, options.scopes),
         ...diagnosticsResponse,
         meta: {
           count: limitedRows.length,

--- a/packages/mama-core/src/mama-api.ts
+++ b/packages/mama-core/src/mama-api.ts
@@ -1590,6 +1590,60 @@ async function saveWithTrustedProvenance(
   return saveInternal(params, options);
 }
 
+/**
+ * Annotate suggest results with topic currency. MAMA semantics treat topic
+ * reuse as supersession, so a result row is stale when the DB holds a newer
+ * decision row for the same topic - even when its status column still says
+ * 'active' (historical chains predate status maintenance). Surfacing
+ * `superseded_by_newer` lets consumers (and LLMs) tell current truth from
+ * superseded history; delta-bench measured 80% -> 92.5% answer accuracy when
+ * the current row is explicitly marked.
+ */
+function annotateTopicCurrency<T extends { id?: unknown; topic?: unknown }>(
+  rows: T[]
+): Array<T & { superseded_by_newer?: boolean }> {
+  try {
+    const topics = [
+      ...new Set(
+        rows.map((r) => r.topic).filter((t): t is string => typeof t === 'string' && t.length > 0)
+      ),
+    ];
+    if (topics.length === 0) return rows;
+    const adapter = getAdapter();
+    const placeholders = topics.map(() => '?').join(',');
+    const all = adapter
+      .prepare(`SELECT id, topic, created_at FROM decisions WHERE topic IN (${placeholders})`)
+      .all(...topics) as Array<{ id: string; topic: string; created_at: number | string | null }>;
+    // created_at mixes epoch seconds, epoch ms, and TEXT datetimes in live DBs.
+    const toMs = (v: number | string | null): number => {
+      if (typeof v === 'number' && Number.isFinite(v)) return v > 1e12 ? v : v * 1000;
+      if (typeof v === 'string') {
+        if (/^\d+$/.test(v.trim())) return toMs(Number(v.trim()));
+        const parsed = Date.parse(v.includes('T') ? v : v.trim().replace(' ', 'T') + 'Z');
+        return Number.isFinite(parsed) ? parsed : NaN;
+      }
+      return NaN;
+    };
+    const newestByTopic = new Map<string, { ms: number; id: string }>();
+    for (const row of all) {
+      const ms = toMs(row.created_at);
+      if (!Number.isFinite(ms)) continue;
+      const cur = newestByTopic.get(row.topic);
+      if (!cur || ms > cur.ms) newestByTopic.set(row.topic, { ms, id: row.id });
+    }
+    return rows.map((r) => {
+      const newest = typeof r.topic === 'string' ? newestByTopic.get(r.topic) : undefined;
+      if (!newest) return r;
+      return { ...r, superseded_by_newer: newest.id !== r.id };
+    });
+  } catch (err) {
+    // Annotation is additive - a failure must degrade to unannotated results,
+    // never break the search itself. But it is logged loudly, not swallowed.
+    logWarn(`[mama.suggest] topic-currency annotation failed: ${String(err)}`);
+    return rows;
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function suggest(userQuestion: string, options: SuggestFunctionOptions = {}): Promise<any> {
   if (!userQuestion || typeof userQuestion !== 'string') {
@@ -1796,7 +1850,7 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
 
       return {
         query: userQuestion,
-        results: limitedResults,
+        results: annotateTopicCurrency(limitedResults),
         ...diagnosticsResponse,
         meta: {
           count: limitedResults.length,
@@ -1864,7 +1918,7 @@ async function suggest(userQuestion: string, options: SuggestFunctionOptions = {
 
       return {
         query: userQuestion,
-        results: limitedRows,
+        results: annotateTopicCurrency(limitedRows),
         ...diagnosticsResponse,
         meta: {
           count: limitedRows.length,
@@ -4039,6 +4093,7 @@ export {
   save,
   saveWithTrustedProvenance,
   suggest,
+  annotateTopicCurrency,
   saveMemory,
   saveMemoryWithTrustedProvenance,
   recallMemory,

--- a/packages/mama-core/src/memory/api.ts
+++ b/packages/mama-core/src/memory/api.ts
@@ -522,10 +522,14 @@ export function topicAffinityBoost(
     return 0;
   }
   const topicText = topic.toLowerCase().replace(/_/g, ' ');
+  // Word-boundary matching (exact word or stem-prefix), not raw substring:
+  // "sent" must not match inside "consent" - a spurious all-tokens match would
+  // vault an unrelated topic over the whole BM25 range.
+  const topicWords = topicText.split(' ');
   let topicMatches = 0;
   for (const token of tokens) {
     const stem = stemToken(token);
-    if (topicText.includes(token) || topicText.includes(stem)) {
+    if (topicWords.some((word) => word === token || word.startsWith(stem))) {
       topicMatches += 1;
     }
   }

--- a/packages/mama-core/src/memory/api.ts
+++ b/packages/mama-core/src/memory/api.ts
@@ -506,6 +506,34 @@ function looksEntityLike(query: string): boolean {
   return /\b[A-Z][A-Za-z0-9_-]{2,}\b/.test(query) || /[#/][A-Za-z0-9_-]{2,}/.test(query);
 }
 
+/**
+ * Boost for how strongly a query matches a record's TOPIC (identity field).
+ * Scaled to dominate normalized BM25 scores (0-1 range): a query whose every
+ * token hits the topic is topic-anchored and must outrank body-text matches
+ * (delta-bench: before this, a topic string failed to surface its own rows in
+ * top-5 for 42.5% of chains - present in the candidate pool, buried by rank).
+ */
+export function topicAffinityBoost(
+  topic: string,
+  tokens: string[],
+  normalizedQuery: string
+): number {
+  if (tokens.length === 0) {
+    return 0;
+  }
+  const topicText = topic.toLowerCase().replace(/_/g, ' ');
+  let topicMatches = 0;
+  for (const token of tokens) {
+    const stem = stemToken(token);
+    if (topicText.includes(token) || topicText.includes(stem)) {
+      topicMatches += 1;
+    }
+  }
+  const allTokensInTopic = topicMatches === tokens.length;
+  const exact = topicText === normalizedQuery;
+  return (exact ? 1 : 0) + (allTokensInTopic ? 2 : 0) + (topicMatches / tokens.length) * 0.5;
+}
+
 function buildLexicalCandidates(
   records: MemoryRecord[],
   query: string
@@ -530,7 +558,11 @@ function buildLexicalCandidates(
         return count + 1;
       }, 0);
       const phraseBoost = haystack.includes(normalizedQuery) ? 2 : 0;
-      const score = tokenMatches + phraseBoost;
+      // Topic is the identity field: a hit there must outweigh a hit buried in
+      // a long decision text. Scale the shared 0-1 affinity boost up to this
+      // scorer's integer range so a full topic match dominates.
+      const topicBoost = topicAffinityBoost(record.topic, tokens, normalizedQuery) * 5;
+      const score = tokenMatches + phraseBoost + topicBoost;
       return { memory: record, score };
     })
     .filter((candidate) => candidate.score > 0)
@@ -1429,6 +1461,20 @@ export async function recallMemory(
       // FTS5 not available — fall through to in-memory lexical
     }
 
+    // Topic-affinity rescore for FTS5 candidates: the OR-joined FTS query
+    // floods the pool with body-text matches and plain BM25 buries rows whose
+    // TOPIC matches the query (observed: target row present at rank 26/50 in
+    // the pool, cut by the limit-5 slice). RRF consumes this array's ORDER,
+    // so rescoring must happen before fusion.
+    if (lexicalCandidates.length > 0) {
+      const boostTokens = getLexicalQueryTokens(query);
+      const boostQuery = query.toLowerCase();
+      for (const candidate of lexicalCandidates) {
+        candidate.score += topicAffinityBoost(candidate.memory.topic, boostTokens, boostQuery);
+      }
+      lexicalCandidates.sort((left, right) => right.score - left.score);
+    }
+
     // Fallback: in-memory lexical if FTS5 returned nothing
     if (lexicalCandidates.length === 0) {
       let lexicalRecords = await loadLexical();
@@ -2106,13 +2152,23 @@ export async function recallMemory(
         ];
       });
       diagnostics.candidate_counts.graph_expanded = bundle.graph_context.expanded.length;
+      // Graph-expanded hits are supporting context for the primary matches -
+      // they must never OUTRANK them. The previous score ((graph_rank)*0.1,
+      // typically 0.05-0.095) sat far above the entire RRF range (<=~0.018),
+      // so expansion hits displaced every primary hit from the fused top-N
+      // (delta-bench root cause: top-5 filled with related-but-wrong topics
+      // while the queried topic's own rows were cut). Scale them into a band
+      // strictly below the weakest primary hit, ordered by graph rank.
+      const minPrimaryScore =
+        fusedHits.length > 0 ? Math.min(...fusedHits.map((hit) => hit.fused_rank_score)) : 0.002;
       fusedHits = [
         ...fusedHits,
         ...bundle.graph_context.expanded.map((record) => ({
           source_type: 'decision' as const,
           source_id: record.id,
           record,
-          fused_rank_score: (record.confidence ?? 0.5) * 0.1,
+          fused_rank_score:
+            minPrimaryScore * 0.9 * Math.min(1, Math.max(0.1, record.confidence ?? 0.5)),
           retrieval_diagnostics: record.retrieval_diagnostics,
         })),
       ].sort((left, right) => right.fused_rank_score - left.fused_rank_score);

--- a/packages/mama-core/tests/unit/memory-v2-topic-recall-repair.test.ts
+++ b/packages/mama-core/tests/unit/memory-v2-topic-recall-repair.test.ts
@@ -30,7 +30,7 @@ vi.mock('../../src/db-manager.js', async (importOriginal) => {
             if (sql.includes('FROM memory_scope_bindings')) {
               return [];
             }
-            if (sql.includes('created_at FROM decisions WHERE topic IN')) {
+            if (sql.includes('WHERE topic IN') || sql.includes('d.topic IN')) {
               return currencyRows;
             }
             if (sql.includes('FROM decisions')) {
@@ -172,6 +172,35 @@ describe('AC3: annotateTopicCurrency marks superseded history', () => {
     currencyRows = [{ id: 'only-row', topic: 'solo_topic', created_at: 1000 }];
     const { annotateTopicCurrency } = await import('../../src/mama-api.js');
     const annotated = annotateTopicCurrency([{ id: 'only-row', topic: 'solo_topic' }]);
+    expect(annotated[0].superseded_by_newer).toBe(false);
+  });
+
+  it('breaks equal-timestamp ties deterministically (higher id wins)', async () => {
+    currencyRows = [
+      { id: 'row-a', topic: 'tie_topic', created_at: 1000 },
+      { id: 'row-b', topic: 'tie_topic', created_at: 1000 },
+    ];
+    const { annotateTopicCurrency } = await import('../../src/mama-api.js');
+    const annotated = annotateTopicCurrency([
+      { id: 'row-a', topic: 'tie_topic' },
+      { id: 'row-b', topic: 'tie_topic' },
+    ]);
+    expect(annotated.find((r) => r.id === 'row-b')?.superseded_by_newer).toBe(false);
+    expect(annotated.find((r) => r.id === 'row-a')?.superseded_by_newer).toBe(true);
+  });
+
+  it('scoped search restricts the currency comparison to the given scopes', async () => {
+    // The mock returns currencyRows for the scoped query too - what matters
+    // here is that the SCOPED branch is exercised (join SQL) and rows outside
+    // the mock "scope result" cannot mark in-scope truth stale.
+    currencyRows = [{ id: 'scoped-current', topic: 'deploy_process', created_at: 1000 }];
+    const { annotateTopicCurrency } = await import('../../src/mama-api.js');
+    const annotated = annotateTopicCurrency(
+      [{ id: 'scoped-current', topic: 'deploy_process' }],
+      [{ kind: 'project', id: '/proj/a' }]
+    );
+    // A newer row exists globally (not in currencyRows because the scoped SQL
+    // excludes it) - the in-scope row must remain current.
     expect(annotated[0].superseded_by_newer).toBe(false);
   });
 });

--- a/packages/mama-core/tests/unit/memory-v2-topic-recall-repair.test.ts
+++ b/packages/mama-core/tests/unit/memory-v2-topic-recall-repair.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Delta-bench retrieval repair (2026-07-19): topic-anchored recall.
+ *
+ * Story: a query that IS a topic string must surface that topic's own rows,
+ * and consumers must be able to tell current truth from superseded history.
+ * Before the repair: topicHit@5 57.5% / currentPresent@5 50% on the real
+ * dev-DB corpus; after: 82.5% / 77.5% (eval/delta-bench in memorybench).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const generateEmbeddingMock = vi.fn();
+const vectorSearchMock = vi.fn();
+
+let decisionRows: Array<Record<string, unknown>> = [];
+let currencyRows: Array<{ id: string; topic: string; created_at: number | string | null }> = [];
+
+vi.mock('../../src/embeddings.js', () => ({
+  generateEmbedding: generateEmbeddingMock,
+}));
+
+vi.mock('../../src/db-manager.js', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    initDB: vi.fn(async () => {}),
+    getAdapter: vi.fn(() => ({
+      prepare(sql: string) {
+        return {
+          all: (..._args: unknown[]) => {
+            if (sql.includes('FROM memory_scope_bindings')) {
+              return [];
+            }
+            if (sql.includes('created_at FROM decisions WHERE topic IN')) {
+              return currencyRows;
+            }
+            if (sql.includes('FROM decisions')) {
+              return decisionRows;
+            }
+            return [];
+          },
+          get: (..._args: unknown[]) => undefined,
+        };
+      },
+    })),
+    insertDecisionWithEmbedding: vi.fn(),
+    ensureMemoryScope: vi.fn(async () => 1),
+    vectorSearch: vectorSearchMock,
+    fts5Search: vi.fn(async () => []),
+  };
+});
+
+function decisionRow(id: string, topic: string, decision: string, created_at: number) {
+  return {
+    id,
+    topic,
+    decision,
+    reasoning: 'reasoning text',
+    confidence: 0.8,
+    created_at,
+    updated_at: created_at,
+    trust_context: null,
+    kind: 'decision',
+    status: 'active',
+    summary: decision,
+  };
+}
+
+describe('AC1: topicAffinityBoost math', () => {
+  it('scores exact topic match > all-tokens-in-topic > partial > none', async () => {
+    const { topicAffinityBoost, getLexicalQueryTokens } = await import('../../src/memory/api.js');
+    const tokens = getLexicalQueryTokens('operator report cadence');
+    const exact = topicAffinityBoost('operator_report_cadence', tokens, 'operator report cadence');
+    const partial = topicAffinityBoost(
+      'operator_console_design',
+      tokens,
+      'operator report cadence'
+    );
+    const none = topicAffinityBoost('billing_policy', tokens, 'operator report cadence');
+    expect(exact).toBeGreaterThan(2);
+    expect(partial).toBeGreaterThan(0);
+    expect(exact).toBeGreaterThan(partial);
+    expect(none).toBe(0);
+  });
+
+  it('returns 0 for empty token lists instead of a spurious boost', async () => {
+    const { topicAffinityBoost } = await import('../../src/memory/api.js');
+    expect(topicAffinityBoost('any_topic', [], 'query')).toBe(0);
+  });
+});
+
+describe('AC2: topic-anchored recall ranks the topic own rows above body-text noise', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    generateEmbeddingMock.mockResolvedValue(new Float32Array(8));
+    vectorSearchMock.mockResolvedValue([]);
+    decisionRows = [
+      // Newer noise: mentions the query tokens only in the body text.
+      decisionRow(
+        'noise-1',
+        'unrelated_launch_notes',
+        'The operator report cadence discussion moved to another channel this week.',
+        4000
+      ),
+      decisionRow(
+        'noise-2',
+        'another_meeting_log',
+        'We talked about the operator report cadence briefly and postponed it.',
+        3000
+      ),
+      // The queried topic's own rows (older than the noise).
+      decisionRow(
+        'target-old',
+        'operator_report_cadence',
+        'Reports go out weekly on Mondays.',
+        1000
+      ),
+      decisionRow('target-new', 'operator_report_cadence', 'Reports go out daily at 08:00.', 2000),
+    ];
+  });
+
+  it('puts operator_report_cadence rows at the top for the topic query', async () => {
+    const { recallMemory } = await import('../../src/memory/api.js');
+    const bundle = await recallMemory('operator report cadence', {
+      limit: 2,
+      includeProfile: false,
+    });
+    const topics = bundle.memories.map((m: { topic: string }) => m.topic);
+    expect(topics[0]).toBe('operator_report_cadence');
+    expect(topics[1]).toBe('operator_report_cadence');
+  });
+});
+
+describe('AC3: annotateTopicCurrency marks superseded history', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('marks a row stale when the DB holds a newer row for the same topic', async () => {
+    currencyRows = [
+      { id: 'old-row', topic: 'billing_policy', created_at: 1000 },
+      { id: 'new-row', topic: 'billing_policy', created_at: 2000 },
+    ];
+    const { annotateTopicCurrency } = await import('../../src/mama-api.js');
+    const annotated = annotateTopicCurrency([
+      { id: 'old-row', topic: 'billing_policy' },
+      { id: 'new-row', topic: 'billing_policy' },
+    ]);
+    expect(annotated.find((r) => r.id === 'old-row')?.superseded_by_newer).toBe(true);
+    expect(annotated.find((r) => r.id === 'new-row')?.superseded_by_newer).toBe(false);
+  });
+
+  it('normalizes mixed created_at encodings (seconds / ms / TEXT) before comparing', async () => {
+    currencyRows = [
+      { id: 'sec-row', topic: 'mixed_topic', created_at: 1770961389 }, // seconds
+      { id: 'ms-row', topic: 'mixed_topic', created_at: 1777041049115 }, // ms (newer)
+      { id: 'text-row', topic: 'mixed_topic', created_at: '2026-02-15 04:29:33' },
+    ];
+    const { annotateTopicCurrency } = await import('../../src/mama-api.js');
+    const annotated = annotateTopicCurrency([
+      { id: 'sec-row', topic: 'mixed_topic' },
+      { id: 'ms-row', topic: 'mixed_topic' },
+      { id: 'text-row', topic: 'mixed_topic' },
+    ]);
+    expect(annotated.find((r) => r.id === 'ms-row')?.superseded_by_newer).toBe(false);
+    expect(annotated.find((r) => r.id === 'sec-row')?.superseded_by_newer).toBe(true);
+    expect(annotated.find((r) => r.id === 'text-row')?.superseded_by_newer).toBe(true);
+  });
+
+  it('leaves rows untouched for topics with a single row', async () => {
+    currencyRows = [{ id: 'only-row', topic: 'solo_topic', created_at: 1000 }];
+    const { annotateTopicCurrency } = await import('../../src/mama-api.js');
+    const annotated = annotateTopicCurrency([{ id: 'only-row', topic: 'solo_topic' }]);
+    expect(annotated[0].superseded_by_newer).toBe(false);
+  });
+});

--- a/packages/memorybench/eval/delta-bench/README.md
+++ b/packages/memorybench/eval/delta-bench/README.md
@@ -1,0 +1,60 @@
+# Delta Bench — temporal-truth QA from real decision chains
+
+Measures the behavioral delta between a plain LLM and the same LLM augmented
+with MAMA memory, on questions whose correct answer CHANGED over time.
+
+## Why this exists
+
+Architecture claims ("decision graph", "truth projection") are not evidence.
+The claim that matters is: **distilled current truth beats a raw history dump
+in long context** — same data, same model, different representation. If raw
+context wins, MAMA's positioning fails; this bench is a falsification test
+before it is a promotion asset.
+
+## How it works
+
+1. **extract.mjs** (read-only) groups a MAMA DB's `decisions` rows into
+   temporal chains by topic (MAMA semantics: topic reuse supersedes). Each
+   chain with a real delta becomes one multiple-choice item:
+   - answer = the newest decision
+   - distractors = prior versions that actually existed
+   - option order is seed-shuffled; test-pollution topics are excluded
+2. **run.mjs** asks each question under three conditions via the Claude CLI
+   (`claude -p`, prompt on stdin, neutral cwd so no CLAUDE.md leaks in):
+   - `vanilla` — question only (floor; most chains have 2 options → ~50% chance)
+   - `raw` — full chronological decision dump in context, then the question
+   - `mama` — what `mama.suggest()` (the real MCP search path) returned
+3. Metrics per condition: accuracy, stale rate (picked a superseded version),
+   invalid rate, approx tokens/item, latency.
+
+## Usage
+
+```bash
+# 1. Extract (read-only against any MAMA DB)
+MAMA_DB_PATH=~/.claude/mama-memory.db \
+  node eval/delta-bench/extract.mjs --out /tmp/delta --max-items 40
+
+# 2. Copy the DB before the mama condition (initDB may migrate)
+cp ~/.claude/mama-memory.db /tmp/delta-copy.db
+
+# 3. Run (resumable; results append to results.jsonl)
+MAMA_DB_PATH=/tmp/delta-copy.db \
+  node eval/delta-bench/run.mjs --qa /tmp/delta --out /tmp/delta/results \
+  --conditions vanilla,raw,mama --limit 40
+```
+
+`run.mjs` refuses to run the mama condition against the live DB paths
+(`~/.claude/mama-memory.db`, `~/.mama/mama-memory.db`).
+
+## Interpreting results
+
+- Most chains have length 2 (one distractor), so the vanilla floor sits near
+  50%, not 25% — compare conditions against each other, not against zero.
+- The mama condition inherits real retrieval behavior, including its defects.
+  A low mama score is a product finding, not a bench bug.
+
+## Tests
+
+```bash
+node --test eval/delta-bench/lib.test.mjs
+```

--- a/packages/memorybench/eval/delta-bench/RESULTS.md
+++ b/packages/memorybench/eval/delta-bench/RESULTS.md
@@ -33,6 +33,26 @@ items → chance ≈ 47%.
      failures (current present but unmarked next to stale versions;
      conditional accuracy when present: 80% vs oracle 92.5% when marked)
 
+## Repair round 1 (same day) — measured gap close
+
+After fixing the three retrieval defects in mama-core (fusion scale inversion
+where graph-expansion hits outscored the entire primary RRF range; missing
+topic-field weighting; no current/superseded marking in suggest results):
+
+| metric                       | before    | after                      |
+| ---------------------------- | --------- | -------------------------- |
+| topicHit@5                   | 57.5%     | 82.5%                      |
+| currentPresent@5             | 50.0%     | 77.5%                      |
+| **mama end-to-end accuracy** | **57.5%** | **75.0%** (~2.2k tok/item) |
+
+mama now sits 7.5pp under raw (82.5% @ 79k tok) at 1/36 the tokens, with
+17.5pp of ceiling headroom left (oracle 92.5%). Remaining misses: 6 retrieval,
+4 choice. An Opus adversarial review then caught a scope-blindness defect in
+the currency marking (topic collisions across projects/channels would mark
+in-scope truth stale) - fixed with scope-restricted comparison, deterministic
+tiebreaks, word-boundary topic matching, and a topic index, with metrics
+unchanged after hardening.
+
 ## Fix list this measures (re-run after each)
 
 1. Retrieval: query-side e5 prefix omission + lexical/topic matching (a topic

--- a/packages/memorybench/eval/delta-bench/RESULTS.md
+++ b/packages/memorybench/eval/delta-bench/RESULTS.md
@@ -1,0 +1,49 @@
+# Delta Bench — first clean run (dev DB, 2026-07-19)
+
+Corpus: the maintainer's real dev DB (1,097 decision rows → 44 temporal chains
+→ 40 MC items; answer = newest version, distractors = actually-existed priors).
+Model: Claude CLI default (claude-opus-4-8), isolated with
+`--setting-sources project` + neutral cwd. Seed 20260719. Mostly 2-option
+items → chance ≈ 47%.
+
+## Headline table
+
+| condition  | what the model saw                         | accuracy  | ~tokens/item |
+| ---------- | ------------------------------------------ | --------- | ------------ |
+| vanilla    | question only (floor)                      | 50.0%     | 286          |
+| **mama**   | `mama.suggest()` top-5 (current pipeline)  | **57.5%** | 1,395        |
+| raw        | full chronological history dump            | 82.5%     | 79,194       |
+| **oracle** | what correct truth projection WOULD return | **92.5%** | 426          |
+
+## Verdict
+
+1. **The design thesis holds at the ceiling**: distilled, marked current truth
+   (oracle) beats the full-history dump by +10pp at 1/186 the tokens.
+2. **The current pipeline does not cash it**: `mama.suggest()` scores 25pp
+   BELOW raw long context and barely above the no-context floor. The
+   falsification threshold defined before the run ("mama must beat raw or halt
+   promotion") FIRED.
+3. **Failure is mostly retrieval, not model choice** (offline decomposition of
+   suggest() top-5 per item):
+   - topicHitRate 57.5% — for 42.5% of items the top-5 contained not a single
+     row of the asked topic, with the topic string itself as the query
+   - currentPresentRate 50.0% — current truth reached the model half the time
+   - currentRank1Rate 17.5%
+   - of 17 mama misses: 13 retrieval failures (current absent), 4 choice
+     failures (current present but unmarked next to stale versions;
+     conditional accuracy when present: 80% vs oracle 92.5% when marked)
+
+## Fix list this measures (re-run after each)
+
+1. Retrieval: query-side e5 prefix omission + lexical/topic matching (a topic
+   string failing to retrieve its own rows 42.5% of the time).
+2. Truth projection surfacing: mark current vs superseded in suggest() results
+   (closes the present-but-unmarked gap, 80% → ~92.5%).
+
+## Experiment-integrity notes (biased runs archived, not deleted)
+
+- `results-biased-preamble.jsonl`: instruction example letter '(e.g. "B")'
+  made every condition answer B for 80%+ of items.
+- `results-hook-contaminated.jsonl`: `claude -p` executes user-level plugin
+  hooks; the user's live MAMA SessionStart injection contaminated every call
+  (oracle 65% → 92.5% once isolated).

--- a/packages/memorybench/eval/delta-bench/analyze.mjs
+++ b/packages/memorybench/eval/delta-bench/analyze.mjs
@@ -17,6 +17,7 @@ import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
 import { createRequire } from "node:module"
+import { fileURLToPath } from "node:url"
 
 const require = createRequire(import.meta.url)
 
@@ -49,7 +50,7 @@ if (liveDbs.includes(resolved)) {
   fail(`MAMA_DB_PATH points at a LIVE DB (${resolved}). Copy it first.`)
 }
 
-const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "../../../..")
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..")
 const distDir = path.join(repoRoot, "packages/mama-core/dist")
 const { initDB } = require(path.join(distDir, "db-manager.js"))
 const mama = require(path.join(distDir, "mama-api.js"))

--- a/packages/memorybench/eval/delta-bench/analyze.mjs
+++ b/packages/memorybench/eval/delta-bench/analyze.mjs
@@ -1,0 +1,134 @@
+// analyze.mjs - decompose delta-bench results without any LLM calls.
+//
+// For every QA item it re-runs mama.suggest() offline and measures what the
+// retrieval layer actually put in front of the model:
+//   topicHit       - any row of the asked topic in top-5
+//   currentPresent - the CURRENT decision row in top-5
+//   currentRank    - its rank when present (1-based)
+//   staleInTop5    - how many superseded versions of the topic are in top-5
+// Then it joins per-condition correctness from results.jsonl and reports:
+//   - chance-corrected accuracy (mean 1/optionCount baseline)
+//   - mama miss decomposition: retrieval failure vs choice failure
+//
+// Usage:
+//   MAMA_DB_PATH=/path/to/COPY.db node analyze.mjs --qa <dir> --results <dir>/full
+
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { createRequire } from "node:module"
+
+const require = createRequire(import.meta.url)
+
+function fail(msg) {
+  console.error(`[delta-bench:analyze] ${msg}`)
+  process.exit(1)
+}
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`)
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback
+}
+
+const qaDir = arg("qa", null)
+const resultsDir = arg("results", null)
+if (!qaDir || !resultsDir) {
+  fail("--qa <dir> and --results <dir> are required.")
+}
+
+const dbPath = process.env.MAMA_DB_PATH
+if (!dbPath) {
+  fail("MAMA_DB_PATH (a COPY) is required.")
+}
+const resolved = path.resolve(dbPath)
+const liveDbs = [
+  path.join(os.homedir(), ".claude", "mama-memory.db"),
+  path.join(os.homedir(), ".mama", "mama-memory.db"),
+].map((p) => path.resolve(p))
+if (liveDbs.includes(resolved)) {
+  fail(`MAMA_DB_PATH points at a LIVE DB (${resolved}). Copy it first.`)
+}
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "../../../..")
+const distDir = path.join(repoRoot, "packages/mama-core/dist")
+const { initDB } = require(path.join(distDir, "db-manager.js"))
+const mama = require(path.join(distDir, "mama-api.js"))
+await initDB()
+
+const qaSet = JSON.parse(fs.readFileSync(path.join(qaDir, "qa-set.json"), "utf8"))
+const results = fs
+  .readFileSync(path.join(resultsDir, "results.jsonl"), "utf8")
+  .trim()
+  .split("\n")
+  .map((l) => JSON.parse(l))
+
+const byItem = new Map()
+for (const r of results) {
+  if (!byItem.has(r.itemId)) {
+    byItem.set(r.itemId, {})
+  }
+  byItem.get(r.itemId)[r.condition] = r
+}
+
+const diags = []
+for (const item of qaSet) {
+  const query = item.topic.replace(/_/g, " ")
+  const res = await mama.suggest(query, { limit: 5 })
+  if (!res || !Array.isArray(res.results)) {
+    fail(`suggest() unexpected shape for "${query}"`)
+  }
+  const top5 = res.results
+  const topicRows = top5.filter((r) => r.topic === item.topic)
+  const currentIdx = top5.findIndex((r) => r.id === item.currentDecisionId)
+  diags.push({
+    itemId: item.id,
+    topic: item.topic,
+    optionCount: item.options.length,
+    topicHit: topicRows.length > 0,
+    currentPresent: currentIdx >= 0,
+    currentRank: currentIdx >= 0 ? currentIdx + 1 : null,
+    staleInTop5: topicRows.filter((r) => r.id !== item.currentDecisionId).length,
+    conditions: Object.fromEntries(
+      Object.entries(byItem.get(item.id) ?? {}).map(([c, r]) => [
+        c,
+        { choice: r.choice, correct: r.correct },
+      ])
+    ),
+  })
+}
+
+// Chance baseline from actual option counts.
+const chance = diags.reduce((s, d) => s + 1 / d.optionCount, 0) / diags.length
+
+const retrievalStats = {
+  items: diags.length,
+  chanceAccuracy: +chance.toFixed(4),
+  topicHitRate: +(diags.filter((d) => d.topicHit).length / diags.length).toFixed(4),
+  currentPresentRate: +(diags.filter((d) => d.currentPresent).length / diags.length).toFixed(4),
+  currentRank1Rate: +(diags.filter((d) => d.currentRank === 1).length / diags.length).toFixed(4),
+  meanStaleInTop5: +(diags.reduce((s, d) => s + d.staleInTop5, 0) / diags.length).toFixed(2),
+}
+
+// mama miss decomposition.
+const mamaMisses = diags.filter((d) => d.conditions.mama && !d.conditions.mama.correct)
+const missRetrieval = mamaMisses.filter((d) => !d.currentPresent).length
+const missChoice = mamaMisses.filter((d) => d.currentPresent).length
+
+const out = {
+  retrievalStats,
+  mamaMissDecomposition: {
+    misses: mamaMisses.length,
+    retrievalFailure: missRetrieval,
+    choiceFailureWithCurrentPresent: missChoice,
+  },
+  items: diags,
+}
+fs.writeFileSync(path.join(resultsDir, "analysis.json"), JSON.stringify(out, null, 2))
+
+console.log("=== retrieval diagnostics (mama.suggest top-5) ===")
+console.log(JSON.stringify(retrievalStats, null, 2))
+console.log("=== mama miss decomposition ===")
+console.log(
+  `misses=${mamaMisses.length} retrievalFailure(current absent)=${missRetrieval} choiceFailure(current present)=${missChoice}`
+)
+console.log(`analysis: ${path.join(resultsDir, "analysis.json")}`)

--- a/packages/memorybench/eval/delta-bench/extract.mjs
+++ b/packages/memorybench/eval/delta-bench/extract.mjs
@@ -1,0 +1,145 @@
+// extract.mjs - build the temporal-truth QA set and the raw-context corpus
+// from a MAMA decisions DB. Read-only: opens the DB with { readonly: true },
+// never calls initDB, never writes to the source DB.
+//
+// Usage:
+//   MAMA_DB_PATH=/path/to/mama-memory.db node extract.mjs --out ./out [--seed 20260719] [--max-items 40]
+//
+// Outputs (in --out dir):
+//   qa-set.json   - [{ id, topic, question, options[], answerLabel, ... }]
+//   corpus.json   - all decision rows, chronological (for the raw-context condition)
+//   meta.json     - counts and filter stats
+
+import fs from "node:fs"
+import path from "node:path"
+import { createRequire } from "node:module"
+import { buildChains, buildQaItem, mulberry32, normalizeCreatedAt } from "./lib.mjs"
+
+const require = createRequire(import.meta.url)
+const Database = require("better-sqlite3")
+
+function fail(msg) {
+  console.error(`[delta-bench:extract] ${msg}`)
+  process.exit(1)
+}
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`)
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback
+}
+
+const dbPath = process.env.MAMA_DB_PATH
+if (!dbPath) {
+  fail("MAMA_DB_PATH is required (never defaults to a live DB).")
+}
+if (!fs.existsSync(dbPath)) {
+  fail(`DB not found: ${dbPath}`)
+}
+
+const outDir = arg("out", null)
+if (!outDir) {
+  fail("--out <dir> is required.")
+}
+const seed = Number(arg("seed", "20260719"))
+const maxItems = Number(arg("max-items", "40"))
+if (!Number.isFinite(seed) || !Number.isFinite(maxItems)) {
+  fail("--seed/--max-items must be numbers.")
+}
+
+fs.mkdirSync(outDir, { recursive: true })
+
+const db = new Database(dbPath, { readonly: true, fileMustExist: true })
+const rawRows = db
+  .prepare(
+    `SELECT id, topic, decision, reasoning, created_at, status, kind
+     FROM decisions
+     WHERE kind IN ('decision', 'preference', 'constraint', 'lesson', 'fact')`
+  )
+  .all()
+db.close()
+
+if (rawRows.length === 0) {
+  fail("No decision rows in DB.")
+}
+
+// Normalize timestamps in JS (the DB mixes seconds / ms / TEXT datetimes, so
+// SQL ORDER BY created_at is unreliable across encodings).
+let droppedBadTimestamp = 0
+const rows = []
+for (const r of rawRows) {
+  const ts = normalizeCreatedAt(r.created_at)
+  if (ts === null) {
+    droppedBadTimestamp += 1
+    continue
+  }
+  rows.push({ ...r, created_at: ts })
+}
+rows.sort((a, b) => a.created_at - b.created_at || String(a.id).localeCompare(String(b.id)))
+if (rows.length === 0) {
+  fail("All rows dropped by timestamp normalization.")
+}
+
+const chains = buildChains(rows)
+if (chains.length === 0) {
+  fail("No usable chains (length>=2 with a real delta) after filtering.")
+}
+
+// Sample chains deterministically when there are more than maxItems.
+const rand = mulberry32(seed)
+const shuffled = chains
+  .map((c) => ({ c, r: rand() }))
+  .sort((a, b) => a.r - b.r)
+  .map((x) => x.c)
+const picked = shuffled.slice(0, maxItems).sort((a, b) => a.topic.localeCompare(b.topic))
+
+const qaSet = []
+for (const chain of picked) {
+  // Per-item seed derived from the global seed + topic for stable option order.
+  let topicSeed = seed
+  for (const ch of chain.topic) {
+    topicSeed = (topicSeed * 31 + ch.charCodeAt(0)) >>> 0
+  }
+  const item = buildQaItem(chain, topicSeed)
+  if (item) {
+    qaSet.push(item)
+  }
+}
+if (qaSet.length === 0) {
+  fail("Chain sampling produced zero QA items.")
+}
+
+// Raw-context corpus: every decision row, chronological, as a user would dump
+// their full history into a long context window. Decision text only by default
+// (reasoning inclusion would roughly double the context; enable via flag later
+// if the experiment needs it).
+const corpus = rows.map((r) => ({
+  topic: r.topic,
+  decision: r.decision,
+  created_at: r.created_at,
+  iso: new Date(r.created_at).toISOString(),
+}))
+
+const meta = {
+  db: path.resolve(dbPath),
+  extractedAt: new Date().toISOString(),
+  seed,
+  totals: {
+    decisionRows: rows.length,
+    droppedBadTimestamp,
+    chains: chains.length,
+    qaItems: qaSet.length,
+    corpusRows: corpus.length,
+  },
+  chainLengthHistogram: qaSet.reduce((h, q) => {
+    h[q.chainLength] = (h[q.chainLength] || 0) + 1
+    return h
+  }, {}),
+}
+
+fs.writeFileSync(path.join(outDir, "qa-set.json"), JSON.stringify(qaSet, null, 2))
+fs.writeFileSync(path.join(outDir, "corpus.json"), JSON.stringify(corpus))
+fs.writeFileSync(path.join(outDir, "meta.json"), JSON.stringify(meta, null, 2))
+
+console.log(
+  `[delta-bench:extract] rows=${rows.length} chains=${chains.length} qaItems=${qaSet.length} -> ${outDir}`
+)

--- a/packages/memorybench/eval/delta-bench/lib.mjs
+++ b/packages/memorybench/eval/delta-bench/lib.mjs
@@ -6,7 +6,9 @@
 // into the live DB before test HOME isolation landed (2026-07-17).
 const EXCLUDED_TOPIC_PATTERNS = [
   /^(alpha|beta|auth_strategy|database_choice|dummy)$/i,
-  /test/i,
+  // Token-anchored so legitimate topics that merely contain the substring
+  // "test" (e.g. "latest_pricing", "fastest_path") are not dropped.
+  /(^|_)test(ing|s)?(_|$)/i,
   /^memory_scopes/i,
   /^session_greeting$/i,
 ]
@@ -37,7 +39,11 @@ export function normalizeCreatedAt(v) {
     if (/^\d+$/.test(trimmed)) {
       return normalizeCreatedAt(Number(trimmed))
     }
-    const parsed = Date.parse(trimmed.includes("T") ? trimmed : trimmed.replace(" ", "T") + "Z")
+    // Stamp UTC only when the text carries no timezone marker: appending "Z" to
+    // a value that already ends in "Z" or an offset would produce NaN.
+    const formatted = trimmed.includes("T") ? trimmed : trimmed.replace(" ", "T")
+    const hasTz = formatted.endsWith("Z") || /[+-]\d{2}:?\d{2}$/.test(formatted)
+    const parsed = Date.parse(hasTz ? formatted : formatted + "Z")
     return Number.isFinite(parsed) ? parsed : null
   }
   return null

--- a/packages/memorybench/eval/delta-bench/lib.mjs
+++ b/packages/memorybench/eval/delta-bench/lib.mjs
@@ -1,0 +1,237 @@
+// lib.mjs - pure helpers for the delta bench (temporal-truth QA from decision chains).
+// No DB access, no model calls. Deterministic given a seed.
+
+// Test-pollution and low-signal topics are excluded from chain building.
+// alpha/beta/auth_strategy/database_choice are known fixture topics that leaked
+// into the live DB before test HOME isolation landed (2026-07-17).
+const EXCLUDED_TOPIC_PATTERNS = [
+  /^(alpha|beta|auth_strategy|database_choice|dummy)$/i,
+  /test/i,
+  /^memory_scopes/i,
+  /^session_greeting$/i,
+]
+
+const MIN_DECISION_CHARS = 40
+const MAX_DISTRACTORS = 3
+const OPTION_LABELS = ["A", "B", "C", "D"]
+
+export function isExcludedTopic(topic) {
+  return EXCLUDED_TOPIC_PATTERNS.some((re) => re.test(topic))
+}
+
+/**
+ * Normalize a decisions.created_at value to epoch milliseconds.
+ * The live DBs mix three encodings: epoch seconds, epoch milliseconds, and at
+ * least one TEXT datetime ("2026-02-15 04:29:33"). Returns null when the value
+ * cannot be interpreted - callers drop (and count) such rows.
+ */
+export function normalizeCreatedAt(v) {
+  if (v === null || v === undefined) {
+    return null
+  }
+  if (typeof v === "number" && Number.isFinite(v)) {
+    return v > 1e12 ? v : v * 1000
+  }
+  if (typeof v === "string") {
+    const trimmed = v.trim()
+    if (/^\d+$/.test(trimmed)) {
+      return normalizeCreatedAt(Number(trimmed))
+    }
+    const parsed = Date.parse(trimmed.includes("T") ? trimmed : trimmed.replace(" ", "T") + "Z")
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+// Deterministic PRNG so QA sets are reproducible run-to-run.
+export function mulberry32(seed) {
+  let a = seed >>> 0
+  return function () {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+export function seededShuffle(arr, rand) {
+  const out = arr.slice()
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1))
+    ;[out[i], out[j]] = [out[j], out[i]]
+  }
+  return out
+}
+
+/**
+ * Group decision rows into temporal chains by topic, ordered oldest -> newest.
+ * MAMA semantics: re-using a topic supersedes the previous decision, so the
+ * newest row of a topic IS the current truth. Explicit supersedes links exist
+ * too but are a subset of topic reuse; topic grouping covers both.
+ *
+ * rows: [{ id, topic, decision, reasoning, created_at, status, kind }]
+ * Returns chains: [{ topic, rows: [...oldest..newest] }] with:
+ *  - length >= 2
+ *  - excluded topics dropped
+ *  - rows shorter than MIN_DECISION_CHARS dropped before grouping
+ *  - chains whose current text duplicates a prior version dropped (no delta)
+ */
+export function buildChains(rows) {
+  const byTopic = new Map()
+  for (const r of rows) {
+    if (!r.topic || !r.decision) {
+      continue
+    }
+    if (isExcludedTopic(r.topic)) {
+      continue
+    }
+    if (r.decision.trim().length < MIN_DECISION_CHARS) {
+      continue
+    }
+    if (!byTopic.has(r.topic)) {
+      byTopic.set(r.topic, [])
+    }
+    byTopic.get(r.topic).push(r)
+  }
+  const chains = []
+  for (const [topic, group] of byTopic) {
+    if (group.length < 2) {
+      continue
+    }
+    group.sort((a, b) => a.created_at - b.created_at || String(a.id).localeCompare(String(b.id)))
+    const current = group[group.length - 1]
+    const priors = group.slice(0, -1)
+    const currentText = normalizeText(current.decision)
+    const distinctPriors = priors.filter((p) => normalizeText(p.decision) !== currentText)
+    if (distinctPriors.length === 0) {
+      continue
+    }
+    chains.push({ topic, rows: group })
+  }
+  chains.sort((a, b) => a.topic.localeCompare(b.topic))
+  return chains
+}
+
+function normalizeText(s) {
+  return s.replace(/\s+/g, " ").trim().toLowerCase()
+}
+
+/**
+ * Build one multiple-choice QA item from a chain.
+ * Answer = the chain's newest decision. Distractors = the most recent distinct
+ * prior versions (they really existed, which is what makes them dangerous).
+ * Option order is a seeded shuffle so the answer position carries no signal.
+ */
+export function buildQaItem(chain, seed) {
+  const rows = chain.rows
+  const current = rows[rows.length - 1]
+  const currentNorm = normalizeText(current.decision)
+  const seen = new Set([currentNorm])
+  const distractors = []
+  for (let i = rows.length - 2; i >= 0 && distractors.length < MAX_DISTRACTORS; i--) {
+    const norm = normalizeText(rows[i].decision)
+    if (seen.has(norm)) {
+      continue
+    }
+    seen.add(norm)
+    distractors.push(rows[i])
+  }
+  if (distractors.length === 0) {
+    return null
+  }
+
+  const rand = mulberry32(seed)
+  const optionRows = seededShuffle([current, ...distractors], rand)
+  const options = optionRows.map((row, idx) => ({
+    label: OPTION_LABELS[idx],
+    text: row.decision.trim(),
+    decisionId: row.id,
+    isCurrent: row.id === current.id,
+  }))
+  const answer = options.find((o) => o.isCurrent)
+  return {
+    id: `delta_${chain.topic}`,
+    topic: chain.topic,
+    chainLength: rows.length,
+    currentDecisionId: current.id,
+    currentCreatedAt: current.created_at,
+    question:
+      `Topic: "${chain.topic}"\n` +
+      "Which option states the CURRENT (most recent, still-valid) decision on this topic? " +
+      "Earlier versions of the decision may appear as options - do not pick a superseded version. " +
+      "Answer with the option letter only.",
+    options,
+    answerLabel: answer.label,
+  }
+}
+
+/** Render the options block appended to every condition prompt. */
+export function renderOptions(item) {
+  return item.options.map((o) => `${o.label}) ${o.text}`).join("\n\n")
+}
+
+/**
+ * Parse a model reply into an option label. Accepts "A", "A)", "**A**",
+ * "Answer: A" etc. Only labels present on the item are valid.
+ */
+export function parseChoice(text, validLabels) {
+  if (!text) {
+    return null
+  }
+  const labels = validLabels.join("")
+  const patterns = [
+    new RegExp(`^\\s*\\**([${labels}])\\**\\s*[).:]?\\s*$`, "m"),
+    new RegExp(`answer\\s*(?:is)?\\s*[:-]?\\s*\\**([${labels}])\\b`, "i"),
+    new RegExp(`\\b([${labels}])\\b`),
+  ]
+  for (const re of patterns) {
+    const m = text.match(re)
+    if (m) {
+      return m[1].toUpperCase()
+    }
+  }
+  return null
+}
+
+/** Rough token estimate (chars/4) - labeled approximate everywhere it is shown. */
+export function approxTokens(str) {
+  return Math.ceil((str || "").length / 4)
+}
+
+/**
+ * Aggregate per-condition results.
+ * results: [{ itemId, condition, choice, answerLabel, valid, promptChars }]
+ */
+export function scoreResults(results) {
+  const byCondition = new Map()
+  for (const r of results) {
+    if (!byCondition.has(r.condition)) {
+      byCondition.set(r.condition, {
+        condition: r.condition,
+        n: 0,
+        correct: 0,
+        stale: 0,
+        invalid: 0,
+        promptChars: 0,
+      })
+    }
+    const s = byCondition.get(r.condition)
+    s.n += 1
+    s.promptChars += r.promptChars || 0
+    if (!r.choice) {
+      s.invalid += 1
+    } else if (r.choice === r.answerLabel) {
+      s.correct += 1
+    } else {
+      s.stale += 1
+    }
+  }
+  return [...byCondition.values()].map((s) => ({
+    ...s,
+    accuracy: s.n ? +(s.correct / s.n).toFixed(4) : null,
+    staleRate: s.n ? +(s.stale / s.n).toFixed(4) : null,
+    invalidRate: s.n ? +(s.invalid / s.n).toFixed(4) : null,
+    approxTokensPerItem: s.n ? Math.round(s.promptChars / 4 / s.n) : null,
+  }))
+}

--- a/packages/memorybench/eval/delta-bench/lib.test.mjs
+++ b/packages/memorybench/eval/delta-bench/lib.test.mjs
@@ -1,0 +1,148 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import {
+  buildChains,
+  buildQaItem,
+  isExcludedTopic,
+  mulberry32,
+  normalizeCreatedAt,
+  parseChoice,
+  renderOptions,
+  scoreResults,
+  seededShuffle,
+} from "./lib.mjs"
+
+const LONG = "a decision text that is comfortably longer than the forty character minimum"
+
+function row(id, topic, decision, created_at) {
+  return { id, topic, decision, created_at, reasoning: null, status: "active", kind: "decision" }
+}
+
+test("isExcludedTopic drops known fixture-pollution topics", () => {
+  assert.equal(isExcludedTopic("auth_strategy"), true)
+  assert.equal(isExcludedTopic("alpha"), true)
+  assert.equal(isExcludedTopic("memory_scopes_project_x"), true)
+  assert.equal(isExcludedTopic("my_integration_test_flow"), true)
+  assert.equal(isExcludedTopic("operator_report_cadence"), false)
+})
+
+test("normalizeCreatedAt handles epoch seconds, epoch ms, TEXT datetimes, and garbage", () => {
+  assert.equal(normalizeCreatedAt(1770961389), 1770961389000) // seconds
+  assert.equal(normalizeCreatedAt(1777041049115), 1777041049115) // already ms
+  assert.equal(normalizeCreatedAt("1770961389"), 1770961389000) // numeric string
+  assert.equal(normalizeCreatedAt("2026-02-15 04:29:33"), Date.parse("2026-02-15T04:29:33Z"))
+  assert.equal(normalizeCreatedAt("not a date"), null)
+  assert.equal(normalizeCreatedAt(null), null)
+  assert.equal(normalizeCreatedAt(undefined), null)
+})
+
+test("buildChains groups by topic oldest->newest and requires a real delta", () => {
+  const rows = [
+    row("d2", "cadence", `${LONG} v2`, 200),
+    row("d1", "cadence", `${LONG} v1`, 100),
+    row("d3", "cadence", `${LONG} v3`, 300),
+    row("x1", "solo_topic", `${LONG} only one`, 100),
+    row("t1", "auth_strategy", `${LONG} fixture`, 100),
+    row("t2", "auth_strategy", `${LONG} fixture2`, 200),
+    row("s1", "short", "too short", 100),
+    row("s2", "short", "too short2", 200),
+    row("n1", "no_delta", `${LONG} same`, 100),
+    row("n2", "no_delta", `${LONG}   SAME`, 200),
+  ]
+  const chains = buildChains(rows)
+  assert.equal(chains.length, 1)
+  assert.equal(chains[0].topic, "cadence")
+  assert.deepEqual(
+    chains[0].rows.map((r) => r.id),
+    ["d1", "d2", "d3"]
+  )
+})
+
+test("buildQaItem marks the newest row as the answer and priors as distractors", () => {
+  const chain = {
+    topic: "cadence",
+    rows: [
+      row("d1", "cadence", `${LONG} v1`, 100),
+      row("d2", "cadence", `${LONG} v2`, 200),
+      row("d3", "cadence", `${LONG} v3`, 300),
+    ],
+  }
+  const item = buildQaItem(chain, 42)
+  assert.equal(item.options.length, 3)
+  const answer = item.options.find((o) => o.label === item.answerLabel)
+  assert.equal(answer.decisionId, "d3")
+  assert.equal(answer.isCurrent, true)
+  assert.equal(item.options.filter((o) => o.isCurrent).length, 1)
+  // Deterministic for a fixed seed.
+  const again = buildQaItem(chain, 42)
+  assert.deepEqual(
+    again.options.map((o) => o.decisionId),
+    item.options.map((o) => o.decisionId)
+  )
+})
+
+test("buildQaItem caps distractors at 3 and dedups identical prior texts", () => {
+  const rows = []
+  for (let i = 1; i <= 6; i++) {
+    rows.push(row(`d${i}`, "t", `${LONG} v${i}`, i * 100))
+  }
+  rows.push(row("dup", "t", `${LONG} v5`, 650)) // duplicate of v5 text
+  rows.sort((a, b) => a.created_at - b.created_at)
+  const item = buildQaItem({ topic: "t", rows }, 7)
+  assert.equal(item.options.length, 4) // 1 answer + 3 distractors
+  const texts = item.options.map((o) => o.text)
+  assert.equal(new Set(texts).size, texts.length)
+})
+
+test("seededShuffle is deterministic per seed", () => {
+  const arr = [1, 2, 3, 4, 5]
+  const a = seededShuffle(arr, mulberry32(1))
+  const b = seededShuffle(arr, mulberry32(1))
+  const c = seededShuffle(arr, mulberry32(2))
+  assert.deepEqual(a, b)
+  assert.notDeepEqual(a, c)
+})
+
+test("parseChoice handles bare letters, prefixed answers, and rejects garbage", () => {
+  const labels = ["A", "B", "C"]
+  assert.equal(parseChoice("B", labels), "B")
+  assert.equal(parseChoice("  **C**  ", labels), "C")
+  assert.equal(parseChoice("Answer: A", labels), "A")
+  assert.equal(parseChoice("The answer is B) because...", labels), "B")
+  assert.equal(parseChoice("none of these", labels), null)
+  assert.equal(parseChoice("", labels), null)
+  // D is not a valid label when only 3 options exist.
+  assert.equal(parseChoice("D", labels), null)
+})
+
+test("renderOptions prints label) text blocks", () => {
+  const item = buildQaItem(
+    {
+      topic: "t",
+      rows: [row("d1", "t", `${LONG} v1`, 100), row("d2", "t", `${LONG} v2`, 200)],
+    },
+    3
+  )
+  const rendered = renderOptions(item)
+  for (const o of item.options) {
+    assert.ok(rendered.includes(`${o.label}) ${o.text}`))
+  }
+})
+
+test("scoreResults computes accuracy, stale and invalid rates per condition", () => {
+  const results = [
+    { itemId: "1", condition: "mama", choice: "A", answerLabel: "A", promptChars: 400 },
+    { itemId: "2", condition: "mama", choice: "B", answerLabel: "A", promptChars: 400 },
+    { itemId: "1", condition: "raw", choice: null, answerLabel: "A", promptChars: 40000 },
+    { itemId: "2", condition: "raw", choice: "A", answerLabel: "A", promptChars: 40000 },
+  ]
+  const scores = scoreResults(results)
+  const mama = scores.find((s) => s.condition === "mama")
+  const raw = scores.find((s) => s.condition === "raw")
+  assert.equal(mama.accuracy, 0.5)
+  assert.equal(mama.staleRate, 0.5)
+  assert.equal(mama.invalidRate, 0)
+  assert.equal(raw.accuracy, 0.5)
+  assert.equal(raw.invalidRate, 0.5)
+  assert.equal(raw.approxTokensPerItem, 10000)
+})

--- a/packages/memorybench/eval/delta-bench/run.mjs
+++ b/packages/memorybench/eval/delta-bench/run.mjs
@@ -22,6 +22,7 @@ import os from "node:os"
 import path from "node:path"
 import { spawn } from "node:child_process"
 import { createRequire } from "node:module"
+import { fileURLToPath } from "node:url"
 import { approxTokens, parseChoice, renderOptions, scoreResults } from "./lib.mjs"
 
 const require = createRequire(import.meta.url)
@@ -47,6 +48,9 @@ const conditions = arg("conditions", "vanilla,raw,mama")
 const limit = Number(arg("limit", "40"))
 const model = arg("model", null)
 const timeoutS = Number(arg("timeout-s", "600"))
+if (!Number.isFinite(limit) || !Number.isFinite(timeoutS)) {
+  fail("--limit/--timeout-s must be numbers.")
+}
 
 const VALID_CONDITIONS = new Set(["vanilla", "raw", "mama", "oracle"])
 for (const c of conditions) {
@@ -92,7 +96,7 @@ if (conditions.includes("mama")) {
   if (!fs.existsSync(resolved)) {
     fail(`MAMA_DB_PATH not found: ${resolved}`)
   }
-  const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "../../../..")
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..")
   const distDir = path.join(repoRoot, "packages/mama-core/dist")
   const { initDB } = require(path.join(distDir, "db-manager.js"))
   mamaApi = require(path.join(distDir, "mama-api.js"))

--- a/packages/memorybench/eval/delta-bench/run.mjs
+++ b/packages/memorybench/eval/delta-bench/run.mjs
@@ -1,0 +1,245 @@
+// run.mjs - run the 3-condition delta experiment over a QA set.
+//
+// Conditions:
+//   vanilla - question only (floor reference; near-chance by construction)
+//   raw     - full chronological decision dump in context (what "just use long
+//             context" actually looks like), then the question
+//   mama    - whatever mama.suggest() returns for the topic query (the real
+//             MCP search runtime path, including its retrieval imperfections)
+//
+// Model calls go through the Claude CLI (`claude -p`, prompt on stdin) - no
+// API keys. Results append to <out>/results.jsonl (safe to re-run; answered
+// (condition,item) pairs are skipped).
+//
+// Usage:
+//   node run.mjs --qa <dir> --out <dir>/results [--conditions vanilla,raw,mama]
+//                [--limit 40] [--model <model>] [--timeout-s 600]
+//   The mama condition additionally requires MAMA_DB_PATH pointing to a COPY
+//   of a MAMA DB - live DB paths are refused.
+
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { spawn } from "node:child_process"
+import { createRequire } from "node:module"
+import { approxTokens, parseChoice, renderOptions, scoreResults } from "./lib.mjs"
+
+const require = createRequire(import.meta.url)
+
+function fail(msg) {
+  console.error(`[delta-bench:run] ${msg}`)
+  process.exit(1)
+}
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`)
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback
+}
+
+const qaDir = arg("qa", null)
+if (!qaDir) {
+  fail("--qa <dir> is required (extract.mjs output dir).")
+}
+const outDir = arg("out", path.join(qaDir, "results"))
+const conditions = arg("conditions", "vanilla,raw,mama")
+  .split(",")
+  .map((s) => s.trim())
+const limit = Number(arg("limit", "40"))
+const model = arg("model", null)
+const timeoutS = Number(arg("timeout-s", "600"))
+
+const VALID_CONDITIONS = new Set(["vanilla", "raw", "mama"])
+for (const c of conditions) {
+  if (!VALID_CONDITIONS.has(c)) {
+    fail(`Unknown condition "${c}".`)
+  }
+}
+
+const qaSet = JSON.parse(fs.readFileSync(path.join(qaDir, "qa-set.json"), "utf8")).slice(0, limit)
+const corpus = JSON.parse(fs.readFileSync(path.join(qaDir, "corpus.json"), "utf8"))
+fs.mkdirSync(outDir, { recursive: true })
+const resultsPath = path.join(outDir, "results.jsonl")
+
+// Resume support: skip (condition,item) pairs that already have a result.
+const done = new Set()
+const priorResults = []
+if (fs.existsSync(resultsPath)) {
+  for (const line of fs.readFileSync(resultsPath, "utf8").split("\n")) {
+    if (!line.trim()) {
+      continue
+    }
+    const r = JSON.parse(line)
+    done.add(`${r.condition}:${r.itemId}`)
+    priorResults.push(r)
+  }
+}
+
+// --- mama condition setup (real MCP search runtime path) ---
+let mamaApi = null
+if (conditions.includes("mama")) {
+  const dbPath = process.env.MAMA_DB_PATH
+  if (!dbPath) {
+    fail("mama condition requires MAMA_DB_PATH (a COPY of a MAMA DB).")
+  }
+  const resolved = path.resolve(dbPath)
+  const liveDbs = [
+    path.join(os.homedir(), ".claude", "mama-memory.db"),
+    path.join(os.homedir(), ".mama", "mama-memory.db"),
+  ].map((p) => path.resolve(p))
+  if (liveDbs.includes(resolved)) {
+    fail(`MAMA_DB_PATH points at a LIVE DB (${resolved}). Copy it first - initDB may migrate.`)
+  }
+  if (!fs.existsSync(resolved)) {
+    fail(`MAMA_DB_PATH not found: ${resolved}`)
+  }
+  const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "../../../..")
+  const distDir = path.join(repoRoot, "packages/mama-core/dist")
+  const { initDB } = require(path.join(distDir, "db-manager.js"))
+  mamaApi = require(path.join(distDir, "mama-api.js"))
+  await initDB()
+}
+
+const PREAMBLE =
+  "You answer a multiple-choice question about the CURRENT state of a decision. " +
+  'Reply with the single option letter only (e.g. "B"). No explanation.'
+
+function corpusBlock() {
+  return corpus.map((r) => `[${r.iso}] ${r.topic}: ${r.decision}`).join("\n")
+}
+
+// Cache the corpus rendering once - it is identical across items.
+let cachedCorpusBlock = null
+
+async function buildPrompt(condition, item) {
+  const qa = `${item.question}\n\n${renderOptions(item)}\n\nAnswer:`
+  if (condition === "vanilla") {
+    return `${PREAMBLE}\n\n${qa}`
+  }
+  if (condition === "raw") {
+    if (cachedCorpusBlock === null) {
+      cachedCorpusBlock = corpusBlock()
+    }
+    return (
+      `${PREAMBLE}\n\nBelow is the full decision history of this workspace, oldest first. ` +
+      `Later entries on the same topic supersede earlier ones.\n\n<history>\n${cachedCorpusBlock}\n</history>\n\n${qa}`
+    )
+  }
+  if (condition === "mama") {
+    const query = item.topic.replace(/_/g, " ")
+    const res = await mamaApi.suggest(query, { limit: 5 })
+    if (!res || !Array.isArray(res.results)) {
+      throw new Error(
+        `suggest() returned unexpected shape for "${query}": ${JSON.stringify(res).slice(0, 200)}`
+      )
+    }
+    const hits = res.results.map((r) => ({
+      topic: r.topic,
+      decision: r.decision,
+      reasoning: r.reasoning,
+      confidence: r.confidence,
+      created_at: r.created_at ? new Date(r.created_at).toISOString() : null,
+    }))
+    return (
+      `${PREAMBLE}\n\nBelow is what the memory system returned for this question:\n\n` +
+      `<memory>\n${JSON.stringify(hits, null, 1)}\n</memory>\n\n${qa}`
+    )
+  }
+  throw new Error(`unreachable condition ${condition}`)
+}
+
+function callClaude(prompt) {
+  return new Promise((resolve, reject) => {
+    const args = ["-p", "--output-format", "text"]
+    if (model) {
+      args.push("--model", model)
+    }
+    // Run from a neutral empty directory so the CLI does not inject this
+    // repo's CLAUDE.md (or any project context) into the experiment prompt.
+    const neutralCwd = path.join(os.tmpdir(), "delta-bench-neutral")
+    fs.mkdirSync(neutralCwd, { recursive: true })
+    const child = spawn("claude", args, { stdio: ["pipe", "pipe", "pipe"], cwd: neutralCwd })
+    let out = ""
+    let err = ""
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL")
+      reject(new Error(`claude CLI timeout after ${timeoutS}s`))
+    }, timeoutS * 1000)
+    child.stdout.on("data", (d) => (out += d))
+    child.stderr.on("data", (d) => (err += d))
+    child.on("error", (e) => {
+      clearTimeout(timer)
+      reject(e)
+    })
+    child.on("close", (code) => {
+      clearTimeout(timer)
+      if (code !== 0) {
+        reject(new Error(`claude CLI exit ${code}: ${err.slice(0, 300)}`))
+      } else {
+        resolve(out.trim())
+      }
+    })
+    child.stdin.write(prompt)
+    child.stdin.end()
+  })
+}
+
+const results = [...priorResults]
+for (const condition of conditions) {
+  for (const item of qaSet) {
+    const key = `${condition}:${item.id}`
+    if (done.has(key)) {
+      continue
+    }
+    const t0 = Date.now()
+    let record
+    try {
+      const prompt = await buildPrompt(condition, item)
+      const reply = await callClaude(prompt)
+      const choice = parseChoice(
+        reply,
+        item.options.map((o) => o.label)
+      )
+      record = {
+        itemId: item.id,
+        topic: item.topic,
+        condition,
+        choice,
+        answerLabel: item.answerLabel,
+        correct: choice === item.answerLabel,
+        replyHead: reply.slice(0, 80),
+        promptChars: prompt.length,
+        approxPromptTokens: approxTokens(prompt),
+        latencyMs: Date.now() - t0,
+      }
+    } catch (e) {
+      record = {
+        itemId: item.id,
+        topic: item.topic,
+        condition,
+        choice: null,
+        answerLabel: item.answerLabel,
+        correct: false,
+        error: String(e).slice(0, 300),
+        promptChars: 0,
+        latencyMs: Date.now() - t0,
+      }
+    }
+    fs.appendFileSync(resultsPath, JSON.stringify(record) + "\n")
+    results.push(record)
+    done.add(key)
+    const mark = record.error ? "ERR" : record.correct ? "ok " : "MISS"
+    console.log(
+      `[${condition}] ${mark} ${item.topic} choice=${record.choice ?? "-"} ans=${item.answerLabel} ${record.latencyMs}ms`
+    )
+  }
+}
+
+const summary = scoreResults(results.filter((r) => conditions.includes(r.condition)))
+fs.writeFileSync(path.join(outDir, "report.json"), JSON.stringify({ summary, results }, null, 2))
+console.log("\n=== delta-bench summary ===")
+for (const s of summary) {
+  console.log(
+    `${s.condition.padEnd(8)} n=${s.n} accuracy=${s.accuracy} stale=${s.staleRate} invalid=${s.invalidRate} ~tokens/item=${s.approxTokensPerItem}`
+  )
+}
+console.log(`report: ${path.join(outDir, "report.json")}`)

--- a/packages/memorybench/eval/delta-bench/run.mjs
+++ b/packages/memorybench/eval/delta-bench/run.mjs
@@ -48,7 +48,7 @@ const limit = Number(arg("limit", "40"))
 const model = arg("model", null)
 const timeoutS = Number(arg("timeout-s", "600"))
 
-const VALID_CONDITIONS = new Set(["vanilla", "raw", "mama"])
+const VALID_CONDITIONS = new Set(["vanilla", "raw", "mama", "oracle"])
 for (const c of conditions) {
   if (!VALID_CONDITIONS.has(c)) {
     fail(`Unknown condition "${c}".`)
@@ -101,7 +101,9 @@ if (conditions.includes("mama")) {
 
 const PREAMBLE =
   "You answer a multiple-choice question about the CURRENT state of a decision. " +
-  'Reply with the single option letter only (e.g. "B"). No explanation.'
+  // NOTE: never put a concrete example letter here - an earlier version used
+  // '(e.g. "B")' and every condition answered "B" for 80%+ of items.
+  "Reply with exactly one option letter and nothing else. No explanation."
 
 function corpusBlock() {
   return corpus.map((r) => `[${r.iso}] ${r.topic}: ${r.decision}`).join("\n")
@@ -144,12 +146,32 @@ async function buildPrompt(condition, item) {
       `<memory>\n${JSON.stringify(hits, null, 1)}\n</memory>\n\n${qa}`
     )
   }
+  if (condition === "oracle") {
+    // Ceiling condition: the context a CORRECT truth projection would return -
+    // the topic's current decision, explicitly marked current. Near-100% by
+    // construction; quantifies the prize for fixing retrieval + projection.
+    const hit = {
+      topic: item.topic,
+      decision: item.options.find((o) => o.label === item.answerLabel).text,
+      status: "current",
+      created_at: item.currentCreatedAt ? new Date(item.currentCreatedAt).toISOString() : null,
+    }
+    return (
+      `${PREAMBLE}\n\nBelow is what the memory system returned for this question:\n\n` +
+      `<memory>\n${JSON.stringify([hit], null, 1)}\n</memory>\n\n${qa}`
+    )
+  }
   throw new Error(`unreachable condition ${condition}`)
 }
 
 function callClaude(prompt) {
   return new Promise((resolve, reject) => {
-    const args = ["-p", "--output-format", "text"]
+    // --setting-sources project: exclude user-level settings so the user's
+    // OWN MAMA plugin SessionStart hook does not inject live memory ("Recent
+    // Decisions") into every bench call. Without this the experiment measuring
+    // MAMA memory is contaminated BY MAMA memory (observed: verbatim-match
+    // oracle items flipping to wrong answers).
+    const args = ["-p", "--output-format", "text", "--setting-sources", "project"]
     if (model) {
       args.push("--model", model)
     }

--- a/packages/memorybench/eval/delta-bench/run.mjs
+++ b/packages/memorybench/eval/delta-bench/run.mjs
@@ -140,6 +140,9 @@ async function buildPrompt(condition, item) {
       reasoning: r.reasoning,
       confidence: r.confidence,
       created_at: r.created_at ? new Date(r.created_at).toISOString() : null,
+      // Topic-currency marking from the repaired pipeline: true = a newer
+      // decision exists for this topic (this row is superseded history).
+      superseded_by_newer: r.superseded_by_newer ?? null,
     }))
     return (
       `${PREAMBLE}\n\nBelow is what the memory system returned for this question:\n\n` +


### PR DESCRIPTION
## Summary

Delta Bench — an in-situ temporal-truth evaluation harness — plus the mama-core recall repairs it uncovered. The bench auto-generates multiple-choice QA from the real DB's supersedes chains (answer = newest decision, distractors = prior versions that actually existed) and measures behavioral deltas across four conditions via the Claude CLI (no API keys).

### Bench results (dev DB, 40 items, isolated runs)

| condition | context | accuracy | ~tokens/item |
|---|---|---|---|
| vanilla | none (floor) | 50.0% | 286 |
| mama (before repair) | `mama.suggest()` top-5 | 57.5% | 1,395 |
| **mama (after repair)** | `mama.suggest()` top-5 | **75.0%** | 2,176 |
| raw | full chronological dump | 82.5% | 79,194 |
| oracle | correct truth projection (ceiling) | 92.5% | 426 |

### mama-core recall repairs (found by bench decomposition)

1. **Fusion scale inversion (root cause)** — graph-expansion hits were scored `graph_rank*0.1` (~0.05–0.095) while the entire primary RRF range sits ≤~0.018, so supporting context displaced every primary hit from the fused top-N. Expansion scores now sit strictly below the weakest primary hit.
2. **Topic-field weighting** — a query that IS a topic string drowned in body-text noise (topicHit@5 57.5%). Shared `topicAffinityBoost` (word-boundary matching) applied to FTS5 rescore + in-memory lexical scorer → topicHit@5 82.5%.
3. **Topic-currency marking** — suggest results now carry `superseded_by_newer` (scope-isolated comparison, mixed created_at encodings normalized, deterministic tiebreak) so consumers can tell current truth from superseded history.

### Review

- Opus adversarial review round completed; its FIX-FIRST finding (scope-blind currency marking would let same-named topics in other projects/channels mark in-scope truth as stale) fixed with scope-restricted comparison; recommendations (deterministic tiebreak, `idx_decisions_topic`, word-boundary matching) all applied with bench metrics unchanged.
- Experiment-integrity defects found and fixed during the bench build (answer-letter parroting from an example letter in the instruction; user-level plugin hook contamination of `claude -p` — isolated via `--setting-sources project`; mixed created_at encodings). Contaminated runs archived, not deleted.

### Tests

- mama-core: 858/858 pass (9 new: boost math, topic-anchored ranking, currency marking incl. mixed encodings, scoped comparison, tiebreak)
- memorybench: 9/9 delta-bench lib tests pass
- Full monorepo `pnpm test` green before push

### Follow-ups (not in this PR)

- Business-DB expanded run (1,671 rows, 151 chains) for statistical confirmation
- Conversational (non-topic-string) query control set (Opus recommendation)
- Remaining gap to ceiling: 10 misses (6 retrieval, 4 choice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Search results now prioritize matches to the requested topic, improving recall and relevance.
  - Results can identify older decisions that have been superseded by newer information.
  - Scoped searches more accurately compare decisions within the selected scope.

- **Bug Fixes**
  - Graph-expanded results no longer displace stronger primary matches.
  - Improved handling of timestamps in different formats.
  - Added migration repair support for missing database indexing.

- **Documentation**
  - Added Delta Bench evaluation tooling, usage guidance, analysis utilities, and initial benchmark results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->