### PR TITLE
chore(standalone): drop the delegation surface nothing ever filled

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1098,10 +1098,6 @@ Update a specific agent's config.
 
 All fields optional. See [CLAUDE.md Multi-Agent API](../../CLAUDE.md#multi-agent-api) for details.
 
-#### GET /api/multi-agent/delegations
-
-Get recent task delegations / swarm tasks.
-
 ---
 
 ### Config API

--- a/packages/standalone/public/viewer/src/utils/api.ts
+++ b/packages/standalone/public/viewer/src/utils/api.ts
@@ -255,16 +255,6 @@ export interface MultiAgentAgentsResponse {
 export interface MultiAgentDashboardStatus {
   enabled: boolean;
   agents: MultiAgentAgent[];
-  recentDelegations?: {
-    id?: string;
-    description?: string;
-    category?: string;
-    wave?: number;
-    status?: string;
-    claimedBy?: string | null;
-    claimedAt?: number | null;
-    completedAt?: number | null;
-  }[];
   activeChains?: number;
 }
 

--- a/packages/standalone/src/api/graph-api-types.ts
+++ b/packages/standalone/src/api/graph-api-types.ts
@@ -42,19 +42,6 @@ export interface CheckpointData {
 
 // === Handler Options ===
 
-export interface DelegationHistoryEntry {
-  id: string;
-  fromAgentId: string;
-  toAgentId: string;
-  task: string;
-  background: boolean;
-  status: 'active' | 'completed' | 'failed';
-  startedAt: string;
-  completedAt: string | null;
-  duration: number | null;
-  error: string | null;
-}
-
 export interface CodeActResult {
   success: boolean;
   value?: unknown;
@@ -74,8 +61,6 @@ export interface CodeActExecutionContext {
 
 export interface GraphHandlerOptions {
   getAgentStates?: () => Map<string, string>;
-  getSwarmTasks?: (limit: number) => SwarmTask[];
-  getRecentDelegations?: (limit: number) => DelegationHistoryEntry[];
   applyMultiAgentConfig?: (config: Record<string, unknown>) => Promise<void>;
   restartMultiAgentAgent?: (agentId: string) => Promise<void>;
   stopMultiAgentAgent?: (agentId: string) => Promise<void>;
@@ -93,18 +78,6 @@ export interface GraphHandlerOptions {
   sessionsDb?: import('../sqlite.js').SQLiteDatabase;
   /** UI command queue for bidirectional Agent↔Viewer communication */
   uiCommandQueue?: import('./ui-command-handler.js').UICommandQueue;
-}
-
-export interface SwarmTask {
-  id: string;
-  description: string;
-  category: string;
-  wave: number;
-  status: string;
-  claimed_by: string | null;
-  claimed_at: number | null;
-  completed_at: number | null;
-  result: string | null;
 }
 
 // === Stats Types ===

--- a/packages/standalone/src/api/graph-api.ts
+++ b/packages/standalone/src/api/graph-api.ts
@@ -2425,12 +2425,6 @@ function createGraphHandler(options: GraphHandlerOptions = {}): GraphHandlerFn {
       return true;
     }
 
-    // Route: GET /api/multi-agent/delegations - get recent delegations
-    if (pathname === '/api/multi-agent/delegations' && req.method === 'GET') {
-      await handleMultiAgentDelegationsRequest(req, res, options);
-      return true;
-    }
-
     // Route: GET /api/mcp-servers - get available MCP servers from config
     if (pathname === '/api/mcp-servers' && req.method === 'GET') {
       await handleMCPServersRequest(req, res);
@@ -3590,15 +3584,11 @@ async function handleMultiAgentStatusRequest(
     // Count active chains (agents currently busy)
     const busyCount = agents.filter((a) => a.status === 'busy').length;
 
-    // Get recent delegations from DelegationManager history
-    const recentDelegations = options.getRecentDelegations ? options.getRecentDelegations(20) : [];
-
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(
       JSON.stringify({
         enabled: multiAgentConfig.enabled || false,
         agents,
-        recentDelegations,
         activeChains: busyCount,
       })
     );
@@ -3923,67 +3913,6 @@ async function handleMultiAgentUpdateAgentRequest(
       JSON.stringify({
         error: true,
         code: 'MULTI_AGENT_UPDATE_ERROR',
-        message,
-      })
-    );
-  }
-}
-
-async function handleMultiAgentDelegationsRequest(
-  req: IncomingMessage,
-  res: ServerResponse,
-  options: GraphHandlerOptions = {}
-): Promise<void> {
-  try {
-    const url = new URL(req.url!, `http://${req.headers.host}`);
-    const limit = parseInt(url.searchParams.get('limit') || '20', 10);
-
-    let delegations: Array<{
-      id: string;
-      description: string;
-      category: string;
-      wave: number;
-      status: string;
-      claimedBy: string | null;
-      claimedAt: number | null;
-      completedAt: number | null;
-      result: string | null;
-    }> = [];
-    if (options.getSwarmTasks) {
-      try {
-        const tasks = options.getSwarmTasks(limit);
-        delegations = tasks.map((task) => ({
-          id: task.id,
-          description: task.description,
-          category: task.category,
-          wave: task.wave,
-          status: task.status,
-          claimedBy: task.claimed_by,
-          claimedAt: task.claimed_at,
-          completedAt: task.completed_at,
-          result: task.result,
-        }));
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.error('[GraphAPI] Failed to fetch swarm tasks:', msg);
-      }
-    }
-
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(
-      JSON.stringify({
-        delegations,
-        count: delegations.length,
-      })
-    );
-  } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error('[GraphAPI] Multi-agent delegations error:', message);
-    res.writeHead(500, { 'Content-Type': 'application/json' });
-    res.end(
-      JSON.stringify({
-        error: true,
-        code: 'MULTI_AGENT_DELEGATIONS_ERROR',
         message,
       })
     );

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -973,28 +973,6 @@ export async function runAgentLoop(
   const { metricsStore, metricsCleanup, healthService, healthCheckService, metricsInterval } =
     await initMetrics(config, db, EMBEDDING_PORT);
 
-  // Ensure swarm_tasks table exists (used by Graph API delegations endpoint)
-  db.prepare(
-    `
-    CREATE TABLE IF NOT EXISTS swarm_tasks (
-      id TEXT PRIMARY KEY,
-      session_id TEXT NOT NULL,
-      description TEXT NOT NULL,
-      category TEXT NOT NULL,
-      priority INTEGER DEFAULT 0,
-      wave INTEGER NOT NULL,
-      status TEXT DEFAULT 'pending',
-      claimed_by TEXT,
-      claimed_at INTEGER,
-      completed_at INTEGER,
-      result TEXT,
-      files_owned TEXT,
-      depends_on TEXT,
-      retry_count INTEGER DEFAULT 0
-    )
-  `
-  ).run();
-
   // ── Phase 2: Session + Tool + Agent Loop ──────────────────────────────────
 
   const sessionStore = new SessionStore(db);

--- a/packages/standalone/src/cli/runtime/gateway-wiring.ts
+++ b/packages/standalone/src/cli/runtime/gateway-wiring.ts
@@ -10,7 +10,7 @@
  *   3. Security alert sender wiring (parseSecurityAlertTargets → healthCheckService.securityAlertSender)
  *   4. CronResultRouter — routes cron results to Discord/Slack/Telegram gateways
  *   5. Graph handler runtime wiring — populates graphHandlerOptions with:
- *      - getAgentStates(), getSwarmTasks(), getRecentDelegations()
+ *      - getAgentStates()
  *      - applyMultiAgentConfig(), restartMultiAgentAgent(), stopMultiAgentAgent()
  *      - delegation count and agent states wired into healthCheckService
  *   6. Plugin gateway loader — PluginLoader for additional gateways (e.g. Chatwork)


### PR DESCRIPTION
## Measured, live

```
GET /api/multi-agent/delegations  →  {"delegations":[],"count":0}
GET /api/multi-agent/status       →  recentDelegations: []
```

Both have always answered that way, and could not answer anything else:

- The delegations handler reads `options.getSwarmTasks` — **no caller in the repo supplies it**.
- It reads from `swarm_tasks`, a table **nothing in the repo writes**; only the `CREATE TABLE IF NOT EXISTS` at boot. (It isn't even in the live `mama.db`.)
- `recentDelegations` reads `options.getRecentDelegations` — **also unsupplied**, so the field shipped as `[]` to a viewer that declares its type and never renders it.

## Removed end to end

route · handler · both optional accessors · `SwarmTask` and `DelegationHistoryEntry` types · the boot-time `CREATE TABLE` · the viewer's type field · the API reference entry.

An endpoint that can only ever answer "nothing" is worse than no endpoint — it reads as a feature that is merely idle. Same reasoning as #204.

## Verification

Live before-state captured before removing (both empty, above). 3,960 standalone tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeHgDc9QpXZH9x7hcc1Fq1