### PR TITLE
fix(standalone): reset the CLI session on a corrupt-transcript API 400

### DIFF
--- a/packages/standalone/src/agent/agent-loop.ts
+++ b/packages/standalone/src/agent/agent-loop.ts
@@ -1707,10 +1707,19 @@ export class AgentLoop {
           const isCodexPolicyMismatch = errorMessage.includes(
             'Codex app-server thread policy mismatch; reset the session explicitly'
           );
+          // 4. API 400 on a resumed session whose stored transcript carries an
+          //    empty content block (live incident 2026-07-27: sonnet emitted an
+          //    empty thinking block, the CLI persisted it, and every subsequent
+          //    replay of that session died with this 400). The transcript is
+          //    unrecoverable - only a fresh session heals it.
+          const isCorruptTranscript = errorMessage.includes(
+            'text content blocks must be non-empty'
+          );
 
           if (
             (isCodex && isCodexPolicyMismatch) ||
-            (!isCodex && (isSessionNotFound || isSessionInUse || isPromptTooLong))
+            (!isCodex &&
+              (isSessionNotFound || isSessionInUse || isPromptTooLong || isCorruptTranscript))
           ) {
             const reason = isCodexPolicyMismatch
               ? 'policy mismatch'
@@ -1718,7 +1727,9 @@ export class AgentLoop {
                 ? 'not found in CLI'
                 : isSessionInUse
                   ? 'already in use'
-                  : 'prompt too long (context overflow)';
+                  : isCorruptTranscript
+                    ? 'transcript corrupt (empty content block)'
+                    : 'prompt too long (context overflow)';
             console.log(`[AgentLoop] Session ${reason}, retrying with new session`);
 
             // Reset session in pool so it creates a new one

--- a/packages/standalone/tests/agent/session-reset-classes.test.ts
+++ b/packages/standalone/tests/agent/session-reset-classes.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Source-guard: the self-healing session-reset allowlist keeps its error
+ * classes. Each class is a live-incident scar; losing one silently turns a
+ * recoverable failure back into a permanently broken chat session.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('session reset error classes (self-healing allowlist)', () => {
+  const source = readFileSync(join(__dirname, '../../src/agent/agent-loop.ts'), 'utf-8');
+
+  it('keeps every recoverable class, including the corrupt-transcript API 400', () => {
+    // 2026-07-27: sonnet emitted an empty thinking block, the claude CLI
+    // persisted it, and every replay of that session died with this API 400 -
+    // the owner chat was bricked until a manual daemon restart. A fresh
+    // session is the only cure, so the class must stay reset-eligible.
+    expect(source).toContain("'text content blocks must be non-empty'");
+    expect(source).toContain('No conversation found with session ID');
+    expect(source).toContain('is already in use');
+    expect(source).toContain('context_length_exceeded');
+    expect(source).toMatch(/isCorruptTranscript/);
+    // The class participates in the claude-side reset condition.
+    expect(source).toMatch(
+      /isSessionNotFound \|\| isSessionInUse \|\| isPromptTooLong \|\| isCorruptTranscript/
+    );
+  });
+});


### PR DESCRIPTION
An empty thinking block persisted by the CLI bricked the owner chat session (every message → API 400 'text content blocks must be non-empty' in ~500ms) until a manual restart. The error class joins the claude-side session-reset allowlist — same self-healing retry as not-found/in-use/context-overflow. Source-guard pins all classes. Full suite 4,591.

🤖 Generated with [Claude Code](https://claude.com/claude-code)