### PR TITLE
chore(release): mama-os v0.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## mama-os [0.29.1] - 2026-07-30
+
+### Fixed
+
+- **The trigger author could not say why it failed.** 193 failures across the log recorded
+  nothing but the 240 KB command line that produced them: the executor destructured
+  `{ stdout }` and dropped Node's `stderr`, `code` and `signal`, while Node's own message
+  embeds the whole argv. Reproducing the exact failing prompt by hand succeeded on the first
+  try, so the cause is intermittent and was never captured. Now captured: exit code, the tail
+  of stderr AND of stdout (the CLI reports API errors on stdout, so an empty stderr is not an
+  absent cause), and whether the process was killed. The argv stays out.
+- **No timeout on that call, where a healthy one takes ~41s.** The author pass is step 3 of a
+  tick and the scheduled report is step 5, so a hung call there does not merely lose
+  authoring - it silently drops that tick's owner report. Bounded at 240s.
+
+### Changed
+
+- **The author prompt no longer feeds itself.** It embedded every active trigger's full
+  `memoryQuery` so the model could avoid proposing variants, but that job is decided by
+  keywords. Measured live: 162 active triggers, memoryQuery averaging 1,261 characters,
+  231 KB of prompt at $1.33 and 126,667 cache-creation tokens per call, every 30 minutes -
+  and growing with every trigger the pass authored. Existing triggers now carry keywords in
+  full and their query as a 160-character gist: **231 KB -> 57 KB**, dedup unaffected.
+
 ## mama-os [0.29.0] / mama-core [2.0.0] / mcp-server [1.15.0] / plugin [1.11.0] - 2026-07-29
 
 The release is one idea in two halves: **a run must be able to name what caused its durable

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ open-source components.
 
 | Package                                          | Version | Description                                           |
 | ------------------------------------------------ | ------- | ----------------------------------------------------- |
-| [@jungjaehoon/mama-os](packages/standalone/)     | 0.29.0  | Always-on runtime, envelopes, connectors, worker APIs |
+| [@jungjaehoon/mama-os](packages/standalone/)     | 0.29.1  | Always-on runtime, envelopes, connectors, worker APIs |
 | [@jungjaehoon/mama-server](packages/mcp-server/) | 1.15.0  | MCP server for Claude Desktop/Code and any MCP client |
 | [@jungjaehoon/mama-core](packages/mama-core/)    | 2.0.0   | Core memory, provenance, raw refs, graph, embeddings  |
 | [mama plugin](packages/claude-code-plugin/)      | 1.11.0  | Claude Code plugin (marketplace)                      |

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -259,7 +259,7 @@ Each package has independent versioning:
 - **mama-core:** 2.0.0 (stable API)
 - **mama-server:** 1.15.0 (follows MAMA version)
 - **claude-code-plugin:** 1.11.0 (follows MAMA version)
-- **mama-os:** 0.29.0 (standalone agent)
+- **mama-os:** 0.29.1 (standalone agent)
 
 ## Distribution Strategy
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -11,7 +11,7 @@ MAMA is a pnpm workspace-based monorepo with four release targets (plus the inte
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.29.0  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.29.1  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.15.0  |
 | MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 2.0.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.11.0  |
@@ -61,7 +61,7 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.29.0          |
+| `packages/standalone/package.json`                       | `version` | 0.29.1          |
 | `packages/mcp-server/package.json`                       | `version` | 1.15.0          |
 | `packages/mama-core/package.json`                        | `version` | 2.0.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.11.0          |

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "MAMA OS - Local AI Runtime. Your scattered knowledge, organized by AI agents that never sleep.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Patch release for the trigger-author fix merged in #201.

Cutting it now rather than batching, because the fix is only useful once it runs: the failure recurred on the live daemon at 01:53 with a 238 KB prompt and, exactly as before, the log recorded nothing but the command line.

- diagnostics: exit code, stderr *and* stdout tails, kill/signal — argv excluded
- a 240s timeout where there was none (healthy call ~41s; a hang here drops that tick's owner report)
- prompt 231 KB → 57 KB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeHgDc9QpXZH9x7hcc1Fq1