### PR TITLE
feat(standalone): Trello poller ingests labels and resolved assignee names

### DIFF
--- a/packages/standalone/src/connectors/trello/index.ts
+++ b/packages/standalone/src/connectors/trello/index.ts
@@ -1,7 +1,14 @@
 /**
  * TrelloConnector — polls Trello boards via native fetch.
  * Auth token format: "apiKey:token" stored in config.auth.token or TRELLO_TOKEN env var.
- * Emits kanban_card NormalizedItems for moved/new cards.
+ * Emits kanban_card NormalizedItems for new/moved/updated cards.
+ *
+ * A card's operational state is more than its list: production boards track the
+ * assignee and the revision round (e.g. a "初稿" / "1回修正" label) on the card
+ * itself. The poller therefore ingests labels and resolved member names, and a
+ * label/member change on an unmoved card is a change worth emitting - owner
+ * question "who owns this and which revision round is it in" must be answerable
+ * from the raw store.
  */
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
@@ -16,10 +23,16 @@ import type {
   NormalizedItem,
 } from '../framework/types.js';
 
+interface TrelloLabel {
+  name: string;
+  color: string | null;
+}
+
 interface TrelloCard {
   id: string;
   name: string;
   idMembers: string[];
+  labels?: TrelloLabel[];
   dateLastActivity: string;
 }
 
