### PR TITLE
fix(standalone): restore the operator agent's tool surface and operating discipline

### DIFF
--- a/packages/standalone/src/agent/agent-loop.ts
+++ b/packages/standalone/src/agent/agent-loop.ts
@@ -1501,6 +1501,20 @@ export class AgentLoop {
         console.log(`[AgentLoop] No systemPrompt in options - using spawn default for this call`);
       }
 
+      // Codex re-anchors a rehydrated durable thread through thread/resume's
+      // baseInstructions rather than replaying instructions as user text. A CONTINUE
+      // turn's per-call prompt is deliberately minimal (message-router
+      // buildMinimalResumePrompt), so resuming with it would REPLACE the thread's full
+      // policy with a stub - only freshSessionSystemPrompt rebuilds the complete one.
+      // That rebuild costs an embedding search, so hand the backend a lazy builder it
+      // invokes only inside the resume branch; a live thread never pays for it.
+      const freshSystemPromptBuilder = options?.freshSessionSystemPrompt;
+      const resumeInstructions =
+        isCodex && freshSystemPromptBuilder
+          ? async (): Promise<string> =>
+              prepareSystemPrompt(await freshSystemPromptBuilder(), false)
+          : undefined;
+
       // Reset StopContinuation state for this channel to prevent leaking
       // retry counts from previous invocations
       if (this.stopContinuationHandler) {
@@ -1659,6 +1673,7 @@ export class AgentLoop {
             model: options?.model,
             resumeSession: shouldResume,
             systemPrompt: requestSystemPrompt,
+            resumeInstructions,
             sessionKey: channelKey,
             sessionPolicyFingerprint: effectiveSessionPolicyFingerprint,
             sessionId: resolvedCliSessionId ?? undefined,

--- a/packages/standalone/src/agent/codex-app-server-process.ts
+++ b/packages/standalone/src/agent/codex-app-server-process.ts
@@ -57,6 +57,15 @@ export interface CodexAppServerPromptOptions {
   policyFingerprint?: string;
   resumeSession?: boolean;
   hostToolBridge?: HostToolBridge;
+  /**
+   * Full instructions to re-supply when this call has to resume a durable thread.
+   * `thread/resume` accepts `baseInstructions` (ThreadResumeParams), so a rehydrated
+   * thread can be re-anchored through the protocol instead of the turn-text
+   * `<system-reminder>` workaround. Lazy on purpose: rebuilding the composed prompt
+   * costs an embedding search, and a live thread never resumes - the callback runs
+   * only inside the resume branch. Omit it to keep the legacy bootstrap behaviour.
+   */
+  resumeInstructions?: () => Promise<string>;
 }
 
 type JsonObject = Record<string, unknown>;
@@ -137,6 +146,7 @@ interface SessionPolicy {
   requestTimeout: number;
   policyFingerprint?: string;
   hostToolBridge?: HostToolBridge;
+  resumeInstructions?: () => Promise<string>;
 }
 
 interface SessionState {
@@ -593,6 +603,7 @@ export class CodexAppServerProcess {
       requestTimeout: overrides.requestTimeout ?? this.options.requestTimeout,
       policyFingerprint: overrides.policyFingerprint ?? this.options.policyFingerprint,
       hostToolBridge,
+      resumeInstructions: overrides.resumeInstructions,
     };
   }
 
@@ -788,18 +799,33 @@ export class CodexAppServerProcess {
   ): Promise<SessionState> {
     const record = this.registry.load(session.sessionKey);
     if (record) {
+      // A rehydrated thread carries its original instructions only in the model's own
+      // history, where compaction eventually erodes them. ThreadResumeParams accepts
+      // baseInstructions, so re-anchor through the protocol when the caller can supply
+      // the full text. assertRegistryPolicy already proved the stored policy fingerprint
+      // matches this session, and the caller builds these instructions from the same
+      // composed-prompt sources that produced that fingerprint - so re-supplying them
+      // restates the agreed policy rather than switching to a new one.
+      const resumeInstructions = session.resumeInstructions
+        ? await session.resumeInstructions()
+        : undefined;
+      if (session.resumeInstructions && !resumeInstructions?.trim()) {
+        // No-fallback: silently resuming without instructions is the very failure this
+        // path exists to remove.
+        throw new Error('Codex app-server resume instructions resolved to empty text');
+      }
+      const resumeParams: JsonObject = {
+        threadId: record.threadId,
+        model: session.model,
+        cwd: session.cwd,
+        approvalPolicy: 'never',
+        sandbox: session.sandbox,
+      };
+      if (resumeInstructions) {
+        resumeParams.baseInstructions = resumeInstructions;
+      }
       const result = object(
-        await this.request(
-          'thread/resume',
-          {
-            threadId: record.threadId,
-            model: session.model,
-            cwd: session.cwd,
-            approvalPolicy: 'never',
-            sandbox: session.sandbox,
-          },
-          session.requestTimeout
-        )
+        await this.request('thread/resume', resumeParams, session.requestTimeout)
       );
       this.validateResponsePolicy(result, session);
       this.validateInstructionMetadata(result, session);
@@ -807,7 +833,9 @@ export class CodexAppServerProcess {
       if (typeof resumed?.id !== 'string' || resumed.id !== record.threadId) {
         throw new Error('Codex app-server resumed an unexpected thread');
       }
-      return { threadId: record.threadId, bootstrapPending: true };
+      // Instructions delivered through the protocol make the turn-text bootstrap
+      // redundant; without them the legacy <system-reminder> replay still applies.
+      return { threadId: record.threadId, bootstrapPending: resumeInstructions === undefined };
     }
     const threadStartParams: JsonObject = {
       model: session.model,

--- a/packages/standalone/src/agent/model-runner.ts
+++ b/packages/standalone/src/agent/model-runner.ts
@@ -128,6 +128,14 @@ export interface PromptOptions {
    * place, so only callers that opt in (operator worker runs) are affected.
    */
   requestTimeout?: number;
+  /**
+   * Rebuilds the FULL instructions for a backend that has to rehydrate a durable
+   * session on this call. Codex re-anchors the resumed thread with them
+   * (thread/resume accepts baseInstructions) instead of replaying a per-call prompt
+   * as user text. Lazy: backends invoke it only when a resume actually happens, so
+   * live sessions never pay the rebuild.
+   */
+  resumeInstructions?: () => Promise<string>;
 }
 
 export type SessionPolicyStatus = 'missing' | 'compatible' | 'mismatch';

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -78,6 +78,7 @@ import {
   failModelRunInAdapter,
 } from '@jungjaehoon/mama-core';
 import type { DBManagerAdapter as DatabaseAdapter } from '@jungjaehoon/mama-core';
+import { OPERATOR_REPORT_SESSION_KEY } from '../../operator/report-run.js';
 import { TaskLedger, type WorkOrderKind } from '../../operator/task-ledger.js';
 import { buildTemporalWorkerContext } from '../../operator/temporal-worker.js';
 import {
@@ -421,9 +422,81 @@ const WORKORDER_TOOL_POLICIES = {
   },
 } as const satisfies Record<WorkOrderKind, WorkOrderToolPolicy>;
 
+/**
+ * Gateway tools the scheduled operator report must be able to EXECUTE.
+ *
+ * The report lane is a short-lived operator job like the Stage-2 workers, so its permissions
+ * are built in rather than derived from optional persona config. Membership is dictated by
+ * what the report is actually instructed to call: report-run.ts GATHER_TOOLS (the audit that
+ * decides whether a full report has task-board substance), the fullReportSelfGather lines,
+ * the board_publish lines, and the single mama_save the report may make.
+ *
+ * Its envelope grants no destinations and filters trello out of the raw connectors
+ * (scopeDaemonRawConnectors 'operator-report'), so no send or task-mutation tool belongs here.
+ */
+const OPERATOR_REPORT_TOOL_POLICY = {
+  roleName: 'operator-report',
+  allowedTools: [
+    'context_compile',
+    'kagemusha_entities',
+    'kagemusha_messages',
+    'kagemusha_overview',
+    'kagemusha_tasks',
+    'mama_recall',
+    'mama_save',
+    'mama_search',
+    'report_publish',
+    'schedule_upcoming',
+    'task_list',
+  ],
+} as const satisfies WorkOrderToolPolicy;
+
 export interface WorkOrderAgentPolicy {
   agentContext: AgentContext;
   gatewayToolsPrompt: string;
+}
+
+/**
+ * Build the Code-Act role the operator report lane runs under.
+ *
+ * Without an agentContext.role, roleAllowsOuterCodeAct() returns false (agent-loop.ts), the
+ * Code-Act branch of prepareSystemPrompt strips the generic gateway catalog, and NOTHING
+ * replaces it - the report agent then runs with zero tool definitions and every full report
+ * logs "executed NO gateway gather tools" while still being delivered. Mirrors
+ * buildWorkOrderAgentPolicy so both operator job families get their permissions the same way.
+ */
+export function buildOperatorReportAgentPolicy(
+  model: string,
+  backend: RuntimeBackend
+): WorkOrderAgentPolicy {
+  const blockedTools: string[] = [];
+  const innerTools = uniqueToolList(OPERATOR_REPORT_TOOL_POLICY.allowedTools);
+  const allowedTools = uniqueToolList(['code_act', ...innerTools]);
+  const agentContext: AgentContext = {
+    source: 'operator',
+    platform: 'cli',
+    roleName: OPERATOR_REPORT_TOOL_POLICY.roleName,
+    role: {
+      allowedTools,
+      blockedTools,
+      allowedPaths: [],
+      systemControl: false,
+      sensitiveAccess: false,
+      model,
+    },
+    session: {
+      sessionId: OPERATOR_REPORT_SESSION_KEY,
+      channelId: 'report',
+      startedAt: new Date(),
+    },
+    capabilities: allowedTools,
+    limitations: blockedTools.map((tool) => `Cannot use ${tool}`),
+    // Write tier: the report may persist one durable decision via mama_save, matching the
+    // tier its envelope already carries.
+    tier: 2,
+    backend,
+  };
+  return { agentContext, gatewayToolsPrompt: ToolRegistry.generatePrompt(innerTools) };
 }
 
 export function buildWorkOrderAgentPolicy(
@@ -1542,8 +1615,7 @@ export async function runAgentLoop(
       const { ReportScheduler, FileReportScheduleStore, parseReportHours } =
         await import('../../operator/report-scheduler.js');
       const { persistLastFullReport } = await import('../../operator/report-carry.js');
-      const { createPersonaReportAsk, OPERATOR_REPORT_SESSION_KEY } =
-        await import('../../operator/report-run.js');
+      const { createPersonaReportAsk } = await import('../../operator/report-run.js');
       const { OPERATOR_FULL_REPORT_TAG } = await import('../../operator/situation-report.js');
       const { buildBoardPublishLines } = await import('../../operator/board-slot-instructions.js');
       const { FilePendingReportStore } = await import('../../operator/pending-report-store.js');
@@ -1660,6 +1732,13 @@ export async function runAgentLoop(
                 sessionKey: OPERATOR_REPORT_SESSION_KEY,
                 source: 'operator',
                 channelId: 'report',
+                // Without a role the Code-Act branch strips the gateway catalog and
+                // injects nothing back, so the report agent gets ZERO tools and cannot
+                // gather no matter what the prompt instructs (roleAllowsOuterCodeAct
+                // fails closed on an absent role - agent-loop.ts). Same built-in
+                // least-privilege treatment the Stage-2 workers get.
+                agentContext: buildOperatorReportAgentPolicy(config.agent.model, runtimeBackend)
+                  .agentContext,
                 // Stateless report lane: each run starts on a fresh session so the
                 // continuous session no longer accumulates every run's gather dumps
                 // (measured 146s -> 521s growth over 3 days). Continuity comes from

--- a/packages/standalone/src/gateways/message-router.ts
+++ b/packages/standalone/src/gateways/message-router.ts
@@ -187,7 +187,9 @@ const OWNER_CONSOLE_OPERATING_DISCIPLINE = `## Owner console operating disciplin
 - You are the owner's operator, not an advisor. Report what you found and what you did; do not hand back work you could have done yourself.
 - Gather before answering. Any question about status, work, or what happened is answered by CALLING your gateway tools first. Never reply "please check X" when a gateway tool can check X - check it, then report.
 - Never claim a check you did not run. If a tool errored or was denied, name the tool and the error; a missing answer is reported as missing, never smoothed over.
-- Multi-step requests: decide the steps and carry them out, then report the outcome. Do not return the plan as a suggestion and stop.
+- Act by default; ask only before the irreversible. Reversible work is yours to do and then report: reading, analysing, ranking, drafting, and writes whose only audience is this console (mama_save, task_create/task_update on the native ledger, report_request, workorder_request). Ask first only when the effect leaves this conversation and cannot be taken back - sending to another channel (telegram_send), uploading or overwriting shared files (drive_upload), storing credentials, or delegating a run you cannot cancel.
+- Do not close by offering work you could have done. "Shall I rank these?" or "want it broken down by person?" is work, not a question - if you can do it now it belongs in this reply. End with what you did and what the OWNER has to decide, never with a menu of things you are willing to do next.
+- Multi-step requests: decide the steps, carry out the reversible ones, then report the outcome. Do not return the plan as a suggestion and stop.
 - Synthesize, do not dump. A raw tool result is evidence, not an answer - say what it means for the owner and cite which source answered.
 - Before saying something is done, verify it (re-read the artifact or re-run the query) and say what you verified.
 - Reply in the language the owner writes in.`;

--- a/packages/standalone/src/gateways/message-router.ts
+++ b/packages/standalone/src/gateways/message-router.ts
@@ -152,20 +152,45 @@ export function hashSessionPolicyFingerprint({
 function buildStableRolePolicyInstructions(
   agentContext: AgentContext,
   roleManager: RoleManager,
-  trelloAvailable: boolean
+  trelloAvailable: boolean,
+  options: { includeOperatingDiscipline?: boolean } = {}
 ): string {
   if (agentContext.roleName !== 'owner_console') {
     return '';
   }
+  const { includeOperatingDiscipline = true } = options;
   const trelloBoundary =
     trelloAvailable && roleManager.isToolAllowed(agentContext.role, 'context_compile')
       ? `
 - ${UNTRUSTED_EXTERNAL_EVIDENCE_INSTRUCTION}
 - Trello is separate external connector evidence and is available only through context_compile. When intentionally isolating Trello evidence, use context_compile({ task: "...", connectors: ['trello'] }); never claim that kagemusha_* is Trello or substitute one store for the other.`
       : '';
-  return `- Task-store canonicity: kagemusha_* is the READ-ONLY project-task truth; the native ledger (task_list/task_create/task_update) holds owner-console tasks. Their status vocabularies DIFFER (e.g. kagemusha has no 'blocked') - when a status query returns nothing, say the vocabulary difference instead of inferring the work is gone.${trelloBoundary}
+  const evidencePolicy = `- Task-store canonicity: kagemusha_* is the READ-ONLY project-task truth; the native ledger (task_list/task_create/task_update) holds owner-console tasks. Their status vocabularies DIFFER (e.g. kagemusha has no 'blocked') - when a status query returns nothing, say the vocabulary difference instead of inferring the work is gone.${trelloBoundary}
 - Answer status questions from artifacts first (board_read, workorder_status, audit_findings_read), then live queries; memory recall is the LAST resort and may be stale - cite which source answered.`;
+  return includeOperatingDiscipline
+    ? `${evidencePolicy}\n\n${OWNER_CONSOLE_OPERATING_DISCIPLINE}`
+    : evidencePolicy;
 }
+
+/**
+ * Owner-console operating posture, restated on every owner turn.
+ *
+ * Without it the only behavioural instruction the chat persona carries is "Be concise", which
+ * reliably yields a cautious advisor ("you may want to check X") instead of an operator that
+ * checks X and reports the result. The scheduled operator report already carries an equivalent
+ * SOP (situation-report.ts buildPrompt); this is the interactive half of the same contract.
+ *
+ * English default, mechanism only - no personal, business, or channel strings (locale overrides
+ * belong in ~/.mama/operator/*.json, as with the other operator prompts).
+ */
+const OWNER_CONSOLE_OPERATING_DISCIPLINE = `## Owner console operating discipline (applies to every reply)
+- You are the owner's operator, not an advisor. Report what you found and what you did; do not hand back work you could have done yourself.
+- Gather before answering. Any question about status, work, or what happened is answered by CALLING your gateway tools first. Never reply "please check X" when a gateway tool can check X - check it, then report.
+- Never claim a check you did not run. If a tool errored or was denied, name the tool and the error; a missing answer is reported as missing, never smoothed over.
+- Multi-step requests: decide the steps and carry them out, then report the outcome. Do not return the plan as a suggestion and stop.
+- Synthesize, do not dump. A raw tool result is evidence, not an answer - say what it means for the owner and cite which source answered.
+- Before saying something is done, verify it (re-read the artifact or re-run the query) and say what you verified.
+- Reply in the language the owner writes in.`;
 
 /** Channel-less host alarms (workorder failures) park here; every resumed
  *  owner turn reads this key in addition to its own channel key. */
@@ -1359,8 +1384,17 @@ This protects your credentials from being exposed in chat logs.`;
     const stableRolePolicy = agentContext
       ? buildStableRolePolicyInstructions(agentContext, this.roleManager, trelloAvailable)
       : '';
-    const appendStableRolePolicy = (basePrompt: string): string =>
-      stableRolePolicy ? `${basePrompt}\n\n${stableRolePolicy}\n` : basePrompt;
+    // Onboarding is guided first contact, not operator duty. The awakening persona asks the
+    // user's name and runs a personality quiz; ordering it to gather via gateway tools and
+    // execute multi-step work would fight that flow and aim it at connectors that do not
+    // exist yet. Evidence policy still travels; the operating posture does not.
+    const onboardingRolePolicy = agentContext
+      ? buildStableRolePolicyInstructions(agentContext, this.roleManager, trelloAvailable, {
+          includeOperatingDiscipline: false,
+        })
+      : '';
+    const appendOnboardingRolePolicy = (basePrompt: string): string =>
+      onboardingRolePolicy ? `${basePrompt}\n\n${onboardingRolePolicy}\n` : basePrompt;
 
     if (isOnboarding) {
       // Check if we have existing conversation
@@ -1369,7 +1403,7 @@ This protects your credentials from being exposed in chat logs.`;
       if (hasHistory) {
         // Continue existing conversation WITH the full prompt context
         // The full prompt has all the phase instructions - just prepend history
-        return appendStableRolePolicy(`${COMPLETE_AUTONOMOUS_PROMPT}
+        return appendOnboardingRolePolicy(`${COMPLETE_AUTONOMOUS_PROMPT}
 
 ---
 
@@ -1409,7 +1443,7 @@ Who are you? And more importantly—who do you want me to become? 💭`;
 
       const greeting = isKorean ? greetingKo : greetingEn;
 
-      return appendStableRolePolicy(`${COMPLETE_AUTONOMOUS_PROMPT}
+      return appendOnboardingRolePolicy(`${COMPLETE_AUTONOMOUS_PROMPT}
 
 ---
 

--- a/packages/standalone/src/multi-agent/runtime-process.ts
+++ b/packages/standalone/src/multi-agent/runtime-process.ts
@@ -132,6 +132,7 @@ export class CodexRuntimeProcess extends EventEmitter implements AgentRuntimePro
         policyFingerprint: promptOptions?.sessionPolicyFingerprint,
         resumeSession: promptOptions?.resumeSession,
         hostToolBridge: promptOptions?.hostToolBridge,
+        resumeInstructions: promptOptions?.resumeInstructions,
       });
 
       this._totalLatencyMs += Date.now() - startTime;

--- a/packages/standalone/tests/agent/codex-app-server-process.test.ts
+++ b/packages/standalone/tests/agent/codex-app-server-process.test.ts
@@ -1924,6 +1924,85 @@ describe('Story: Codex app-server process', () => {
     expect(input).toContain('second message');
   });
 
+  it('omits baseInstructions on thread/resume when no resume instructions are supplied', async () => {
+    const item = fixture();
+    const first = new CodexAppServerProcess({
+      ...item.options,
+      systemPrompt: 'initial runtime bootstrap',
+      policyFingerprint: 'stable-policy',
+    });
+    await first.prompt('first message');
+    await first.stop();
+
+    const resumed = new CodexAppServerProcess({
+      ...item.options,
+      systemPrompt: 'minimal per-call prompt',
+      policyFingerprint: 'stable-policy',
+    });
+    await resumed.prompt('second message');
+    await resumed.stop();
+
+    const resume = messages(item.capture).find((entry) => entry.method === 'thread/resume');
+    expect(resume).toBeDefined();
+    expect(resume?.params).not.toHaveProperty('baseInstructions');
+  });
+
+  it('carries resume instructions on thread/resume instead of the turn-text bootstrap', async () => {
+    const item = fixture();
+    const first = new CodexAppServerProcess({
+      ...item.options,
+      systemPrompt: 'initial runtime bootstrap',
+      policyFingerprint: 'stable-policy',
+    });
+    await first.prompt('first message');
+    await first.stop();
+
+    const resumed = new CodexAppServerProcess({
+      ...item.options,
+      systemPrompt: 'minimal per-call prompt',
+      policyFingerprint: 'stable-policy',
+    });
+    const resumeInstructions = vi.fn().mockResolvedValue('full operator instructions');
+    await resumed.prompt('second message', undefined, { resumeInstructions });
+    await resumed.stop();
+
+    const sent = messages(item.capture);
+    const resumeIndex = sent.findIndex((entry) => entry.method === 'thread/resume');
+    const resumedTurn = sent.slice(resumeIndex + 1).find((entry) => entry.method === 'turn/start');
+    const input = (
+      (resumedTurn?.params as Record<string, unknown>)?.input as Array<{ text?: string }>
+    )?.[0]?.text;
+
+    expect(resumeIndex).toBeGreaterThan(-1);
+    expect((sent[resumeIndex]?.params as Record<string, unknown>)?.baseInstructions).toBe(
+      'full operator instructions'
+    );
+    expect(resumeInstructions).toHaveBeenCalledTimes(1);
+    // The protocol channel replaces the user-text workaround: no reminder wrapper, no
+    // minimal per-call prompt leaking into the turn.
+    expect(input).toBe('second message');
+    expect(input).not.toContain('system-reminder');
+    expect(input).not.toContain('minimal per-call prompt');
+  });
+
+  it('does not build resume instructions while the durable thread stays live', async () => {
+    const item = fixture();
+    const runner = new CodexAppServerProcess({
+      ...item.options,
+      systemPrompt: 'initial durable policy',
+      policyFingerprint: 'stable-policy',
+    });
+    const resumeInstructions = vi.fn().mockResolvedValue('full operator instructions');
+
+    await runner.prompt('first message', undefined, { resumeInstructions });
+    await runner.prompt('second message', undefined, { resumeInstructions });
+    await runner.stop();
+
+    // thread/start opened the thread; neither turn resumed, so the expensive rebuild
+    // must never run on the hot path.
+    expect(resumeInstructions).not.toHaveBeenCalled();
+  });
+
   it('does not re-inject a per-call system prompt while the same durable thread stays live', async () => {
     const item = fixture();
     const runner = new CodexAppServerProcess({

--- a/packages/standalone/tests/cli/code-act-policy.test.ts
+++ b/packages/standalone/tests/cli/code-act-policy.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+  buildOperatorReportAgentPolicy,
   buildWorkOrderAgentPolicy,
   deriveCodeActToolPolicy,
   resolveCodeActMemoryScopes,
@@ -12,6 +13,8 @@ import {
   resolveCodeActAgentPolicy,
 } from '../../src/cli/commands/start.js';
 import { projectCodeActToolPolicy } from '../../src/agent/code-act/tool-policy.js';
+import { CODE_ACT_MARKER } from '../../src/agent/code-act/index.js';
+import { ToolRegistry } from '../../src/agent/tool-registry.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -282,6 +285,90 @@ describe('STORY-B6: Code-Act runtime policy hardening', () => {
         }
       }
     );
+
+    it('gives the operator report lane a Code-Act role so it can execute gather tools', () => {
+      const policy = buildOperatorReportAgentPolicy('gpt-5.4', 'codex');
+      const context = policy.agentContext;
+      const projected = projectCodeActToolPolicy({ tier: context.tier, role: context.role });
+
+      expect(context).toMatchObject({
+        source: 'operator',
+        platform: 'cli',
+        roleName: 'operator-report',
+        backend: 'codex',
+        // The report may mama_save, matching the write tier its envelope already carries.
+        tier: 2,
+        role: { blockedTools: [], model: 'gpt-5.4' },
+      });
+      // The regression this guards: without a role, roleAllowsOuterCodeAct() returns
+      // false, the generic gateway catalog is stripped, and the report agent runs with
+      // ZERO tool definitions - every full report then logs "executed NO gateway gather
+      // tools" while still being sent.
+      expect(
+        ToolRegistry.getHostToolDefinitions({
+          allowedTools: context.role.allowedTools,
+          blockedTools: context.role.blockedTools,
+        }).some((tool) => tool.name === CODE_ACT_MARKER)
+      ).toBe(true);
+      expect(projected.names).toEqual([
+        'context_compile',
+        'kagemusha_entities',
+        'kagemusha_messages',
+        'kagemusha_overview',
+        'kagemusha_tasks',
+        'mama_recall',
+        'mama_save',
+        'mama_search',
+        'report_publish',
+        'schedule_upcoming',
+        'task_list',
+      ]);
+      // Prompt/permission coherence: advertise exactly what the executor will run.
+      const advertised = [
+        ...policy.gatewayToolsPrompt.matchAll(/^- \*\*([A-Za-z0-9_]+)\*\*/gm),
+      ].map((match) => match[1]);
+      expect(advertised.sort()).toEqual([...projected.names].sort());
+      // The report envelope grants no send surface and filters trello out of its raw
+      // connectors, so no destination or task-mutation tool may be advertised.
+      for (const forbidden of ['task_create', 'task_update', 'send_message', 'Bash', 'Write']) {
+        expect(projected.names).not.toContain(forbidden);
+        expect(policy.gatewayToolsPrompt).not.toContain(`**${forbidden}**`);
+      }
+    });
+
+    it('covers every gather tool the report audit counts as substance', () => {
+      const policy = buildOperatorReportAgentPolicy('gpt-5.4', 'codex');
+      const projected = projectCodeActToolPolicy({
+        tier: policy.agentContext.tier,
+        role: policy.agentContext.role,
+      });
+      // report-run.ts GATHER_TOOLS: a full report that executes none of these is WARNED
+      // as substance-unverified, so the role must be able to execute all of them.
+      for (const gather of [
+        'kagemusha_overview',
+        'kagemusha_entities',
+        'kagemusha_tasks',
+        'kagemusha_messages',
+        'mama_recall',
+        'mama_search',
+        'context_compile',
+      ]) {
+        expect(projected.names).toContain(gather);
+      }
+    });
+
+    it('passes the report role into the report lane run', () => {
+      const startSource = readFileSync(join(__dirname, '../../src/cli/commands/start.ts'), 'utf-8');
+      const reportRun = startSource.slice(
+        startSource.indexOf('sessionKey: OPERATOR_REPORT_SESSION_KEY')
+      );
+      // A report run without agentContext is exactly the zero-tool regression; the
+      // freshSession marker anchors the assertion to the report lane's run options.
+      expect(reportRun).toMatch(
+        /agentContext:\s*buildOperatorReportAgentPolicy\([\s\S]{0,120}?\)\s*\.?\s*\n?\s*\.?agentContext/
+      );
+      expect(reportRun.slice(0, reportRun.indexOf('freshSession: true'))).toContain('agentContext');
+    });
 
     it('wires one temporal runtime from projected and registered transport tools', () => {
       const startSource = readFileSync(join(__dirname, '../../src/cli/commands/start.ts'), 'utf-8');

--- a/packages/standalone/tests/gateways/message-router.test.ts
+++ b/packages/standalone/tests/gateways/message-router.test.ts
@@ -747,6 +747,116 @@ describe('MessageRouter', () => {
       }
     });
 
+    it('gives the owner console an active operating discipline instead of advisory brevity', async () => {
+      resetRoleManager();
+      const ownerChannelId = 'synthetic-owner-operating-discipline';
+      getRoleManager().setTelegramTrust([ownerChannelId]);
+      let systemPrompt = '';
+      const customRouter = new MessageRouter(
+        sessionStore,
+        {
+          run: vi.fn(async (_prompt, options) => {
+            systemPrompt = options?.systemPrompt ?? '';
+            return { response: 'Response' };
+          }),
+        },
+        createMockMamaApi(mockDecisions),
+        { backend: 'codex' }
+      );
+
+      try {
+        await customRouter.process({
+          source: 'telegram',
+          channelId: ownerChannelId,
+          userId: ownerChannelId,
+          text: 'What is the status?',
+          metadata: { chatType: 'private' },
+        });
+
+        expect(systemPrompt).toContain('Owner console operating discipline');
+        // The reported failure was an agent that answers "please check X" instead of
+        // checking X and reporting the result.
+        expect(systemPrompt).toContain('Gather before answering');
+        expect(systemPrompt).toContain('Never claim a check you did not run');
+        expect(systemPrompt).toContain('Synthesize, do not dump');
+      } finally {
+        resetRoleManager();
+      }
+    });
+
+    it('keeps the owner operating discipline out of the onboarding conversation', async () => {
+      resetRoleManager();
+      const ownerChannelId = 'synthetic-owner-onboarding';
+      getRoleManager().setTelegramTrust([ownerChannelId]);
+      let systemPrompt = '';
+      const customRouter = new MessageRouter(
+        sessionStore,
+        {
+          run: vi.fn(async (_prompt, options) => {
+            systemPrompt = options?.systemPrompt ?? '';
+            return { response: 'Response' };
+          }),
+        },
+        createMockMamaApi(mockDecisions),
+        { backend: 'codex' }
+      );
+
+      // Onboarding is gated on SOUL.md being absent. Re-onboarding an existing install
+      // hits this state WITH telegram already allowlisted, so owner_console + onboarding
+      // is a normal path, not a corner case.
+      rmSync(testSoulPath, { force: true });
+      try {
+        await customRouter.process({
+          source: 'telegram',
+          channelId: ownerChannelId,
+          userId: ownerChannelId,
+          text: 'hello',
+          metadata: { chatType: 'private' },
+        });
+
+        expect(systemPrompt).toContain('waking up for the first time');
+        // The operator posture contradicts the awakening persona: it orders the agent to
+        // gather via gateway tools and execute multi-step work, while onboarding must ask
+        // the user's name and run a quiz against connectors that do not exist yet.
+        expect(systemPrompt).not.toContain('Owner console operating discipline');
+        expect(systemPrompt).not.toContain('Gather before answering');
+      } finally {
+        writeFileSync(testSoulPath, '# Synthetic test persona\n', { mode: 0o600 });
+        resetRoleManager();
+      }
+    });
+
+    it('keeps the owner operating discipline out of non-owner roles', async () => {
+      resetRoleManager();
+      let systemPrompt = '';
+      const customRouter = new MessageRouter(
+        sessionStore,
+        {
+          run: vi.fn(async (_prompt, options) => {
+            systemPrompt = options?.systemPrompt ?? '';
+            return { response: 'Response' };
+          }),
+        },
+        createMockMamaApi(mockDecisions),
+        { backend: 'codex' }
+      );
+
+      try {
+        await customRouter.process({
+          source: 'telegram',
+          channelId: 'untrusted-group',
+          userId: '42',
+          text: 'What is the status?',
+          metadata: { chatType: 'group' },
+        });
+
+        expect(systemPrompt).not.toContain('Owner console operating discipline');
+        expect(systemPrompt).not.toContain('Task-store canonicity');
+      } finally {
+        resetRoleManager();
+      }
+    });
+
     it('treats owner-visible Trello and context_compile evidence as untrusted data', async () => {
       resetRoleManager();
       const ownerChannelId = 'synthetic-owner-untrusted-evidence';

--- a/packages/standalone/tests/gateways/message-router.test.ts
+++ b/packages/standalone/tests/gateways/message-router.test.ts
@@ -774,11 +774,17 @@ describe('MessageRouter', () => {
         });
 
         expect(systemPrompt).toContain('Owner console operating discipline');
-        // The reported failure was an agent that answers "please check X" instead of
-        // checking X and reporting the result.
         expect(systemPrompt).toContain('Gather before answering');
         expect(systemPrompt).toContain('Never claim a check you did not run');
         expect(systemPrompt).toContain('Synthesize, do not dump');
+        // Observed 2026-07-23: the agent gathers and analyses well, then closes by
+        // offering to do the obvious next step instead of doing it. These two rules
+        // target that closing move and draw the boundary it needs to act inside.
+        expect(systemPrompt).toContain('Act by default; ask only before the irreversible');
+        expect(systemPrompt).toContain('Do not close by offering work you could have done');
+        // The boundary must name irreversible effects, not just assert one exists.
+        expect(systemPrompt).toContain('telegram_send');
+        expect(systemPrompt).toContain('drive_upload');
       } finally {
         resetRoleManager();
       }


### PR DESCRIPTION
Three independent defects found while resuming a checkpoint and monitoring the live runtime. All three make the agent look capable while it is not.

## 1. The operator report lane ran with zero tools

`roleAllowsOuterCodeAct()` fails closed on an absent role, and the report run passed no `agentContext`. So the Code-Act branch of `prepareSystemPrompt` stripped the generic gateway catalog and injected nothing back.

Measured in `daemon.log`: **42/42** `operator:report` prompts logged `tools: 0`, and the **last seven** scheduled full reports were delivered while logging `executed NO gateway gather tools - task-board substance NOT verified` (2026-07-21 18:00 through 2026-07-23 13:00). The last clean gather was 2026-07-21 13:00. The no-fallback warning fired correctly every time; nothing was reading it.

Fix: a built-in least-privilege `operator-report` role, built the same way the Stage-2 workers get theirs. The allowlist is derived from what the report is actually instructed to call, not guessed.

## 2. The owner console had one line of behavioural instruction

`## Instructions\n- Be concise. Save important decisions.` — that was the whole behavioural contract for the chat persona. It reliably produces a cautious advisor instead of an operator that checks and reports.

Fix: seven rules, `owner_console` only, English default, no personal strings. Excluded from onboarding, where an operator posture would fight the awakening flow and aim it at connectors that do not exist yet.

## 3. Resumed Codex threads dropped their instructions

`thread/resume` accepts `baseInstructions`; we sent only `{threadId, model, cwd, approvalPolicy, sandbox}` and compensated by replaying instructions as user text in a `<system-reminder>`.

Fix: carry them through the protocol. The builder is a lazy callback because a CONTINUE turn's per-call prompt is deliberately minimal (~32 chars) — resuming with that would replace the thread's full policy with a stub. Omitting the callback is byte-identical to current behaviour.

## Verification

- `pnpm test` — 4,561 passed, 6 skipped (+9 new)
- `pnpm typecheck`, `prettier --check` clean
- The start.ts wiring guard was checked for non-vacuity: removing the `agentContext` line makes it fail, then restored

## Not covered

Production runs the published package, so none of this is live until release. The report-lane warning is expected to persist until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Codex session resumption by restoring required instructions only when a durable session is resumed.
  - Added dedicated permissions and tool access for operator report generation.

- **Bug Fixes**
  - Prevented unnecessary instruction rebuilding during active sessions.
  - Refined onboarding guidance so it excludes owner-console operating rules that do not apply.
  - Ensured resumed conversations receive clean user messages without duplicated system instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->