### PR TITLE
fix(standalone): allow composed media Code-Act runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.27.2] / mama-core [1.9.0] / mama-os [0.27.2] - 2026-07-22
+
+### Fixed
+
+- **Kagemusha-parity media composition budget** — Code-Act now keeps the reference five-minute
+  execution budget, allowing one owner turn to compose several bounded Drive downloads and OCR
+  calls without the previous 30-second whole-program deadline aborting a healthy workflow. Memory,
+  host-call, concurrency, parent-cancellation, and mutation-settlement safety limits remain active.
+
+### Upgrade notes
+
+- This patch bumps only `@jungjaehoon/mama-os` to `0.27.2`; MAMA Core, MCP Server, and the Claude
+  Code plugin keep their existing versions.
+
 ## [0.27.1] / mama-core [1.9.0] / mama-os [0.27.1] - 2026-07-22
 
 ### Fixed — Codex session and Code-Act runtime stability

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ open-source components.
 
 | Package                                          | Version | Description                                           |
 | ------------------------------------------------ | ------- | ----------------------------------------------------- |
-| [@jungjaehoon/mama-os](packages/standalone/)     | 0.27.1  | Always-on runtime, envelopes, connectors, worker APIs |
+| [@jungjaehoon/mama-os](packages/standalone/)     | 0.27.2  | Always-on runtime, envelopes, connectors, worker APIs |
 | [@jungjaehoon/mama-server](packages/mcp-server/) | 1.14.0  | MCP server for Claude Desktop/Code and any MCP client |
 | [@jungjaehoon/mama-core](packages/mama-core/)    | 1.9.0   | Core memory, provenance, raw refs, graph, embeddings  |
 | [mama plugin](packages/claude-code-plugin/)      | 1.10.0  | Claude Code plugin (marketplace)                      |

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -259,7 +259,7 @@ Each package has independent versioning:
 - **mama-core:** 1.9.0 (stable API)
 - **mama-server:** 1.14.0 (follows MAMA version)
 - **claude-code-plugin:** 1.10.0 (follows MAMA version)
-- **mama-os:** 0.27.1 (standalone agent)
+- **mama-os:** 0.27.2 (standalone agent)
 
 ## Distribution Strategy
 

--- a/docs/development/kagemusha-telegram-parity.md
+++ b/docs/development/kagemusha-telegram-parity.md
@@ -136,6 +136,21 @@ entry. Coverage, security, and temporal reviewers closed every P0-P3 finding; ex
 Code-Act variants remain bounded by the outer run ceiling and must pass the same role, disallowed
 tool, and envelope checks on every nested host call.
 
+## Runtime verification correction: 2026-07-22 multi-image owner turn
+
+A real owner turn downloaded four Drive images and composed OCR calls in one Code-Act program. The
+first OCR calls completed in roughly 18-22 seconds each, but MAMA's 30-second whole-program deadline
+aborted the next `translate_conti` call. Because that tool may create an output artifact, the
+existing settlement guard correctly returned `CODE_ACT_MUTATION_OUTCOME_UNKNOWN` after its finite
+grace instead of retrying an uncertain operation. The Telegram turn therefore failed even though
+the same composition fits Kagemusha's 300-second Code-Act budget.
+
+The parity correction sets MAMA's default Code-Act budget to the reference 300 seconds. It does not
+split the agent-selected program or introduce a scenario workflow. The memory cap, 50 host-call
+ceiling, eight-execution process cap, parent cancellation, abort propagation, and five-second
+mutation-settlement boundary remain unchanged. `code-act/sandbox.test.ts` pins the reference budget,
+and the MCP request timeout continues to derive from the sandbox deadline plus settlement grace.
+
 The workorder consumer now raises its stopping barrier before awaiting the active tick. It leaves
 the active claim for the existing boot-recovery transaction and never claims another pending row
 after shutdown starts. This is verified independently of model behavior in

--- a/docs/guides/code-act-sandbox.md
+++ b/docs/guides/code-act-sandbox.md
@@ -152,7 +152,7 @@ The QuickJS WASM engine provides a fully isolated environment.
 | ----------------------- | ---------------------------------------------------------------------------------- |
 | **Node.js API access**  | `require`, `process`, `fs` not injected (do not exist)                             |
 | **Network access**      | No `fetch()`, `XMLHttpRequest`, or sockets                                         |
