### PR TITLE
feat(standalone): default role models to claude-sonnet-5

### DIFF
--- a/packages/standalone/src/cli/config/types.ts
+++ b/packages/standalone/src/cli/config/types.ts
@@ -88,7 +88,7 @@ export interface RolesConfig {
 export const DEFAULT_ROLES: RolesConfig = {
   definitions: {
     os_agent: {
-      model: 'claude-sonnet-4-6', // Full-featured model for OS control
+      model: 'claude-sonnet-5', // Full-featured model for OS control
       maxTurns: 20,
       allowedTools: ['*'],
       allowedPaths: ['~/**'],
@@ -96,7 +96,7 @@ export const DEFAULT_ROLES: RolesConfig = {
       sensitiveAccess: true,
     },
     chat_bot: {
-      model: 'claude-sonnet-4-6', // Balanced model for chat
+      model: 'claude-sonnet-5', // Balanced model for chat
       maxTurns: 10,
       allowedTools: [
         'mama_search',
@@ -116,7 +116,7 @@ export const DEFAULT_ROLES: RolesConfig = {
     // chat). Read/query surface is wide and Drive mutations are constrained to
     // the private workspace; Bash/Write, system control, and delegation stay blocked.
     owner_console: {
-      model: 'claude-sonnet-4-6',
+      model: 'claude-sonnet-5',
       maxTurns: 10,
       allowedTools: [
         'mama_search',
@@ -718,7 +718,7 @@ export const DEFAULT_CONFIG: MAMAConfig = {
   version: 1,
   agent: {
     backend: 'claude',
-    model: 'claude-sonnet-4-6',
+    model: 'claude-sonnet-5',
     max_turns: 10,
     timeout: 300000, // 5 minutes
     tools: {


### PR DESCRIPTION
Built-in role defaults move to claude-sonnet-5 (quality-parity finding: the reference operator's reports run sonnet-5; MAMA ran gpt-5.4). Full suite 4,590.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the default AI model to Claude Sonnet 5 for agents, chat bots, and owner console roles.
  * New default configurations will use Claude Sonnet 5 automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->