### PR TITLE
Let a chat turn name the message that caused it

### DIFF
--- a/packages/standalone/src/gateways/message-router.ts
+++ b/packages/standalone/src/gateways/message-router.ts
@@ -83,9 +83,17 @@ export function causeFromOwnerMessage(
   sourceTurnId: string,
   sourceMessageRef: string
 ): { causeEventIds: readonly string[] } | null {
-  if (!sourceTurnId || sourceTurnId.startsWith('generated:')) return null;
+  // Trimmed first. A whitespace-only turn id is truthy and does not start with `generated:`,
+  // and the router prefixes source and channel onto it - so `'   '` produced
+  // `telegram:C1:   `, a non-empty ref naming no message at all. Found in review.
+  const turnId = sourceTurnId.trim();
+  if (!turnId || turnId.startsWith('generated:')) {
+    return null;
+  }
   const ref = sourceMessageRef.trim();
-  if (!ref) return null;
+  if (!ref) {
+    return null;
+  }
   return { causeEventIds: [ref] };
 }
 

--- a/packages/standalone/src/gateways/message-router.ts
+++ b/packages/standalone/src/gateways/message-router.ts
@@ -69,6 +69,26 @@ const { DebugLogger } = debugLogger as {
 };
 const logger = new DebugLogger('MessageRouter');
 
