### PR TITLE
fix(standalone): carry the author into report window excerpts

### DIFF
--- a/packages/standalone/src/operator/situation-report.ts
+++ b/packages/standalone/src/operator/situation-report.ts
@@ -150,8 +150,15 @@ export class SituationReporter {
       }
       const w = this.windowByChannel.get(e.channelId) ?? { count: 0, excerpts: [] };
       w.count += 1;
-      const text = e.content.trim();
-      if (text) {
+      const body = e.content.trim();
+      if (body) {
+        // Carry the author INTO the excerpt: the report prompt's attribution
+        // discipline can only quote senders it can see, and windows without
+        // authors produced owner-facing reports full of "(sender unclear)"
+        // (live complaint 2026-07-27). userId carries the resolved display
+        // name for connector-indexed events.
+        const author = (e.userId ?? '').trim();
+        const text = author && author !== 'unknown' ? `${author}: ${body}` : body;
         w.excerpts.push(text.slice(0, MAX_EXCERPT_CHARS));
         if (w.excerpts.length > MAX_EXCERPTS_PER_CHANNEL) {
           w.excerpts.shift();

--- a/packages/standalone/tests/operator/situation-report.test.ts
+++ b/packages/standalone/tests/operator/situation-report.test.ts
@@ -150,6 +150,9 @@ describe('SituationReporter (M2, supersedes TriggerReporter M1.5)', () => {
     expect(prompt).toContain('slack:a: 2 msg');
     expect(prompt).toContain('deploy is failing again');
     expect(prompt).toContain('slack:b: 1 msg');
+    // Live complaint 2026-07-27: excerpts without authors made every quoted
+    // line "(sender unclear)" in owner reports. The author rides the excerpt.
+    expect(prompt).toContain('u1: deploy is failing again');
   });
 
   it('window excerpts are bounded: only the last K per channel, each truncated', async () => {


### PR DESCRIPTION
Reports quoted every line as '(sender unclear)': window excerpts dropped the event author, so the prompt's attribution discipline had nothing to cite. The author now rides each excerpt. Tests updated; full suite 4,590.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recent situation report excerpts now include the event author when available, making activity summaries easier to understand and attribute.

* **Bug Fixes**
  * Improved excerpt attribution when summarizing recent channel activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->