### PR TITLE
fix(standalone): recover report body from history when the final segment is empty

### DIFF
--- a/packages/standalone/src/operator/report-run.ts
+++ b/packages/standalone/src/operator/report-run.ts
@@ -230,9 +230,48 @@ export function createPersonaReportAsk<E = unknown>(deps: PersonaReportAskDeps<E
     for (const line of formatReportToolAudit(summarizeReportToolUse(history), isFull)) {
       deps.log(line);
     }
-    if (!response || response.trim() === '') {
+    let reportText = (response ?? '').trim();
+    if (reportText === '') {
+      // Text-gateway multi-turn runs return only the LAST assistant segment
+      // (agent-loop extractTextResponse), and after a closing tool round that
+      // segment is often empty - the composed report body lives in an EARLIER
+      // assistant turn (live incident 2026-07-27: gather+save succeeded, the
+      // cadence then died on 'empty report response'). Recover the last
+      // non-empty assistant text from history (its text blocks are already
+      // stripped of tool_call JSON by the gateway parser) and stay loud.
+      reportText = lastAssistantText(history);
+      if (reportText !== '') {
+        deps.log('[trigger-loop] report body recovered from an earlier assistant turn');
+      }
+    }
+    if (reportText === '') {
       throw new Error('persona agent returned an empty report response');
     }
-    return response;
+    return reportText;
   };
+}
+
+/** Last non-empty assistant TEXT across the run history (structural walk; text
+ *  blocks on the gateway path carry prose only - tool_call JSON is parsed out
+ *  before history assembly, agent-loop.ts removeToolCallBlocks). */
+export function lastAssistantText(history: ReadonlyArray<ReportHistoryMessage>): string {
+  for (let i = history.length - 1; i >= 0; i--) {
+    const message = history[i];
+    if (!message || message.role !== 'assistant') continue;
+    const { content } = message;
+    let text = '';
+    if (typeof content === 'string') {
+      text = content;
+    } else if (Array.isArray(content)) {
+      text = content
+        .map((block) => {
+          const b = block as { type?: unknown; text?: unknown };
+          return b?.type === 'text' && typeof b.text === 'string' ? b.text : '';
+        })
+        .filter((part) => part !== '')
+        .join('\n');
+    }
+    if (text.trim() !== '') return text.trim();
+  }
+  return '';
 }

--- a/packages/standalone/tests/operator/report-run.test.ts
+++ b/packages/standalone/tests/operator/report-run.test.ts
@@ -145,6 +145,26 @@ describe('createPersonaReportAsk (M3-T4)', () => {
     expect(logs.join('\n')).toMatch(/NO gateway gather tools/);
   });
 
+  it('empty FINAL segment recovers the report body from an earlier assistant turn', async () => {
+    // Live incident 2026-07-27: on the claude text-gateway path the loop
+    // returns only the LAST assistant segment; after a closing tool round it
+    // was empty, killing the cadence although the composed report existed in
+    // an earlier turn.
+    const logs: string[] = [];
+    const run = async () => ({
+      response: '',
+      history: [
+        { role: 'assistant', content: [{ type: 'text', text: '1) key situation: quiet day' }] },
+        ...exchange('mama_save'),
+        { role: 'assistant', content: [{ type: 'tool_use', id: 'tu_x', name: 'noop', input: {} }] },
+      ],
+    });
+    const ask = createPersonaReportAsk({ run, log: (l) => logs.push(l), fullReportTag: TAG });
+    const out = await ask(`${TAG}\nwrite`);
+    expect(out).toBe('1) key situation: quiet day');
+    expect(logs.join('\n')).toMatch(/recovered from an earlier assistant turn/);
+  });
+
   it('a digest prompt (no tag) does not warn about missing gather tools', async () => {
     const logs: string[] = [];
     const run = async () => ({ response: 'digest', history: [] });


### PR DESCRIPTION
Scheduled full reports on the claude text-gateway path gathered fine, then died on 'empty report response': the loop returns only the last assistant segment, which is empty after a closing tool round. Recover the body from the last non-empty assistant turn (loud log); the empty-throw remains when no prose exists anywhere. Repro pinned in tests (23/23; full suite 4,591).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report generation when the final response is empty by recovering the latest available assistant text from the conversation history.
  * Added clearer error handling when no report content can be recovered.

* **Tests**
  * Added coverage for recovering report content after an empty final response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->