### PR TITLE
fix(standalone): carry backfill cursors before the rekey, not after

### DIFF
--- a/packages/standalone/scripts/backfill-channel-keys.ts
+++ b/packages/standalone/scripts/backfill-channel-keys.ts
@@ -41,7 +41,7 @@
  *     1..N sequences; the moved rows are renumbered above the target's high-water mark
  *     rather than left to abort the transaction on the unique index.
  */
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import Database from 'better-sqlite3';
@@ -356,6 +356,79 @@ export function runningDaemonPid(): number | null {
   }
 }
 
+/**
+ * Carry the delta cursors, then rekey the rows - in that order, and not the other one.
+ *
+ * Cursors are carried BEFORE the rekey commits, and the direction is not arbitrary.
+ *
+ * The two halves of this migration live in different stores - rows in SQLite, delta
+ * cursors in a JSON file - so no transaction spans them and a crash can land between.
+ * Both orders leave an inconsistent pair; they are not equally bad:
+ *
+ *   rekey first, then cursors  ->  rows under the new key, cursors still on the old one.
+ *                                  `drainNew` finds no cursor for the new key and starts
+ *                                  from 0, REDELIVERING every event in the partition -
+ *                                  the exact outcome the merge rules exist to prevent.
+ *                                  Re-running does not heal it: the plan finds no old
+ *                                  keys left to rekey, so the cursors are never carried.
+ *
+ *   cursors first, then rekey  ->  cursors on the new key, rows still under the old one.
+ *                                  The partition stalls, delivering nothing new until the
+ *                                  script is re-run - and a re-run DOES heal it, because
+ *                                  the rows are still there to be found and re-planned.
+ *
+ * A recoverable stall beats an unrecoverable flood, so cursors go first. If the rekey then
+ * fails, the file is restored from the pre-image rather than left ahead of the rows.
+ */
+export function rekeyWithCursorsFirst(
+  db: Db,
+  plan: Plan,
+  cursorPath: string,
+  cursors: Record<string, number>
+): Record<string, number> {
+  const carried = carryDeltaCursors(cursors, plan.rekeys);
+  const cursorsWritten = carried.carried > 0;
+  if (cursorsWritten) {
+    writeFileSync(`${cursorPath}.before-channel-rekey`, JSON.stringify(cursors, null, 2));
+    writeCursorsAtomically(cursorPath, carried.cursors);
+    console.log(`  delta cursors carried: ${carried.carried}`);
+  }
+
+  const moved: Record<string, number> = {};
+  try {
+    const run = db.transaction(() => {
+      for (const rekey of plan.rekeys) {
+        for (const [table, count] of Object.entries(applyRekey(db, rekey))) {
+          moved[table] = (moved[table] ?? 0) + count;
+        }
+      }
+    });
+    run();
+  } catch (error) {
+    if (cursorsWritten) {
+      writeCursorsAtomically(cursorPath, cursors);
+      console.error('  rekey failed; delta cursors restored to their pre-image');
+    }
+    throw error;
+  }
+  return moved;
+}
+
+/**
+ * Replace the cursor file in one step.
+ *
+ * A plain `writeFileSync` truncates before it writes, so a crash mid-write leaves a
+ * half-written JSON file - and an unparseable cursor file is worse than either
+ * inconsistent state the ordering above guards against, because every partition falls
+ * back to starting from 0 at once. Write beside it, then rename: on the same filesystem
+ * the rename is atomic, so a reader sees the old file or the new one, never a partial.
+ */
+export function writeCursorsAtomically(cursorPath: string, cursors: Record<string, number>): void {
+  const tmp = `${cursorPath}.tmp`;
+  writeFileSync(tmp, JSON.stringify(cursors, null, 2));
+  renameSync(tmp, cursorPath);
+}
+
 function main(): void {
   const apply = process.argv.includes('--apply');
   const dbPath = process.env.MAMA_DB_PATH ?? join(homedir(), '.mama', 'mama-memory.db');
@@ -420,25 +493,10 @@ function main(): void {
   db.prepare('VACUUM INTO ?').run(backup);
   console.log(`\nbackup: ${backup}`);
 
-  const moved: Record<string, number> = {};
-  const run = db.transaction(() => {
-    for (const rekey of plan.rekeys) {
-      for (const [table, count] of Object.entries(applyRekey(db, rekey))) {
-        moved[table] = (moved[table] ?? 0) + count;
-      }
-    }
-  });
-  run();
+  const moved = rekeyWithCursorsFirst(db, plan, cursorPath, cursors);
 
   for (const [table, count] of Object.entries(moved)) {
     console.log(`  ${table}: ${count}`);
-  }
-
-  const carried = carryDeltaCursors(cursors, plan.rekeys);
-  if (carried.carried > 0) {
-    writeFileSync(`${cursorPath}.before-channel-rekey`, JSON.stringify(cursors, null, 2));
-    writeFileSync(cursorPath, JSON.stringify(carried.cursors, null, 2));
-    console.log(`  delta cursors carried: ${carried.carried}`);
   }
   db.close();
 }

--- a/packages/standalone/tests/scripts/backfill-channel-keys.test.ts
+++ b/packages/standalone/tests/scripts/backfill-channel-keys.test.ts
@@ -15,8 +15,10 @@ import {
   buildPlan,
   carryDeltaCursors,
   runningDaemonPid,
+  writeCursorsAtomically,
+  rekeyWithCursorsFirst,
 } from '../../scripts/backfill-channel-keys.js';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
 import { join } from 'node:path';
 
@@ -259,5 +261,88 @@ describe('runningDaemonPid: the live-daemon rail', () => {
     expect(runningDaemonPid()).toBeNull();
     writeFileSync(join(fakeHome, '.mama', 'mama.pid'), 'not a pid');
     expect(runningDaemonPid()).toBeNull();
+  });
+});
+
+// The write that must not leave a partial file behind. An unparseable cursor file is worse
+// than either inconsistent state the ordering guards against: `drainNew` starts from 0 for
+// an absent key, so a truncated file redelivers EVERY partition at once, not just one.
+describe('writeCursorsAtomically', () => {
+  it('replaces the file via rename, leaving no temp file behind', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cursor-atomic-'));
+    const path = join(dir, 'trigger-loop-cursors.json');
+    writeFileSync(path, JSON.stringify({ 'a:1': 10 }));
+
+    writeCursorsAtomically(path, { 'a:1': 10, 'b:2': 44 });
+
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({ 'a:1': 10, 'b:2': 44 });
+    expect(existsSync(`${path}.tmp`)).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes a file that did not exist yet', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cursor-atomic-'));
+    const path = join(dir, 'trigger-loop-cursors.json');
+
+    writeCursorsAtomically(path, { 'c:3': 7 });
+
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({ 'c:3': 7 });
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+// The ordering IS the fix, so it is asserted directly rather than left to the comment.
+// Rows and cursors live in different stores, so no transaction spans them and a crash can
+// land between. Carrying cursors AFTER the rekey leaves `drainNew` with no cursor for the
+// new key - it starts from 0 and redelivers the whole partition, and re-running does not
+// heal it because the plan finds no old keys left to carry.
+describe('rekeyWithCursorsFirst', () => {
+  let dir: string;
+  let cursorPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'rekey-order-'));
+    cursorPath = join(dir, 'trigger-loop-cursors.json');
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  const plan = {
+    rekeys: [{ connector: 'chat', from: 'general', to: 'C001', events: 3 }],
+  } as unknown as Parameters<typeof rekeyWithCursorsFirst>[1];
+
+  /** Enough of a db for applyRekey to run; the rows are not what these tests assert. */
+  const okDb = () =>
+    ({
+      transaction: (fn: () => void) => fn,
+      prepare: () => ({ run: () => ({ changes: 0 }), get: () => undefined }),
+    }) as never;
+
+  it('leaves the cursors carried when the rekey commits', () => {
+    rekeyWithCursorsFirst(okDb(), plan, cursorPath, { 'chat\u0000general': 91 });
+
+    expect(JSON.parse(readFileSync(cursorPath, 'utf8'))).toEqual({ 'chat\u0000C001': 91 });
+  });
+
+  // The half that matters: a failed rekey must not leave cursors ahead of the rows, or the
+  // partition stalls with nothing to re-plan.
+  it('restores the pre-image when the rekey throws, and rethrows', () => {
+    const boom = new Error('constraint failed');
+    const db = {
+      transaction: () => () => {
+        throw boom;
+      },
+      prepare: () => ({ run: () => ({ changes: 0 }) }),
+    } as never;
+
+    expect(() => rekeyWithCursorsFirst(db, plan, cursorPath, { 'chat\u0000general': 91 })).toThrow(
+      boom
+    );
+
+    expect(JSON.parse(readFileSync(cursorPath, 'utf8'))).toEqual({ 'chat\u0000general': 91 });
+  });
+
+  it('writes no cursor file at all when there is nothing to carry', () => {
+    rekeyWithCursorsFirst(okDb(), plan, cursorPath, { 'slack\u0000unrelated': 5 });
+    expect(existsSync(cursorPath)).toBe(false);
   });
 });


