### PR TITLE
fix(standalone): trigger author names its effort instead of inheriting one

### DIFF
--- a/packages/standalone/src/operator/trigger-author.ts
+++ b/packages/standalone/src/operator/trigger-author.ts
@@ -246,11 +246,33 @@ export function validateTriggerSpec(spec: unknown): TriggerSpec {
 }
 
 /** Build the legacy bare-Claude JSON runner while allowing command injection in tests. */
+/**
+ * Effort for the bare-CLI structured-JSON calls, named rather than inherited.
+ *
+ * Without this the call inherits `effortLevel` from ~/.claude/settings.json, which on the
+ * owner's install is `xhigh` - and the daemon exports MAX_THINKING_TOKENS=0 (added
+ * 2026-07-27 to stop sonnet-5 empty thinking blocks corrupting chat transcripts). The two
+ * together are a hard API 400: "output_config.effort 'xhigh' is not supported when thinking
+ * is disabled on this model."
+ *
+ * The trigger author died on that from 2026-07-28 onward - 46 failures against 8 successes
+ * that day, then 34 against ZERO the next - and nobody could see it, because the executor
+ * dropped the CLI's output and Node's message carried only the 240 KB command line. The
+ * diagnostics added in 0.29.1 printed the cause on the first failure after deploy.
+ *
+ * Naming the effort here keeps the daemon-wide thinking setting untouched: it exists for a
+ * real transcript-corruption problem, and this call is a small structured-JSON task that
+ * never needed the top tier.
+ */
+const TRIGGER_AUTHOR_EFFORT = 'high';
+
 export function createAskAgentCLI(execute: ClaudeCliExecutor = executeClaudeCLI): AskAgent {
   return async (prompt) => {
-    const { stdout } = await execute('claude', ['-p', prompt, '--output-format', 'json'], {
-      maxBuffer: 16 * 1024 * 1024,
-    });
+    const { stdout } = await execute(
+      'claude',
+      ['-p', prompt, '--output-format', 'json', '--effort', TRIGGER_AUTHOR_EFFORT],
+      { maxBuffer: 16 * 1024 * 1024 }
+    );
     const parsed = JSON.parse(stdout) as { type?: string; result?: unknown };
     if (parsed.type === 'result' && typeof parsed.result === 'string') return parsed.result;
     throw new Error('claude CLI did not return a text result');
@@ -347,6 +369,10 @@ async function executeClaudeCLI(
     const { stdout } = await execFileAsync(file, args, {
       ...options,
       timeout: CLAUDE_CLI_TIMEOUT_MS,
+      // The CLI's "no stdin data received in 3s" warning rides along on stderr here. It is
+      // noise, not the cause - closing stdin is not available on this path, because execFile
+      // does not forward `stdio` to the spawn beneath it. Left alone deliberately: the
+      // failure text captures stdout too, so the warning no longer hides the real error.
     });
     return { stdout: String(stdout) };
   } catch (error) {

--- a/packages/standalone/tests/operator/trigger-author.test.ts
+++ b/packages/standalone/tests/operator/trigger-author.test.ts
@@ -177,6 +177,26 @@ describe('authorTriggers', () => {
   // 193 failures over the log's lifetime recorded nothing but the 240 KB command line that
   // produced them, because the executor destructured `{ stdout }` and Node's own message
   // embeds the whole argv. The tick that dies here takes the scheduled report with it.
+  // The bug the 0.29.1 diagnostics found on their first live failure. The call inherited
+  // `effortLevel: xhigh` from the user's settings, the daemon exports MAX_THINKING_TOKENS=0,
+  // and the pair is a hard API 400. Measured: 46 failures against 8 successes on 2026-07-28,
+  // then 34 against ZERO on 07-29 - the lane had been dead for two days.
+  it('names its own effort instead of inheriting one the daemon cannot satisfy', async () => {
+    const calls: string[][] = [];
+    const ask = createAskAgentCLI(async (_file, args) => {
+      calls.push(args);
+      return { stdout: JSON.stringify({ type: 'result', result: '[]' }) };
+    });
+
+    await ask('anything');
+
+    const args = calls[0];
+    const i = args.indexOf('--effort');
+    expect(i, 'the call must name an effort').toBeGreaterThan(-1);
+    // Anything above 'high' is rejected when thinking is disabled.
+    expect(['high', 'medium', 'low']).toContain(args[i + 1]);
+  });
+
   describe('describeCliFailure', () => {
     it('names a timeout kill rather than reporting a bare failure', () => {
       const note = describeCliFailure('claude', {
@@ -255,7 +275,7 @@ describe('trigger agent provider boundary', () => {
     await expect(askAgent('author prompt')).resolves.toBe('[{"kind":"k"}]');
     expect(execute).toHaveBeenCalledWith(
       'claude',
-      ['-p', 'author prompt', '--output-format', 'json'],
+      ['-p', 'author prompt', '--output-format', 'json', '--effort', 'high'],
       { maxBuffer: 16 * 1024 * 1024 }
     );
   });


### PR DESCRIPTION
## What died

The trigger loop's authoring step has been failing on **every tick for two days**:

| date | author success | tick failed |
|---|---|---|
| 2026-07-26 | 57 | 0 |
| 2026-07-27 | 46 | 11 |
| 2026-07-28 | 8 | **46** |
| 2026-07-29 | **0** | 34 |

## Why

The call is a bare `claude -p`, so it inherits `effortLevel` from the user's settings — `xhigh` here — while the daemon exports `MAX_THINKING_TOKENS=0` (added 2026-07-27 to stop sonnet-5 empty thinking blocks corrupting chat transcripts). The pair is a hard API 400:

> `output_config.effort 'xhigh' is not supported when thinking is disabled on this model. Use effort 'high' or below, or enable thinking.`

Reproduced exactly — same command **succeeds** bare, **400s** under the daemon's env, **succeeds** again with `--effort high`.

The chat path (`claude-cli-wrapper`) already passes both `--effort` and `--setting-sources`. This was the *only* bare call site, which is precisely why chat survived the same environment and the author did not.

## The fix

Name the effort at the call site. That leaves the daemon-wide thinking setting alone — it addresses a real transcript-corruption problem, and this is a small structured-JSON call that never needed the top tier.

My earlier hypothesis — the 231 KB prompt — **was wrong**, and the hand reproduction that succeeded at 41s was already evidence against it. The prompt-size reduction shipped in 0.29.1 stands on its own as a cost fix, not as this cure.

## How it was found

By the diagnostics added in 0.29.1, on their **first live failure after deploy**. The same 193 failures before those printed a 240 KB command line and no cause. stderr carried only the stdin warning; **stdout carried the actual error** — which is why the diagnostics capture both.

## Tests

`--effort` presence is now asserted two ways: the exact-args contract test, and a behavioral test that rejects any level above `high` (the levels the API refuses when thinking is disabled). 519 standalone tests pass.

## Live status

Not yet live: the daemon runs the released build and the release freeze holds. Because the daemon's cwd is `$HOME`, its "project" settings file *is* `~/.claude/settings.json` — so the only config-only workarounds are lowering your global effort (which would also lower your own interactive sessions) or re-enabling thinking (which reopens the corruption this was set to fix). Both are your call; this PR removes the need for either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeHgDc9QpXZH9x7hcc1Fq1