### PR TITLE
Give the trigger author a bound and a voice

### DIFF
--- a/packages/standalone/src/operator/trigger-author.ts
+++ b/packages/standalone/src/operator/trigger-author.ts
@@ -373,11 +373,15 @@ export function describeCliFailure(file: string, error: unknown): string {
   if (e.killed === true || e.signal) {
     parts.push(`killed (signal=${String(e.signal ?? 'unknown')}) - likely the timeout`);
   }
-  if (e.code !== undefined && e.code !== null) parts.push(`exit=${String(e.code)}`);
+  if (e.code !== undefined && e.code !== null) {
+    parts.push(`exit=${String(e.code)}`);
+  }
 
   const tail = (value: unknown, label: string): void => {
     const text = typeof value === 'string' ? value.trim() : '';
-    if (text) parts.push(`${label}=${text.slice(-400)}`);
+    if (text) {
+      parts.push(`${label}=${text.slice(-400)}`);
+    }
   };
   tail(e.stderr, 'stderr');
   // The CLI reports API errors on stdout, so an empty stderr is not an absent cause.

--- a/packages/standalone/src/operator/trigger-author.ts
+++ b/packages/standalone/src/operator/trigger-author.ts
@@ -113,6 +113,28 @@ export async function authorTriggers(
   return created;
 }
 
+/**
+ * How much of a trigger's memoryQuery the author pass needs to see.
+ *
+ * The list exists for ONE job, stated in the prompt itself: do not propose a variant of a
+ * trigger that already exists. Keywords decide that; the full recall instruction does not.
+ *
+ * Measured on the live registry 2026-07-30: 162 active triggers, memoryQuery averaging 1,261
+ * characters, 204 KB of the 240 KB prompt - and growing with every trigger the pass authors,
+ * which is a loop that feeds itself. One call cost $1.33 at 126,667 cache-creation tokens and
+ * took 41 seconds, every 30 minutes.
+ */
+const EXISTING_TRIGGER_QUERY_CHARS = 160;
+
+function summarizeExistingTrigger(t: TriggerRecord): string {
+  const query = t.memoryQuery ?? '';
+  const gist =
+    query.length > EXISTING_TRIGGER_QUERY_CHARS
+      ? `${query.slice(0, EXISTING_TRIGGER_QUERY_CHARS).trimEnd()}...`
+      : query;
+  return `- ${t.id}: keywords=[${t.match.keywords.join(', ')}] gist="${gist}"`;
+}
+
 export function buildAuthorPrompt(
   events: OperatorChannelEvent[],
   existing: TriggerRecord[]
@@ -120,14 +142,7 @@ export function buildAuthorPrompt(
   // English default. Personal phrasing overrides load from ~/.mama/operator/*.json (later refinement).
   const window = events.map((e) => `- [${e.channelId}] ${e.content}`).join('\n');
   const existingList =
-    existing.length === 0
-      ? '(none yet)'
-      : existing
-          .map(
-            (t) =>
-              `- ${t.id}: keywords=[${t.match.keywords.join(', ')}] memoryQuery="${t.memoryQuery}"`
-          )
-          .join('\n');
+    existing.length === 0 ? '(none yet)' : existing.map(summarizeExistingTrigger).join('\n');
   return [
     "You maintain a personal operator's library of TRIGGERS. A trigger fires on future messages",
     'that match its keywords and then recalls a memory to help the operator intervene proactively.',
@@ -305,13 +320,74 @@ export function createTriggerAgentRuntime(
   };
 }
 
+/**
+ * A run that outlives this has stopped being a 30-minute background pass.
+ *
+ * Measured: a healthy call takes ~41s. Without a bound, a hung CLI holds the tick open
+ * forever, and the report leg runs AFTER the author pass in the same tick.
+ */
+const CLAUDE_CLI_TIMEOUT_MS = 240_000;
+
+/**
+ * Run the CLI and, when it fails, say WHY.
+ *
+ * The previous version destructured `{ stdout }` and let everything else go. Node puts the
+ * cause on the rejection - `stderr`, `code`, `signal` - and none of it was read, so 193
+ * failures over the log's lifetime recorded nothing but the 240 KB command line that
+ * produced them. The tick that dies here takes the scheduled report with it (author runs at
+ * step 3, the report at step 5), so an undiagnosable failure here is a silently missing
+ * owner report.
+ */
 async function executeClaudeCLI(
   file: string,
   args: string[],
   options: { maxBuffer: number }
 ): Promise<{ stdout: string }> {
-  const { stdout } = await execFileAsync(file, args, options);
-  return { stdout: String(stdout) };
+  try {
+    const { stdout } = await execFileAsync(file, args, {
+      ...options,
+      timeout: CLAUDE_CLI_TIMEOUT_MS,
+    });
+    return { stdout: String(stdout) };
+  } catch (error) {
+    throw new Error(describeCliFailure(file, error));
+  }
+}
+
+/**
+ * One line naming the failure, with the command line left OUT.
+ *
+ * Node's own message embeds the whole argv, which here is the 240 KB prompt - that is what
+ * made every past failure unreadable in the log without telling anyone anything.
+ */
+export function describeCliFailure(file: string, error: unknown): string {
+  const e = (error ?? {}) as {
+    code?: unknown;
+    signal?: unknown;
+    killed?: boolean;
+    stderr?: unknown;
+    stdout?: unknown;
+    message?: unknown;
+  };
+  const parts: string[] = [`${file} failed`];
+  if (e.killed === true || e.signal) {
+    parts.push(`killed (signal=${String(e.signal ?? 'unknown')}) - likely the timeout`);
+  }
+  if (e.code !== undefined && e.code !== null) parts.push(`exit=${String(e.code)}`);
+
+  const tail = (value: unknown, label: string): void => {
+    const text = typeof value === 'string' ? value.trim() : '';
+    if (text) parts.push(`${label}=${text.slice(-400)}`);
+  };
+  tail(e.stderr, 'stderr');
+  // The CLI reports API errors on stdout, so an empty stderr is not an absent cause.
+  tail(e.stdout, 'stdout');
+
+  if (parts.length === 1 && typeof e.message === 'string') {
+    // Last resort. Strip the embedded argv so the log stays readable.
+    parts.push(e.message.split('\n')[0].slice(0, 300));
+  }
+  return parts.join(' | ');
 }
 
 // ---- helpers ----

--- a/packages/standalone/tests/operator/trigger-author.test.ts
+++ b/packages/standalone/tests/operator/trigger-author.test.ts
@@ -12,6 +12,7 @@ import {
   authorTriggers,
   createAskAgentCLI,
   createTriggerAgentRuntime,
+  describeCliFailure,
   parseTriggerSpecs,
   validateTriggerSpec,
 } from '../../src/operator/trigger-author.js';
@@ -141,6 +142,78 @@ describe('authorTriggers', () => {
     const prompt = buildAuthorPrompt([ev('x')], reg.listActive());
     expect(prompt).toContain('partial keyword overlap');
     expect(prompt).toContain('proposing NOTHING over proposing a variant');
+  });
+
+  // The list's job is dedup, and keywords decide that. Carrying the full recall instruction
+  // for every trigger made the prompt grow with every trigger the pass authored - a loop
+  // feeding itself. Measured live 2026-07-30: 162 active triggers, memoryQuery averaging
+  // 1,261 chars, 231 KB of prompt, $1.33 and 41s per call, every 30 minutes.
+  it('carries every existing trigger by keywords, and its recall query only as a gist', async () => {
+    const { buildAuthorPrompt } = await import('../../src/operator/trigger-author.js');
+    const long = 'x'.repeat(4000);
+    reg.create({
+      id: 'gist-probe',
+      kind: 'k',
+      memoryQuery: long,
+      match: { keywords: ['unmistakable-keyword'], keywordMode: 'any', minConfidence: 0.5 },
+      procedure: [{ action: 'a', description: 'd' }],
+      requiredEvidence: [],
+      authoredBy: 'agent',
+      provenance: { createdFrom: 'seed', note: '' },
+    });
+
+    const prompt = buildAuthorPrompt([ev('x')], reg.listActive());
+
+    // Dedup still possible: the keyword is intact.
+    expect(prompt).toContain('unmistakable-keyword');
+    // The instruction body is not.
+    expect(prompt).not.toContain(long);
+    expect(prompt).toContain('...');
+    // And the gist is bounded, not merely shorter.
+    const gist = /gist="([^"]*)"/.exec(prompt)?.[1] ?? '';
+    expect(gist.length).toBeLessThanOrEqual(200);
+  });
+
+  // 193 failures over the log's lifetime recorded nothing but the 240 KB command line that
+  // produced them, because the executor destructured `{ stdout }` and Node's own message
+  // embeds the whole argv. The tick that dies here takes the scheduled report with it.
+  describe('describeCliFailure', () => {
+    it('names a timeout kill rather than reporting a bare failure', () => {
+      const note = describeCliFailure('claude', {
+        killed: true,
+        signal: 'SIGTERM',
+        code: null,
+        stderr: '',
+        stdout: '',
+      });
+      expect(note).toContain('killed');
+      expect(note).toContain('SIGTERM');
+      expect(note).toContain('timeout');
+    });
+
+    it('reports the exit code and the tail of stderr', () => {
+      const note = describeCliFailure('claude', { code: 1, stderr: 'Error: overloaded_error' });
+      expect(note).toContain('exit=1');
+      expect(note).toContain('overloaded_error');
+    });
+
+    // The CLI puts API errors on stdout, so an empty stderr is not an absent cause.
+    it('falls back to stdout when stderr is empty', () => {
+      const note = describeCliFailure('claude', {
+        code: 1,
+        stderr: '',
+        stdout: '{"is_error":true,"result":"rate limit"}',
+      });
+      expect(note).toContain('rate limit');
+    });
+
+    // Never the argv: that is what made the log unreadable and told nobody anything.
+    it('leaves the command line out no matter how large it was', () => {
+      const argv = 'x'.repeat(240_000);
+      const note = describeCliFailure('claude', { message: `Command failed: claude -p ${argv}` });
+      expect(note.length).toBeLessThan(600);
+      expect(note).not.toContain('x'.repeat(400));
+    });
   });
 
   it('parseTriggerSpecs extracts the JSON array even with surrounding prose', () => {


### PR DESCRIPTION
Item 1 of the post-0.29.0 list: the trigger loop dies in its author pass, and the report leg runs *after* it in the same tick — so an undiagnosable failure here is a silently missing owner report.

**It could not say why it failed.** 193 failures across the log recorded nothing but the 240 KB command line that produced them. The executor destructured `{ stdout }` and dropped Node's `stderr`, `code` and `signal`; Node's own message embeds the whole argv. Reproducing the exact failing prompt by hand **succeeded** — 41s, exit 0 — so the cause is intermittent and was never captured.

Now captured: exit code, the tail of stderr *and* of stdout (the CLI reports API errors on stdout, so an empty stderr is not an absent cause), and whether the process was killed. The argv stays out. Plus a 240s timeout where there was none.

**It fed itself.** The prompt embedded every active trigger's full `memoryQuery` so the model could avoid proposing variants — but that job is decided by keywords, not by the recall instruction. Measured live: 162 active triggers, memoryQuery averaging 1,261 chars, **231 KB** of prompt at **$1.33** and 126,667 cache-creation tokens per call, every 30 minutes, growing with every trigger the pass authors.

Existing triggers now carry keywords in full and their query as a 160-char gist. **231 KB → 57 KB, 75% smaller**, dedup unaffected.

Whether size was ever the failure cause is still unknown — that is what the diagnostics are for.

3,960 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeHgDc9QpXZH9x7hcc1Fq1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced the size of trigger authoring prompts while preserving key information, improving responsiveness and efficiency for large trigger sets.

* **Bug Fixes**
  * Added clearer, concise diagnostics for command failures, including timeout, signal, exit-code, and output details.
  * Prevented oversized command arguments from appearing in failure messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->