### PR TITLE
feat(memorybench): delta-bench lineage QA type + mama-lineage condition (R2 prototype)

### DIFF
--- a/packages/memorybench/eval/delta-bench/README.md
+++ b/packages/memorybench/eval/delta-bench/README.md
@@ -1,4 +1,4 @@
-# Delta Bench — temporal-truth QA from real decision chains
+# Delta Bench — temporal-truth + lineage QA from real decision chains
 
 Measures the behavioral delta between a plain LLM and the same LLM augmented
 with MAMA memory, on questions whose correct answer CHANGED over time.
@@ -11,47 +11,76 @@ in long context** — same data, same model, different representation. If raw
 context wins, MAMA's positioning fails; this bench is a falsification test
 before it is a promotion asset.
 
+## Two QA types
+
+- **truth** — which option is the CURRENT decision on a topic. Answer = the
+  newest version; distractors = superseded versions of the same topic.
+- **lineage** — which statement describes why a topic's decision was revised.
+  Answer = the newest version's actual `reasoning` text (the revision
+  rationale); distractors = OTHER topics' revision reasonings (real recorded
+  text, never generated). Filters: chain length ≥ 2, the answer reasoning ≥ 40
+  chars and distinct from every prior version's reasoning. Chains that fail are
+  counted (`excludedLineageChains`) in `meta.json`.
+
 ## How it works
 
 1. **extract.mjs** (read-only) groups a MAMA DB's `decisions` rows into
    temporal chains by topic (MAMA semantics: topic reuse supersedes). Each
-   chain with a real delta becomes one multiple-choice item:
-   - answer = the newest decision
-   - distractors = prior versions that actually existed
-   - option order is seed-shuffled; test-pollution topics are excluded
-2. **run.mjs** asks each question under three conditions via the Claude CLI
+   chain with a real delta becomes multiple-choice items. `--types truth,lineage`
+   (default both) selects which to emit; every item carries a `qaType` field.
+   Option order is seed-shuffled; test-pollution topics are excluded.
+2. **run.mjs** asks each question under these conditions via the Claude CLI
    (`claude -p`, prompt on stdin, neutral cwd so no CLAUDE.md leaks in):
    - `vanilla` — question only (floor; most chains have 2 options → ~50% chance)
    - `raw` — full chronological decision dump in context, then the question
-   - `mama` — what `mama.suggest()` (the real MCP search path) returned
-3. Metrics per condition: accuracy, stale rate (picked a superseded version),
-   invalid rate, approx tokens/item, latency.
+   - `mama` — what `mama.suggest()` (the real MCP search path) returned (flat)
+   - `mama-lineage` — `mama.suggest()`'s topics, each topic's FULL chain
+     re-fetched from the DB copy and rendered as a lineage block
+     (`v1 (reasoning head) -> ... -> CURRENT: decision`). **This rendering is
+     the R2 reasoning-precompute prototype under test** — the falsification is
+     `mama-lineage` vs `mama`.
+   - `oracle` — the context a CORRECT projection WOULD return (ceiling): the
+     current decision marked current (truth) or the asked chain rendered
+     perfectly (lineage).
+3. Metrics per condition AND per qaType: accuracy, stale rate (picked a
+   superseded version), invalid rate, approx tokens/item, latency.
 
 ## Usage
 
 ```bash
-# 1. Extract (read-only against any MAMA DB)
+# 1. Extract (read-only against any MAMA DB); default emits both QA types
 MAMA_DB_PATH=~/.claude/mama-memory.db \
-  node eval/delta-bench/extract.mjs --out /tmp/delta --max-items 40
+  node eval/delta-bench/extract.mjs --out /tmp/delta --max-items 40 \
+  --types truth,lineage
 
-# 2. Copy the DB before the mama condition (initDB may migrate)
+# 2. Copy the DB before the mama / mama-lineage conditions (initDB may migrate)
 cp ~/.claude/mama-memory.db /tmp/delta-copy.db
 
 # 3. Run (resumable; results append to results.jsonl)
 MAMA_DB_PATH=/tmp/delta-copy.db \
   node eval/delta-bench/run.mjs --qa /tmp/delta --out /tmp/delta/results \
-  --conditions vanilla,raw,mama --limit 40
+  --conditions vanilla,raw,mama,mama-lineage,oracle --limit 40
+
+# 4. Offline retrieval decomposition + per-type accuracy (no LLM calls)
+MAMA_DB_PATH=/tmp/delta-copy.db \
+  node eval/delta-bench/analyze.mjs --qa /tmp/delta --results /tmp/delta/results
 ```
 
-`run.mjs` refuses to run the mama condition against the live DB paths
-(`~/.claude/mama-memory.db`, `~/.mama/mama-memory.db`).
+`run.mjs` refuses to run the mama / mama-lineage conditions against the live DB
+paths (`~/.claude/mama-memory.db`, `~/.mama/mama-memory.db`).
 
 ## Interpreting results
 
 - Most chains have length 2 (one distractor), so the vanilla floor sits near
   50%, not 25% — compare conditions against each other, not against zero.
-- The mama condition inherits real retrieval behavior, including its defects.
-  A low mama score is a product finding, not a bench bug.
+- The mama and mama-lineage conditions inherit real retrieval behavior,
+  including its defects. A low score is a product finding, not a bench bug.
+- Lineage items: `mama` carries the current `reasoning` field verbatim, while
+  `mama-lineage` renders prior reasoning heads + the current decision. Whether
+  the structured lineage rendering beats the flat hit list is exactly the
+  question the falsification design answers — it may not, and that is a result.
+- `run.mjs` prints an all-items summary and one per qaType; `report.json` also
+  stores `summaryByType`.
 
 ## Tests
 

