### PR TITLE
chore(release): mama-os v0.27.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ open-source components.
 
 | Package                                          | Version | Description                                           |
 | ------------------------------------------------ | ------- | ----------------------------------------------------- |
-| [@jungjaehoon/mama-os](packages/standalone/)     | 0.27.4  | Always-on runtime, envelopes, connectors, worker APIs |
+| [@jungjaehoon/mama-os](packages/standalone/)     | 0.27.5  | Always-on runtime, envelopes, connectors, worker APIs |
 | [@jungjaehoon/mama-server](packages/mcp-server/) | 1.14.0  | MCP server for Claude Desktop/Code and any MCP client |
 | [@jungjaehoon/mama-core](packages/mama-core/)    | 1.9.0   | Core memory, provenance, raw refs, graph, embeddings  |
 | [mama plugin](packages/claude-code-plugin/)      | 1.10.0  | Claude Code plugin (marketplace)                      |

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -259,7 +259,7 @@ Each package has independent versioning:
 - **mama-core:** 1.9.0 (stable API)
 - **mama-server:** 1.14.0 (follows MAMA version)
 - **claude-code-plugin:** 1.10.0 (follows MAMA version)
-- **mama-os:** 0.27.4 (standalone agent)
+- **mama-os:** 0.27.5 (standalone agent)
 
 ## Distribution Strategy
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -11,7 +11,7 @@ MAMA is a pnpm workspace-based monorepo with four release targets (plus the inte
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.27.4  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.27.5  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.14.0  |
 | MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 1.9.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.10.0  |
@@ -61,7 +61,7 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.27.4          |
+| `packages/standalone/package.json`                       | `version` | 0.27.5          |
 | `packages/mcp-server/package.json`                       | `version` | 1.14.0          |
 | `packages/mama-core/package.json`                        | `version` | 1.9.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.10.0          |

--- a/packages/standalone/CHANGELOG.md
+++ b/packages/standalone/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.5] - 2026-07-24
+
+Observability repairs: the report audit now sees Code-Act gather, and token
+telemetry flows again on the Stage-2 workorder path.
+
+- The full-report tool-use audit classifies the host tools a `code_act` run
+  actually executed (carried as `hostToolsInvoked` in the result), ending the
+  false "executed NO gateway gather tools" warning introduced when the report
+  lane moved onto Code-Act in 0.27.4. A compute-only or write-only report still
+  warns; the no-fallback guarantee is unchanged.
+- Stage-2 workorder runs record `tokens_used` in `agent_activity` again. The
+  legacy persona recorder was lost at the 07-21 cutover, blinding cost
+  measurement (13,927 runs unmeasured). Usage now rides the worker run result
+  through the consumer's completion events, including temporal completions,
+  whose receipt arbitration path previously dropped it.
+- Absent usage persists as NULL instead of a fabricated 0, so "unmeasured"
+  stays distinguishable from "measured as free"; explicitly reported zeros
+  still store 0, keeping aggregates comparable with the pre-cutover baseline.
+
 ## [0.27.4] - 2026-07-24
 
 Restores the operator agent's tool surface and gives the owner console an explicit operating

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.27.4",
+  "version": "0.27.5",
   "description": "MAMA OS - Local AI Runtime. Your scattered knowledge, organized by AI agents that never sleep.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Version bump + CHANGELOG for the observability repairs merged in #175 (report-audit Code-Act visibility, Stage-2 token telemetry, NULL-vs-0 persistence). Tag push on this bump triggers publish.yml; mama-core unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)