@@ -27,6 +40,45 @@ interface TrelloList {
   id: string;
   name: string;
   cards: TrelloCard[];
+}
+
+interface TrelloBoardMember {
+  id: string;
+  fullName?: string;
+  username?: string;
+}
+
+/** Stored per-card state. Legacy entries are the plain list name; v2 entries
+ *  carry the full fingerprint so label/assignee changes are detectable. */
+interface CardState {
+  list: string;
+  labels: string[];
+  members: string[];
+}
+
+const STATE_V2_PREFIX = 'v2:';
+
+function encodeCardState(state: CardState): string {
+  return `${STATE_V2_PREFIX}${JSON.stringify([state.list, state.labels, state.members])}`;
+}
+
+function decodeCardState(raw: string): { state: CardState; legacy: boolean } {
+  if (raw.startsWith(STATE_V2_PREFIX)) {
+    try {
+      const [list, labels, members] = JSON.parse(raw.slice(STATE_V2_PREFIX.length)) as [
+        string,
+        string[],
+        string[],
+      ];
+      return { state: { list, labels: labels ?? [], members: members ?? [] }, legacy: false };
+    } catch {
+      /* fall through to legacy interpretation */
+    }
+  }
+  // Legacy value: the bare list name (pre-label/member polling). Treated as
+  // list-only so the format upgrade never floods the raw store with a
+  // "changed" item for every open card.
+  return { state: { list: raw, labels: [], members: [] }, legacy: true };
 }
 
 export class TrelloConnector implements IConnector {
@@ -41,7 +93,7 @@ export class TrelloConnector implements IConnector {
   private lastPollCount = 0;
   private lastError: string | undefined = undefined;
 
-  /** boardId → (cardId → listName) */
+  /** boardId → (cardId → encoded card state) */
   private lastCardStates: Map<string, Map<string, string>> = new Map();
 
   private readonly stateFilePath = join(
@@ -133,6 +185,36 @@ export class TrelloConnector implements IConnector {
     }
   }
 
+  private async fetchWithTimeout(url: string): Promise<Response> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 30_000);
+    try {
+      return await fetch(url, { signal: controller.signal });
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  /** id → display name for a board's members. Failure degrades to raw ids
+   *  (name resolution is enrichment, never a reason to drop a poll). */
+  private async fetchMemberNames(boardId: string): Promise<Map<string, string>> {
+    const names = new Map<string, string>();
+    try {
+      const res = await this.fetchWithTimeout(
+        `${this.baseUrl}/boards/${boardId}/members?fields=fullName,username&key=${this.apiKey}&token=${this.token}`
+      );
+      if (!res.ok) return names;
+      const members = (await res.json()) as TrelloBoardMember[];
+      for (const m of members) {
+        const name = m.fullName || m.username;
+        if (name) names.set(m.id, name);
+      }
+    } catch {
+      /* degrade to ids */
+    }
+    return names;
+  }
+
   async poll(_since: Date): Promise<NormalizedItem[]> {
     if (!this.apiKey || !this.token) throw new Error('TrelloConnector not initialized');
 
@@ -149,17 +231,10 @@ export class TrelloConnector implements IConnector {
       try {
         const url =
           `${this.baseUrl}/boards/${boardId}/lists` +
-          `?cards=open&card_fields=name,idMembers,dateLastActivity` +
+          `?cards=open&card_fields=name,idMembers,labels,dateLastActivity` +
           `&key=${this.apiKey}&token=${this.token}`;
 
-        const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), 30_000);
-        let res: Response;
-        try {
-          res = await fetch(url, { signal: controller.signal });
-        } finally {
-          clearTimeout(timeout);
-        }
+        const res = await this.fetchWithTimeout(url);
 
         if (!res.ok) {
           hadError = true;
@@ -168,6 +243,9 @@ export class TrelloConnector implements IConnector {
         }
 
         const lists = (await res.json()) as TrelloList[];
+        // Lazy: boards whose open cards carry no members need no roster call.
+        const anyMembers = lists.some((l) => l.cards.some((c) => c.idMembers.length > 0));
+        const memberNames = anyMembers ? await this.fetchMemberNames(boardId) : new Map();
 
         // Get or init previous card states for this board
         if (!this.lastCardStates.has(boardId)) {
@@ -178,16 +256,41 @@ export class TrelloConnector implements IConnector {
 
         for (const list of lists) {
           for (const card of list.cards) {
-            newCardState.set(card.id, list.name);
+            const labels = (card.labels ?? []).map((l) => l.name).filter(Boolean);
+            const assignees = card.idMembers.map((id) => memberNames.get(id) ?? id);
+            const current: CardState = { list: list.name, labels, members: assignees };
+            newCardState.set(card.id, encodeCardState(current));
 
-            const prevList = prevCardState.get(card.id);
-            const isNew = prevList === undefined;
-            const isMoved = prevList !== undefined && prevList !== list.name;
+            const prevRaw = prevCardState.get(card.id);
+            const isNew = prevRaw === undefined;
+            const prev = prevRaw !== undefined ? decodeCardState(prevRaw) : undefined;
+            const isMoved = prev !== undefined && prev.state.list !== list.name;
+            // Label/assignee deltas only fire against v2 state: a legacy entry
+            // carries no labels/members, so comparing against it would emit a
+            // one-time "changed" flood across every open card on upgrade.
+            const isUpdated =
+              prev !== undefined &&
+              !prev.legacy &&
+              !isMoved &&
+              (prev.state.labels.join(' ') !== labels.join(' ') ||
+                prev.state.members.join(' ') !== assignees.join(' '));
 
-            if (isNew || isMoved) {
+            if (isNew || isMoved || isUpdated) {
               let content = `${card.name} | ${list.name}`;
               if (isMoved) {
-                content += ` (from: ${prevList})`;
+                content += ` (from: ${prev!.state.list})`;
+              }
+              if (isUpdated && prev!.state.labels.join(' ') !== labels.join(' ')) {
+                content += ` (labels: ${prev!.state.labels.join(', ') || 'none'} -> ${labels.join(', ') || 'none'})`;
+              }
+              if (isUpdated && prev!.state.members.join(' ') !== assignees.join(' ')) {
+                content += ` (assignees changed)`;
+              }
+              if (labels.length > 0) {
+                content += ` | labels: ${labels.join(', ')}`;
+              }
+              if (assignees.length > 0) {
+                content += ` | assignees: ${assignees.join(', ')}`;
               }
 
               items.push({
@@ -204,9 +307,11 @@ export class TrelloConnector implements IConnector {
                   listName: list.name,
                   // Omit when absent: the canonical raw-ref serializer rejects
                   // undefined values ("undefined is not serializable at $.prevListName").
-                  ...(prevList !== undefined ? { prevListName: prevList } : {}),
+                  ...(prev !== undefined ? { prevListName: prev.state.list } : {}),
                   cardName: card.name,
                   members: card.idMembers,
+                  memberNames: assignees,
+                  labels,
                 },
               });
             }

--- a/packages/standalone/tests/connectors/trello.test.ts
+++ b/packages/standalone/tests/connectors/trello.test.ts
@@ -338,6 +338,164 @@ describe('TrelloConnector', () => {
     });
   });
 
+  describe('labels + assignees enrichment', () => {
+    // Owner question this exists for: "who owns this card and which revision
+    // round is it in?" Production boards track both ON the card (members + a
+    // 初稿/1回修正-style label), so the poller ingests them and treats a
+    // label/member change on an unmoved card as a change worth emitting.
+    type FakeCard = {
+      id: string;
+      name: string;
+      idMembers?: string[];
+      labels?: Array<{ name: string; color: string | null }>;
+      dateLastActivity?: string;
+    };
+    const richLists = (name: string, cards: FakeCard[]) => [
+      {
+        id: 'l1',
+        name,
+        cards: cards.map((c) => ({
+          idMembers: [],
+          labels: [],
+          dateLastActivity: '2024-01-01T00:00:00.000Z',
+          ...c,
+        })),
+      },
+    ];
+    const routedFetch = (
+      lists: unknown,
+      members: Array<{ id: string; fullName?: string; username?: string }> | 'fail'
+    ) =>
+      vi.fn(async (url: string | URL) => {
+        const u = String(url);
+        if (u.includes('/lists')) return { ok: true, json: async () => lists };
+        if (u.includes('/members?')) {
+          if (members === 'fail') return { ok: false, status: 500 };
+          return { ok: true, json: async () => members };
+        }
+        return { ok: false, status: 404 };
+      });
+
+    it('new cards carry resolved assignee names and labels in content and metadata', async () => {
+      const lists = richLists('進行', [
+        {
+          id: 'c1',
+          name: 'ex_100_card',
+          idMembers: ['m1', 'm2'],
+          labels: [
+            { name: '初稿', color: 'sky' },
+            { name: 'artist-a', color: 'green' },
+          ],
+        },
+      ]);
+      vi.stubGlobal(
+        'fetch',
+        routedFetch(lists, [
+          { id: 'm1', fullName: 'Alice Kim' },
+          { id: 'm2', username: 'bob' },
+        ])
+      );
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(1);
+      expect(items[0]?.content).toBe(
+        'ex_100_card | 進行 | labels: 初稿, artist-a | assignees: Alice Kim, bob'
+      );
+      expect(items[0]?.metadata).toMatchObject({
+        labels: ['初稿', 'artist-a'],
+        memberNames: ['Alice Kim', 'bob'],
+        members: ['m1', 'm2'],
+      });
+    });
+
+    it('a label change on an unmoved card emits with the old -> new transition', async () => {
+      const card: FakeCard = {
+        id: 'c1',
+        name: 'ex_100_card',
+        idMembers: ['m1'],
+        labels: [{ name: '初稿', color: 'sky' }],
+      };
+      const roster = [{ id: 'm1', fullName: 'Alice Kim' }];
+      vi.stubGlobal('fetch', routedFetch(richLists('進行', [card]), roster));
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0)); // baseline
+
+      vi.stubGlobal(
+        'fetch',
+        routedFetch(
+          richLists('進行', [{ ...card, labels: [{ name: '1回修正', color: 'sky' }] }]),
+          roster
+        )
+      );
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(1);
+      expect(items[0]?.content).toContain('(labels: 初稿 -> 1回修正)');
+      expect(items[0]?.content).toContain('| labels: 1回修正');
+      // A pure label change is not a move.
+      expect(items[0]?.content).not.toContain('(from:');
+    });
+
+    it('member-name resolution failure degrades to raw ids, never drops the poll', async () => {
+      vi.stubGlobal(
+        'fetch',
+        routedFetch(
+          richLists('進行', [{ id: 'c1', name: 'ex_100_card', idMembers: ['m9'] }]),
+          'fail'
+        )
+      );
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      const items = await connector.poll(new Date(0));
+      expect(items).toHaveLength(1);
+      expect(items[0]?.content).toContain('assignees: m9');
+    });
+
+    it('skips the member roster call when no open card has members', async () => {
+      const mockFetch = routedFetch(richLists('進行', [{ id: 'c1', name: 'plain_card' }]), []);
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date(0));
+      expect(mockFetch.mock.calls.map((c) => String(c[0]))).toHaveLength(1);
+    });
+
+    it('legacy plain-listName state upgrades silently instead of flooding every card', async () => {
+      const fs = await import('fs');
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({ lastCardStates: { 'board-abc123': { c1: '進行' } } })
+      );
+      vi.stubGlobal(
+        'fetch',
+        routedFetch(
+          richLists('進行', [
+            {
+              id: 'c1',
+              name: 'ex_100_card',
+              idMembers: ['m1'],
+              labels: [{ name: '初稿', color: 'sky' }],
+            },
+          ]),
+          [{ id: 'm1', fullName: 'Alice Kim' }]
+        )
+      );
+      const connector = new TrelloConnector(makeConfig());
+      await connector.init();
+      // Same list + newly-visible labels/members must NOT emit (the legacy
+      // baseline has no label/member knowledge to diff against) ...
+      expect(await connector.poll(new Date(0))).toHaveLength(0);
+      // ... and the persisted state is upgraded to v2 so future label changes DO emit.
+      const written = vi
+        .mocked(fs.writeFileSync)
+        .mock.calls.map((c) => String(c[1]))
+        .find((s) => s.includes('lastCardStates'));
+      expect(written).toBeDefined();
+      expect(written).toContain('v2:');
+    });
+  });
+
   describe('healthCheck', () => {
     it('reflects lastPollTime and lastPollCount after poll', async () => {
       vi.stubGlobal(


### PR DESCRIPTION
## Summary

Owner question the agent structurally could not answer: "who owns this card and which revision round is it in?" The poller stored only card name + list moves — labels dropped entirely, members as unresolved ids. On these production boards the artist and revision round (初稿/1回修正-style) live exactly there.

- `card_fields` now includes labels; board member roster fetched lazily (only when an open card carries members) and resolved to display names, degrading to raw ids on roster failure
- content lines gain `| labels: ...` and `| assignees: ...`; a label/assignee change on an UNMOVED card now emits, with the old → new label transition inline
- per-card state upgrades from bare list names to a v2 fingerprint; legacy entries upgrade silently so the format change never floods the raw store

## Verification

- 35/35 connector tests (30 existing untouched + 5 new)
- Live one-shot poll against the real production board: 374 open cards, labels on 366, assignees on 306 — revision-round labels (初稿/2稿目/FB진행중) and artist labels visible in content lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)