### PR TITLE
fix(standalone): trello_search falls back to board-scan substring matching (CJK)

### DIFF
--- a/packages/standalone/src/connectors/trello/query-tools.ts
+++ b/packages/standalone/src/connectors/trello/query-tools.ts
@@ -132,9 +132,88 @@ function summarize(card: RawSearchCard, boardNames: Map<string, string>): Trello
   };
 }
 
+interface BoardScanList {
+  name: string;
+  cards: Array<{
+    id: string;
+    name: string;
+    due: string | null;
+    dateLastActivity: string;
+    idMembers?: string[];
+    labels?: Array<{ name: string }>;
+  }>;
+}
+
+/** Board-scan substring match: Trello's /search tokenizes on word boundaries
+ *  and misses CJK substrings and underscore compounds (e.g. 'エルデリーゼ',
+ *  'ex_1055003'), which is most of this board vocabulary. Scanning open cards
+ *  per board and filtering locally is the reliable path (the same reason
+ *  Kagemusha's agent leans on its full-kanban scan). */
+async function scanBoardsForCards(
+  query: string,
+  limit: number,
+  auth: TrelloAuth,
+  fetchFn: typeof fetch
+): Promise<TrelloCardSummary[]> {
+  const needle = query.toLowerCase();
+  const matches: TrelloCardSummary[] = [];
+  for (const [boardId, boardName] of auth.boardNames) {
+    if (matches.length >= limit) break;
+    let lists: BoardScanList[];
+    try {
+      lists = await trelloGet<BoardScanList[]>(
+        `/boards/${boardId}/lists`,
+        { cards: 'open', card_fields: 'name,due,dateLastActivity,idMembers,labels' },
+        auth,
+        fetchFn
+      );
+    } catch {
+      continue; // a single unreadable board must not sink the whole search
+    }
+    const hits = lists.flatMap((list) =>
+      list.cards
+        .filter((card) => card.name.toLowerCase().includes(needle))
+        .map((card) => ({ list: list.name, card }))
+    );
+    if (hits.length === 0) continue;
+    // Resolve assignee names only for boards that actually matched.
+    let roster = new Map<string, string>();
+    if (hits.some((h) => (h.card.idMembers ?? []).length > 0)) {
+      try {
+        const members = await trelloGet<
+          Array<{ id: string; fullName?: string; username?: string }>
+        >(`/boards/${boardId}/members`, { fields: 'fullName,username' }, auth, fetchFn);
+        roster = new Map(
+          members.flatMap((m) =>
+            m.fullName || m.username ? [[m.id, m.fullName || m.username!]] : []
+          )
+        );
+      } catch {
+        /* degrade to raw ids */
+      }
+    }
+    for (const { list, card } of hits) {
+      if (matches.length >= limit) break;
+      matches.push({
+        cardId: card.id,
+        name: card.name,
+        board: boardName,
+        list,
+        labels: (card.labels ?? []).map((l) => l.name).filter(Boolean),
+        assignees: (card.idMembers ?? []).map((id) => roster.get(id) ?? id),
+        due: card.due,
+        lastActivity: card.dateLastActivity,
+      });
+    }
+  }
+  return matches;
+}
+
 /**
  * Search cards across the configured boards, LIVE. Returns current list,
- * labels (revision round / artist), and assignee names per card.
+ * labels (revision round / artist), and assignee names per card. Tries
+ * Trello's /search first (fast for ASCII terms), then fills up from a
+ * board scan with local substring matching (reliable for CJK names).
  */
 export async function searchTrelloCards(
   input: { query: string; limit?: number },
@@ -162,7 +241,15 @@ export async function searchTrelloCards(
     auth,
     fetchFn
   );
-  return (result.cards ?? []).map((card) => summarize(card, auth.boardNames));
+  const fromSearch = (result.cards ?? []).map((card) => summarize(card, auth.boardNames));
+  if (fromSearch.length >= limit || auth.boardNames.size === 0) {
+    return fromSearch.slice(0, limit);
+  }
+  const seen = new Set(fromSearch.map((c) => c.cardId));
+  const scanned = (await scanBoardsForCards(query, limit, auth, fetchFn)).filter(
+    (c) => !seen.has(c.cardId)
+  );
+  return [...fromSearch, ...scanned].slice(0, limit);
 }
 
 export interface TrelloCardDetail extends TrelloCardSummary {

--- a/packages/standalone/tests/connectors/trello-query-tools.test.ts
+++ b/packages/standalone/tests/connectors/trello-query-tools.test.ts
@@ -108,6 +108,59 @@ describe('searchTrelloCards', () => {
     ]);
   });
 
+  it('falls back to a board scan with local substring match when /search misses (CJK)', async () => {
+    // Trello's /search tokenizes on word boundaries and misses CJK substrings
+    // and underscore compounds - most of the production board vocabulary.
+    writeConfig();
+    const fetchFn = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.includes('/search?')) return new Response(JSON.stringify({ cards: [] }));
+      if (u.includes('/boards/b1/lists')) {
+        return new Response(
+          JSON.stringify([
+            {
+              name: '提出中',
+              cards: [
+                {
+                  id: 'c1',
+                  name: 'ex_100_エルデリーゼ(メイド)',
+                  due: null,
+                  dateLastActivity: '2026-07-24T10:00:00.000Z',
+                  idMembers: ['m1'],
+                  labels: [{ name: '初稿' }],
+                },
+                {
+                  id: 'c2',
+                  name: 'unrelated_card',
+                  due: null,
+                  dateLastActivity: '2026-07-24T10:00:00.000Z',
+                  idMembers: [],
+                  labels: [],
+                },
+              ],
+            },
+          ])
+        );
+      }
+      if (u.includes('/boards/b1/members')) {
+        return new Response(JSON.stringify([{ id: 'm1', fullName: 'Alice Kim' }]));
+      }
+      return new Response('not found', { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const cards = await searchTrelloCards({ query: 'エルデリーゼ' }, { configPath, fetchFn });
+    expect(cards).toHaveLength(1);
+    expect(cards[0]?.name).toBe('ex_100_エルデリーゼ(メイド)');
+    expect(cards[0]?.list).toBe('提出中');
+    expect(cards[0]?.labels).toEqual(['初稿']);
+    expect(cards[0]?.assignees).toEqual(['Alice Kim']);
+    // The ignore-role board (b2) is never scanned.
+    const scannedBoards = fetchFn.mock.calls
+      .map((c) => String(c[0]))
+      .filter((u) => u.includes('/boards/'));
+    expect(scannedBoards.every((u) => u.includes('/boards/b1/'))).toBe(true);
+  });
+
   it('refuses an empty query and surfaces HTTP failures loudly', async () => {
     writeConfig();
     await expect(searchTrelloCards({ query: '  ' }, { configPath })).rejects.toThrow(/non-empty/);


### PR DESCRIPTION
Live smoke test on the production boards: /search returned zero results for CJK names and underscore compounds — the entire board vocabulary. Now fills from a per-board open-card scan with local substring matching (assignee rosters resolved only for matching boards). 8/8 query-tool tests, full suite 4,588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)