+/**
+ * The owner's message, as the cause of whatever the turn it started changes.
+ *
+ * Returns the run option to spread, or null when there is nothing honest to cite.
+ *
+ * `sourceTurnId` is the platform's own message id when it gave one, and
+ * `generated:<uuid>` when it did not. A generated id names nothing any reader could
+ * resolve, and the effect ledger's whole point is that a cited cause be resolvable - so an
+ * unattributed change is the correct answer there, not a synthetic citation.
+ */
+export function causeFromOwnerMessage(
+  sourceTurnId: string,
+  sourceMessageRef: string
+): { causeEventIds: readonly string[] } | null {
+  if (!sourceTurnId || sourceTurnId.startsWith('generated:')) return null;
+  const ref = sourceMessageRef.trim();
+  if (!ref) return null;
+  return { causeEventIds: [ref] };
+}
+
 export function protectImageAnalysis(message: NormalizedMessage, analysisText: string): string {
   return message.metadata?.untrustedWrapped
     ? wrapUntrustedContent('telegram-forward-image', analysisText)
@@ -1064,6 +1084,17 @@ This protects your credentials from being exposed in chat logs.`;
           envelope,
           sourceTurnId,
           sourceMessageRef,
+          // The owner's message is what caused whatever this turn changes, and the router
+          // knows it BEFORE the agent runs - the same shape as a reconcile work order
+          // carrying its delta batch. Without this the chat lane had no cause wire at all:
+          // measured on the live ledger, every unattributed task_update came from the
+          // conductor, and conductor runs outnumber board-worker runs 1,611 to 45.
+          //
+          // Only when the ref rests on a real platform message id. `sourceTurnId` falls back
+          // to `generated:<uuid>` when the platform gave none, and a synthetic id names
+          // nothing a reader could ever resolve - which is the definition of a fabricated
+          // citation this ledger exists to refuse.
+          ...(causeFromOwnerMessage(sourceTurnId, sourceMessageRef) ?? {}),
         };
         if (this.config.backend === 'codex' && shouldResume) {
           options.freshSessionSystemPrompt = async () => {

--- a/packages/standalone/tests/gateways/chat-cause.test.ts
+++ b/packages/standalone/tests/gateways/chat-cause.test.ts
@@ -1,0 +1,46 @@
+/**
+ * The chat lane's cause wire.
+ *
+ * A reconcile work order carries its delta batch, so every durable change the run makes can
+ * name what caused it. The chat lane had no such wire at all - `causeEventIds` was supplied
+ * by exactly one caller in the codebase, the work-order consumer.
+ *
+ * Measured on the live effect ledger 2026-07-30: 3 attributed, 14 unattributed, and every
+ * unattributed row was a `task_update` from `agent=conductor`. Over the preceding six hours
+ * the run registry held 1,611 conductor runs against 45 board-worker runs - so the lane with
+ * no cause wire is the one doing most of the work.
+ *
+ * The owner's message IS the cause, and the router knows it before the agent runs.
+ */
+import { describe, it, expect } from 'vitest';
+import { causeFromOwnerMessage } from '../../src/gateways/message-router.js';
+
+describe('causeFromOwnerMessage', () => {
+  it('cites the owner message that started the turn', () => {
+    expect(causeFromOwnerMessage('msg_9182', 'telegram:7026976631:msg_9182')).toEqual({
+      causeEventIds: ['telegram:7026976631:msg_9182'],
+    });
+  });
+
+  // The line that keeps this from becoming the thing the ledger exists to refuse. A
+  // generated id names no message; citing it would be a fabricated citation dressed as
+  // provenance, and an unattributed change is the honest answer instead.
+  it('refuses a generated turn id rather than citing something unresolvable', () => {
+    expect(causeFromOwnerMessage('generated:0f9a1c', 'discord:C1:generated:0f9a1c')).toBeNull();
+  });
+
+  it('refuses an empty turn id or an empty ref', () => {
+    expect(causeFromOwnerMessage('', 'telegram:1:x')).toBeNull();
+    expect(causeFromOwnerMessage('msg_1', '   ')).toBeNull();
+  });
+
+  // Spread into the run options, so "no honest cause" leaves the field absent rather than
+  // present-and-empty - the ledger treats those differently, and an empty array would claim
+  // the run had a batch and it was blank.
+  it('is spreadable, and contributes nothing when there is no cause', () => {
+    const withCause = { a: 1, ...(causeFromOwnerMessage('m1', 'slack:C1:m1') ?? {}) };
+    const without = { a: 1, ...(causeFromOwnerMessage('generated:x', 'slack:C1:y') ?? {}) };
+    expect(withCause).toHaveProperty('causeEventIds');
+    expect(without).not.toHaveProperty('causeEventIds');
+  });
+});

--- a/packages/standalone/tests/gateways/chat-cause.test.ts
+++ b/packages/standalone/tests/gateways/chat-cause.test.ts
@@ -34,6 +34,20 @@ describe('causeFromOwnerMessage', () => {
     expect(causeFromOwnerMessage('msg_1', '   ')).toBeNull();
   });
 
+  // Found in review. A whitespace-only turn id is truthy and is not `generated:`, and the
+  // router prefixes source and channel onto it - so the ref came out non-empty
+  // (`telegram:C1:   `) and named no message at all.
+  it('refuses a whitespace-only turn id, which the ref would otherwise hide', () => {
+    expect(causeFromOwnerMessage('   ', 'telegram:C1:   ')).toBeNull();
+    expect(causeFromOwnerMessage('\t\n', 'discord:C1:\t\n')).toBeNull();
+  });
+
+  it('still accepts a turn id that merely has padding around a real id', () => {
+    expect(causeFromOwnerMessage(' msg_9182 ', 'telegram:C1:msg_9182')).toEqual({
+      causeEventIds: ['telegram:C1:msg_9182'],
+    });
+  });
+
   // Spread into the run options, so "no honest cause" leaves the field absent rather than
   // present-and-empty - the ledger treats those differently, and an empty array would claim
   // the run had a batch and it was blank.


### PR DESCRIPTION
Item 2 of the post-0.29.0 list, after measurement moved the target.

**The premise was wrong.** The list said `board:full`'s 539 batch-less runs were the attribution gap. The live ledger says otherwise: 3 attributed, 14 unattributed, and every unattributed row is a `task_update` from `agent=conductor`. Tracing those run ids through the model-run registry puts all of them on the chat lane — which over the preceding six hours held **1,611 runs against the board worker's 45**.

Grepping the tree shows why: `causeEventIds` has exactly one caller in the entire codebase, the work-order consumer. The chat lane has no cause wire at all.

**The router already knows the cause.** It builds `sourceMessageRef` — source, channel, and the platform's own message id — before the agent runs. Same shape as a reconcile work order carrying its delta batch: the system knows the cause first, so the agent never restates it and cannot choose its own attribution.

**Not cited when it would be a fiction.** `sourceTurnId` falls back to `generated:<uuid>` when the platform gave no message id. A generated id names nothing a reader could resolve; citing it would be the fabricated citation this ledger exists to refuse. Those turns stay unattributed, which is the honest answer.

3,964 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeHgDc9QpXZH9x7hcc1Fq1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attribution of owner messages to their originating platform events.
  * Prevented invalid, generated, or incomplete message references from creating cause information.

* **Tests**
  * Added coverage for valid attribution and invalid or missing message references.
  * Verified that unavailable cause information is omitted cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->