### PR TITLE
chore(release): mama-os v0.27.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ open-source components.
 
 | Package                                          | Version | Description                                           |
 | ------------------------------------------------ | ------- | ----------------------------------------------------- |
-| [@jungjaehoon/mama-os](packages/standalone/)     | 0.27.3  | Always-on runtime, envelopes, connectors, worker APIs |
+| [@jungjaehoon/mama-os](packages/standalone/)     | 0.27.4  | Always-on runtime, envelopes, connectors, worker APIs |
 | [@jungjaehoon/mama-server](packages/mcp-server/) | 1.14.0  | MCP server for Claude Desktop/Code and any MCP client |
 | [@jungjaehoon/mama-core](packages/mama-core/)    | 1.9.0   | Core memory, provenance, raw refs, graph, embeddings  |
 | [mama plugin](packages/claude-code-plugin/)      | 1.10.0  | Claude Code plugin (marketplace)                      |

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -259,7 +259,7 @@ Each package has independent versioning:
 - **mama-core:** 1.9.0 (stable API)
 - **mama-server:** 1.14.0 (follows MAMA version)
 - **claude-code-plugin:** 1.10.0 (follows MAMA version)
-- **mama-os:** 0.27.3 (standalone agent)
+- **mama-os:** 0.27.4 (standalone agent)
 
 ## Distribution Strategy
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -11,7 +11,7 @@ MAMA is a pnpm workspace-based monorepo with four release targets (plus the inte
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.27.3  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.27.4  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.14.0  |
 | MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 1.9.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.10.0  |
@@ -61,7 +61,7 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.27.3          |
+| `packages/standalone/package.json`                       | `version` | 0.27.4          |
 | `packages/mcp-server/package.json`                       | `version` | 1.14.0          |
 | `packages/mama-core/package.json`                        | `version` | 1.9.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.10.0          |

--- a/packages/standalone/CHANGELOG.md
+++ b/packages/standalone/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.4] - 2026-07-24
+
+Restores the operator agent's tool surface and gives the owner console an explicit operating
+discipline, after live monitoring showed the agent gathering and analysing well but handing the
+next step back instead of taking it.
+
+- The scheduled operator report now runs under a built-in least-privilege `operator-report`
+  Code-Act role. Without a role the Code-Act path stripped the gateway catalogue and injected
+  nothing back, so the report agent ran with zero tool definitions: full reports were delivered
+  while logging "executed NO gateway gather tools - task-board substance NOT verified". The role's
+  allowlist is derived from what the report is instructed to call, and its envelope still grants no
+  send surface and no Trello.
+- The owner console carries a stated operating discipline on every reply. It gathers before
+  answering, never claims a check it did not run, synthesises instead of dumping tool output, and
+  acts by default - doing reversible work (reads, analysis, ranking, drafts, and writes whose only
+  audience is the 1:1 console) and reporting the outcome, while still asking first before
+  irreversible effects that leave the conversation (cross-channel sends, shared-file uploads,
+  credential storage, uncancellable delegation). Onboarding is deliberately excluded.
+- Resumed Codex threads are re-anchored through `thread/resume`'s `baseInstructions` instead of a
+  user-text `<system-reminder>` replay. The rebuild is lazy and runs only inside the resume branch,
+  so live threads and the operator/worker lanes are byte-identical to before.
+
 ## [0.27.3] - 2026-07-22
 
 - Verified owner-console Drive workflows can resolve and upload to the folder explicitly selected

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.27.3",
+  "version": "0.27.4",
   "description": "MAMA OS - Local AI Runtime. Your scattered knowledge, organized by AI agents that never sleep.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Version bump + CHANGELOG for the operator agent fixes merged in #173.

Contents (all shipped in #173, this PR only bumps the version and changelog):
- operator report lane Code-Act role (was running with zero tools)
- owner console operating discipline with the act-vs-ask boundary
- Codex thread/resume re-anchoring through baseInstructions

The tag push on this bump triggers `.github/workflows/publish.yml`. mama-core is unchanged, so no core-first publish ordering is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved operator report execution with more appropriate permissions and controlled tool access.
  * Improved owner console responses with clearer, evidence-based answers and safer action handling.
  * Improved resumed Codex conversations by restoring their operating context reliably.

* **Documentation**
  * Updated package and deployment documentation to reference MAMA OS version 0.27.4.

* **Chores**
  * Published MAMA OS version 0.27.4 and added its changelog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->