### PR DESCRIPTION
## The gap

Rows live in SQLite, delta cursors in a JSON file. No transaction spans them, so a crash can land between — and the script committed the rekey **first**, cursors after. That is the worse of the two orders:

| order | crash leaves | consequence | heals on re-run? |
|---|---|---|---|
| **rekey first** (before) | rows on new key, cursors on old | `drainNew` finds no cursor for the new key, starts from **0**, and redelivers *every event in the partition* | ❌ the plan finds no old keys left, so cursors are never carried |
| **cursors first** (after) | cursors on new key, rows on old | the partition stalls, delivering nothing new | ✅ rows are still there to be re-planned |

Redelivering the whole partition is the exact outcome the merge rules in this script exist to prevent — and it is the one that cannot be repaired by running the script again. A recoverable stall beats an unrecoverable flood.

A failed rekey now also restores the cursor file from its pre-image rather than leaving it ahead of the rows.

## The write is atomic now too

`writeFileSync` truncates before it writes, so a crash mid-write left a half-written JSON file. That is worse than *either* inconsistent state above: an unparseable cursor file sends **every** partition back to 0, not just one. Write beside it, then rename.

## Asserted, not just commented

The ordering is extracted into `rekeyWithCursorsFirst` so it is testable:

- cursors carried when the rekey commits
- **pre-image restored and the error rethrown when it fails** — the half that matters
- no file written when there is nothing to carry

3,965 standalone tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeHgDc9QpXZH9x7hcc1Fq1