### PR TITLE
fix(standalone): preserve future workorder kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.24.2] / mama-core [1.9.0] / mama-os [0.24.2] - 2026-07-22
+
+### Fixed — Workorder forward compatibility
+
+- **Version-owned workorder reads** — older MAMA OS binaries now count, claim, recover, and cancel
+  only the workorder kinds they understand. Rows written by a newer version remain untouched,
+  preventing downgrade crashes and preserving future work for the binary that owns it.
+
+### Upgrade notes
+
+- This patch bumps only `@jungjaehoon/mama-os` to `0.24.2`; MAMA Core, MCP Server, and the Claude
+  Code plugin keep their existing versions.
+
 ## [0.24.1] / mama-core [1.9.0] / mama-os [0.24.1] - 2026-07-21
 
 ### Fixed — Codex report recovery and tool parity

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ open-source components.
 
 | Package                                          | Version | Description                                           |
 | ------------------------------------------------ | ------- | ----------------------------------------------------- |
-| [@jungjaehoon/mama-os](packages/standalone/)     | 0.24.1  | Always-on runtime, envelopes, connectors, worker APIs |
+| [@jungjaehoon/mama-os](packages/standalone/)     | 0.24.2  | Always-on runtime, envelopes, connectors, worker APIs |
 | [@jungjaehoon/mama-server](packages/mcp-server/) | 1.14.0  | MCP server for Claude Desktop/Code and any MCP client |
 | [@jungjaehoon/mama-core](packages/mama-core/)    | 1.9.0   | Core memory, provenance, raw refs, graph, embeddings  |
 | [mama plugin](packages/claude-code-plugin/)      | 1.10.0  | Claude Code plugin (marketplace)                      |

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -259,7 +259,7 @@ Each package has independent versioning:
 - **mama-core:** 1.9.0 (stable API)
 - **mama-server:** 1.14.0 (follows MAMA version)
 - **claude-code-plugin:** 1.10.0 (follows MAMA version)
-- **mama-os:** 0.24.1 (standalone agent)
+- **mama-os:** 0.24.2 (standalone agent)
 
 ## Distribution Strategy
 
@@ -414,4 +414,4 @@ Existing decisions remain valid across all package updates. SQLite schema change
 
 ---
 
-**Last Updated:** 2026-02-22
+**Last Updated:** 2026-07-22

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -11,7 +11,7 @@ MAMA is a pnpm workspace-based monorepo with four release targets (plus the inte
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.24.1  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.24.2  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.14.0  |
 | MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 1.9.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.10.0  |
@@ -61,7 +61,7 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.24.1          |
+| `packages/standalone/package.json`                       | `version` | 0.24.2          |
 | `packages/mcp-server/package.json`                       | `version` | 1.14.0          |
 | `packages/mama-core/package.json`                        | `version` | 1.9.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.10.0          |
@@ -346,4 +346,4 @@ pnpm vitest run tests/hooks/pretooluse-hook.test.js
 
 ---
 
-_Last Updated: 2026-02-13_
+_Last Updated: 2026-07-22_

--- a/packages/standalone/CHANGELOG.md
+++ b/packages/standalone/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.2] - 2026-07-22
+
+Workorder forward-compatibility patch: older binaries now ignore and preserve system workorders
+whose kinds are owned by a newer MAMA OS version. Full details are in the repository root
+CHANGELOG.md.
+
 ## [0.24.1] - 2026-07-21
 
 Codex report-recovery patch: bounded durable-thread reset, full policy rebuild, replacement-session

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "MAMA OS - Local AI Runtime. Your scattered knowledge, organized by AI agents that never sleep.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/standalone/src/operator/task-ledger.ts
+++ b/packages/standalone/src/operator/task-ledger.ts
@@ -47,6 +47,10 @@ export type WorkOrderKind = (typeof WORKORDER_KINDS)[number];
 
 /** source_channel namespace for workorder rows: 'workorder:<workKind>'. */
 export const WORKORDER_CHANNEL_PREFIX = 'workorder:';