--- a/packages/memorybench/eval/delta-bench/analyze.mjs
+++ b/packages/memorybench/eval/delta-bench/analyze.mjs
@@ -84,6 +84,7 @@ for (const item of qaSet) {
   diags.push({
     itemId: item.id,
     topic: item.topic,
+    qaType: item.qaType || "truth",
     optionCount: item.options.length,
     topicHit: topicRows.length > 0,
     currentPresent: currentIdx >= 0,
@@ -98,38 +99,90 @@ for (const item of qaSet) {
   })
 }
 
-// Chance baseline from actual option counts.
-const chance = diags.reduce((s, d) => s + 1 / d.optionCount, 0) / diags.length
-
-const retrievalStats = {
-  items: diags.length,
-  chanceAccuracy: +chance.toFixed(4),
-  topicHitRate: +(diags.filter((d) => d.topicHit).length / diags.length).toFixed(4),
-  currentPresentRate: +(diags.filter((d) => d.currentPresent).length / diags.length).toFixed(4),
-  currentRank1Rate: +(diags.filter((d) => d.currentRank === 1).length / diags.length).toFixed(4),
-  meanStaleInTop5: +(diags.reduce((s, d) => s + d.staleInTop5, 0) / diags.length).toFixed(2),
+// Retrieval diagnostics over a set of diags (what mama.suggest put in front of
+// the model). currentPresent/rank are truth-oriented but stay informative for
+// lineage items (the current row anchors the topic's chain).
+function computeRetrievalStats(subset) {
+  if (subset.length === 0) {
+    return { items: 0 }
+  }
+  const chance = subset.reduce((s, d) => s + 1 / d.optionCount, 0) / subset.length
+  return {
+    items: subset.length,
+    chanceAccuracy: +chance.toFixed(4),
+    topicHitRate: +(subset.filter((d) => d.topicHit).length / subset.length).toFixed(4),
+    currentPresentRate: +(subset.filter((d) => d.currentPresent).length / subset.length).toFixed(4),
+    currentRank1Rate: +(subset.filter((d) => d.currentRank === 1).length / subset.length).toFixed(
+      4
+    ),
+    meanStaleInTop5: +(subset.reduce((s, d) => s + d.staleInTop5, 0) / subset.length).toFixed(2),
+  }
 }
 
-// mama miss decomposition.
-const mamaMisses = diags.filter((d) => d.conditions.mama && !d.conditions.mama.correct)
-const missRetrieval = mamaMisses.filter((d) => !d.currentPresent).length
-const missChoice = mamaMisses.filter((d) => d.currentPresent).length
+// Per-condition accuracy over a set of diags (uses the correctness joined from
+// results.jsonl). Covers every condition present, including mama-lineage.
+function conditionAccuracy(subset) {
+  const acc = {}
+  for (const d of subset) {
+    for (const [c, r] of Object.entries(d.conditions)) {
+      if (!acc[c]) {
+        acc[c] = { n: 0, correct: 0 }
+      }
+      acc[c].n += 1
+      if (r.correct) {
+        acc[c].correct += 1
+      }
+    }
+  }
+  return Object.fromEntries(
+    Object.entries(acc).map(([c, s]) => [
+      c,
+      { n: s.n, correct: s.correct, accuracy: s.n ? +(s.correct / s.n).toFixed(4) : null },
+    ])
+  )
+}
+
+// mama miss decomposition (retrieval failure vs choice failure) over a subset.
+function mamaMissDecomposition(subset) {
+  const misses = subset.filter((d) => d.conditions.mama && !d.conditions.mama.correct)
+  return {
+    misses: misses.length,
+    retrievalFailure: misses.filter((d) => !d.currentPresent).length,
+    choiceFailureWithCurrentPresent: misses.filter((d) => d.currentPresent).length,
+  }
+}
+
+const qaTypes = [...new Set(diags.map((d) => d.qaType))].sort()
+const byType = {}
+for (const t of qaTypes) {
+  const subset = diags.filter((d) => d.qaType === t)
+  byType[t] = {
+    retrievalStats: computeRetrievalStats(subset),
+    conditionAccuracy: conditionAccuracy(subset),
+    mamaMissDecomposition: mamaMissDecomposition(subset),
+  }
+}
 
 const out = {
-  retrievalStats,
-  mamaMissDecomposition: {
-    misses: mamaMisses.length,
-    retrievalFailure: missRetrieval,
-    choiceFailureWithCurrentPresent: missChoice,
-  },
+  retrievalStats: computeRetrievalStats(diags),
+  conditionAccuracy: conditionAccuracy(diags),
+  mamaMissDecomposition: mamaMissDecomposition(diags),
+  byType,
   items: diags,
 }
 fs.writeFileSync(path.join(resultsDir, "analysis.json"), JSON.stringify(out, null, 2))
 
-console.log("=== retrieval diagnostics (mama.suggest top-5) ===")
-console.log(JSON.stringify(retrievalStats, null, 2))
-console.log("=== mama miss decomposition ===")
+console.log("=== retrieval diagnostics (mama.suggest top-5, all items) ===")
+console.log(JSON.stringify(out.retrievalStats, null, 2))
+console.log("=== condition accuracy (all items) ===")
+console.log(JSON.stringify(out.conditionAccuracy, null, 2))
+console.log("=== mama miss decomposition (all items) ===")
 console.log(
-  `misses=${mamaMisses.length} retrievalFailure(current absent)=${missRetrieval} choiceFailure(current present)=${missChoice}`
+  `misses=${out.mamaMissDecomposition.misses} retrievalFailure(current absent)=${out.mamaMissDecomposition.retrievalFailure} choiceFailure(current present)=${out.mamaMissDecomposition.choiceFailureWithCurrentPresent}`
 )
-console.log(`analysis: ${path.join(resultsDir, "analysis.json")}`)
+for (const t of qaTypes) {
+  console.log(`\n=== per-type: ${t} ===`)
+  console.log("retrieval:", JSON.stringify(byType[t].retrievalStats))
+  console.log("accuracy:", JSON.stringify(byType[t].conditionAccuracy))
+}
+console.log(`\nanalysis: ${path.join(resultsDir, "analysis.json")}`)

--- a/packages/memorybench/eval/delta-bench/extract.mjs
+++ b/packages/memorybench/eval/delta-bench/extract.mjs
@@ -1,19 +1,34 @@
-// extract.mjs - build the temporal-truth QA set and the raw-context corpus
-// from a MAMA decisions DB. Read-only: opens the DB with { readonly: true },
+// extract.mjs - build the temporal-truth + lineage QA sets and the raw-context
+// corpus from a MAMA decisions DB. Read-only: opens the DB with { readonly: true },
 // never calls initDB, never writes to the source DB.
 //
+// Two QA types (select via --types, default both):
+//   truth   - which option is the CURRENT decision on a topic (answer = newest
+//             version; distractors = superseded versions of the same topic)
+//   lineage - which statement describes why a topic's decision was revised
+//             (answer = the newest version's reasoning; distractors = OTHER
+//             topics' revision reasonings - real text, never generated)
+//
 // Usage:
-//   MAMA_DB_PATH=/path/to/mama-memory.db node extract.mjs --out ./out [--seed 20260719] [--max-items 40]
+//   MAMA_DB_PATH=/path/to/mama-memory.db node extract.mjs --out ./out \
+//     [--seed 20260719] [--max-items 40] [--types truth,lineage]
 //
 // Outputs (in --out dir):
-//   qa-set.json   - [{ id, topic, question, options[], answerLabel, ... }]
+//   qa-set.json   - [{ id, qaType, topic, question, options[], answerLabel, ... }]
 //   corpus.json   - all decision rows, chronological (for the raw-context condition)
 //   meta.json     - counts and filter stats
 
 import fs from "node:fs"
 import path from "node:path"
 import { createRequire } from "node:module"
-import { buildChains, buildQaItem, mulberry32, normalizeCreatedAt } from "./lib.mjs"
+import {
+  buildChains,
+  buildLineageItem,
+  buildQaItem,
+  chainRevisionReasoning,
+  mulberry32,
+  normalizeCreatedAt,
+} from "./lib.mjs"
 
 const require = createRequire(import.meta.url)
 const Database = require("better-sqlite3")
@@ -44,6 +59,19 @@ const seed = Number(arg("seed", "20260719"))
 const maxItems = Number(arg("max-items", "40"))
 if (!Number.isFinite(seed) || !Number.isFinite(maxItems)) {
   fail("--seed/--max-items must be numbers.")
+}
+const VALID_TYPES = new Set(["truth", "lineage"])
+const types = arg("types", "truth,lineage")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean)
+if (types.length === 0) {
+  fail("--types must name at least one of: truth, lineage.")
+}
+for (const t of types) {
+  if (!VALID_TYPES.has(t)) {
+    fail(`Unknown QA type "${t}" (valid: truth, lineage).`)
+  }
 }
 
 fs.mkdirSync(outDir, { recursive: true })
@@ -92,16 +120,49 @@ const shuffled = chains
   .map((x) => x.c)
 const picked = shuffled.slice(0, maxItems).sort((a, b) => a.topic.localeCompare(b.topic))
 
-const qaSet = []
-for (const chain of picked) {
-  // Per-item seed derived from the global seed + topic for stable option order.
-  let topicSeed = seed
-  for (const ch of chain.topic) {
-    topicSeed = (topicSeed * 31 + ch.charCodeAt(0)) >>> 0
+// Distractor pool for lineage items: every chain's revision reasoning (drawn
+// from the FULL chain set, not just the sampled ones, so the pool of real
+// cross-topic rationales stays rich even with a small --max-items).
+const lineagePool = []
+for (const chain of chains) {
+  const reasoning = chainRevisionReasoning(chain)
+  if (reasoning) {
+    lineagePool.push({ topic: chain.topic, reasoning })
   }
-  const item = buildQaItem(chain, topicSeed)
-  if (item) {
-    qaSet.push(item)
+}
+
+// Per-topic seed derived from the global seed + topic for stable option order.
+function topicSeedFor(topic) {
+  let s = seed
+  for (const ch of topic) {
+    s = (s * 31 + ch.charCodeAt(0)) >>> 0
+  }
+  return s
+}
+
+// Emit truth then lineage per topic so the two types interleave in file order
+// (a small --limit at run time then still exercises both types).
+const qaSet = []
+let truthItems = 0
+let lineageItems = 0
+let excludedLineageChains = 0
+for (const chain of picked) {
+  const topicSeed = topicSeedFor(chain.topic)
+  if (types.includes("truth")) {
+    const item = buildQaItem(chain, topicSeed)
+    if (item) {
+      qaSet.push(item)
+      truthItems += 1
+    }
+  }
+  if (types.includes("lineage")) {
+    const item = buildLineageItem(chain, lineagePool, topicSeed)
+    if (item) {
+      qaSet.push(item)
+      lineageItems += 1
+    } else {
+      excludedLineageChains += 1
+    }
   }
 }
 if (qaSet.length === 0) {
@@ -123,11 +184,18 @@ const meta = {
   db: path.resolve(dbPath),
   extractedAt: new Date().toISOString(),
   seed,
+  types,
   totals: {
     decisionRows: rows.length,
     droppedBadTimestamp,
     chains: chains.length,
     qaItems: qaSet.length,
+    truthItems,
+    lineageItems,
+    // Sampled chains that yielded no lineage item (reasoning missing/short/not
+    // distinct, or no distinct cross-topic distractor available).
+    excludedLineageChains,
+    lineagePoolSize: lineagePool.length,
     corpusRows: corpus.length,
   },
   chainLengthHistogram: qaSet.reduce((h, q) => {
@@ -141,5 +209,6 @@ fs.writeFileSync(path.join(outDir, "corpus.json"), JSON.stringify(corpus))
 fs.writeFileSync(path.join(outDir, "meta.json"), JSON.stringify(meta, null, 2))
 
 console.log(
-  `[delta-bench:extract] rows=${rows.length} chains=${chains.length} qaItems=${qaSet.length} -> ${outDir}`
+  `[delta-bench:extract] rows=${rows.length} chains=${chains.length} ` +
+    `qaItems=${qaSet.length} (truth=${truthItems} lineage=${lineageItems}) -> ${outDir}`
 )

--- a/packages/memorybench/eval/delta-bench/lib.mjs
+++ b/packages/memorybench/eval/delta-bench/lib.mjs
@@ -14,6 +14,12 @@ const EXCLUDED_TOPIC_PATTERNS = [
 ]
 
 const MIN_DECISION_CHARS = 40
+// Lineage (L-type) items answer with a real `reasoning` string; require it to be
+// substantial so the QA is not decided by a one-word rationale.
+const MIN_REASONING_CHARS = 40
+// Head length for a reasoning shown inside a rendered lineage block. Long enough
+// to identify the rationale, short enough that the block stays compact.
+const REASONING_HEAD_CHARS = 120
 const MAX_DISTRACTORS = 3
 const OPTION_LABELS = ["A", "B", "C", "D"]
 
@@ -158,6 +164,7 @@ export function buildQaItem(chain, seed) {
   const answer = options.find((o) => o.isCurrent)
   return {
     id: `delta_${chain.topic}`,
+    qaType: "truth",
     topic: chain.topic,
     chainLength: rows.length,
     currentDecisionId: current.id,
@@ -170,6 +177,132 @@ export function buildQaItem(chain, seed) {
     options,
     answerLabel: answer.label,
   }
+}
+
+/**
+ * The revision rationale of a chain = the newest version's `reasoning`.
+ * MAMA semantics: the newest row is the current truth, so its reasoning is why
+ * the topic ended up at its current decision (the "why it was revised" answer).
+ * Returns the trimmed reasoning, or null when the chain does not qualify:
+ *  - fewer than 2 versions
+ *  - current reasoning missing or shorter than MIN_REASONING_CHARS
+ *  - current reasoning not distinct (normalized) from every prior version's
+ *    reasoning (no real reasoning delta - would be a trivial or duplicate item)
+ */
+export function chainRevisionReasoning(chain) {
+  const rows = chain && chain.rows
+  if (!rows || rows.length < 2) {
+    return null
+  }
+  const current = rows[rows.length - 1]
+  const reasoning = (current.reasoning || "").trim()
+  if (reasoning.length < MIN_REASONING_CHARS) {
+    return null
+  }
+  const currentNorm = normalizeText(reasoning)
+  for (let i = 0; i < rows.length - 1; i++) {
+    if (normalizeText(rows[i].reasoning || "") === currentNorm) {
+      return null
+    }
+  }
+  return reasoning
+}
+
+/**
+ * Build one lineage (L-type) multiple-choice item from a chain.
+ * Answer = this chain's revision rationale (the newest version's reasoning).
+ * Distractors = OTHER topics' revision rationales - real reasoning text drawn
+ * from distractorPool ([{ topic, reasoning }]), never generated. The chain's own
+ * topic is excluded and duplicate normalized texts are deduped. Option order is
+ * a seeded shuffle so the answer position carries no signal. Deterministic given
+ * seed. Returns null when the chain fails the reasoning filters or the pool has
+ * no distinct distractor.
+ */
+export function buildLineageItem(chain, distractorPool, seed) {
+  const answerReasoning = chainRevisionReasoning(chain)
+  if (!answerReasoning) {
+    return null
+  }
+  const rows = chain.rows
+  const current = rows[rows.length - 1]
+  const answerNorm = normalizeText(answerReasoning)
+  const rand = mulberry32(seed)
+  const seen = new Set([answerNorm])
+  const pool = (distractorPool || []).filter((d) => d.topic !== chain.topic)
+  const shuffledPool = seededShuffle(pool, rand)
+  const distractors = []
+  for (const cand of shuffledPool) {
+    const text = (cand.reasoning || "").trim()
+    const norm = normalizeText(text)
+    if (norm.length === 0 || seen.has(norm)) {
+      continue
+    }
+    seen.add(norm)
+    distractors.push(text)
+    if (distractors.length >= MAX_DISTRACTORS) {
+      break
+    }
+  }
+  if (distractors.length === 0) {
+    return null
+  }
+  const optionRows = seededShuffle(
+    [
+      { text: answerReasoning, isAnswer: true },
+      ...distractors.map((text) => ({ text, isAnswer: false })),
+    ],
+    rand
+  )
+  const options = optionRows.map((row, idx) => ({
+    label: OPTION_LABELS[idx],
+    text: row.text.trim(),
+    isAnswer: row.isAnswer,
+  }))
+  const answer = options.find((o) => o.isAnswer)
+  return {
+    id: `lineage_${chain.topic}`,
+    qaType: "lineage",
+    topic: chain.topic,
+    chainLength: rows.length,
+    currentDecisionId: current.id,
+    currentCreatedAt: current.created_at,
+    // Full topic chain (oldest -> newest) so the oracle can render it perfectly
+    // offline; the mama-lineage condition re-fetches the same chain from the DB.
+    lineageChain: rows.map((r) => ({ decision: r.decision, reasoning: r.reasoning })),
+    question:
+      `Topic: "${chain.topic}"\n` +
+      "Which statement describes why this topic's decision was revised? " +
+      "Answer with the option letter only.",
+    options,
+    answerLabel: answer.label,
+  }
+}
+
+/** Collapse whitespace and truncate a reasoning to a short head for a lineage block. */
+export function reasoningHead(text, max = REASONING_HEAD_CHARS) {
+  const clean = (text || "").replace(/\s+/g, " ").trim()
+  if (clean.length === 0) {
+    return "no reasoning recorded"
+  }
+  return clean.length <= max ? clean : clean.slice(0, max).trimEnd() + "..."
+}
+
+/**
+ * Render a topic's full chain as an R2 lineage block (the reasoning-precompute
+ * prototype under test):
+ *   <topic>: v1 (<reasoning head>) -> v2 (<reasoning head>) -> CURRENT: <decision>
+ * Prior versions surface their reasoning heads; the current version surfaces its
+ * decision. rows must be oldest -> newest (each { decision, reasoning }).
+ */
+export function renderLineageBlock(topic, rows) {
+  if (!rows || rows.length === 0) {
+    return `${topic}: (no history)`
+  }
+  const priors = rows.slice(0, -1)
+  const current = rows[rows.length - 1]
+  const parts = priors.map((r, i) => `v${i + 1} (${reasoningHead(r.reasoning)})`)
+  parts.push(`CURRENT: ${(current.decision || "").replace(/\s+/g, " ").trim()}`)
+  return `${topic}: ${parts.join(" -> ")}`
 }
 
 /** Render the options block appended to every condition prompt. */

--- a/packages/memorybench/eval/delta-bench/lib.test.mjs
+++ b/packages/memorybench/eval/delta-bench/lib.test.mjs
@@ -2,20 +2,25 @@ import { test } from "node:test"
 import assert from "node:assert/strict"
 import {
   buildChains,
+  buildLineageItem,
   buildQaItem,
+  chainRevisionReasoning,
   isExcludedTopic,
   mulberry32,
   normalizeCreatedAt,
   parseChoice,
+  reasoningHead,
+  renderLineageBlock,
   renderOptions,
   scoreResults,
   seededShuffle,
 } from "./lib.mjs"
 
 const LONG = "a decision text that is comfortably longer than the forty character minimum"
+const LONG_REASON = "we switched because the earlier rationale no longer held under new load"
 
-function row(id, topic, decision, created_at) {
-  return { id, topic, decision, created_at, reasoning: null, status: "active", kind: "decision" }
+function row(id, topic, decision, created_at, reasoning = null) {
+  return { id, topic, decision, created_at, reasoning, status: "active", kind: "decision" }
 }
 
 test("isExcludedTopic drops known fixture-pollution topics", () => {
@@ -68,6 +73,7 @@ test("buildQaItem marks the newest row as the answer and priors as distractors",
     ],
   }
   const item = buildQaItem(chain, 42)
+  assert.equal(item.qaType, "truth")
   assert.equal(item.options.length, 3)
   const answer = item.options.find((o) => o.label === item.answerLabel)
   assert.equal(answer.decisionId, "d3")
@@ -145,4 +151,162 @@ test("scoreResults computes accuracy, stale and invalid rates per condition", ()
   assert.equal(raw.accuracy, 0.5)
   assert.equal(raw.invalidRate, 0.5)
   assert.equal(raw.approxTokensPerItem, 10000)
+})
+
+test("chainRevisionReasoning returns the newest version's reasoning when it qualifies", () => {
+  const chain = {
+    topic: "cadence",
+    rows: [
+      row(
+        "d1",
+        "cadence",
+        `${LONG} v1`,
+        100,
+        "original rationale for the first cadence choice here"
+      ),
+      row("d2", "cadence", `${LONG} v2`, 200, LONG_REASON),
+    ],
+  }
+  assert.equal(chainRevisionReasoning(chain), LONG_REASON)
+})
+
+test("chainRevisionReasoning rejects short, missing, single-version, and duplicate reasonings", () => {
+  // too short
+  assert.equal(
+    chainRevisionReasoning({
+      topic: "t",
+      rows: [
+        row("a", "t", `${LONG} v1`, 100, "long enough prior reasoning here to pass"),
+        row("b", "t", `${LONG} v2`, 200, "too short"),
+      ],
+    }),
+    null
+  )
+  // missing on current
+  assert.equal(
+    chainRevisionReasoning({
+      topic: "t",
+      rows: [row("a", "t", `${LONG} v1`, 100, LONG_REASON), row("b", "t", `${LONG} v2`, 200, null)],
+    }),
+    null
+  )
+  // single version
+  assert.equal(
+    chainRevisionReasoning({ topic: "t", rows: [row("a", "t", `${LONG} v1`, 100, LONG_REASON)] }),
+    null
+  )
+  // current reasoning duplicates a prior version's reasoning (no delta)
+  assert.equal(
+    chainRevisionReasoning({
+      topic: "t",
+      rows: [
+        row("a", "t", `${LONG} v1`, 100, LONG_REASON),
+        row("b", "t", `${LONG} v2`, 200, `  ${LONG_REASON.toUpperCase()}  `),
+      ],
+    }),
+    null
+  )
+})
+
+test("buildLineageItem: answer is the chain reasoning, distractors are other topics, deterministic", () => {
+  const chain = {
+    topic: "cadence",
+    rows: [
+      row("d1", "cadence", `${LONG} v1`, 100, "first cadence rationale that is plenty long here"),
+      row("d2", "cadence", `${LONG} v2`, 200, LONG_REASON),
+    ],
+  }
+  const pool = [
+    { topic: "cadence", reasoning: LONG_REASON }, // own topic - must be excluded
+    {
+      topic: "budget",
+      reasoning: "budget was reallocated to the new priority workstream this quarter",
+    },
+    {
+      topic: "vendor",
+      reasoning: "the incumbent vendor missed the reliability targets three months running",
+    },
+    {
+      topic: "schema",
+      reasoning: "the denormalized shape made the hot query path far too slow to ship",
+    },
+  ]
+  const item = buildLineageItem(chain, pool, 42)
+  assert.equal(item.qaType, "lineage")
+  assert.equal(item.id, "lineage_cadence")
+  assert.equal(item.options.length, 4) // 1 answer + 3 distractors
+  const answer = item.options.find((o) => o.label === item.answerLabel)
+  assert.equal(answer.text, LONG_REASON)
+  // No distractor is drawn from the chain's own topic.
+  assert.ok(
+    item.options.every(
+      (o) =>
+        o.text === LONG_REASON || pool.some((p) => p.topic !== "cadence" && p.reasoning === o.text)
+    )
+  )
+  // Deterministic for a fixed seed.
+  const again = buildLineageItem(chain, pool, 42)
+  assert.deepEqual(
+    again.options.map((o) => o.text),
+    item.options.map((o) => o.text)
+  )
+  assert.equal(again.answerLabel, item.answerLabel)
+})
+
+test("buildLineageItem dedups identical distractor reasonings and returns null with no pool", () => {
+  const chain = {
+    topic: "cadence",
+    rows: [
+      row("d1", "cadence", `${LONG} v1`, 100, "prior cadence reasoning long enough to count"),
+      row("d2", "cadence", `${LONG} v2`, 200, LONG_REASON),
+    ],
+  }
+  const dupPool = [
+    { topic: "a", reasoning: "the same shared rationale text repeated across two topics here" },
+    { topic: "b", reasoning: "the same shared rationale text repeated across two topics here" },
+  ]
+  const item = buildLineageItem(chain, dupPool, 5)
+  const texts = item.options.map((o) => o.text)
+  assert.equal(new Set(texts).size, texts.length) // deduped
+  assert.equal(item.options.length, 2) // answer + one unique distractor
+  // Empty pool (only own topic available) -> no item.
+  assert.equal(buildLineageItem(chain, [{ topic: "cadence", reasoning: LONG_REASON }], 5), null)
+})
+
+test("reasoningHead collapses whitespace, truncates, and handles empties", () => {
+  assert.equal(reasoningHead("  a   b\n c  "), "a b c")
+  assert.equal(reasoningHead(""), "no reasoning recorded")
+  assert.equal(reasoningHead(null), "no reasoning recorded")
+  const long = "x".repeat(200)
+  const head = reasoningHead(long, 50)
+  assert.ok(head.length <= 53) // 50 chars + ellipsis
+  assert.ok(head.endsWith("..."))
+})
+
+test("renderLineageBlock shows prior reasoning heads and CURRENT decision", () => {
+  const rows = [
+    row(
+      "d1",
+      "cadence",
+      "the very first cadence decision was daily",
+      100,
+      "chose daily to stay tightly in sync early on"
+    ),
+    row(
+      "d2",
+      "cadence",
+      "cadence moved to twice a week to cut noise",
+      200,
+      "daily was too noisy so we spaced it out here"
+    ),
+    row("d3", "cadence", "the current cadence is a weekly digest only", 300, LONG_REASON),
+  ]
+  const block = renderLineageBlock("cadence", rows)
+  assert.ok(block.startsWith("cadence: v1 ("))
+  assert.ok(block.includes("v2 ("))
+  assert.ok(block.includes("CURRENT: the current cadence is a weekly digest only"))
+  // The current version surfaces its decision, not its reasoning.
+  assert.ok(!block.includes(LONG_REASON))
+  // Empty chain is handled.
+  assert.equal(renderLineageBlock("t", []), "t: (no history)")
 })

--- a/packages/memorybench/eval/delta-bench/run.mjs
+++ b/packages/memorybench/eval/delta-bench/run.mjs
@@ -189,7 +189,9 @@ async function buildPrompt(condition, item) {
     const res = await mamaApi.suggest(query, { limit: 5 })
     if (!res || !Array.isArray(res.results)) {
       throw new Error(
-        `suggest() returned unexpected shape for "${query}": ${JSON.stringify(res).slice(0, 200)}`
+        // Guard: JSON.stringify(undefined) === undefined, so slice() would throw
+        // a TypeError and mask the real "unexpected shape" error.
+        `suggest() returned unexpected shape for "${query}": ${String(JSON.stringify(res)).slice(0, 200)}`
       )
     }
     const hits = res.results.map((r) => ({
@@ -217,7 +219,9 @@ async function buildPrompt(condition, item) {
     const res = await mamaApi.suggest(query, { limit: 5 })
     if (!res || !Array.isArray(res.results)) {
       throw new Error(
-        `suggest() returned unexpected shape for "${query}": ${JSON.stringify(res).slice(0, 200)}`
+        // Guard: JSON.stringify(undefined) === undefined, so slice() would throw
+        // a TypeError and mask the real "unexpected shape" error.
+        `suggest() returned unexpected shape for "${query}": ${String(JSON.stringify(res)).slice(0, 200)}`
       )
     }
     const topics = []

--- a/packages/memorybench/eval/delta-bench/run.mjs
+++ b/packages/memorybench/eval/delta-bench/run.mjs
@@ -1,21 +1,29 @@
-// run.mjs - run the 3-condition delta experiment over a QA set.
+// run.mjs - run the delta experiment over a QA set (truth + lineage items).
 //
 // Conditions:
-//   vanilla - question only (floor reference; near-chance by construction)
-//   raw     - full chronological decision dump in context (what "just use long
-//             context" actually looks like), then the question
-//   mama    - whatever mama.suggest() returns for the topic query (the real
-//             MCP search runtime path, including its retrieval imperfections)
+//   vanilla      - question only (floor reference; near-chance by construction)
+//   raw          - full chronological decision dump in context (what "just use
+//                  long context" actually looks like), then the question
+//   mama         - whatever mama.suggest() returns for the topic query (the real
+//                  MCP search runtime path, including its retrieval imperfections)
+//   mama-lineage - mama.suggest() results grouped by topic, each topic's FULL
+//                  chain re-fetched from the DB copy and rendered as a lineage
+//                  block (v1 (reasoning head) -> ... -> CURRENT: decision). This
+//                  rendering is the R2 reasoning-precompute prototype under test.
+//   oracle       - the context a CORRECT projection WOULD return (ceiling): for
+//                  truth items the current decision marked current; for lineage
+//                  items the asked chain rendered perfectly.
 //
-// Model calls go through the Claude CLI (`claude -p`, prompt on stdin) - no
-// API keys. Results append to <out>/results.jsonl (safe to re-run; answered
-// (condition,item) pairs are skipped).
+// Both QA types run under every condition. Model calls go through the Claude CLI
+// (`claude -p`, prompt on stdin) - no API keys. Results append to
+// <out>/results.jsonl (safe to re-run; answered (condition,item) pairs skipped).
 //
 // Usage:
-//   node run.mjs --qa <dir> --out <dir>/results [--conditions vanilla,raw,mama]
+//   node run.mjs --qa <dir> --out <dir>/results
+//                [--conditions vanilla,raw,mama,mama-lineage,oracle]
 //                [--limit 40] [--model <model>] [--timeout-s 600]
-//   The mama condition additionally requires MAMA_DB_PATH pointing to a COPY
-//   of a MAMA DB - live DB paths are refused.
+//   The mama and mama-lineage conditions additionally require MAMA_DB_PATH
+//   pointing to a COPY of a MAMA DB - live DB paths are refused.
 
 import fs from "node:fs"
 import os from "node:os"
@@ -23,7 +31,14 @@ import path from "node:path"
 import { spawn } from "node:child_process"
 import { createRequire } from "node:module"
 import { fileURLToPath } from "node:url"
-import { approxTokens, parseChoice, renderOptions, scoreResults } from "./lib.mjs"
+import {
+  approxTokens,
+  normalizeCreatedAt,
+  parseChoice,
+  renderLineageBlock,
+  renderOptions,
+  scoreResults,
+} from "./lib.mjs"
 
 const require = createRequire(import.meta.url)
 
@@ -45,6 +60,7 @@ const outDir = arg("out", path.join(qaDir, "results"))
 const conditions = arg("conditions", "vanilla,raw,mama")
   .split(",")
   .map((s) => s.trim())
+  .filter(Boolean)
 const limit = Number(arg("limit", "40"))
 const model = arg("model", null)
 const timeoutS = Number(arg("timeout-s", "600"))
@@ -52,7 +68,7 @@ if (!Number.isFinite(limit) || !Number.isFinite(timeoutS)) {
   fail("--limit/--timeout-s must be numbers.")
 }
 
-const VALID_CONDITIONS = new Set(["vanilla", "raw", "mama", "oracle"])
+const VALID_CONDITIONS = new Set(["vanilla", "raw", "mama", "mama-lineage", "oracle"])
 for (const c of conditions) {
   if (!VALID_CONDITIONS.has(c)) {
     fail(`Unknown condition "${c}".`)
@@ -78,12 +94,18 @@ if (fs.existsSync(resultsPath)) {
   }
 }
 
-// --- mama condition setup (real MCP search runtime path) ---
+// --- mama / mama-lineage condition setup (real MCP search runtime path) ---
+// Both conditions call mama.suggest(); mama-lineage additionally re-fetches each
+// returned topic's full chain from a read-only handle on the DB copy.
+const needsSuggest = conditions.includes("mama") || conditions.includes("mama-lineage")
+const needsLineageDb = conditions.includes("mama-lineage")
+const KIND_FILTER = "('decision', 'preference', 'constraint', 'lesson', 'fact')"
 let mamaApi = null
-if (conditions.includes("mama")) {
+let lineageDb = null
+if (needsSuggest) {
   const dbPath = process.env.MAMA_DB_PATH
   if (!dbPath) {
-    fail("mama condition requires MAMA_DB_PATH (a COPY of a MAMA DB).")
+    fail("mama/mama-lineage conditions require MAMA_DB_PATH (a COPY of a MAMA DB).")
   }
   const resolved = path.resolve(dbPath)
   const liveDbs = [
@@ -101,6 +123,38 @@ if (conditions.includes("mama")) {
   const { initDB } = require(path.join(distDir, "db-manager.js"))
   mamaApi = require(path.join(distDir, "mama-api.js"))
   await initDB()
+  if (needsLineageDb) {
+    const Database = require("better-sqlite3")
+    lineageDb = new Database(resolved, { readonly: true, fileMustExist: true })
+  }
+}
+
+// Fetch a topic's full chain from the DB copy, oldest -> newest, using the same
+// JS timestamp normalization as extract (SQL ORDER BY created_at is unreliable
+// across the seconds/ms/TEXT encodings the live DBs mix).
+const chainCache = new Map()
+function fetchChain(topic) {
+  if (chainCache.has(topic)) {
+    return chainCache.get(topic)
+  }
+  const raw = lineageDb
+    .prepare(
+      `SELECT id, topic, decision, reasoning, created_at
+       FROM decisions
+       WHERE topic = ? AND kind IN ${KIND_FILTER}`
+    )
+    .all(topic)
+  const rows = []
+  for (const r of raw) {
+    const ts = normalizeCreatedAt(r.created_at)
+    if (ts === null) {
+      continue
+    }
+    rows.push({ ...r, created_at: ts })
+  }
+  rows.sort((a, b) => a.created_at - b.created_at || String(a.id).localeCompare(String(b.id)))
+  chainCache.set(topic, rows)
+  return rows
 }
 
 const PREAMBLE =
@@ -153,10 +207,49 @@ async function buildPrompt(condition, item) {
       `<memory>\n${JSON.stringify(hits, null, 1)}\n</memory>\n\n${qa}`
     )
   }
+  if (condition === "mama-lineage") {
+    // R2 prototype: take mama.suggest()'s topics, then re-fetch each returned
+    // topic's FULL chain from the DB copy and render it as a lineage block. The
+    // rendering (not the flat hit list) is what the model sees. Retrieval
+    // imperfection carries through: if suggest misses the asked topic, its
+    // lineage never reaches the model.
+    const query = item.topic.replace(/_/g, " ")
+    const res = await mamaApi.suggest(query, { limit: 5 })
+    if (!res || !Array.isArray(res.results)) {
+      throw new Error(
+        `suggest() returned unexpected shape for "${query}": ${JSON.stringify(res).slice(0, 200)}`
+      )
+    }
+    const topics = []
+    const seenTopics = new Set()
+    for (const r of res.results) {
+      if (!r.topic || seenTopics.has(r.topic)) {
+        continue
+      }
+      seenTopics.add(r.topic)
+      topics.push(r.topic)
+    }
+    const blocks = topics
+      .map((t) => renderLineageBlock(t, fetchChain(t)))
+      .filter((b) => b && !b.endsWith("(no history)"))
+    const lineage = blocks.length ? blocks.join("\n\n") : "(no matching topics found)"
+    return (
+      `${PREAMBLE}\n\nBelow is the decision lineage the memory system rendered for this question:\n\n` +
+      `<lineage>\n${lineage}\n</lineage>\n\n${qa}`
+    )
+  }
   if (condition === "oracle") {
-    // Ceiling condition: the context a CORRECT truth projection would return -
-    // the topic's current decision, explicitly marked current. Near-100% by
-    // construction; quantifies the prize for fixing retrieval + projection.
+    // Ceiling condition: the context a CORRECT projection would return.
+    if (item.qaType === "lineage") {
+      // The asked chain rendered perfectly (guaranteed present, unlike the
+      // retrieval-gated mama-lineage condition).
+      const block = renderLineageBlock(item.topic, item.lineageChain || [])
+      return (
+        `${PREAMBLE}\n\nBelow is the decision lineage the memory system rendered for this question:\n\n` +
+        `<lineage>\n${block}\n</lineage>\n\n${qa}`
+      )
+    }
+    // Truth items: the topic's current decision, explicitly marked current.
     const hit = {
       topic: item.topic,
       decision: item.options.find((o) => o.label === item.answerLabel).text,
@@ -231,6 +324,7 @@ for (const condition of conditions) {
       record = {
         itemId: item.id,
         topic: item.topic,
+        qaType: item.qaType,
         condition,
         choice,
         answerLabel: item.answerLabel,
@@ -244,6 +338,7 @@ for (const condition of conditions) {
       record = {
         itemId: item.id,
         topic: item.topic,
+        qaType: item.qaType,
         condition,
         choice: null,
         answerLabel: item.answerLabel,
@@ -263,12 +358,35 @@ for (const condition of conditions) {
   }
 }
 
-const summary = scoreResults(results.filter((r) => conditions.includes(r.condition)))
-fs.writeFileSync(path.join(outDir, "report.json"), JSON.stringify({ summary, results }, null, 2))
-console.log("\n=== delta-bench summary ===")
-for (const s of summary) {
-  console.log(
-    `${s.condition.padEnd(8)} n=${s.n} accuracy=${s.accuracy} stale=${s.staleRate} invalid=${s.invalidRate} ~tokens/item=${s.approxTokensPerItem}`
-  )
+if (lineageDb) {
+  lineageDb.close()
 }
-console.log(`report: ${path.join(outDir, "report.json")}`)
+
+const scored = results.filter((r) => conditions.includes(r.condition))
+const summary = scoreResults(scored)
+// Per-type breakdown: the whole point of the lineage extension is comparing
+// mama vs mama-lineage separately for truth and lineage questions.
+const qaTypes = [...new Set(scored.map((r) => r.qaType).filter(Boolean))].sort()
+const summaryByType = {}
+for (const t of qaTypes) {
+  summaryByType[t] = scoreResults(scored.filter((r) => r.qaType === t))
+}
+fs.writeFileSync(
+  path.join(outDir, "report.json"),
+  JSON.stringify({ summary, summaryByType, results }, null, 2)
+)
+
+function printSummary(rows) {
+  for (const s of rows) {
+    console.log(
+      `${s.condition.padEnd(12)} n=${s.n} accuracy=${s.accuracy} stale=${s.staleRate} invalid=${s.invalidRate} ~tokens/item=${s.approxTokensPerItem}`
+    )
+  }
+}
+console.log("\n=== delta-bench summary (all items) ===")
+printSummary(summary)
+for (const t of qaTypes) {
+  console.log(`\n=== delta-bench summary (${t}) ===`)
+  printSummary(summaryByType[t])
+}
+console.log(`\nreport: ${path.join(outDir, "report.json")}`)


### PR DESCRIPTION
## What

Extends `packages/memorybench/eval/delta-bench/` with a second QA type and a new experiment condition to test the R2 (reasoning-precomputation) hypothesis.

- **`lineage` QA type** (extract.mjs, lib.mjs): alongside the existing `truth` type. An L-item asks *"Topic X: which statement describes why this topic's decision was revised?"* Answer = the newest version's actual `reasoning` text (the revision rationale). Distractors = revision reasonings from OTHER topics' chains — real recorded text, deterministically selected, never generated. Filters: chain length >= 2, answer reasoning >= 40 chars and distinct from every prior version's reasoning. Excluded chains are counted (`excludedLineageChains`) in `meta.json`. Every item now carries a `qaType` field.
- **`--types truth,lineage`** arg on extract (default both); items interleave truth-then-lineage per topic so a small `--limit` still exercises both.
- **`mama-lineage` condition** (run.mjs): calls `mama.suggest()` like `mama`, groups results by topic, and for each returned topic re-fetches the FULL chain from the read-only DB copy (better-sqlite3, JS timestamp normalization matching extract) and renders `<topic>: v1 (<reasoning head>) -> ... -> CURRENT: <decision>`. **That rendering is the R2 prototype.** `oracle` for L-items renders the asked chain perfectly (guaranteed present, unlike retrieval-gated mama-lineage); truth-oracle unchanged.
- Both QA types run under every condition (vanilla / raw / mama / mama-lineage / oracle). Per-condition AND per-qaType summaries in run.mjs + `summaryByType` in report.json; analyze.mjs is now qaType-aware (per-type retrieval stats + per-type condition accuracy).
- All existing hygiene reused: no example letters in the preamble, seeded option shuffle, neutral cwd, `--setting-sources project`, resumable checkpointing, live-DB refusal for mama/mama-lineage, per-item `promptChars`.

## Why (falsification design)

The claim under test: *pre-rendering decision lineage (R2) improves agent answers.* The bench is built to potentially FALSIFY it — the primary comparison is `mama-lineage` vs `mama`. Note the honest tension: for lineage items the flat `mama` condition carries the current `reasoning` field verbatim, while `mama-lineage` renders prior reasoning heads + the current decision. Whether the structured lineage rendering beats the flat hit list is exactly what the data will answer; it may not, and that is a valid result.

## Smoke evidence (real Claude CLI, end-to-end)

Copied the live dev DB to a scratch copy, extracted `--max-items 6`, ran `--conditions vanilla,mama-lineage --limit 2` (4 real CLI calls):

```
extract: rows=1091 chains=44 qaItems=12 (truth=6 lineage=6); excludedLineageChains=0; lineagePoolSize=43
run:  vanilla      n=2 accuracy=1  ~tokens/item=634
      mama-lineage n=2 accuracy=1  ~tokens/item=989
  per-type lineage: vanilla n=1 / mama-lineage n=1 (~1345 tok/item, lineage block present)
  per-type truth:   vanilla n=1 / mama-lineage n=1
resume: re-run skipped all 4 pairs (0 new CLI calls)
analyze: per-type output OK (lineage chance=0.25 [4 opts], truth chance=0.5 [2 opts])
```

(n is tiny — this proves the pipeline, not an effect. Full business-DB runs are executed separately by the orchestrator.)

## Tests

`node --test eval/delta-bench/lib.test.mjs` → 15/15 pass (added coverage for `chainRevisionReasoning`, `buildLineageItem` determinism/dedup/pool-exclusion, `reasoningHead`, `renderLineageBlock`, and a `qaType` assertion on truth items). Full repo pre-commit suite: 3688 passed / 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)