### PR TITLE
chore(release): bump mama-os to v0.28.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.28.4] / mama-core [1.9.0] / mama-os [0.28.4] - 2026-07-24
+
+### Added
+
+- **`trello_kanban` bulk snapshot** — one live call returns every open card grouped by
+  board+list with labels and assignee names, the right tool for whole-project reports
+  (replaces a per-card search fan-out).
+
+### Fixed
+
+- **Trello read latency** — boards are fetched in parallel into a 45-second in-process
+  snapshot; repeated `trello_search` calls within a report turn reuse one snapshot instead of
+  re-scanning every board serially (~2m40s of Trello time in a report turn drops to ~2s).
+
 ## [0.28.3] / mama-core [1.9.0] / mama-os [0.28.3] - 2026-07-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ open-source components.
 
 | Package                                          | Version | Description                                           |
 | ------------------------------------------------ | ------- | ----------------------------------------------------- |
-| [@jungjaehoon/mama-os](packages/standalone/)     | 0.28.3  | Always-on runtime, envelopes, connectors, worker APIs |
+| [@jungjaehoon/mama-os](packages/standalone/)     | 0.28.4  | Always-on runtime, envelopes, connectors, worker APIs |
 | [@jungjaehoon/mama-server](packages/mcp-server/) | 1.14.0  | MCP server for Claude Desktop/Code and any MCP client |
 | [@jungjaehoon/mama-core](packages/mama-core/)    | 1.9.0   | Core memory, provenance, raw refs, graph, embeddings  |
 | [mama plugin](packages/claude-code-plugin/)      | 1.10.0  | Claude Code plugin (marketplace)                      |

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -259,7 +259,7 @@ Each package has independent versioning:
 - **mama-core:** 1.9.0 (stable API)
 - **mama-server:** 1.14.0 (follows MAMA version)
 - **claude-code-plugin:** 1.10.0 (follows MAMA version)
-- **mama-os:** 0.28.3 (standalone agent)
+- **mama-os:** 0.28.4 (standalone agent)
 
 ## Distribution Strategy
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -11,7 +11,7 @@ MAMA is a pnpm workspace-based monorepo with four release targets (plus the inte
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.28.3  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.28.4  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.14.0  |
 | MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 1.9.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.10.0  |
@@ -61,7 +61,7 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.28.3          |
+| `packages/standalone/package.json`                       | `version` | 0.28.4          |
 | `packages/mcp-server/package.json`                       | `version` | 1.14.0          |
 | `packages/mama-core/package.json`                        | `version` | 1.9.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.10.0          |

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "description": "MAMA OS - Local AI Runtime. Your scattered knowledge, organized by AI agents that never sleep.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Release: trello_kanban bulk snapshot + parallel cached board reads (PR #189).

🤖 Generated with [Claude Code](https://claude.com/claude-code)