### PR TITLE
fix(standalone): report-audit Code-Act visibility + Stage-2 token telemetry

### DIFF
--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -4823,12 +4823,20 @@ export class GatewayToolExecutor {
     };
     const bridge = new HostBridge(this, this.roleManager, nestedExecutionContext);
     let usedUntrustedExternalEvidence = false;
+    // Names of host tools that actually EXECUTED inside the sandbox (post-call hook fire,
+    // result !== undefined - host-bridge.ts:1049; the pre-call fire at :1037 is skipped).
+    // Ride in the result message so downstream audits (report-run summarizeReportToolUse)
+    // can classify nested gather/write without code_act becoming an opaque blob.
+    const hostToolsInvoked: string[] = [];
     bridge.onToolUse = (toolName, _toolInput, result) => {
+      if (result === undefined) {
+        return;
+      }
+      hostToolsInvoked.push(toolName);
       if (
-        result !== undefined &&
-        ((toolName.startsWith('drive_') && toolName !== 'drive_upload') ||
-          toolName === 'ocr_image' ||
-          toolName === 'translate_conti')
+        (toolName.startsWith('drive_') && toolName !== 'drive_upload') ||
+        toolName === 'ocr_image' ||
+        toolName === 'translate_conti'
       ) {
         usedUntrustedExternalEvidence = true;
       }
@@ -4853,6 +4861,7 @@ export class GatewayToolExecutor {
       value: result.value,
       logs: result.logs,
       metrics: result.metrics,
+      hostToolsInvoked,
     });
 
     return {

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -1510,6 +1510,10 @@ export async function runAgentLoop(
             type: `workorder_${event.type}`,
             input_summary: `#${event.workOrderId}`,
             output_summary: event.reason ?? '',
+            // Token telemetry continuity: the legacy persona path recorded
+            // tokens_used via executeValidatedRun; the Stage-2 cutover
+            // (2026-07-21) silently zeroed it, blinding all cost measurement.
+            tokens_used: event.tokensUsed,
             execution_status: 'completed',
             trigger_reason: 'workorder-consumer',
           });