+const KNOWN_WORKORDER_CHANNELS = WORKORDER_KINDS.map(
+  (workKind) => `${WORKORDER_CHANNEL_PREFIX}${workKind}`
+);
+const KNOWN_WORKORDER_CHANNELS_SQL = KNOWN_WORKORDER_CHANNELS.map(() => '?').join(',');
 
 export interface EnqueueWorkOrderInput {
   workKind: WorkOrderKind;
@@ -587,11 +591,12 @@ export class TaskLedger implements TaskSource {
         .prepare(
           `SELECT * FROM operator_tasks
            WHERE kind = 'system' AND status = 'pending'
+             AND source_channel IN (${KNOWN_WORKORDER_CHANNELS_SQL})
            ORDER BY CASE priority WHEN 'high' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END ASC,
                     id ASC
            LIMIT 1`
         )
-        .get() as TaskRow | undefined;
+        .get(...KNOWN_WORKORDER_CHANNELS) as TaskRow | undefined;
       if (row) {
         this.db
           .prepare(`UPDATE operator_tasks SET status = 'in_progress', updated_at = ? WHERE id = ?`)
@@ -644,17 +649,23 @@ export class TaskLedger implements TaskSource {
   countPendingWorkOrders(): number {
     const row = this.db
       .prepare(
-        `SELECT COUNT(*) AS count FROM operator_tasks WHERE kind = 'system' AND status = 'pending'`
+        `SELECT COUNT(*) AS count FROM operator_tasks
+         WHERE kind = 'system' AND status = 'pending'
+           AND source_channel IN (${KNOWN_WORKORDER_CHANNELS_SQL})`
       )
-      .get() as { count: number };
+      .get(...KNOWN_WORKORDER_CHANNELS) as { count: number };
     return row.count;
   }
 
   /** In-progress system rows at boot = crash artifacts (single serial consumer). */
   listStaleClaims(): WorkOrderRecord[] {
     const rows = this.db
-      .prepare(`SELECT * FROM operator_tasks WHERE kind = 'system' AND status = 'in_progress'`)
-      .all() as TaskRow[];
+      .prepare(
+        `SELECT * FROM operator_tasks
+         WHERE kind = 'system' AND status = 'in_progress'
+           AND source_channel IN (${KNOWN_WORKORDER_CHANNELS_SQL})`
+      )
+      .all(...KNOWN_WORKORDER_CHANNELS) as TaskRow[];
     return rows.map((row) => this.rowToWorkOrder(row));
   }
 
@@ -670,11 +681,9 @@ export class TaskLedger implements TaskSource {
     if (onlyKinds !== undefined && onlyKinds.length === 0) {
       return 0;
     }
-    const kindFilter =
-      onlyKinds && onlyKinds.length > 0
-        ? ` AND source_channel IN (${onlyKinds.map(() => '?').join(',')})`
-        : '';
-    const kindParams = (onlyKinds ?? []).map((kind) => `${WORKORDER_CHANNEL_PREFIX}${kind}`);
+    const selectedKinds = onlyKinds ?? WORKORDER_KINDS;
+    const kindFilter = ` AND source_channel IN (${selectedKinds.map(() => '?').join(',')})`;
+    const kindParams = selectedKinds.map((kind) => `${WORKORDER_CHANNEL_PREFIX}${kind}`);
     const result = this.db
       .prepare(
         `UPDATE operator_tasks

--- a/packages/standalone/tests/agent/codex-app-server-process.test.ts
+++ b/packages/standalone/tests/agent/codex-app-server-process.test.ts
@@ -1328,7 +1328,7 @@ describe('Story: Codex app-server process', () => {
           codexHome: item.options.codexHome,
           codexIsolatedHome: item.options.isolatedHome,
           codexRegistryRoot: item.options.registryRoot,
-          requestTimeout: 500,
+          requestTimeout: 2_000,
         }
       );
       manager.setGatewayToolExecutor(executor);

--- a/packages/standalone/tests/agent/codex-app-server-process.test.ts
+++ b/packages/standalone/tests/agent/codex-app-server-process.test.ts
@@ -1387,15 +1387,17 @@ describe('Story: Codex app-server process', () => {
     const item = fixture('timeout-once');
     const runtime = new CodexRuntimeProcess({ ...item.options, requestTimeout: 500 });
 
-    const timedOut = runtime.prompt('slow', undefined, {
-      sessionKey: 'slow',
-      requestTimeout: 60,
-    });
+    const timedOut = expect(
+      runtime.prompt('slow', undefined, {
+        sessionKey: 'slow',
+        requestTimeout: 60,
+      })
+    ).rejects.toThrow('timed out');
     await waitForFile(join(item.root, 'timed-out'));
     await expect(
       runtime.prompt('fast', undefined, { sessionKey: 'fast', requestTimeout: 500 })
     ).resolves.toMatchObject({ response: 'hello' });
-    await expect(timedOut).rejects.toThrow('timed out');
+    await timedOut;
 
     const launches = messages(item.capture).filter((entry) => Array.isArray(entry.argv));
     expect(launches).toHaveLength(1);

--- a/packages/standalone/tests/operator/task-ledger.test.ts
+++ b/packages/standalone/tests/operator/task-ledger.test.ts
@@ -281,6 +281,23 @@ describe('Story S2-T1: TaskLedger workorder extension', () => {
   });
 
   describe('AC #4: workorder API - dedup, claim ordering, transitions, cleanup', () => {
+    function insertFutureWorkOrder(
+      status: 'pending' | 'in_progress',
+      idempotencyKey: string
+    ): number {
+      const now = Date.now();
+      const result = db
+        .prepare(
+          `INSERT INTO operator_tasks
+             (title, status, priority, kind, payload, source_channel, source_event_id,
+              auto_created, confirmed, created_at, updated_at)
+           VALUES ('workorder:temporal', ?, 'high', 'system', ?, 'workorder:temporal', ?,
+                   1, 0, ?, ?)`
+        )
+        .run(status, JSON.stringify({ attempts: 1 }), idempotencyKey, now, now);
+      return Number(result.lastInsertRowid);
+    }
+
     it('dedups open keyed rows, reinserts after terminal', () => {
       const a = ledger.enqueueWorkOrder({
         workKind: 'board',
@@ -328,6 +345,36 @@ describe('Story S2-T1: TaskLedger workorder extension', () => {
       expect(ledger.claimNextWorkOrder()?.id).toBe(normal.id);
       expect(ledger.claimNextWorkOrder()?.id).toBe(low.id);
       expect(ledger.claimNextWorkOrder()).toBeNull();
+    });
+
+    it('ignores and preserves pending workorders owned by a future version', () => {
+      const futureId = insertFutureWorkOrder('pending', 'temporal:slot-1');
+      const known = ledger.enqueueWorkOrder({
+        workKind: 'board',
+        idempotencyKey: 'board:slot-1',
+        input: {},
+      });
+
+      expect(ledger.countPendingWorkOrders()).toBe(1);
+      expect(ledger.claimNextWorkOrder()?.id).toBe(known.id);
+      expect(ledger.cancelOpenWorkOrders('flag-off')).toBe(1);
+
+      const future = db.prepare(`SELECT status FROM operator_tasks WHERE id = ?`).get(futureId) as {
+        status: string;
+      };
+      expect(future.status).toBe('pending');
+    });
+
+    it('ignores stale claims owned by a future version', () => {
+      insertFutureWorkOrder('in_progress', 'temporal:slot-2');
+      const known = ledger.enqueueWorkOrder({
+        workKind: 'wiki',
+        idempotencyKey: 'wiki:slot-2',
+        input: {},
+      });
+      ledger.claimNextWorkOrder();
+
+      expect(ledger.listStaleClaims().map((workorder) => workorder.id)).toEqual([known.id]);
     });
 
     it('transitions guard against wrong states', () => {


### PR DESCRIPTION
## Summary

- restrict 0.24.x workorder consumption and cleanup to the workorder kinds this binary owns
- preserve unknown future-version system rows across downgrade and restart
- add regression coverage for pending and stale future workorders
- bump MAMA OS to 0.24.2 and synchronize release documentation

## Verification

- `pnpm --filter mama-os typecheck`
- `pnpm --filter mama-os build`
- `pnpm --filter mama-os test` (293 files, 4,115 tests passed; 4 files and 6 tests skipped)
- targeted ESLint and Prettier checks
- independent pre-landing review: no remaining findings

## Documentation

- root and standalone changelogs describe the compatibility patch
- README, package structure, and deployment version tables now show 0.24.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forward compatibility for workorders.
  * Older MAMA OS versions now ignore and preserve workorders created by newer versions, preventing downgrade issues.
  * Known workorders continue to support counting, claiming, recovery, and cancellation as expected.

* **Documentation**
  * Updated release notes, package references, deployment guidance, and architecture documentation for MAMA OS 0.24.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->