### PR TITLE
chore(release): bump mama-os to v0.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ## [0.28.1] / mama-core [1.9.0] / mama-os [0.28.1] - 2026-07-24
 
+### Added
+
+- **Trello labels + assignees in the raw store** — the Trello poller now ingests card labels
+  and resolves member ids to display names, so "who owns this card and which revision round is
+  it in" is answerable from connector data. Content lines gain `| labels: ...` and
+  `| assignees: ...`, and a label/assignee change on an unmoved card now emits as a change
+  (with the old → new label transition inline). Existing per-card poll state upgrades silently.
+
 ### Fixed
 
 - **Owner-console brief self-update is append-only** — on the loop's first live fire the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.28.1] / mama-core [1.9.0] / mama-os [0.28.1] - 2026-07-24
+
+### Fixed
+
+- **Owner-console brief self-update is append-only** — on the loop's first live fire the
+  full-replace contract let the model overwrite the entire seeded operating manual (including
+  the self-update rule itself) with its one new lesson. `console_brief_update` now takes a
+  `lesson` and appends it under `## Lessons` with today's date, preserving everything else;
+  a missing brief is re-seeded before appending, and a ceiling-busting brief is refused loudly
+  (owner curation, never truncation).
+
 ## [0.28.0] / mama-core [1.9.0] / mama-os [0.28.0] - 2026-07-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ open-source components.
 
 | Package                                          | Version | Description                                           |
 | ------------------------------------------------ | ------- | ----------------------------------------------------- |
-| [@jungjaehoon/mama-os](packages/standalone/)     | 0.28.0  | Always-on runtime, envelopes, connectors, worker APIs |
+| [@jungjaehoon/mama-os](packages/standalone/)     | 0.28.1  | Always-on runtime, envelopes, connectors, worker APIs |
 | [@jungjaehoon/mama-server](packages/mcp-server/) | 1.14.0  | MCP server for Claude Desktop/Code and any MCP client |
 | [@jungjaehoon/mama-core](packages/mama-core/)    | 1.9.0   | Core memory, provenance, raw refs, graph, embeddings  |
 | [mama plugin](packages/claude-code-plugin/)      | 1.10.0  | Claude Code plugin (marketplace)                      |

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -259,7 +259,7 @@ Each package has independent versioning:
 - **mama-core:** 1.9.0 (stable API)
 - **mama-server:** 1.14.0 (follows MAMA version)
 - **claude-code-plugin:** 1.10.0 (follows MAMA version)
-- **mama-os:** 0.28.0 (standalone agent)
+- **mama-os:** 0.28.1 (standalone agent)
 
 ## Distribution Strategy
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -11,7 +11,7 @@ MAMA is a pnpm workspace-based monorepo with four release targets (plus the inte
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.28.0  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.28.1  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.14.0  |
 | MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 1.9.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.10.0  |
@@ -61,7 +61,7 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.28.0          |
+| `packages/standalone/package.json`                       | `version` | 0.28.1          |
 | `packages/mcp-server/package.json`                       | `version` | 1.14.0          |
 | `packages/mama-core/package.json`                        | `version` | 1.9.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.10.0          |

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "MAMA OS - Local AI Runtime. Your scattered knowledge, organized by AI agents that never sleep.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Hotfix release: console_brief_update append-only semantics (PR #181).

🤖 Generated with [Claude Code](https://claude.com/claude-code)