### PR TITLE
chore(release): bump mama-os to v0.28.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.28.2] / mama-core [1.9.0] / mama-os [0.28.2] - 2026-07-24
+
+### Added
+
+- **Live Trello read tools** — `trello_search` and `trello_card` answer current-state card
+  questions by reading the live board at question time (current list, labels such as the
+  revision round and artist, assignee names, due, checklists), the same pattern as the
+  `kagemusha_*` truth reads. The connector change log remains the delta/trigger source and no
+  longer serves state questions — the root fix for the projection-loss bug class.
+
+### Fixed
+
+- **First-sight Trello items stamped at observation time** — a fresh install (or poll-state
+  reset) no longer emits cards with years-old activity timestamps that sink below every
+  retrieval window; the card's own activity time moves to `metadata.lastActivityAt`.
+
 ## [0.28.1] / mama-core [1.9.0] / mama-os [0.28.1] - 2026-07-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ open-source components.
 
 | Package                                          | Version | Description                                           |
 | ------------------------------------------------ | ------- | ----------------------------------------------------- |
-| [@jungjaehoon/mama-os](packages/standalone/)     | 0.28.1  | Always-on runtime, envelopes, connectors, worker APIs |
+| [@jungjaehoon/mama-os](packages/standalone/)     | 0.28.2  | Always-on runtime, envelopes, connectors, worker APIs |
 | [@jungjaehoon/mama-server](packages/mcp-server/) | 1.14.0  | MCP server for Claude Desktop/Code and any MCP client |
 | [@jungjaehoon/mama-core](packages/mama-core/)    | 1.9.0   | Core memory, provenance, raw refs, graph, embeddings  |
 | [mama plugin](packages/claude-code-plugin/)      | 1.10.0  | Claude Code plugin (marketplace)                      |

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -259,7 +259,7 @@ Each package has independent versioning:
 - **mama-core:** 1.9.0 (stable API)
 - **mama-server:** 1.14.0 (follows MAMA version)
 - **claude-code-plugin:** 1.10.0 (follows MAMA version)
-- **mama-os:** 0.28.1 (standalone agent)
+- **mama-os:** 0.28.2 (standalone agent)
 
 ## Distribution Strategy
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -11,7 +11,7 @@ MAMA is a pnpm workspace-based monorepo with four release targets (plus the inte
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.28.1  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.28.2  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.14.0  |
 | MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 1.9.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.10.0  |
@@ -61,7 +61,7 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.28.1          |
+| `packages/standalone/package.json`                       | `version` | 0.28.2          |
 | `packages/mcp-server/package.json`                       | `version` | 1.14.0          |
 | `packages/mama-core/package.json`                        | `version` | 1.9.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.10.0          |

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "description": "MAMA OS - Local AI Runtime. Your scattered knowledge, organized by AI agents that never sleep.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Release: live Trello read tools (PR #185) + first-sight timestamp fix (PR #184).

🤖 Generated with [Claude Code](https://claude.com/claude-code)