### PR TITLE
chore(release): bump mama-os to v0.28.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.28.6] / mama-core [1.9.0] / mama-os [0.28.6] - 2026-07-27
+
+### Fixed — claude-backend chat and report resilience
+
+- **Corrupt-transcript self-heal** — a session whose stored transcript carries an empty content
+  block (e.g. an empty thinking block persisted by the CLI) bricked the chat with API 400 on
+  every subsequent message; the error now joins the session-reset allowlist and retries on a
+  fresh session automatically.
+- **Report body recovery** — scheduled full reports on the text-gateway path no longer die on
+  "empty report response" when the composed body lives in an earlier assistant turn; it is
+  recovered from history with a loud log.
+- **Report excerpts carry authors** — owner reports quoted channel lines as "(sender unclear)"
+  because window excerpts dropped the event author; the author now rides each excerpt.
+- **Outer Code-Act defaults on only for the codex backend** — the claude main chat is
+  persona-locked with no Code-Act transport; its instructions pointed at a tool that cannot
+  exist there. Explicit per-agent `useCodeAct` config still wins.
+
 ## [0.28.5] / mama-core [1.9.0] / mama-os [0.28.5] - 2026-07-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ open-source components.
 
 | Package                                          | Version | Description                                           |
 | ------------------------------------------------ | ------- | ----------------------------------------------------- |
-| [@jungjaehoon/mama-os](packages/standalone/)     | 0.28.5  | Always-on runtime, envelopes, connectors, worker APIs |
+| [@jungjaehoon/mama-os](packages/standalone/)     | 0.28.6  | Always-on runtime, envelopes, connectors, worker APIs |
 | [@jungjaehoon/mama-server](packages/mcp-server/) | 1.14.0  | MCP server for Claude Desktop/Code and any MCP client |
 | [@jungjaehoon/mama-core](packages/mama-core/)    | 1.9.0   | Core memory, provenance, raw refs, graph, embeddings  |
 | [mama plugin](packages/claude-code-plugin/)      | 1.10.0  | Claude Code plugin (marketplace)                      |

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -259,7 +259,7 @@ Each package has independent versioning:
 - **mama-core:** 1.9.0 (stable API)
 - **mama-server:** 1.14.0 (follows MAMA version)
 - **claude-code-plugin:** 1.10.0 (follows MAMA version)
-- **mama-os:** 0.28.5 (standalone agent)
+- **mama-os:** 0.28.6 (standalone agent)
 
 ## Distribution Strategy
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -11,7 +11,7 @@ MAMA is a pnpm workspace-based monorepo with four release targets (plus the inte
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.28.5  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.28.6  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.14.0  |
 | MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 1.9.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.10.0  |
@@ -61,7 +61,7 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.28.5          |
+| `packages/standalone/package.json`                       | `version` | 0.28.6          |
 | `packages/mcp-server/package.json`                       | `version` | 1.14.0          |
 | `packages/mama-core/package.json`                        | `version` | 1.9.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.10.0          |

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "description": "MAMA OS - Local AI Runtime. Your scattered knowledge, organized by AI agents that never sleep.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Claude-backend resilience train: corrupt-transcript self-heal (#195), report body recovery (#194), report excerpt authors (#196), backend-aware Code-Act default (#193).

🤖 Generated with [Claude Code](https://claude.com/claude-code)