### PR TITLE
fix(operator): raise workorder worker-run request timeout (600s default, env-tunable)

### DIFF
--- a/packages/standalone/src/agent/agent-loop.ts
+++ b/packages/standalone/src/agent/agent-loop.ts
@@ -1237,6 +1237,9 @@ export class AgentLoop {
             resumeSession: shouldResume,
             systemPrompt: perCallSystemPrompt,
             sessionId: resolvedCliSessionId ?? undefined,
+            // Per-run request timeout (operator worker runs); undefined leaves
+            // the pool's construction-time default untouched (chat).
+            requestTimeout: options?.requestTimeoutMs,
           });
           // Emit prompt latency metric
           this.onMetric?.('prompt_latency_ms', Date.now() - promptStart, {
@@ -1282,6 +1285,8 @@ export class AgentLoop {
               resumeSession: false, // Force new session
               systemPrompt: perCallSystemPrompt,
               sessionId: newSessionId,
+              // Carry the per-run timeout onto the reset session too.
+              requestTimeout: options?.requestTimeoutMs,
             });
             // Prepend reset notice so user knows context was lost
             if (isPromptTooLong && piResult.response) {

--- a/packages/standalone/src/agent/model-runner.ts
+++ b/packages/standalone/src/agent/model-runner.ts
@@ -42,6 +42,12 @@ export interface PromptOptions {
    * without mutating shared adapter state.
    */
   sessionId?: string;
+  /**
+   * Per-call CLI request timeout (ms) applied when this call spawns a fresh
+   * pooled process. Undefined leaves the pool's construction-time default in
+   * place, so only callers that opt in (operator worker runs) are affected.
+   */
+  requestTimeout?: number;
 }
 
 // ─── Metrics ─────────────────────────────────────────────────────────────────

--- a/packages/standalone/src/agent/persistent-cli-adapter.ts
+++ b/packages/standalone/src/agent/persistent-cli-adapter.ts
@@ -86,6 +86,8 @@ export class PersistentCLIAdapter implements IModelRunner {
       // so the CLI never reloads disk history. Routes this prompt without mutating
       // shared adapter state.
       sessionId?: string;
+      // Per-call request timeout (ms) for a freshly spawned pooled process.
+      requestTimeout?: number;
     }
   ): Promise<PromptResult> {
     // Get or create process for this channel
@@ -101,6 +103,9 @@ export class PersistentCLIAdapter implements IModelRunner {
       useGatewayTools: this.options.useGatewayTools,
       allowedTools: options?.allowedTools || this.options.allowedTools,
       disallowedTools: options?.disallowedTools || this.options.disallowedTools,
+      // Coalesce to the adapter default so an absent per-call value never nulls
+      // out the pool's construction-time requestTimeout (chat runs keep it).
+      requestTimeout: options?.requestTimeout ?? this.options.requestTimeout,
       env: { MAMA_HOOK_FEATURES: 'rules,agents' },
     });
     // Keep the legacy accessor pointing at the most recent process, but NEVER

--- a/packages/standalone/src/agent/types.ts
+++ b/packages/standalone/src/agent/types.ts
@@ -962,6 +962,13 @@ export interface AgentLoopOptions {
   maxTokens?: number;
   /** Request timeout in milliseconds (mapped to Codex CLI `timeoutMs`) */
   timeoutMs?: number;
+  /**
+   * Per-run override for the CLI request timeout (ms), threaded to the model
+   * runner for THIS run only. Unlike `timeoutMs` (fixed at construction on the
+   * shared boot executor), this lets a single long run (operator worker gather
+   * runs) lift the request bound without touching chat runs on the same pool.
+   */
+  requestTimeoutMs?: number;
   /** Claude model to use (must be provided via config) */
   model?: string;
   /** Callback for each turn */

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -1089,6 +1089,11 @@ export async function runAgentLoop(
   // started AFTER it - the boot invariant below enforces that ordering.
   const { readStage2Flag } = await import('../../operator/workorder-publishers.js');
   const stage2Flag = readStage2Flag();
+  // Validate the worker-run timeout override at boot (no-fallback): a malformed
+  // MAMA_WORKER_TIMEOUT_SECONDS must crash the daemon loudly, not silently
+  // revert worker runs to the 300s bound. Mirrors readStage2Flag above.
+  const { resolveWorkerRequestTimeoutMs } = await import('../../operator/worker-run.js');
+  resolveWorkerRequestTimeoutMs();
   let workOrderConsumer: import('../../operator/workorder-consumer.js').WorkOrderConsumer | null =
     null;
 

--- a/packages/standalone/src/operator/worker-run.ts
+++ b/packages/standalone/src/operator/worker-run.ts
@@ -58,6 +58,39 @@ export interface WorkerRunInput {
 
 const KIND_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
 
+/** Env override for the worker-run per-request CLI timeout, in whole seconds. */
+export const WORKER_TIMEOUT_ENV = 'MAMA_WORKER_TIMEOUT_SECONDS';
+
+/**
+ * Default worker request timeout: 600s. Worker gather runs (board/wiki briefs)
+ * are long single model turns that overrun the 300s chat request bound - live
+ * shadow evidence killed 8 of 31 orders mid-run at 300s ("CLI error: Request
+ * timeout"). 600s is the plan's original per-kind number, un-dropped by that
+ * evidence.
+ */
+export const DEFAULT_WORKER_TIMEOUT_SECONDS = 600;
+
+/**
+ * Resolve the worker-run per-request CLI timeout in ms. Unset/empty -> the
+ * 600s default; any other value MUST be a positive integer number of seconds.
+ * A malformed value throws (no silent fallback: a typo must not quietly revert
+ * workers to the 300s bound this raise exists to lift). Mirrors the
+ * MAMA_STAGE2_WORKORDERS tri-state precedent (workorder-publishers.ts).
+ */
+export function resolveWorkerRequestTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = (env[WORKER_TIMEOUT_ENV] ?? '').trim();
+  if (raw === '') {
+    return DEFAULT_WORKER_TIMEOUT_SECONDS * 1000;
+  }
+  const seconds = Number(raw);
+  if (!Number.isInteger(seconds) || seconds <= 0) {
+    throw new Error(
+      `${WORKER_TIMEOUT_ENV} must be a positive integer number of seconds (or unset), got: '${raw}'`
+    );
+  }
+  return seconds * 1000;
+}
+
 /**
  * Worker-specific system prompt (shadow-gate finding §8.2): the spawn-default
  * persona prompt carries code-act sandbox instructions, so worker tool calls
@@ -104,7 +137,12 @@ export async function workerRun(
   const prompt = `${brief.trim()}\n\n---\n\nWork order:\n${input.trim()}`;
 
   const result = await runner.runWithContent([{ type: 'text', text: prompt }], {
-    // runOptions FIRST: identity fields below always win (plan E7/G3).
+    // Raised per-run CLI request timeout for long gather runs. Placed BEFORE
+    // runOptions so an explicit caller override still wins; identity fields
+    // below always win (plan E7/G3). Chat runs never route through workerRun,
+    // so their request bound is untouched.
+    requestTimeoutMs: resolveWorkerRequestTimeoutMs(),
+    // runOptions: identity fields below always win (plan E7/G3).
     ...(runOptions ?? {}),
     sessionKey: buildWorkerSessionKey(kind),
     // freshSession pool reset keys on source+channelId (agent-loop.ts) -

--- a/packages/standalone/tests/operator/worker-run-timeout.test.ts
+++ b/packages/standalone/tests/operator/worker-run-timeout.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Story M0-2: workorder worker-run request timeout
+ *
+ * Live evidence (first shadow day): 8 of 31 operator workorder runs failed with
+ * "CLI error: Request timeout" - long board/wiki gather runs overran the 300s
+ * chat request bound. This story raises the per-request CLI timeout for OPERATOR
+ * WORKER lane runs only (600s default, env-tunable), leaving chat untouched.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_WORKER_TIMEOUT_SECONDS,
+  WORKER_TIMEOUT_ENV,
+  resolveWorkerRequestTimeoutMs,
+  workerRun,
+  type WorkerRunner,
+} from '../../src/operator/worker-run.js';
+import { PersistentCLIAdapter } from '../../src/agent/persistent-cli-adapter.js';
+import {
+  PersistentClaudeProcess,
+  PersistentProcessPool,
+} from '../../src/agent/persistent-cli-process.js';
+
+describe('Story M0-2: workorder worker-run request timeout', () => {
+  describe('AC #1: env parsing fails loud, never silently falls back', () => {
+    it('defaults to 600s when the override is unset', () => {
+      expect(resolveWorkerRequestTimeoutMs({})).toBe(DEFAULT_WORKER_TIMEOUT_SECONDS * 1000);
+      expect(DEFAULT_WORKER_TIMEOUT_SECONDS).toBe(600);
+    });
+
+    it('defaults to 600s for an empty or whitespace value', () => {
+      expect(resolveWorkerRequestTimeoutMs({ [WORKER_TIMEOUT_ENV]: '' })).toBe(600_000);
+      expect(resolveWorkerRequestTimeoutMs({ [WORKER_TIMEOUT_ENV]: '   ' })).toBe(600_000);
+    });
+
+    it('parses a positive integer number of seconds into ms', () => {
+      expect(resolveWorkerRequestTimeoutMs({ [WORKER_TIMEOUT_ENV]: '900' })).toBe(900_000);
+      expect(resolveWorkerRequestTimeoutMs({ [WORKER_TIMEOUT_ENV]: ' 120 ' })).toBe(120_000);
+    });
+
+    it('throws on malformed values (non-numeric, zero, negative, non-integer)', () => {
+      for (const bad of ['abc', '0', '-5', '1.5', '10s', 'NaN', 'Infinity']) {
+        expect(() => resolveWorkerRequestTimeoutMs({ [WORKER_TIMEOUT_ENV]: bad })).toThrow(
+          new RegExp(WORKER_TIMEOUT_ENV)
+        );
+      }
+    });
+  });
+
+  describe('AC #2: workerRun threads the raised timeout, identity still wins', () => {
+    const ORIGINAL = process.env[WORKER_TIMEOUT_ENV];
+    beforeEach(() => {
+      // Isolate from any ambient developer override so the default is deterministic.
+      delete process.env[WORKER_TIMEOUT_ENV];
+    });
+    afterEach(() => {
+      if (ORIGINAL === undefined) delete process.env[WORKER_TIMEOUT_ENV];
+      else process.env[WORKER_TIMEOUT_ENV] = ORIGINAL;
+    });
+
+    function capturingRunner(): WorkerRunner & { options: Record<string, unknown> } {
+      const holder = { options: {} as Record<string, unknown> };
+      return {
+        options: holder.options,
+        runWithContent: vi.fn(async (_content, options) => {
+          Object.assign(holder.options, options as Record<string, unknown>);
+          return { response: 'ok' };
+        }),
+      } as WorkerRunner & { options: Record<string, unknown> };
+    }
+
+    it('applies the 600s default to the run options', async () => {
+      const runner = capturingRunner();
+      await workerRun(runner, { kind: 'board', brief: 'b', input: 'i' });
+      expect(runner.options.requestTimeoutMs).toBe(600_000);
+    });
+
+    it('lets an explicit runOptions.requestTimeoutMs override win over the default', async () => {
+      const runner = capturingRunner();
+      await workerRun(runner, {
+        kind: 'wiki',
+        brief: 'b',
+        input: 'i',
+        runOptions: { requestTimeoutMs: 123_000 },
+      });
+      expect(runner.options.requestTimeoutMs).toBe(123_000);
+    });
+
+    it('never lets runOptions override identity even while setting a timeout', async () => {
+      const runner = capturingRunner();
+      await workerRun(runner, {
+        kind: 'board',
+        brief: 'b',
+        input: 'i',
+        runOptions: {
+          requestTimeoutMs: 700_000,
+          sessionKey: 'chat:main:hijack',
+          source: 'telegram',
+        },
+      });
+      expect(runner.options.requestTimeoutMs).toBe(700_000);
+      expect(runner.options.sessionKey).toBe('operator:worker:board');
+      expect(runner.options.source).toBe('operator');
+    });
+  });
+
+  describe('AC #3: the raised timeout reaches the CLI layer; chat is untouched', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('adapter forwards a per-call requestTimeout to the pool, else the construction default', async () => {
+      const adapter = new PersistentCLIAdapter({ sessionId: 'ctor', requestTimeout: 300_000 });
+      const calls: Array<{ key: string; options: Record<string, unknown> }> = [];
+      const getProcess = vi.fn(async (key: string, options: Record<string, unknown>) => {
+        calls.push({ key, options });
+        return {
+          isAlive: () => true,
+          sendMessage: vi.fn().mockResolvedValue({
+            response: 'ok',
+            toolUseBlocks: [],
+            usage: { input_tokens: 0, output_tokens: 0 },
+          }),
+        };
+      });
+      (adapter as unknown as { processPool: { getProcess: unknown } }).processPool = { getProcess };
+
+      // Worker run: per-call override reaches the pool.
+      await adapter.prompt('work', undefined, {
+        sessionId: 'worker:board',
+        requestTimeout: 600_000,
+      });
+      // Chat run: no override -> the pool keeps the construction-time default.
+      await adapter.prompt('chat', undefined, { sessionId: 'chat:main' });
+
+      expect(calls[0].options.requestTimeout).toBe(600_000);
+      expect(calls[1].options.requestTimeout).toBe(300_000);
+    });
+
+    it('pool merges the per-call requestTimeout into the spawned process effective timeout', async () => {
+      vi.spyOn(PersistentClaudeProcess.prototype, 'start').mockResolvedValue(undefined);
+      vi.spyOn(PersistentClaudeProcess.prototype, 'stop').mockImplementation(() => {});
+      const pool = new PersistentProcessPool({
+        requestTimeout: 300_000,
+        idleTimeoutMs: 0,
+        cleanupIntervalMs: 0,
+        pendingToolUseTimeoutMs: 0,
+      });
+
+      const workerProc = await pool.getProcess('worker:board', { requestTimeout: 600_000 });
+      const chatProc = await pool.getProcess('chat:main');
+
+      const effective = (p: PersistentClaudeProcess): number =>
+        (p as unknown as { _getRequestTimeoutMs(): number })._getRequestTimeoutMs();
+      expect(effective(workerProc)).toBe(600_000);
+      expect(effective(chatProc)).toBe(300_000);
+
+      pool.stopAll();
+    });
+  });
+});


### PR DESCRIPTION
## What

Raises the per-request CLI timeout for **operator worker lane runs only** (session keys `operator:worker:*`, source `operator`) to **600s** (default), configurable via `MAMA_WORKER_TIMEOUT_SECONDS`. Chat runs on the same shared pool are untouched.

## Why (live evidence)

On the first Stage-2 shadow day, **8 of 31** operator workorder runs failed with `CLI error: Request timeout`, landing in the TaskLedger as `operator_tasks(kind='system', status='failed')`. Long board/wiki *gather* runs overran the ~300s per-request bound (`config.agent.timeout`) that the boot executor's process pool applies uniformly to chat and worker lanes — blocking the shadow equivalence gate.

## Root cause

`PersistentClaudeProcess` enforces `this.options.requestTimeout` per turn (`persistent-cli-process.ts:460/537` via `_getRequestTimeoutMs`), set once at `AgentLoop` construction from `options.timeoutMs`. There was no per-run override, so worker runs could not get a longer bound without also loosening chat.

## Fix

Thread a per-run `requestTimeoutMs` through the existing seam:

`workerRun` → `AgentLoop.runWithContent` → `PersistentCLIAdapter.prompt` → `pool.getProcess`

The worker channel's freshly spawned process picks up the raised timeout; chat processes keep the pool default (an absent per-call value coalesces to the construction-time default, so it is never nulled). `workerRun` sets the timeout **before** `runOptions` so an explicit caller override still wins, and identity fields still win (merge order unchanged). A malformed `MAMA_WORKER_TIMEOUT_SECONDS` **fails the boot loudly** (validated in `start.ts` next to `readStage2Flag`) — no silent fallback, mirroring the `MAMA_STAGE2_WORKORDERS` tri-state precedent.

Nothing in the "Agent Isolation — Do Not Modify" table is touched.

## Tests

New `tests/operator/worker-run-timeout.test.ts` (Story/AC blocks, `$HOME`/env isolated):
- **AC #1** env parsing — unset/empty → 600s default; positive integer → ms; malformed (non-numeric, `0`, negative, non-integer) → throws.
- **AC #2** `workerRun` threads the timeout; explicit `runOptions` override wins; identity still wins.
- **AC #3** the raised timeout reaches the CLI layer — adapter forwards per-call `requestTimeout` to the pool (else construction default), and the pool merges it into the spawned process's effective timeout; chat unaffected.

Full standalone suite green: **3688 passed** (6 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable per-run request timeouts for agent and worker operations.
  * Worker request timeouts now default to 10 minutes and can be overridden through configuration.
  * Explicit per-run timeout settings take precedence over defaults.

* **Bug Fixes**
  * Invalid timeout configuration values are now rejected during startup.
  * Timeout settings are consistently applied across worker, chat, and recovery operations.

* **Tests**
  * Added coverage for defaults, overrides, invalid values, and timeout propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->