### PR TITLE
chore(release): bump mama-os to v0.28.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.28.3] / mama-core [1.9.0] / mama-os [0.28.3] - 2026-07-24
+
+### Fixed
+
+- **trello_search matches CJK card names** — Trello's `/search` tokenizes on word boundaries
+  and returned nothing for CJK substrings and underscore compounds. The tool now fills its
+  results from a per-board open-card scan with local substring matching, resolving assignee
+  rosters only for boards that matched.
+
 ## [0.28.2] / mama-core [1.9.0] / mama-os [0.28.2] - 2026-07-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ open-source components.
 
 | Package                                          | Version | Description                                           |
 | ------------------------------------------------ | ------- | ----------------------------------------------------- |
-| [@jungjaehoon/mama-os](packages/standalone/)     | 0.28.2  | Always-on runtime, envelopes, connectors, worker APIs |
+| [@jungjaehoon/mama-os](packages/standalone/)     | 0.28.3  | Always-on runtime, envelopes, connectors, worker APIs |
 | [@jungjaehoon/mama-server](packages/mcp-server/) | 1.14.0  | MCP server for Claude Desktop/Code and any MCP client |
 | [@jungjaehoon/mama-core](packages/mama-core/)    | 1.9.0   | Core memory, provenance, raw refs, graph, embeddings  |
 | [mama plugin](packages/claude-code-plugin/)      | 1.10.0  | Claude Code plugin (marketplace)                      |

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -259,7 +259,7 @@ Each package has independent versioning:
 - **mama-core:** 1.9.0 (stable API)
 - **mama-server:** 1.14.0 (follows MAMA version)
 - **claude-code-plugin:** 1.10.0 (follows MAMA version)
-- **mama-os:** 0.28.2 (standalone agent)
+- **mama-os:** 0.28.3 (standalone agent)
 
 ## Distribution Strategy
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -11,7 +11,7 @@ MAMA is a pnpm workspace-based monorepo with four release targets (plus the inte
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.28.2  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.28.3  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.14.0  |
 | MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 1.9.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.10.0  |
@@ -61,7 +61,7 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.28.2          |
+| `packages/standalone/package.json`                       | `version` | 0.28.3          |
 | `packages/mcp-server/package.json`                       | `version` | 1.14.0          |
 | `packages/mama-core/package.json`                        | `version` | 1.9.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.10.0          |

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "description": "MAMA OS - Local AI Runtime. Your scattered knowledge, organized by AI agents that never sleep.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Hotfix: trello_search CJK board-scan fallback (PR #187).

🤖 Generated with [Claude Code](https://claude.com/claude-code)