### PR TITLE
fix(standalone): forward totalUsage through the agentLoopClient wrapper (v0.27.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ open-source components.
 
 | Package                                          | Version | Description                                           |
 | ------------------------------------------------ | ------- | ----------------------------------------------------- |
-| [@jungjaehoon/mama-os](packages/standalone/)     | 0.27.5  | Always-on runtime, envelopes, connectors, worker APIs |
+| [@jungjaehoon/mama-os](packages/standalone/)     | 0.27.6  | Always-on runtime, envelopes, connectors, worker APIs |
 | [@jungjaehoon/mama-server](packages/mcp-server/) | 1.14.0  | MCP server for Claude Desktop/Code and any MCP client |
 | [@jungjaehoon/mama-core](packages/mama-core/)    | 1.9.0   | Core memory, provenance, raw refs, graph, embeddings  |
 | [mama plugin](packages/claude-code-plugin/)      | 1.10.0  | Claude Code plugin (marketplace)                      |

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -259,7 +259,7 @@ Each package has independent versioning:
 - **mama-core:** 1.9.0 (stable API)
 - **mama-server:** 1.14.0 (follows MAMA version)
 - **claude-code-plugin:** 1.10.0 (follows MAMA version)
-- **mama-os:** 0.27.5 (standalone agent)
+- **mama-os:** 0.27.6 (standalone agent)
 
 ## Distribution Strategy
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -11,7 +11,7 @@ MAMA is a pnpm workspace-based monorepo with four release targets (plus the inte
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.27.5  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.27.6  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.14.0  |
 | MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 1.9.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.10.0  |
@@ -61,7 +61,7 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.27.5          |
+| `packages/standalone/package.json`                       | `version` | 0.27.6          |
 | `packages/mcp-server/package.json`                       | `version` | 1.14.0          |
 | `packages/mama-core/package.json`                        | `version` | 1.9.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.10.0          |

--- a/packages/standalone/CHANGELOG.md
+++ b/packages/standalone/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.6] - 2026-07-24
+
+Hotfix: the 0.27.5 token telemetry recorded NULL for every workorder because the
+agent-loop client wrapper rebuilt its return value and stripped `totalUsage`.
+The wrapper now forwards it, and a wiring guard pins the return shape. The NULL
+rows were themselves the honest signal the 0.27.5 persistence fix was designed
+to produce - under the old zero-coercion this gap would have been invisible.
+
 ## [0.27.5] - 2026-07-24
 
 Observability repairs: the report audit now sees Code-Act gather, and token

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.27.5",
+  "version": "0.27.6",
   "description": "MAMA OS - Local AI Runtime. Your scattered knowledge, organized by AI agents that never sleep.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/standalone/src/cli/runtime/agent-loop-init.ts
+++ b/packages/standalone/src/cli/runtime/agent-loop-init.ts
@@ -379,7 +379,11 @@ export function initMainAgentLoop(
         autoRecallUsed
       );
       const response = `${header}\n${result.response}`;
-      return { response };
+      // totalUsage must survive this wrapper: workerRun reads it for the
+      // Stage-2 token telemetry (0.27.5). The first live run under 0.27.5
+      // recorded NULL because this return stripped the field - the structural
+      // WorkerRunner type could not catch a concrete wrapper dropping it.
+      return { response, totalUsage: result.totalUsage };
     },
   };
 

--- a/packages/standalone/tests/cli/runtime/agent-loop-client-usage.test.ts
+++ b/packages/standalone/tests/cli/runtime/agent-loop-client-usage.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Wiring guard: the agentLoopClient wrapper must forward totalUsage.
+ *
+ * The Stage-2 token telemetry (0.27.5) threads usage structurally:
+ * AgentLoopResult.totalUsage -> WorkerRunner -> workerRun -> consumer event ->
+ * agent_activity. Unit tests inject fake runners that return totalUsage, so
+ * they cannot catch the CONCRETE client wrapper stripping the field - which is
+ * exactly what shipped in 0.27.5: the first live workorder completion recorded
+ * NULL because runWithContent returned `{ response }` only. Source-guard the
+ * wrapper the same way code-act-policy.test.ts guards the report-lane wiring.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('agentLoopClient wrapper preserves run usage', () => {
+  it('runWithContent returns totalUsage alongside the response', () => {
+    const source = readFileSync(
+      join(__dirname, '../../../src/cli/runtime/agent-loop-init.ts'),
+      'utf-8'
+    );
+    const wrapper = source.slice(source.indexOf('runWithContent: async'));
+    expect(wrapper.length).toBeGreaterThan(0);
+    // The wrapper's return must carry the field workerRun reads; a bare
+    // `return { response }` here silently re-blinds the telemetry.
+    expect(wrapper).toMatch(/return \{ response, totalUsage: result\.totalUsage \}/);
+  });
+});


### PR DESCRIPTION
Hotfix for 0.27.5: live verification showed the first workorder completion recording tokens_used NULL. The telemetry chain was correct except the concrete client wrapper (agent-loop-init.ts runWithContent), which rebuilt its return as `{ response }` and stripped `totalUsage`. Structural types and unit tests (whose fake runners DO return the field) could not catch a concrete wrapper dropping it — a source-level wiring guard now pins the return shape.

The NULL row was the honest signal the 0.27.5 NULL-persistence fix was designed to produce; under the old `?? 0` coercion this gap would have been invisible.

Follows the CLAUDE.md hotfix flow: fix commit + bump commit on one branch.

- `pnpm test` — 4,575 passed (+1 wiring guard)
- typecheck / prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token telemetry so total usage data is preserved and recorded correctly.
  * Corrected usage signaling for work orders affected by the previous release.

* **Documentation**
  * Updated package version references to 0.27.6.
  * Added changelog notes for the telemetry hotfix.

* **Chores**
  * Bumped the standalone package version from 0.27.5 to 0.27.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->