### PR TITLE
docs: correct README and site against what the system actually is

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node Version](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org)
 [![LongMemEval 100Q](https://img.shields.io/badge/LongMemEval%20100Q-93%25-blue)](packages/memorybench/)
-[![Tests](https://img.shields.io/badge/tests-4900%2B%20passing-success)](https://github.com/jungjaehoon-lifegamez/MAMA)
+[![Tests](https://img.shields.io/badge/tests-4958%20passing-success)](https://github.com/jungjaehoon-lifegamez/MAMA)
 
 > Local operating memory that lets AI agents read the board, cite the evidence, and stay inside
 > explicit boundaries.
@@ -56,8 +56,9 @@ coverage kept inseparable.
   shape in which a change can quietly lose its provenance.
 - **Bounded runs** — a run is `{channel, delta batch}`. The batch the host handed the run becomes the
   cause of everything that run changes; the agent never restates it, and a host batch always beats an
-  agent-supplied source id, which is forgeable. A run given no batch produces changes that are
-  honestly marked unattributed rather than plausibly attributed.
+  agent-supplied source id, which is forgeable. When the host handed the run no batch, a named source
+  event is still used — weaker evidence, not worthless. Only when there is neither is the change
+  marked unattributed, which is the honest answer rather than a plausible-looking one.
 - **`changes_read`** — what this system durably changed since a given point, with coverage counts.
   The full report leads with it.
 - **`mama_provenance`** — what a memory rests on. A citation must not out-read reading: the same

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node Version](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org)
 [![LongMemEval 100Q](https://img.shields.io/badge/LongMemEval%20100Q-93%25-blue)](packages/memorybench/)
-[![Tests](https://img.shields.io/badge/tests-3000%2B%20passing-success)](https://github.com/jungjaehoon-lifegamez/MAMA)
+[![Tests](https://img.shields.io/badge/tests-4900%2B%20passing-success)](https://github.com/jungjaehoon-lifegamez/MAMA)
 
 > Local operating memory that lets AI agents read the board, cite the evidence, and stay inside
 > explicit boundaries.
@@ -44,6 +44,30 @@ What runs continuously today:
 - **Hourly self-audit** — a conductor pass checks process health, databases, config, and security
   posture, deduplicating alerts against a state file so the owner hears about a finding once, not
   every hour.
+
+## Evidence and Effects
+
+A system that changes things on your behalf should be able to say what caused each change — or say
+plainly that it cannot. MAMA OS records that in one place, with the numerator and denominator of
+coverage kept inseparable.
+
+- **Effect ledger** — one table, `evidence_effects`. A database CHECK forbids both "attributed with
+  no cause" and "unattributed with a cause", and a trigger rejects unusable cause ids. There is no
+  shape in which a change can quietly lose its provenance.
+- **Bounded runs** — a run is `{channel, delta batch}`. The batch the host handed the run becomes the
+  cause of everything that run changes; the agent never restates it, and a host batch always beats an
+  agent-supplied source id, which is forgeable. A run given no batch produces changes that are
+  honestly marked unattributed rather than plausibly attributed.
+- **`changes_read`** — what this system durably changed since a given point, with coverage counts.
+  The full report leads with it.
+- **`mama_provenance`** — what a memory rests on. A citation must not out-read reading: the same
+  channel grant bounds both.
+- **Channel grant** — one rule decides which `(connector, channel)` pairs a run may read, compiled
+  both to a boolean and to a SQL clause that a differential test pins against each other.
+- **Lane verification** — a work order reaching `done` proves only that the agent replied. Each
+  lane's claim is reconciled against completed tool traces since a run-bound snapshot. It observes
+  and reports; it never blocks. Where a tool cannot distinguish a read from a write, the verdict says
+  so rather than claiming more than it knows.
 
 ## Target Workflow
 
@@ -120,7 +144,7 @@ legacy viewer at `/viewer` remains available with `Dashboard`, `Memory`, `Feed`,
 
 **Current building blocks and direction:**
 
-- **Read connected sources** — 15 connectors poll Slack, Gmail, Trello, Obsidian, and more
+- **Read connected sources** — 14 connectors poll Slack, Gmail, Trello, Obsidian, and more
 - **Reconstruct timelines** — Show raw, memory, case, entity, and edge events in order
 - **Build the relationship graph** — Link people, projects, customers, channels, documents, PRs, and decisions across sources
 - **Surface risk signals** — Highlight stale coverage, blocked cases, low-confidence memories, open questions, and conflicting evidence candidates
@@ -185,8 +209,8 @@ MAMA answers "why did we switch?" — not just "what do we use?"
 ## Architecture
 
 ```
-Connectors (15)              Gateways (4)
-Slack, Gmail, Sheets...      Discord, Slack, Telegram, Chatwork
+Connectors (14)              Gateways (3)
+Slack, Gmail, Sheets...      Discord, Slack, Telegram
        |                            |
        v                            v
  3-Pass Extraction          Reactive Runtime Envelopes
@@ -199,6 +223,11 @@ Slack, Gmail, Sheets...      Discord, Slack, Telegram, Chatwork
              memory, raw refs, model runs,
              tool traces, twin edges,
              worker packets, context packets
+                    |
+             Effect ledger (operator/triggers.db)
+             every durable change, with the delta
+             batch that caused it - or an explicit
+             "unattributed"
                     |
              +------+------+
              |             |
@@ -319,7 +348,7 @@ legacy viewer at `http://localhost:3847/viewer` with `Dashboard`, `Memory`, `Fee
 
 Anyone who installs MAMA OS and connects their apps gets:
 
-- **Automatic knowledge extraction** — Connectors poll 15 sources, AI extracts decisions/deadlines/changes without manual input
+- **Automatic knowledge extraction** — Connectors poll 14 sources, AI extracts decisions/deadlines/changes without manual input
 - **Cross-source evidence reads** — "What happened with X?" can pull from connected raw sources and decisions together
 - **Noise-resistant search** — Strict and balanced modes can reject vector-only matches and show why a result was included
 - **Bounded agent calls** — Gateway and worker calls can be tied to runtime envelopes and audited for scope or destination mismatches
@@ -341,14 +370,18 @@ that selects, rejects, and explains evidence before a worker writes memory or co
 | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **Done** | v0.15   | Search quality overhaul, FTS5, evolution engine (58% -> 88%)                                                                                                                                                                                                                         |
 | **Done** | v0.16   | `event_date` API, tool-use answer, memory agent v5 (88% -> 93%)                                                                                                                                                                                                                      |
-| **Done** | v0.17   | Connector framework (15 connectors), truth-first 3-pass extraction                                                                                                                                                                                                                   |
+| **Done** | v0.17   | Connector framework (13 connectors at the time), truth-first 3-pass extraction                                                                                                                                                                                                       |
 | **Done** | v0.18   | Output layer: knowledge agents, viewer redesign, security hardening                                                                                                                                                                                                                  |
 | **Done** | v0.19   | Agent-management foundation: viewer-aware frontdoor, validation UI, activity telemetry, conductor isolation                                                                                                                                                                          |
 | **Done** | v0.20.1 | M1-M6 runtime foundation plus Context Compile V0: envelopes, model/tool trace ledger, raw/situation/graph worker APIs, strict search diagnostics, append-only `context_packets`, `context_compile`, and downstream `context_packet_id` provenance                                    |
 | **Done** | v0.21   | The operator runtime: self-evolving trigger loop with a citation success circuit, `/ui` operator board (four live report slots + trigger library), task-truth from the real task ledger, wiki v5 daily journal + lessons, scheduled memory promotion, self-auditing with alert dedup |
 | **Done** | v0.23   | The owner console + workorder ownership: trust-conditional `owner_console` role, artifact-hub tools, secret-safe memory writes, and the Stage-2 durable workorder pipeline                                                                                                           |
 | **Done** | v0.24   | Codex app-server parity: durable multiplexed threads, native MAMA host tools (including connector/Trello surfaces), role-scoped Code-Act, strict managed runtime isolation, and automatic migration from the legacy `codex-mcp` backend                                              |
-| **Now**  | v0.25   | Verified temporal owner-task reconciliation with source-bound evidence, authoritative receipts, mixed-version safety, and bounded shutdown handling                                                                                                                                  |
+| **Done** | v0.25   | Verified temporal owner-task reconciliation with source-bound evidence, authoritative receipts, mixed-version safety, and bounded shutdown handling                                                                                                                                  |
+| **Done** | v0.26   | Telegram media conversations, owner-scoped Drive operations, and fail-closed media handling                                                                                                                                                                                          |
+| **Done** | v0.27   | Composable owner workflows, local document and image processing, and durable Telegram delivery                                                                                                                                                                                       |
+| **Done** | v0.28   | Agent-owned owner-console operating brief, per-call session keys, and deletion of the legacy persona run path                                                                                                                                                                        |
+| **Now**  | v0.29   | Evidence and effects: an effect ledger where every durable change names its cause or admits it has none, bounded runs, `changes_read` and `mama_provenance`, one channel-grant rule pinned by a differential test, and lane verification that observes without blocking              |
 |          | Later   | Cross-language retrieval hardening, domain extraction templates, cross-worker packet analytics, and team-scoped context review workflows                                                                                                                                             |
 |          | v1.0    | Team mode: shared scoped knowledge graph for organizations. General release                                                                                                                                                                                                          |
 
@@ -357,12 +390,12 @@ that selects, rejects, and explains evidence before a worker writes memory or co
 ```bash
 git clone https://github.com/jungjaehoon-lifegamez/MAMA.git
 cd MAMA && pnpm install && pnpm build
-pnpm test     # 3000+ tests across all packages
+pnpm test     # 4,958 tests across all packages
 ```
 
 See [CLAUDE.md](CLAUDE.md) for development guidelines.
 
-_Last updated: 2026-07-21_
+_Last updated: 2026-07-30_
 
 ## License
 

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -992,7 +992,7 @@
           <a href="#local">Local</a>
           <a href="#install">Install</a>
         </div>
-        <span class="nav-cta">v0.21</span>
+        <span class="nav-cta">v0.29</span>
         <button
           class="nav-toggle"
           type="button"
@@ -1078,7 +1078,7 @@
               next year can both re-simulate the same history.
             </p>
             <ul>
-              <li>15 connectors poll chats, docs, sheets, repos, and work logs</li>
+              <li>14 connectors poll chats, docs, sheets, repos, and work logs</li>
               <li>Raw layer: cross-source unified search, windowing, and as-of time travel</li>
               <li>
                 Graph: entities, cases, decisions linked by typed edges (supersedes · builds_on ·
@@ -1235,25 +1235,29 @@
       <div class="container">
         <div class="section-head">
           <span class="eyebrow">Today and next</span>
-          <h2>v0.20 shipped the foundation. v0.21 ships the operator.</h2>
+          <h2>The operator runs. v0.29 makes it accountable.</h2>
           <p>
-            Substrate, agent surfaces, envelopes, decision evolution, and
-            <code style="font-family: var(--mono)">context_compile</code> are the foundation. On
-            top of it now runs a self-evolving operator: agent-authored triggers, a live report
-            board, scheduled memory curation, and a wiki that reads like a journal.
+            The substrate and the self-evolving operator both ship: agent-authored triggers, a live
+            report board, scheduled memory curation, and a wiki that reads like a journal. What
+            v0.29 adds is the part that makes an autonomous system answerable — every durable change
+            can name what caused it, or say plainly that it cannot.
           </p>
         </div>
         <div class="today-next">
           <article class="tn-col shipped">
-            <span class="badge">v0.20 · SHIPPED</span>
-            <h3>The runtime foundation.</h3>
+            <span class="badge">v0.21–v0.28 · SHIPPED</span>
+            <h3>The foundation, and the operator on top of it.</h3>
             <p>
               Local ingestion, worker evidence surfaces, provenance, graph APIs, situation packets,
-              runtime envelopes, decision evolution.
+              runtime envelopes, decision evolution — then the operator runtime, the owner console,
+              and a durable workorder pipeline on top.
             </p>
             <ul class="tn-list">
-              <li>15 connectors and local ingestion</li>
-              <li>Operator board at /ui · four live report slots + trigger library (legacy viewer retained)</li>
+              <li>14 connectors and local ingestion</li>
+              <li>
+                Operator board at /ui · four live report slots + trigger library (legacy viewer
+                retained)
+              </li>
               <li>Raw search and raw window APIs</li>
               <li>Graph, entity, and timeline APIs</li>
               <li>Worker situation packets</li>
@@ -1265,35 +1269,41 @@
             </ul>
           </article>
           <article class="tn-col planned">
-            <span class="badge">v0.21 · THE OPERATOR RUNTIME</span>
-            <h3>A trigger loop that evolves itself.</h3>
+            <span class="badge">v0.29 · EVIDENCE AND EFFECTS</span>
+            <h3>Every change names its cause, or admits it has none.</h3>
             <p>
-              The agent authors its own triggers from recurring situations, fires them to recall
-              the right memory, and reports to the owner. Delivered reports that cite a trigger
-              feed a success signal back; a review pass retires the noisy ones. Every six hours a
-              curation pass promotes durable judgments into memory, and promoted decisions compile
-              into an Obsidian wiki of daily journals and lessons.
+              A run is bounded by the delta batch it was handed, and that batch becomes the cause of
+              everything the run changes — the agent never restates it, and a host batch beats an
+              agent-supplied id, which is forgeable. A run given no batch produces changes marked
+              honestly unattributed rather than plausibly attributed.
             </p>
             <pre class="cc-code">
-author → fire → recall → report
-        ↑ cited in a delivered report → succeeded</pre
+{channel, delta batch} → run → change
+        cause derived by the host, never claimed by the agent</pre
             >
             <div class="cc-cells">
               <div class="cc-cell selected">
-                <div class="label">Board</div>
-                <div class="desc">four live slots, task truth from the ledger</div>
+                <div class="label">Effect ledger</div>
+                <div class="desc">
+                  one table; a CHECK forbids a cause without attribution, and attribution without a
+                  cause
+                </div>
               </div>
               <div class="cc-cell rejected">
-                <div class="label">Triggers</div>
-                <div class="desc">agent-authored, review-pruned, success-scored</div>
+                <div class="label">changes_read</div>
+                <div class="desc">what changed since a point, with coverage counts</div>
               </div>
               <div class="cc-cell missing">
-                <div class="label">Promotion</div>
-                <div class="desc">durable judgments only, never task states</div>
+                <div class="label">Provenance</div>
+                <div class="desc">
+                  what a memory rests on — a citation must not out-read reading
+                </div>
               </div>
               <div class="cc-cell caveats">
-                <div class="label">Wiki</div>
-                <div class="desc">daily journal + lessons in Obsidian</div>
+                <div class="label">Lane verification</div>
+                <div class="desc">
+                  claims reconciled against completed tool traces; observes, never blocks
+                </div>
               </div>
             </div>
           </article>
@@ -1346,16 +1356,14 @@ author → fire → recall → report
         <div class="footer-brand">
           <img src="assets/mama-icon.svg" alt="" />
           <span>MAMA OS</span>
-          <span class="footer-version">v0.21</span>
+          <span class="footer-version">v0.29</span>
         </div>
         <div class="footer-links">
           <a href="https://github.com/jungjaehoon-lifegamez/MAMA">GitHub</a>
           <a href="https://www.npmjs.com/package/@jungjaehoon/mama-os">npm</a>
           <a href="https://github.com/jungjaehoon-lifegamez/MAMA/issues">Issues</a>
         </div>
-        <p class="footer-legal">
-          MIT · Operator runtime · Local-first · AI provider independent.
-        </p>
+        <p class="footer-legal">MIT · Operator runtime · Local-first · AI provider independent.</p>
       </div>
     </footer>
     <script>

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -1274,8 +1274,9 @@
             <p>
               A run is bounded by the delta batch it was handed, and that batch becomes the cause of
               everything the run changes — the agent never restates it, and a host batch beats an
-              agent-supplied id, which is forgeable. A run given no batch produces changes marked
-              honestly unattributed rather than plausibly attributed.
+              agent-supplied id, which is forgeable. With no batch, a named source event is still
+              used: weaker evidence, not worthless. Only when there is neither is a change marked
+              unattributed — the honest answer rather than a plausible-looking one.
             </p>
             <pre class="cc-code">
 {channel, delta batch} → run → change


### PR DESCRIPTION
Every number here was measured against the code, not recalled.

## Facts that had drifted

| claim | README said | measured |
|---|---|---|
| connectors | 15 | **14** (`connectors/index.ts` registry) |
| gateways | 4, incl. Chatwork | **3** — only Discord/Slack/Telegram have a Gateway class *and* a construction site in `gateway-init.ts` |
| tests | "3000+" | **4,958** (standalone 3,969 + core 613 + mcp-server 198 + plugin 178) |
| roadmap | "Now: v0.25" | v0.29.2 is published |

Two of these were self-contradictions the page already contained: Quick Start said three chat platforms while the architecture diagram said four, and the v0.17 roadmap row also claimed 15 connectors — checking that tag shows it held **13**, so the figure was wrong when written and has been carried forward ever since.

## The bigger gap

**v0.29 — the release this repo just shipped — appeared nowhere in the README.** Added an *Evidence and Effects* section: the effect ledger and the CHECK that forbids both "attributed with no cause" and "unattributed with a cause", bounded runs where the host's delta batch beats a forgeable agent-supplied id, `changes_read`, `mama_provenance`, the single channel-grant rule pinned by a differential test, and lane verification that observes without blocking. The architecture diagram now shows the effect ledger next to the memory database.

## The published site

`pages.yml` deploys **`docs/website`**, not `docs/index.md` — worth stating, because the site still read *"v0.20 shipped the foundation. v0.21 ships the operator."* Version labels (nav, footer), connector counts, and the entire Today-and-next block are updated: the operator is shipped; what is *now* is accountability.

HTML validated as well-formed after the edit (two columns, four cells, no unclosed tags); Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeHgDc9QpXZH9x7hcc1Fq1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README and website content for release v0.29.
  * Added documentation for evidence and effects, including change attribution, provenance, effect tracking, and verification.
  * Refreshed architecture diagrams and capability descriptions to reflect 14 connectors and 3 gateways.
  * Expanded the roadmap through v0.29 and updated test counts and last-updated information.
  * Updated website release messaging, badges, feature cards, and footer version details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->