-| **Infinite loops**      | Engine-level CPU timeout (default 30 seconds)                                      |
+| **Infinite loops**      | Engine-level CPU timeout (default 5 minutes)                                       |
 | **Memory exhaustion**   | `setMemoryLimit()` hard cap (default 256MB via quickjs-emscripten WASM allocation) |
 | **Prototype pollution** | QuickJS isolates from host Object.prototype                                        |
 | **Code injection**      | Only injected functions are available                                              |

--- a/docs/guides/code-act-sandbox.md
+++ b/docs/guides/code-act-sandbox.md
@@ -152,7 +152,7 @@ The QuickJS WASM engine provides a fully isolated environment.
 | ----------------------- | ---------------------------------------------------------------------------------- |
 | **Node.js API access**  | `require`, `process`, `fs` not injected (do not exist)                             |
 | **Network access**      | No `fetch()`, `XMLHttpRequest`, or sockets                                         |
-| **Infinite loops**      | Engine-level CPU timeout (default 5 minutes)                                       |
+| **Infinite loops**      | Whole-program wall-clock deadline, including host operations (default 5 minutes)   |
 | **Memory exhaustion**   | `setMemoryLimit()` hard cap (default 256MB via quickjs-emscripten WASM allocation) |
 | **Prototype pollution** | QuickJS isolates from host Object.prototype                                        |
 | **Code injection**      | Only injected functions are available                                              |

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -11,7 +11,7 @@ MAMA is a pnpm workspace-based monorepo with four release targets (plus the inte
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.27.1  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.27.2  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.14.0  |
 | MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 1.9.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.10.0  |
@@ -61,7 +61,7 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.27.1          |
+| `packages/standalone/package.json`                       | `version` | 0.27.2          |
 | `packages/mcp-server/package.json`                       | `version` | 1.14.0          |
 | `packages/mama-core/package.json`                        | `version` | 1.9.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.10.0          |

--- a/packages/standalone/CHANGELOG.md
+++ b/packages/standalone/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.2] - 2026-07-22
+
+- Code-Act now uses the Kagemusha five-minute composition budget so bounded multi-image Drive and
+  OCR workflows do not fail at the previous 30-second whole-program deadline. Existing memory,
+  call-count, concurrency, cancellation, and mutation-settlement guards are unchanged.
+
 ## [0.27.1] - 2026-07-22
 
 Codex app-server policy changes and missing durable records are now detected before a model request

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "description": "MAMA OS - Local AI Runtime. Your scattered knowledge, organized by AI agents that never sleep.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/standalone/src/agent/code-act/types.ts
+++ b/packages/standalone/src/agent/code-act/types.ts
@@ -1,7 +1,7 @@
 export interface SandboxConfig {
   memoryLimitBytes: number; // default: 32MB
   maxStackSizeBytes: number; // default: 512KB
-  timeoutMs: number; // default: 30_000
+  timeoutMs: number; // default: 300_000
   maxConcurrentCalls: number; // default: 50
   maxConcurrentExecutions: number; // default: 8 (process-wide hard maximum)
   mutationSettlementGraceMs: number; // default: 5_000 (bounded ambiguous-write drain)
@@ -71,7 +71,7 @@ export interface ParamDescriptor {
 export const DEFAULT_SANDBOX_CONFIG: SandboxConfig = {
   memoryLimitBytes: 32 * 1024 * 1024,
   maxStackSizeBytes: 512 * 1024,
-  timeoutMs: 30_000,
+  timeoutMs: 300_000,
   maxConcurrentCalls: 50,
   maxConcurrentExecutions: 8,
   mutationSettlementGraceMs: 5_000,

--- a/packages/standalone/tests/code-act/sandbox.test.ts
+++ b/packages/standalone/tests/code-act/sandbox.test.ts
@@ -11,6 +11,85 @@ describe('CodeActSandbox', () => {
     expect(DEFAULT_SANDBOX_CONFIG.timeoutMs).toBe(300_000);
   });
 
+  it('TG-03 applies the five-minute deadline and abort guards to multi-image composition', async () => {
+    const sandbox = new CodeActSandbox();
+    const observedDeadlines: number[] = [];
+    const observedSignals: AbortSignal[] = [];
+    sandbox.registerAbortableFunction(
+      'translate_conti',
+      async (context, input) => {
+        observedDeadlines.push(context.deadlineMs);
+        observedSignals.push(context.signal);
+        const image = input as { id: string };
+        return { id: image.id, translated: true };
+      },
+      { settleOnAbort: true }
+    );
+
+    const startedAt = Date.now();
+    const result = await sandbox.execute(`
+      var images = ['image-1', 'image-2', 'image-3', 'image-4'];
+      var translated = [];
+      for (var i = 0; i < images.length; i++) {
+        translated.push(translate_conti({ id: images[i] }));
+      }
+      translated;
+    `);
+
+    expect(result).toMatchObject({
+      success: true,
+      value: [
+        { id: 'image-1', translated: true },
+        { id: 'image-2', translated: true },
+        { id: 'image-3', translated: true },
+        { id: 'image-4', translated: true },
+      ],
+    });
+    expect(observedDeadlines).toHaveLength(4);
+    expect(new Set(observedDeadlines)).toHaveLength(1);
+    expect(observedDeadlines[0] - startedAt).toBeGreaterThanOrEqual(300_000);
+    expect(observedDeadlines[0] - startedAt).toBeLessThan(300_100);
+    expect(observedSignals.every((signal) => !signal.aborted)).toBe(true);
+
+    const parent = new AbortController();
+    let markMutationStarted: (() => void) | undefined;
+    const mutationStarted = new Promise<void>((resolve) => {
+      markMutationStarted = resolve;
+    });
+    let settleMutation: (() => void) | undefined;
+    const mutationSettled = new Promise<void>((resolve) => {
+      settleMutation = resolve;
+    });
+    let mutationSignal: AbortSignal | undefined;
+    const guarded = new CodeActSandbox();
+    guarded.registerAbortableFunction(
+      'translate_conti',
+      async (context) => {
+        mutationSignal = context.signal;
+        markMutationStarted?.();
+        await mutationSettled;
+        return { uploaded: true };
+      },
+      { settleOnAbort: true }
+    );
+
+    const guardedRun = guarded.execute('translate_conti({ id: "image-5" })', {
+      signal: parent.signal,
+    });
+    await mutationStarted;
+    parent.abort(new Error('owning turn stopped'));
+    settleMutation?.();
+
+    await expect(guardedRun).resolves.toMatchObject({
+      success: false,
+      error: {
+        code: 'CODE_ACT_MUTATION_COMMITTED_AFTER_ABORT',
+        retryable: false,
+      },
+    });
+    expect(mutationSignal?.aborted).toBe(true);
+  });
+
   describe('basic execution', () => {
     it('evaluates simple expressions', async () => {
       const sandbox = new CodeActSandbox();

--- a/packages/standalone/tests/code-act/sandbox.test.ts
+++ b/packages/standalone/tests/code-act/sandbox.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { CodeActSandbox } from '../../src/agent/code-act/sandbox.js';
+import { DEFAULT_SANDBOX_CONFIG } from '../../src/agent/code-act/types.js';
 
 describe('CodeActSandbox', () => {
   beforeAll(async () => {
     await CodeActSandbox.warmup();
+  });
+
+  it('preserves the Kagemusha five-minute budget for composed media workflows', () => {
+    expect(DEFAULT_SANDBOX_CONFIG.timeoutMs).toBe(300_000);
   });
 
   describe('basic execution', () => {


### PR DESCRIPTION
## Summary
- raise the Code-Act sandbox default deadline from 30 seconds to 5 minutes, matching the Kagemusha reference runtime
- add a regression test for multi-image media workflows
- document the execution budget and release standalone 0.27.2

## Root cause
A four-image Drive OCR/translation request exceeded MAMA’s 30-second whole-program deadline. The fourth call was interrupted and surfaced as `CODE_ACT_MUTATION_OUTCOME_UNKNOWN`, even though the equivalent Kagemusha sandbox allows 300 seconds.

## Verification
- focused Code-Act tests: 66 passed
- broader Code-Act/image/MCP tests: 134 passed
- standalone full suite: 4,551 passed, 6 skipped
- typecheck, lint, formatting, build, version sync: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended the Code-Act execution budget to five minutes, allowing bounded multi-image Drive download, OCR, and translation workflows to complete without premature timeout failures.
  * Preserved existing memory, call-count, concurrency, cancellation, and mutation-settlement safeguards.

* **Documentation**
  * Updated release notes, deployment guidance, architecture references, and sandbox documentation for version 0.27.2 and the five-minute execution window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->