--- a/packages/standalone/src/db/agent-store.ts
+++ b/packages/standalone/src/db/agent-store.ts
@@ -286,7 +286,8 @@ export interface ActivityRow {
   type: string;
   input_summary: string | null;
   output_summary: string | null;
-  tokens_used: number;
+  /** NULL = the run reported no usage (unmeasured); 0 = measured as zero. */
+  tokens_used: number | null;
   tools_called: string | null;
   duration_ms: number;
   score: number | null;
@@ -342,7 +343,9 @@ export function logActivity(db: DB, input: LogActivityInput): ActivityRow {
     input.type,
     input.input_summary ?? null,
     input.output_summary ?? null,
-    input.tokens_used ?? 0,
+    // NULL, not 0: absent usage must stay distinguishable from a measured zero,
+    // or the Stage-2 telemetry restoration re-fabricates the ambiguity it fixed.
+    input.tokens_used ?? null,
     input.tools_called ? JSON.stringify(input.tools_called) : null,
     input.duration_ms ?? 0,
     input.score ?? null,

--- a/packages/standalone/src/operator/report-run.ts
+++ b/packages/standalone/src/operator/report-run.ts
@@ -45,6 +45,32 @@ const WRITE_TOOLS = new Set<string>([
   'wiki_publish',
 ]);
 
+/** Local literal, deliberately NOT an import of code-act CODE_ACT_MARKER: this module keeps
+ *  zero agent-internal imports so the audit stays unit-testable with plain synthetic objects.
+ *  Must match code-act/constants.ts CODE_ACT_MARKER ('code_act'). */
+const CODE_ACT_TOOL_NAME = 'code_act';
+
+/** Under a Code-Act role the report gathers INSIDE the sandbox: history carries one code_act
+ *  tool_use, and the host tools it actually executed ride in the result message's
+ *  hostToolsInvoked field (executeCodeAct collects them from the HostBridge onToolUse hook).
+ *  Defensive on purpose: unparseable content, a missing field, or a wrong shape yield [] -
+ *  the audit then falls back to warning, never to a throw or a false positive. */
+function parseHostToolsInvoked(content: unknown): string[] {
+  const body = typeof content === 'string' ? content : JSON.stringify(content ?? '');
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      const invoked = (parsed as { hostToolsInvoked?: unknown }).hostToolsInvoked;
+      if (Array.isArray(invoked)) {
+        return invoked.filter((name): name is string => typeof name === 'string');
+      }
+    }
+  } catch {
+    // Not JSON - no nested-tool evidence.
+  }
+  return [];
+}
+
 /** Minimal structural view of AgentLoopResult.history (types.ts:1105). Structural on purpose:
  *  keeps this module free of agent-internal imports so tests use plain synthetic objects. */
 export interface ReportHistoryMessage {
@@ -88,9 +114,11 @@ function isErroredOrDenied(block: { is_error?: boolean; content?: unknown }): bo
 export function summarizeReportToolUse(
   history: ReadonlyArray<ReportHistoryMessage>
 ): ReportToolAudit {
-  // Pass 1: index result health by tool_use_id (results live in the user messages the agent loop
-  // pushes after each tool batch - agent-loop.ts:1408-1411).
+  // Pass 1: index result health AND content by tool_use_id (results live in the user messages
+  // the agent loop pushes after each tool batch - agent-loop.ts:1408-1411). Content is kept so
+  // an executed code_act can surface the nested host tools recorded in its result message.
   const resultOkById = new Map<string, boolean>();
+  const resultContentById = new Map<string, unknown>();
   for (const msg of history) {
     if (!msg || msg.role !== 'user' || !Array.isArray(msg.content)) continue;
     for (const block of msg.content as Array<{
@@ -101,6 +129,7 @@ export function summarizeReportToolUse(
     }>) {
       if (!block || block.type !== 'tool_result' || typeof block.tool_use_id !== 'string') continue;
       resultOkById.set(block.tool_use_id, !isErroredOrDenied(block));
+      resultContentById.set(block.tool_use_id, block.content);
     }
   }
   // Pass 2: classify assistant tool_use blocks; only a paired healthy result counts as executed.
@@ -114,6 +143,14 @@ export function summarizeReportToolUse(
       all.push(block.name);
       const executed = typeof block.id === 'string' && resultOkById.get(block.id) === true;
       if (!executed) continue;
+      if (block.name === CODE_ACT_TOOL_NAME) {
+        // Nested gather/write: classify what the sandbox actually executed, not code_act itself.
+        for (const nested of parseHostToolsInvoked(resultContentById.get(block.id as string))) {
+          if (GATHER_TOOLS.has(nested)) gatherTools.push(nested);
+          else if (WRITE_TOOLS.has(nested)) writeTools.push(nested);
+        }
+        continue;
+      }
       if (GATHER_TOOLS.has(block.name)) gatherTools.push(block.name);
       else if (WRITE_TOOLS.has(block.name)) writeTools.push(block.name);
     }

--- a/packages/standalone/src/operator/worker-run.ts
+++ b/packages/standalone/src/operator/worker-run.ts
@@ -37,12 +37,24 @@ export type WorkerRunnerOptions = WorkerIdentityOptions &
   Pick<AgentLoopOptions, 'workorderAttemptId'> &
   Record<string, unknown>;
 
-/** Minimal surface of AgentLoop.runWithContent that workerRun needs (DI seam). */
+/** Minimal surface of AgentLoop.runWithContent that workerRun needs (DI seam).
+ *  totalUsage is optional because the seam is structural: the real AgentLoopResult
+ *  always carries it, but injected test runners and older adapters may not. */
 export interface WorkerRunner {
   runWithContent(
     content: ContentBlock[],
     options: WorkerRunnerOptions
-  ): Promise<{ response: string }>;
+  ): Promise<{
+    response: string;
+    totalUsage?: { input_tokens: number; output_tokens: number };
+  }>;
+}
+
+export interface WorkerRunOutput {
+  response: string;
+  /** input+output tokens of the run; undefined when the runner reported no usage
+   *  (never a fabricated 0 - absence must stay distinguishable from "free"). */
+  tokensUsed?: number;
 }
 
 export interface WorkerRunInput {
@@ -169,7 +181,7 @@ export function attachWorkOrderAttemptContext(
 export async function workerRun(
   runner: WorkerRunner,
   { kind, brief, input, runOptions }: WorkerRunInput
-): Promise<string> {
+): Promise<WorkerRunOutput> {
   if (!KIND_PATTERN.test(kind)) {
     throw new Error(`[worker-run] invalid worker kind "${kind}" (expected kebab-case)`);
   }
@@ -204,5 +216,10 @@ export async function workerRun(
   if (!response) {
     throw new Error(`[worker-run] worker "${kind}" returned an empty response`);
   }
-  return response;
+  const usage = result.totalUsage;
+  const tokensUsed =
+    usage && Number.isFinite(usage.input_tokens) && Number.isFinite(usage.output_tokens)
+      ? usage.input_tokens + usage.output_tokens
+      : undefined;
+  return tokensUsed === undefined ? { response } : { response, tokensUsed };
 }

--- a/packages/standalone/src/operator/workorder-consumer.ts
+++ b/packages/standalone/src/operator/workorder-consumer.ts
@@ -137,7 +137,7 @@ export class WorkOrderConsumer {
   private readonly lastAlarmAt = new Map<string, number>();
   private readonly unresolvedTemporalEffects = new Map<
     number,
-    { workOrder: WorkOrderRecord; reason: string; allowRetry: boolean }
+    { workOrder: WorkOrderRecord; reason: string; allowRetry: boolean; tokensUsed?: number }
   >();
   private timer: NodeJS.Timeout | null = null;
   private consuming = false;
@@ -346,7 +346,7 @@ export class WorkOrderConsumer {
     if (wo.workKind === 'temporal') {
       // Temporal responses may contain private task or connector evidence.
       // The durable receipt is authoritative, so never log model prose here.
-      this.arbitrateTemporalAttempt(wo, 'temporal-effect-missing');
+      this.arbitrateTemporalAttempt(wo, 'temporal-effect-missing', true, tokensUsed);
       return;
     }
     // Shadow-gate diagnostics (§8.2): the worker's actual output decides
@@ -408,19 +408,31 @@ export class WorkOrderConsumer {
   }
 
   /** Durable row+generation+receipt state always wins over runner prose/errors. */
-  private arbitrateTemporalAttempt(wo: WorkOrderRecord, reason: string, allowRetry = true): void {
+  private arbitrateTemporalAttempt(
+    wo: WorkOrderRecord,
+    reason: string,
+    allowRetry = true,
+    tokensUsed?: number
+  ): void {
     const auditReason = temporalFailureAuditReason(reason);
     let state: TemporalAttemptState;
     try {
       state = this.deps.ledger.inspectTemporalAttempt(wo.id);
     } catch (err) {
-      this.deferTemporalArbitration(wo, auditReason, err, allowRetry);
+      this.deferTemporalArbitration(wo, auditReason, err, allowRetry, tokensUsed);
       return;
     }
 
     if (state.workOrder.status === 'done' && state.receipt) {
       this.unresolvedTemporalEffects.delete(wo.id);
-      this.emitEvent({ type: 'complete', workKind: 'temporal', workOrderId: wo.id });
+      this.emitEvent({
+        type: 'complete',
+        workKind: 'temporal',
+        workOrderId: wo.id,
+        // Temporal completions route through this receipt arbitration, not the
+        // generic complete path - carry the run's usage the same way.
+        ...(tokensUsed === undefined ? {} : { tokensUsed }),
+      });
       this.log(
         `[workorder-consumer] completed temporal#${wo.id} from receipt (${state.receipt.outcome})`
       );
@@ -487,7 +499,8 @@ export class WorkOrderConsumer {
         new Error(
           `attempt is '${state.workOrder.status}' with generation '${state.generation.disposition}'`
         ),
-        allowRetry
+        allowRetry,
+        tokensUsed
       );
       return;
     }
@@ -498,7 +511,7 @@ export class WorkOrderConsumer {
     } catch (err) {
       // A competing effect/supersession may have won after the read. Do not
       // guess which transition won; force another authoritative read first.
-      this.deferTemporalArbitration(wo, auditReason, err, allowRetry);
+      this.deferTemporalArbitration(wo, auditReason, err, allowRetry, tokensUsed);
       return;
     }
     this.unresolvedTemporalEffects.delete(wo.id);
@@ -547,9 +560,12 @@ export class WorkOrderConsumer {
     wo: WorkOrderRecord,
     reason: string,
     err: unknown,
-    allowRetry = true
+    allowRetry = true,
+    tokensUsed?: number
   ): void {
-    this.unresolvedTemporalEffects.set(wo.id, { workOrder: wo, reason, allowRetry });
+    // tokensUsed survives the deferral so a later receipt-complete still
+    // carries the run's usage (a deferred effect is not an unmeasured one).
+    this.unresolvedTemporalEffects.set(wo.id, { workOrder: wo, reason, allowRetry, tokensUsed });
     const message = `workorder temporal#${wo.id} effect state unresolved: ${errMessage(err)}`;
     this.log(`[workorder-consumer] ${message}`);
     this.alarm('temporal', message, 'temporal-state-unresolved');
@@ -557,7 +573,12 @@ export class WorkOrderConsumer {
 
   private recheckUnresolvedTemporalEffects(): void {
     for (const pending of [...this.unresolvedTemporalEffects.values()]) {
-      this.arbitrateTemporalAttempt(pending.workOrder, pending.reason, pending.allowRetry);
+      this.arbitrateTemporalAttempt(
+        pending.workOrder,
+        pending.reason,
+        pending.allowRetry,
+        pending.tokensUsed
+      );
     }
   }
 

--- a/packages/standalone/src/operator/workorder-consumer.ts
+++ b/packages/standalone/src/operator/workorder-consumer.ts
@@ -86,6 +86,10 @@ export interface WorkOrderConsumerEvent {
   workKind: WorkOrderKind;
   workOrderId: number;
   reason?: string;
+  /** input+output tokens of the completed run, when the runner reported usage.
+   *  Restores the tokens_used telemetry the legacy persona path had
+   *  (executeValidatedRun) and the Stage-2 cutover lost. */
+  tokensUsed?: number;
 }
 
 export interface WorkOrderConsumerDeps {
@@ -274,17 +278,20 @@ export class WorkOrderConsumer {
     }
 
     let response: string;
+    let tokensUsed: number | undefined;
     try {
       // Inside the try: a runOptionsFor throw/reject (shadow capture publisher
       // missing, envelope issuance failure) fails the order instead of running
       // with the live publisher / without an envelope.
       const runOptions = await this.deps.runOptionsFor?.(wo);
-      response = await workerRun(this.deps.runner, {
+      const runResult = await workerRun(this.deps.runner, {
         kind: wo.workKind,
         brief,
         input: JSON.stringify(wo.payload),
         runOptions,
       });
+      response = runResult.response;
+      tokensUsed = runResult.tokensUsed;
     } catch (err) {
       if (this.stopping) {
         this.log(`[workorder-consumer] interrupted ${wo.workKind}#${wo.id}; boot will recover it`);
@@ -348,7 +355,15 @@ export class WorkOrderConsumer {
       `[workorder-consumer] ${wo.workKind}#${wo.id} response head: ${response.slice(0, 200).replace(/\n/g, ' | ')}`
     );
     this.deps.ledger.completeWorkOrder(wo.id);
-    this.emitEvent({ type: 'complete', workKind: wo.workKind, workOrderId: wo.id });
+    this.emitEvent({
+      type: 'complete',
+      workKind: wo.workKind,
+      workOrderId: wo.id,
+      // Token telemetry for agent_activity (start.ts onEvent): the consumer is
+      // the only seam that sees the run result AND emits the event. Absent when
+      // the runner reported no usage - never a fabricated zero.
+      ...(tokensUsed === undefined ? {} : { tokensUsed }),
+    });
     this.log(`[workorder-consumer] completed ${wo.workKind}#${wo.id}`);
   }
 

--- a/packages/standalone/tests/agent/gateway-tool-executor.test.ts
+++ b/packages/standalone/tests/agent/gateway-tool-executor.test.ts
@@ -1581,6 +1581,38 @@ describe('STORY-V019 - GatewayToolExecutor', () => {
         });
       });
 
+      describe('code_act result records executed host tools (report-audit evidence)', () => {
+        it('lists nested host tools that actually executed, in call order', async () => {
+          const executor = new GatewayToolExecutor({ mamaApi: createMockApi() });
+          executor.setAgentContext(createViewerContext());
+
+          const result = await executor.execute('code_act', {
+            code: `
+              mama_search({ query: "a" });
+              mama_search({ query: "b" });
+              ({ done: true })
+            `,
+            allowedTools: ['mama_search'],
+          });
+
+          expect(result.success).toBe(true);
+          const payload = JSON.parse(String(result.message));
+          // Post-call hook only: these names are EXECUTIONS, the evidence the
+          // report audit (report-run.ts parseHostToolsInvoked) classifies.
+          expect(payload.hostToolsInvoked).toEqual(['mama_search', 'mama_search']);
+        });
+
+        it('yields an empty list when the script calls no host tool', async () => {
+          const executor = new GatewayToolExecutor({ mamaApi: createMockApi() });
+          executor.setAgentContext(createViewerContext());
+
+          const result = await executor.execute('code_act', { code: '({ math: 1 + 1 })' });
+
+          expect(result.success).toBe(true);
+          expect(JSON.parse(String(result.message)).hostToolsInvoked).toEqual([]);
+        });
+      });
+
       describe('AC #2: request blocklists subtract from injected Code-Act functions', () => {
         it('removes request-blocked gateway tools inside code_act', async () => {
           const executor = new GatewayToolExecutor({ mamaApi: createMockApi() });

--- a/packages/standalone/tests/db/agent-activity.test.ts
+++ b/packages/standalone/tests/db/agent-activity.test.ts
@@ -177,6 +177,34 @@ describe('Story V19.6 - Agent Activity Logging', () => {
     });
   });
 
+  describe('token telemetry: absent usage persists as NULL, never a fabricated zero', () => {
+    it('stores NULL when tokens_used is omitted and 0 only when explicitly reported', () => {
+      const unmeasured = logActivity(db, {
+        agent_id: 'workorder-board',
+        agent_version: 0,
+        type: 'workorder_complete',
+      });
+      const genuinelyFree = logActivity(db, {
+        agent_id: 'workorder-board',
+        agent_version: 0,
+        type: 'workorder_complete',
+        tokens_used: 0,
+      });
+
+      const raw = db
+        .prepare('SELECT id, tokens_used FROM agent_activity WHERE id IN (?, ?) ORDER BY id')
+        .all(unmeasured.id, genuinelyFree.id) as Array<{ id: number; tokens_used: number | null }>;
+      // "Unmeasured" must stay distinguishable from "measured as free": the
+      // 05-08~07-21 dataset can only be compared against new data if zeros mean
+      // zero (PR #175 review - agent-store used `?? 0`, re-fabricating the very
+      // ambiguity the event layer removed).
+      expect(raw).toEqual([
+        { id: unmeasured.id, tokens_used: null },
+        { id: genuinelyFree.id, tokens_used: 0 },
+      ]);
+    });
+  });
+
   describe('Acceptance Criteria - activity CRUD', () => {
     it('AC #4: logs activity with details JSON', () => {
       const row = logActivity(db, {
@@ -246,13 +274,15 @@ describe('Story V19.6 - Agent Activity Logging', () => {
       expect(rows).toHaveLength(1);
     });
 
-    it('AC #8: defaults tokens_used and duration_ms to 0', () => {
+    it('AC #8: defaults tokens_used to NULL (unmeasured) and duration_ms to 0', () => {
       const row = logActivity(db, {
         agent_id: 'dev',
         agent_version: 1,
         type: 'task_start',
       });
-      expect(row.tokens_used).toBe(0);
+      // Contract change (PR #175): unmeasured usage persists as NULL so it stays
+      // distinguishable from a measured zero; durations remain 0-defaulted.
+      expect(row.tokens_used).toBeNull();
       expect(row.duration_ms).toBe(0);
     });
 

--- a/packages/standalone/tests/operator/report-run.test.ts
+++ b/packages/standalone/tests/operator/report-run.test.ts
@@ -204,3 +204,70 @@ describe('createPersonaReportAsk (M3-T4)', () => {
     expect(ran).toBe(0);
   });
 });
+
+describe('report tool-use audit: Code-Act nested gather (v0.27.4 false-positive fix)', () => {
+  /** A code_act exchange whose result message carries the nested host tools it executed
+   *  (executeCodeAct includes hostToolsInvoked in the successful message JSON). */
+  function codeActExchange(
+    hostToolsInvoked: unknown,
+    opts: { error?: boolean; rawBody?: string } = {}
+  ) {
+    const body =
+      opts.rawBody ??
+      JSON.stringify({ value: 'ok', logs: [], metrics: { calls: 1 }, hostToolsInvoked });
+    return exchange('code_act', { error: opts.error, body });
+  }
+
+  it('classifies nested host gather tools from an executed code_act result', () => {
+    const history = [
+      { role: 'user', content: [{ type: 'text', text: 'report' }] },
+      ...codeActExchange(['kagemusha_overview', 'kagemusha_tasks', 'mama_recall']),
+    ];
+    const a = summarizeReportToolUse(history);
+    expect(a.gatherTools).toEqual(['kagemusha_overview', 'kagemusha_tasks', 'mama_recall']);
+    expect(a.all).toEqual(['code_act']);
+    expect(formatReportToolAudit(a, true).join('\n')).not.toMatch(/NO gateway gather tools/);
+    expect(formatReportToolAudit(a, true).join('\n')).toMatch(/gathered via kagemusha_overview/);
+  });
+
+  it('classifies nested writes and still warns when code_act gathered nothing', () => {
+    const a = summarizeReportToolUse([...codeActExchange(['mama_save', 'report_publish'])]);
+    expect(a.gatherTools).toEqual([]);
+    expect(a.writeTools).toEqual(['mama_save', 'report_publish']);
+    expect(formatReportToolAudit(a, true).join('\n')).toMatch(/NO gateway gather tools/);
+  });
+
+  it('an errored code_act does NOT count its nested tools (executed-only semantics)', () => {
+    const a = summarizeReportToolUse([...codeActExchange(['kagemusha_tasks'], { error: true })]);
+    expect(a.gatherTools).toEqual([]);
+    expect(a.all).toEqual(['code_act']);
+  });
+
+  it('malformed or field-less code_act results yield no nested tools and never throw', () => {
+    const a = summarizeReportToolUse([
+      ...codeActExchange(undefined, { rawBody: '{not json' }),
+      ...codeActExchange(undefined, { rawBody: '{"value":"ok","logs":[]}' }),
+      ...codeActExchange({ nested: 'wrong-shape' }),
+      ...codeActExchange([42, null, 'kagemusha_tasks']), // non-strings ignored, valid one kept
+    ]);
+    expect(a.gatherTools).toEqual(['kagemusha_tasks']);
+  });
+
+  it('mixes direct tool_use and nested code_act gather in one audit', () => {
+    const a = summarizeReportToolUse([
+      ...exchange('context_compile'),
+      ...codeActExchange(['kagemusha_overview', 'mama_save']),
+    ]);
+    expect(a.gatherTools).toEqual(['context_compile', 'kagemusha_overview']);
+    expect(a.writeTools).toEqual(['mama_save']);
+  });
+
+  it('duplicate nested names are de-duplicated in the audit line, preserved in counts', () => {
+    const a = summarizeReportToolUse([
+      ...codeActExchange(['kagemusha_tasks', 'kagemusha_tasks', 'mama_recall']),
+    ]);
+    expect(a.gatherTools).toEqual(['kagemusha_tasks', 'kagemusha_tasks', 'mama_recall']);
+    const line = formatReportToolAudit(a, true).join('\n');
+    expect(line.match(/kagemusha_tasks/g)).toHaveLength(1); // uniq() in formatting
+  });
+});

--- a/packages/standalone/tests/operator/temporal-workorder-integration.test.ts
+++ b/packages/standalone/tests/operator/temporal-workorder-integration.test.ts
@@ -174,7 +174,10 @@ describe('Story A2 Task 12: temporal workorder vertical slice', () => {
     return nextConsumer;
   }
 
-  async function runModelAction(options: WorkerRunnerOptions): Promise<{ response: string }> {
+  async function runModelAction(options: WorkerRunnerOptions): Promise<{
+    response: string;
+    totalUsage: { input_tokens: number; output_tokens: number };
+  }> {
     const trusted = options.temporalWorkContext as TemporalWorkContext | undefined;
     if (!trusted) throw new Error('fake model transport did not receive trusted temporal context');
     const executionContext = buildAgentToolExecutionContext(
@@ -186,7 +189,12 @@ describe('Story A2 Task 12: temporal workorder vertical slice', () => {
     const action = actions.shift();
     if (!action) throw new Error('fake model response was not configured');
     runs.push(trusted.attemptId);
-    return { response: await action(executionContext, trusted) };
+    return {
+      response: await action(executionContext, trusted),
+      // Every fake run reports usage so the receipt-completion assertions can
+      // verify tokensUsed survives temporal arbitration (PR #175 review).
+      totalUsage: { input_tokens: 30_000, output_tokens: 1_500 },
+    };
   }
 
   function createExact(title = 'Confirm the 14:00 meeting outcome'): TaskRecord {
@@ -272,6 +280,9 @@ describe('Story A2 Task 12: temporal workorder vertical slice', () => {
       type: 'complete',
       workKind: 'temporal',
       workOrderId: attemptId,
+      // Temporal completions route through arbitrateTemporalAttempt, which must
+      // not drop the run's usage the way the pre-review code did.
+      tokensUsed: 31_500,
     });
     expect(evidenceReads).toEqual([
       {

--- a/packages/standalone/tests/operator/worker-run.test.ts
+++ b/packages/standalone/tests/operator/worker-run.test.ts
@@ -43,7 +43,8 @@ describe('Story OPS-0: workerRun primitive', () => {
         input: 'Refresh the pipeline slot.',
       });
 
-      expect(result).toBe('board updated');
+      // No usage from the runner -> response only, no fabricated tokensUsed.
+      expect(result).toEqual({ response: 'board updated' });
       expect(runner.calls).toHaveLength(1);
       const { content, options } = runner.calls[0];
       expect(content).toContain('You update the owner board slots.');
@@ -52,6 +53,32 @@ describe('Story OPS-0: workerRun primitive', () => {
       expect(options.source).toBe('operator');
       expect(options.channelId).toBe('worker:board');
       expect(options.freshSession).toBe(true);
+    });
+
+    it('sums runner totalUsage into tokensUsed for activity telemetry', async () => {
+      const runner: WorkerRunner = {
+        runWithContent: vi.fn(async () => ({
+          response: 'done',
+          totalUsage: { input_tokens: 40_000, output_tokens: 3_000 },
+        })),
+      };
+      const result = await workerRun(runner, {
+        kind: 'board',
+        brief: 'brief',
+        input: 'input',
+      });
+      expect(result).toEqual({ response: 'done', tokensUsed: 43_000 });
+    });
+
+    it('drops non-finite usage instead of fabricating a number', async () => {
+      const runner: WorkerRunner = {
+        runWithContent: vi.fn(async () => ({
+          response: 'done',
+          totalUsage: { input_tokens: Number.NaN, output_tokens: 3 },
+        })),
+      };
+      const result = await workerRun(runner, { kind: 'board', brief: 'b', input: 'i' });
+      expect(result).toEqual({ response: 'done' });
     });
 
     it('maps kinds onto the operator global-lane prefix', () => {

--- a/packages/standalone/tests/operator/workorder-consumer.test.ts
+++ b/packages/standalone/tests/operator/workorder-consumer.test.ts
@@ -165,6 +165,50 @@ describe('Story S2-T3: WorkOrderConsumer', () => {
     expect(ctx.activeSends.join('\n')).toContain('automatic retry suppressed');
   });
 
+  describe('token telemetry: run usage rides the completion event', () => {
+    it('carries totalUsage from the runner into the complete event as tokensUsed', async () => {
+      // The 05-08~07-21 measurement gap: legacy personas recorded tokens_used,
+      // the Stage-2 workorder path never did. The consumer is the only place
+      // that sees the run result AND emits the telemetry event.
+      ctx.deps.runner = {
+        runWithContent: async () => ({
+          response: 'DONE',
+          totalUsage: { input_tokens: 41_000, output_tokens: 2_200 },
+        }),
+      };
+      const consumer = new WorkOrderConsumer(ctx.deps);
+      const wo = ctx.ledger.enqueueWorkOrder({
+        workKind: 'board',
+        idempotencyKey: 'board:tokens:1',
+        input: { mode: 'full' },
+      });
+
+      await consumer.tick();
+
+      expect(ctx.events).toContainEqual({
+        type: 'complete',
+        workKind: 'board',
+        workOrderId: wo.id,
+        tokensUsed: 43_200,
+      });
+    });
+
+    it('omits tokensUsed when the runner reports no usage (no fake zeros)', async () => {
+      const consumer = new WorkOrderConsumer(ctx.deps);
+      const wo = ctx.ledger.enqueueWorkOrder({
+        workKind: 'board',
+        idempotencyKey: 'board:tokens:2',
+        input: { mode: 'full' },
+      });
+
+      await consumer.tick();
+
+      const complete = ctx.events.find((e) => e.type === 'complete' && e.workOrderId === wo.id);
+      expect(complete).toBeDefined();
+      expect(complete).not.toHaveProperty('tokensUsed');
+    });
+  });
+
   describe('AC #1: enqueue -> consume -> complete e2e', () => {
     it('drains pending workorders serially and marks them done', async () => {
       const consumer = new WorkOrderConsumer(ctx.deps);


### PR DESCRIPTION
Two observability repairs, bundled because they answer the same question: is the operator actually doing what it claims, and what does it cost?

## 1. Report audit false-positive under Code-Act (follow-up to #173)

The v0.27.4 operator-report role works: the first live full report under it executed code_act **11 times** and published all four board slots. But `summarizeReportToolUse` predates Code-Act and counts only direct tool_use names, so every full report now false-warns `executed NO gateway gather tools`.

The evidence was being generated and discarded: `HostBridge.onToolUse` sees every nested host call, and `executeCodeAct` used the hook only for the untrusted-evidence flag. Now the post-call (executed-only) hook collects the names, rides them in the code_act result as `hostToolsInvoked`, and the audit classifies them with the same gather/write sets as direct calls. `code_act` itself stays out of `GATHER_TOOLS` — a sandbox run can gather, write, both, or neither, so a compute-only or write-only report still warns. The no-fallback guarantee is restored, not weakened.

## 2. Token telemetry lost at the Stage-2 cutover

Measurement over 05-08~07-21 (`agent_activity.tokens_used`): 17,669 runs, **588M tokens**, and 44% of it (260M) went to legacy dashboard/wiki persona runs that gathered everything then skipped — no-op runs averaged **2.3x more tokens** than completed ones.

Those personas were replaced by Stage-2 event-driven workorders on 07-21, which plausibly fixed the waste — but the new path never recorded `tokens_used` (13,927 rows since, all zero), so nothing can be proven. Usage was dropped at two seams: the `WorkerRunner` structural type narrowed it away and `workerRun` returned a bare string. This threads it through: runner exposes optional `totalUsage`, `workerRun` returns `{response, tokensUsed?}`, the consumer rides it on the complete event, `start.ts` writes it to `agent_activity`. Absent usage stays absent — never a fabricated zero.

Optimization (delta anchors / two-tier memory) deliberately **not** included: 2-3 days of restored data decides whether the 44% is already gone.

## Verification
- `pnpm test` — 4,573 passed, 6 skipped (+12 new: 6 audit, 2 executor, 2 consumer, 2 workerRun)
- `pnpm typecheck`, `prettier` clean
- New audit tests cover: nested gather, nested write-only (still warns), errored code_act (not counted), malformed results (never throw), mixed direct+nested, dedup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visibility into tools used during sandboxed code execution for more accurate activity auditing.
  * Added token-usage reporting to completed work orders when reliable usage data is available.

* **Bug Fixes**
  * Improved audit classification for nested gather and write actions.
  * Prevented failed or malformed executions from being incorrectly counted as completed tool activity.
  * Preserved token telemetry across work-order processing stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->