### PR TITLE
docs: the hero shows the product now - a message, not a metaphor

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 > MAMA reads them instead, and sends you the few things that need you.
 > Every claim links to its source.
 
-![The operator board: live report slots with linked evidence](docs/website/assets/mama-os-hero-evidence-board.png)
+![The briefing MAMA sends: three items with source links, one action, one recorded decision](docs/website/assets/mama-briefing-hero.svg)
 
 ## The product is a message that arrives
 

--- a/docs/website/assets/mama-briefing-hero.svg
+++ b/docs/website/assets/mama-briefing-hero.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="720" viewBox="0 0 1200 720" role="img"
+  aria-label="A briefing message from MAMA as it arrives in chat: three items with source links, one action needed, one decision recorded.">
+  <defs>
+    <style>
+      .brand { font: 700 21px ui-sans-serif, -apple-system, "Segoe UI", sans-serif; fill: #e8eaf0; }
+      .meta  { font: 500 18px ui-sans-serif, -apple-system, "Segoe UI", sans-serif; fill: #8b94a5; }
+      .sec   { font: 700 22px ui-monospace, SFMono-Regular, Menlo, monospace; fill: #7dd3a8; }
+      .line  { font: 400 22px ui-monospace, SFMono-Regular, Menlo, monospace; fill: #d7dbe4; }
+      .chip  { font: 600 16px ui-monospace, SFMono-Regular, Menlo, monospace; fill: #8ab4ff; }
+      .foot  { font: 500 19px ui-sans-serif, -apple-system, "Segoe UI", sans-serif; fill: #8b94a5; }
+    </style>
+  </defs>
+
+  <rect x="60" y="28" width="1080" height="664" rx="28" fill="#171a21" stroke="#2a2f3a" stroke-width="1.5"/>
+
+  <!-- header -->
+  <circle cx="112" cy="86" r="7" fill="#4ade80"/>
+  <text x="134" y="94" class="brand">MAMA</text>
+  <text x="212" y="94" class="meta">· Telegram</text>
+  <text x="1100" y="94" text-anchor="end" class="meta">Wed 08:00</text>
+  <line x1="92" y1="120" x2="1108" y2="120" stroke="#2a2f3a" stroke-width="1.5"/>
+
+  <!-- briefing -->
+  <text x="100" y="172" class="sec">■ Briefing</text>
+  <text x="100" y="218" class="line">1. Client A sent the revised files overnight</text><rect x="991" y="197" width="109" height="30" rx="15" fill="#1e2f4d"/><text x="1045" y="218" text-anchor="middle" class="chip">→ source</text>
+  <text x="100" y="262" class="line">2. The #alpha deadline moved: Friday → Wednesday</text><rect x="991" y="241" width="109" height="30" rx="15" fill="#1e2f4d"/><text x="1045" y="262" text-anchor="middle" class="chip">→ source</text>
+  <text x="100" y="306" class="line">3. B's invoice question: 14 hours unanswered</text><rect x="991" y="285" width="109" height="30" rx="15" fill="#1e2f4d"/><text x="1045" y="306" text-anchor="middle" class="chip">→ source</text>
+
+  <!-- action -->
+  <text x="100" y="376" class="sec">■ Needs your action</text>
+  <text x="100" y="422" class="line">- Approve the revised scope before the 11:00 call</text><rect x="991" y="401" width="109" height="30" rx="15" fill="#1e2f4d"/><text x="1045" y="422" text-anchor="middle" class="chip">→ thread</text>
+
+  <!-- recorded -->
+  <text x="100" y="492" class="sec">■ Recorded yesterday</text>
+  <text x="100" y="538" class="line">- Decision: rotate the staging API keys weekly</text><rect x="991" y="517" width="109" height="30" rx="15" fill="#1e2f4d"/><text x="1045" y="538" text-anchor="middle" class="chip">→ source</text>
+
+  <!-- footer -->
+  <line x1="92" y1="590" x2="1108" y2="590" stroke="#2a2f3a" stroke-width="1.5"/>
+  <text x="100" y="636" class="foot">While you slept: 14 sources read · 3 things need you · every line links to its source</text>
+</svg>

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -1009,20 +1009,18 @@
     <section class="hero" id="top">
       <div class="container">
         <div class="hero-copy">
-          <span class="eyebrow">Local-first operating memory</span>
-          <h1>This is what an agent does <em>with the record.</em></h1>
+          <span class="eyebrow">A local operator that reads your channels</span>
+          <h1>The product is a message <em>that arrives.</em></h1>
           <p>
-            MAMA holds a living, append-only record of your team's <em>work</em> — chats about
-            projects, decisions made, files shipped, work logs. Preserved like a game record so
-            stronger models tomorrow can re-read the same history. Agents read it, simulate past
-            positions, infer what's missing, predict project risk, and act inside explicit
-            boundaries.
+            You pick the hours. MAMA reads 14 sources overnight — Slack, Telegram, Gmail, Trello, an
+            Obsidian vault — and sends you the few things that need you. Every line links to the
+            message it came from. Nothing is uploaded anywhere: the record lives on your machine.
           </p>
         </div>
         <div class="hero-image">
           <img
-            src="assets/mama-os-hero-evidence-board.png"
-            alt="A bright daylight scene: on the left, a corkboard holds the project_a investigation — four people portraits, multiple event cards on a timeline, channel icons, sticky notes with open questions, an empty pin labeled missing demo_scope, all connected by red yarn, framed as an envelope with green allow seals and red deny seals. On the right, a wooden desk with the agent's open notebook showing a structured cited report — judgment, evidence, inference, missing, next, boundary — plus a stack of cited reference cards, a magnifying glass, and a MAMA OS coffee mug. Thin teal threads connect notebook lines back to specific board pins as visible provenance."
+            src="assets/mama-briefing-hero.svg"
+            alt="A briefing message from MAMA as it arrives in chat: three items with source links, one action needed, one decision recorded."
           />
         </div>
         <div class="hero-actions">
@@ -1131,6 +1129,12 @@
             four properties by form, not by policy. The substrate refuses to let the agent hide
             them.
           </p>
+        </div>
+        <div class="hero-image" style="margin-bottom: 2.5rem">
+          <img
+            src="assets/mama-os-hero-evidence-board.png"
+            alt="The evidence board as an illustration: event cards on a timeline connected by threads, and a notebook where every line of the agent's judgment points back to a specific pinned source."
+          />
         </div>
         <div class="honesty-grid">
           <article class="honesty-card">


### PR DESCRIPTION
## The verdict on the current hero

The corkboard illustration is charming and well-made — but it illustrates the **old** pitch: an agent reading an evidence board. The current pitch, on both the README and the site, is *"the product is a message that arrives"* — and no visual anywhere showed that message. The README even captioned the illustration as "the operator board: live report slots", which it is not; it is concept art.

## The new hero

A hand-authored SVG of the briefing exactly as the daemon formats it — three items with `→ source` chips, one action, one recorded decision, and a footer that carries the whole pitch:

> *While you slept: 14 sources read · 3 things need you · every line links to its source*

Vector, 3 KB, self-contained, dark card that reads on both themes. Names match the README's synthetic example.

## Nothing wasted

The corkboard moves to the **"Most AI gives you a black box"** section, where an illustration of evidence-connected-by-threads is exactly on topic. The site hero copy drops the substrate framing ("append-only record… game record") for the same message-first pitch as the README.

HTML validated well-formed; Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeHgDc9QpXZH9x7hcc1Fq1