### PR TITLE
v0.32.3 fix: bound MAMA OS trigger maintenance costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## mama-os [0.32.3] - 2026-08-03
+
+### Fixed
+
+- **Operator trigger maintenance no longer drains Claude usage while idle or failing.** Successful
+  author windows are consumed once, failed author and review calls use durable 6-to-24-hour
+  backoff, missed intervals collapse into one maintenance pass, and review work advances from a
+  persistent watermark.
+- **Trigger authoring and review stay within fixed provider budgets.** MAMA pins the configured
+  model, uses tool-free non-persistent Claude sessions, preserves the newest bounded evidence, and
+  caps both new and legacy trigger fields before the final provider boundary.
+- **Stopping MAMA now cancels and drains trigger-loop provider work.** Shutdown aborts active
+  author and reviewer calls, waits for the running loop, and prevents deferred review or report
+  legs from restarting work or recording false provider failures.
+
 ## mama-os [0.32.2] - 2026-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node Version](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org)
 [![LongMemEval 100Q](https://img.shields.io/badge/LongMemEval%20100Q-93%25-blue)](packages/memorybench/)
-[![Tests](https://img.shields.io/badge/tests-4958%20passing-success)](https://github.com/jungjaehoon-lifegamez/MAMA)
+[![Tests](https://img.shields.io/badge/tests-5005%20passing-success)](https://github.com/jungjaehoon-lifegamez/MAMA)
 
 > Right now, you read every channel yourself so nothing slips past you.
 > MAMA reads them instead, and sends you the few things that need you.
@@ -129,8 +129,8 @@ running, and skips quietly when it is not:
 
 | Package                                       | What it is                                                                                                     | You run it?          |
 | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------------- |
-| [mama-os](packages/standalone/) 0.32.0        | The always-on server: connectors, trigger loop, reports, task board, web UI. 92k lines. "MAMA" means this.     | `mama start`         |
-| [mama-core](packages/mama-core/) 2.1.1        | The library underneath: memory, provenance, graph, embeddings. Everything imports it; it imports nothing here. | No binary            |
+| [mama-os](packages/standalone/) 0.32.3        | The always-on server: connectors, trigger loop, reports, task board, web UI. 92k lines. "MAMA" means this.     | `mama start`         |
+| [mama-core](packages/mama-core/) 2.1.2        | The library underneath: memory, provenance, graph, embeddings. Everything imports it; it imports nothing here. | No binary            |
 | [mama-server](packages/mcp-server/) 1.15.0    | A deliberately thin MCP adapter over the core — 3.7k lines, no logic of its own.                               | As an MCP server     |
 | [plugin](packages/claude-code-plugin/) 1.11.0 | Claude Code hooks + slash commands. No background process.                                                     | Installed, not run   |
 | [memorybench](packages/memorybench/) 1.0.0    | The benchmark harness behind the retrieval numbers.                                                            | To reproduce a score |
@@ -192,7 +192,7 @@ cd MAMA && pnpm install && pnpm build
 pnpm test     # 5,005 tests across five packages
 ```
 
-Guidelines in [CLAUDE.md](CLAUDE.md). _Last updated: 2026-07-31_
+Guidelines in [CLAUDE.md](CLAUDE.md). _Last updated: 2026-08-03_
 
 ## License
 

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -411,4 +411,4 @@ Existing decisions remain valid across all package updates. SQLite schema change
 
 ---
 
-**Last Updated:** 2026-07-31
+**Last Updated:** 2026-08-03

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -259,7 +259,7 @@ Each package has independent versioning:
 - **mama-core:** 2.1.2 (stable API)
 - **mama-server:** 1.15.0 (follows MAMA version)
 - **claude-code-plugin:** 1.11.0 (follows MAMA version)
-- **mama-os:** 0.32.2 (standalone agent)
+- **mama-os:** 0.32.3 (standalone agent)
 
 ## Distribution Strategy
 

--- a/docs/development/kagemusha-telegram-parity.md
+++ b/docs/development/kagemusha-telegram-parity.md
@@ -60,6 +60,29 @@ Corrective verification is in `telegram.test.ts`, `telegram-message-ledger.test.
 `pending-report-store.test.ts`, `message-router.test.ts`, `role-manager.test.ts`,
 `attachment-text-extractor.test.ts`, and `gateway-tool-executor.test.ts`.
 
+### Trigger-loop token-cost closure: 2026-08-03
+
+- **TG-05:** trigger authoring consumes each successful event window once. Provider or parse
+  failures persist a process-independent 6-to-24-hour exponential backoff, so maintenance ticks,
+  connector nudges, new events, and daemon restarts cannot resend a poison window continuously.
+  Author input keeps the newest bounded evidence, caps every new trigger field and collection,
+  and invokes an explicit configured model in a tool-free, non-persistent JSON session.
+- **TG-06:** review advances a durable per-trigger fire watermark only after applying a decision,
+  backs off failed candidates without starving later rows, and reviews one candidate per default
+  maintenance pass. Prompt construction bounds both legacy trigger fields and the newest context
+  through the final provider boundary. Agent retire/refine writes require an active source row, so
+  a late decision cannot overwrite an owner veto; refine replacement remains transactional.
+  Daemon shutdown concurrently drains the active loop tick and aborts author/reviewer provider
+  calls; abort completion cannot start a later review/report leg or create a false provider
+  backoff.
+- Evidence: `operator-trigger-loop.test.ts`, `trigger-author.test.ts`,
+  `trigger-registry.test.ts`, `trigger-review.test.ts`, and `trigger-runtime-wiring.test.ts` cover
+  unchanged-window consumption, failure/restart backoff, newest-context preservation through the
+  final prompt, fixed prompt ceilings, one-pass catch-up after five missed intervals, review
+  isolation, migration locking, owner-state races, refine rollback, provider abort/drain, and
+  shutdown wiring. The focused gate passed 134 tests; the complete standalone gate passed 344
+  files and 4,600 tests with four files and seven tests skipped.
+
 ### Principal-following Code-Act correction: 2026-07-31
 
 - **TG-03/TG-04:** every persistent Claude process generation owns a random 32-byte context key.
@@ -389,8 +412,19 @@ change unless they are release-blocking security or data-loss issues.
       red-team review passed 297 focused tests plus 27 setup/security tests, and independent
       testing review passed 334 focused tests; both returned CLEAR. Root-wide Prettier still
       reports 37 pre-existing branch-unrelated files and is retained as repository format debt.
+- [x] The 2026-08-03 TG-05/TG-06 trigger-loop token-cost gate passed 134 focused tests and the
+      complete standalone suite (344 files, 4,600 tests; 4 files / 7 tests skipped). Durable
+      author/review backoff, newest bounded final prompts, owner-state races, collapsed missed
+      intervals, and shutdown provider abort/drain are covered; security/migration,
+      cost/performance, testing, and final red-team reviewers returned clear.
 
 ## Change log
+
+- 2026-08-03: Closed TG-05/TG-06 trigger-loop token leakage. Author and review calls now consume
+  durable work exactly once, back off provider/parse failures across restarts, keep newest evidence
+  under fixed provider-input ceilings, and cannot overwrite an owner state change. Maintenance
+  overlap collapses to one catch-up pass, and isolated JSON calls use the configured model without
+  tools or session persistence.
 
 - 2026-08-02: Closed the final Cline release review. The setup wizard now uses a backend-neutral,
   nonce-bound host-action protocol, validates Discord/Slack/Telegram credentials through official

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -11,7 +11,7 @@ MAMA is a pnpm workspace-based monorepo with four release targets (plus the inte
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.32.2  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.32.3  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.15.0  |
 | MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 2.1.2   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.11.0  |
@@ -61,7 +61,7 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.32.2          |
+| `packages/standalone/package.json`                       | `version` | 0.32.3          |
 | `packages/mcp-server/package.json`                       | `version` | 1.15.0          |
 | `packages/mama-core/package.json`                        | `version` | 2.1.2           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.11.0          |

--- a/docs/guides/standalone-setup.md
+++ b/docs/guides/standalone-setup.md
@@ -105,7 +105,7 @@ npm install -g @jungjaehoon/mama-os
 
 ```bash
 mama --version
-# Should output: 0.32.2
+# Should output: 0.32.3
 
 mama --help
 # Should show available commands

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,7 +157,7 @@ _Contributing, testing, and development guidelines_
 
 ---
 
-**Status:** MAMA OS v0.32.2 — Claude CLI, Codex app-server, and Cline Hub are equivalent supported
+**Status:** MAMA OS v0.32.3 — Claude CLI, Codex app-server, and Cline Hub are equivalent supported
 backends with backend-owned durable context, role-scoped Code-Act projection, bounded recovery,
 and explicit non-replayable mutation outcomes. Configured private connectors remain installation-
 local and are never promoted into generic catalogs or prompts.

--- a/docs/index.md
+++ b/docs/index.md
@@ -161,4 +161,4 @@ _Contributing, testing, and development guidelines_
 backends with backend-owned durable context, role-scoped Code-Act projection, bounded recovery,
 and explicit non-replayable mutation outcomes. Configured private connectors remain installation-
 local and are never promoted into generic catalogs or prompts.
-**Last Updated:** 2026-08-02
+**Last Updated:** 2026-08-03

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1237,5 +1237,5 @@ If upgrading from v1.1 (11 tools) to v1.2+ (5 tools):
 
 ---
 
-**Last Updated:** 2026-07-31
-**Version:** mama-server 1.15.0 / mama-os 0.32.0
+**Last Updated:** 2026-08-03
+**Version:** mama-server 1.15.0 / mama-os 0.32.3

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.32.2",
+  "version": "0.32.3",
   "description": "MAMA OS - Local AI Runtime. Your scattered knowledge, organized by AI agents that never sleep.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -2285,8 +2285,7 @@ export async function runAgentLoop(
           // stays 'claimed', and every launchd restart replays the batch
           // (review F7).
           if (conductorTickPromise) await conductorTickPromise;
-          stopTriggerLoop();
-          await triggerAgentRuntime.stop();
+          await Promise.all([stopTriggerLoop(), triggerAgentRuntime.stop()]);
           // The shared operator DB handle is closed by the unconditional stop
           // hook above (single owner); nothing to close here.
         },

--- a/packages/standalone/src/operator/operator-trigger-loop.ts
+++ b/packages/standalone/src/operator/operator-trigger-loop.ts
@@ -28,7 +28,7 @@ import { applyReview, type ReviewDecision } from './trigger-review.js';
 import { SituationReporter, type DeliveredFullReport } from './situation-report.js';
 import type { ReportSchedule } from './report-scheduler.js';
 import type { BackendType } from '../agent/model-runner.js';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import {
   pendingReportDeliveryPayloadIdentity,
   pendingReportRequestPayloadIdentity,
@@ -54,6 +54,8 @@ export interface TriggerLoopConfig {
   drainLimit: number;
   authorEveryNTicks: number;
   reviewEveryNTicks: number;
+  /** Maximum distinct newly-fired triggers reviewed in one maintenance pass. Default 1. */
+  reviewBatchLimit?: number;
   authorWindowSize: number;
   /** Situational-digest cadence (M1.5 + M2 output leg). Only used when deps.output is set. */
   reportEveryNTicks?: number;
@@ -77,13 +79,13 @@ export interface TriggerLoopDeps {
   delta: DeltaSource;
   memory: OperatorMemoryPort;
   registry: TriggerRegistry;
-  /** Agent for structured-JSON tasks: authorTriggers (real: askAgentCLI - bare CLI parses reliably). */
+  /** Agent for structured-JSON tasks: authorTriggers (isolated JSON-only provider runtime). */
   askAgent: AskAgent;
   /**
    * Agent for REPORT composition (M2.2). Bind this to the daemon's persona AgentLoop
    * (SOUL.md system prompt, pinned model, session continuity) - tone/quality come from the
    * generation inputs, and reports deserve the persona path while JSON tasks stay on the
-   * bare CLI. Absent -> reports use askAgent (explicit config choice, not a failure fallback).
+   * isolated CLI. Absent -> reports use askAgent (explicit config choice, not a failure fallback).
    */
   reportAsk?: AskAgent;
   /** Agent review of one trigger (real: reviewTriggerCLI). */
@@ -144,11 +146,23 @@ export interface TickResult {
   fullReported: boolean;
 }
 
+interface TickOptions {
+  /** Connector freshness ticks drain data but must not accelerate LLM maintenance passes. */
+  advanceMaintenance?: boolean;
+}
+
 export class OperatorTriggerLoop {
   private deps: TriggerLoopDeps;
   private tickCount = 0;
+  private maintenanceTickCount = 0;
+  private authorWindowGeneration = 0;
+  private authoredWindowGeneration = 0;
   private recentEvents: OperatorChannelEvent[] = [];
   private running = false;
+  private maintenancePending = false;
+  private schedulerActive = false;
+  private stopping = false;
+  private activeRunPromise: Promise<void> | null = null;
   private nudgeTimer: ReturnType<typeof setTimeout> | null = null;
   private digest: SituationReporter;
   private fullReporter: SituationReporter;
@@ -434,18 +448,35 @@ export class OperatorTriggerLoop {
     return recovered;
   }
 
-  async tick(): Promise<TickResult> {
+  async tick(options: TickOptions = {}): Promise<TickResult> {
     const { delta, memory, registry, askAgent, review, config, log } = this.deps;
     const { output, reportScheduler } = this.deps;
     const fullLegOn = Boolean(output && reportScheduler);
     this.tickCount += 1;
     const tick = this.tickCount;
+    const maintenanceTick =
+      options.advanceMaintenance === false ? null : (this.maintenanceTickCount += 1);
+    let fires = 0;
+    let authored = 0;
+    let reviewed = 0;
+    let reported = false;
+    let fullReported = false;
+    const result = (drained = 0): TickResult => ({
+      tick,
+      drained,
+      fires,
+      authored,
+      reviewed,
+      reported,
+      fullReported,
+    });
 
     // Outbox recovery is the first effect in a tick. It reuses the persisted
     // delivery id, allowing Telegram's confirmed-chunk ledger to suppress a
     // send that was accepted just before the prior daemon stopped.
     this.refreshPendingReportState();
     const recoveredPendingWork = await this.recoverPendingReportWork();
+    if (this.stopping) return result();
 
     // 1. Drain new deltas (commit AFTER processing - at-least-once).
     const events = delta.drainNew(config.drainLimit);
@@ -457,11 +488,11 @@ export class OperatorTriggerLoop {
     }
 
     // 2. Match + fire + recordFire, folding fire activity into the report accumulators.
-    let fires = 0;
     for (const event of reportEvents) {
       const signals = matchTriggers(event, registry);
       for (const signal of signals) {
-        const result = await fireTrigger(signal, memory);
+        const fireResult = await fireTrigger(signal, memory);
+        if (this.stopping) return result(events.length);
         fires += 1;
         if (signal.triggerId) {
           registry.recordFire(signal.triggerId);
@@ -472,7 +503,7 @@ export class OperatorTriggerLoop {
             triggerId: signal.triggerId ?? signal.detector,
             kind: signal.kind,
             channelId: signal.channelId,
-            recalled: result.recalled,
+            recalled: fireResult.recalled,
           });
         }
         if (fullLegOn) {
@@ -480,12 +511,12 @@ export class OperatorTriggerLoop {
             triggerId: signal.triggerId ?? signal.detector,
             kind: signal.kind,
             channelId: signal.channelId,
-            recalled: result.recalled,
+            recalled: fireResult.recalled,
           });
         }
         log(
           `[trigger-loop] tick ${tick}: fire trigger=${signal.triggerId ?? signal.detector} ` +
-            `recalled=${result.recalled.length} channel=${signal.channelId}`
+            `recalled=${fireResult.recalled.length} channel=${signal.channelId}`
         );
       }
     }
@@ -499,6 +530,7 @@ export class OperatorTriggerLoop {
         }
       }
       this.recentEvents = [...this.recentEvents, ...reportEvents].slice(-config.authorWindowSize);
+      this.authorWindowGeneration += 1;
       this.persistPendingReports();
     }
     // Group per channel ONCE, before the cursor moves: the conductor inbox
@@ -580,40 +612,93 @@ export class OperatorTriggerLoop {
     }
 
     // 3. Agent authors new triggers from the recent window.
-    let authored = 0;
-    if (tick % config.authorEveryNTicks === 0 && this.recentEvents.length > 0) {
-      const created = await authorTriggers(this.recentEvents, registry, askAgent, {
-        note: `authored at tick ${tick}`,
-      });
-      authored = created.length;
-      if (authored > 0) {
-        if (output) {
-          this.digest.recordAuthored(authored);
+    if (
+      maintenanceTick !== null &&
+      maintenanceTick % config.authorEveryNTicks === 0 &&
+      this.recentEvents.length > 0 &&
+      this.authorWindowGeneration > this.authoredWindowGeneration
+    ) {
+      if (registry.canAttemptAuthor()) {
+        try {
+          const created = await authorTriggers(this.recentEvents, registry, askAgent, {
+            note: `authored at tick ${tick}`,
+          });
+          if (this.stopping) return result(events.length);
+          authored = created.length;
+          registry.clearAuthorFailure();
+          this.authoredWindowGeneration = this.authorWindowGeneration;
+          if (authored > 0) {
+            if (output) {
+              this.digest.recordAuthored(authored);
+            }
+            if (fullLegOn) {
+              this.fullReporter.recordAuthored(authored);
+            }
+            this.persistPendingReports();
+          }
+          log(`[trigger-loop] tick ${tick}: author pass created ${authored} trigger(s)`);
+        } catch (error) {
+          if (this.stopping) {
+            log(`[trigger-loop] tick ${tick}: author pass cancelled by shutdown`);
+            return result(events.length);
+          }
+          registry.recordAuthorFailure(authorWindowFingerprint(this.recentEvents));
+          log(
+            `[trigger-loop] tick ${tick}: author pass FAILED; backed off: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
         }
-        if (fullLegOn) {
-          this.fullReporter.recordAuthored(authored);
-        }
-        this.persistPendingReports();
       }
-      log(`[trigger-loop] tick ${tick}: author pass created ${authored} trigger(s)`);
     }
 
     // 4. Agent reviews triggers that have actually fired.
-    let reviewed = 0;
-    if (tick % config.reviewEveryNTicks === 0) {
-      const firedTriggers = registry.listActive().filter((t) => t.stats.fired > 0);
-      const context = this.recentEvents.map((e) => `[${e.channelId}] ${e.content}`);
+    if (this.stopping) return result(events.length);
+    if (maintenanceTick !== null && maintenanceTick % config.reviewEveryNTicks === 0) {
+      const configuredReviewLimit = config.reviewBatchLimit;
+      const reviewBatchLimit =
+        typeof configuredReviewLimit === 'number' &&
+        Number.isInteger(configuredReviewLimit) &&
+        configuredReviewLimit > 0
+          ? configuredReviewLimit
+          : 1;
+      const firedTriggers = registry.listReviewCandidates(reviewBatchLimit);
+      const context = boundedReviewContext(this.recentEvents);
       for (const trigger of firedTriggers) {
-        const decision = await review(trigger, context);
-        const action = applyReview(decision, trigger.id, registry);
-        reviewed += 1;
-        log(`[trigger-loop] tick ${tick}: review trigger=${trigger.id} -> ${action}`);
+        try {
+          const decision = await review(trigger, context);
+          if (this.stopping) return result(events.length);
+          const action = applyReview(decision, trigger.id, registry);
+          if (action === 'kept') {
+            registry.markReviewed(trigger.id, trigger.stats.fired);
+          }
+          reviewed += 1;
+          log(`[trigger-loop] tick ${tick}: review trigger=${trigger.id} -> ${action}`);
+        } catch (error) {
+          if (this.stopping) {
+            log(`[trigger-loop] tick ${tick}: review trigger=${trigger.id} cancelled by shutdown`);
+            return result(events.length);
+          }
+          let backoffNote = 'backed off';
+          try {
+            registry.recordReviewFailure(trigger.id);
+          } catch (stateError) {
+            backoffNote = `state changed before backoff: ${
+              stateError instanceof Error ? stateError.message : String(stateError)
+            }`;
+          }
+          log(
+            `[trigger-loop] tick ${tick}: review trigger=${trigger.id} FAILED; ${backoffNote}: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+        }
       }
     }
 
     // 5. Situational digest (M1.5 cadence, M2 window-aware): the agent composes it from the
     //    window + fire activity + recalled memory; the sink delivers it. Agent may reply NOTHING.
-    let reported = false;
+    if (this.stopping) return result(events.length);
     const reportAsk = this.deps.reportAsk ?? askAgent;
     const reportEvery = config.reportEveryNTicks ?? 0;
     if (
@@ -624,6 +709,7 @@ export class OperatorTriggerLoop {
       this.digest.hasActivity()
     ) {
       reported = await this.prepareAndDeliverReport(reportAsk, 'digest', { kind: 'digest' });
+      if (this.stopping) return result(events.length);
       log(`[trigger-loop] tick ${tick}: owner digest ${reported ? 'SENT' : 'suppressed by agent'}`);
     }
 
@@ -632,8 +718,13 @@ export class OperatorTriggerLoop {
     //    rely on the scheduled report arriving). Fires once per hour (markFired persists the
     //    hour key -> restart-safe). Send failure throws (no-fallback) WITHOUT marking the hour,
     //    so the next tick retries with the buffer intact.
-    let fullReported = false;
-    if (!recoveredPendingWork && !this.isPendingReportWorkBlocked() && output && reportScheduler) {
+    if (
+      !this.stopping &&
+      !recoveredPendingWork &&
+      !this.isPendingReportWorkBlocked() &&
+      output &&
+      reportScheduler
+    ) {
       const { fire, hourKey } = reportScheduler.shouldFire(new Date());
       if (fire) {
         // On-demand merge suppression (plan v6 S1-T3): an owner-requested full
@@ -660,6 +751,7 @@ export class OperatorTriggerLoop {
             hourKey,
             firedAtIso,
           });
+          if (this.stopping) return result(events.length);
           log(
             `[trigger-loop] tick ${tick}: full report ${fullReported ? 'SENT' : 'suppressed by agent'} (${hourKey})`
           );
@@ -667,7 +759,7 @@ export class OperatorTriggerLoop {
       }
     }
 
-    return { tick, drained: events.length, fires, authored, reviewed, reported, fullReported };
+    return result(events.length);
   }
 
   /**
@@ -679,8 +771,8 @@ export class OperatorTriggerLoop {
    * a quiet window arms one timer; further nudges while it is armed are ignored, so a burst of poll
    * batches collapses to a single extra tick. Busy-safe (agent-awareness.ts:343-346 mechanism): if a
    * tick is in flight when the timer fires, the nudge is skipped - never concurrent ticks; the
-   * uncommitted deltas simply wait for the next tick. Pure timing assist: it only changes WHEN an
-   * existing tick runs, never WHAT it does.
+   * uncommitted deltas simply wait for the next tick. The extra tick drains and reports, but does
+   * not advance author/review maintenance cadence.
    */
   /**
    * On-demand full report (plan v6 S1-T3): the owner's "give me the full
@@ -694,6 +786,7 @@ export class OperatorTriggerLoop {
    * the delta anchor exactly like a scheduled run.
    */
   startFullReport(): { accepted: boolean; reason?: 'busy' | 'unavailable' } {
+    if (this.stopping) return { accepted: false, reason: 'unavailable' };
     const output = this.deps.output;
     const reportScheduler = this.deps.reportScheduler;
     if (!output || this.isPendingReportWorkBlocked()) {
@@ -745,27 +838,19 @@ export class OperatorTriggerLoop {
       );
       return { accepted: false, reason: 'unavailable' };
     }
-    this.running = true;
-    void this.preparePendingRequest()
-      .then((sent) => {
+    this.launchRun(
+      this.preparePendingRequest().then((sent) => {
         this.deps.log(
           `[trigger-loop] on-demand full report ${sent ? 'SENT' : 'suppressed by agent'}`
         );
-      })
-      .catch((error: unknown) => {
-        this.deps.log(
-          `[trigger-loop] on-demand full report FAILED: ${
-            error instanceof Error ? error.message : String(error)
-          }`
-        );
-      })
-      .finally(() => {
-        this.running = false;
-      });
+      }),
+      'on-demand full report FAILED'
+    );
     return { accepted: true };
   }
 
   nudge(): void {
+    if (this.stopping) return;
     if (this.nudgeTimer) return; // already armed - debounce collapses the burst
     const configured = this.deps.config.nudgeDebounceMs;
     const debounceMs =
@@ -780,16 +865,7 @@ export class OperatorTriggerLoop {
         );
         return;
       }
-      this.running = true;
-      void this.tick()
-        .catch((error: unknown) => {
-          this.deps.log(
-            `[trigger-loop] nudge tick failed: ${error instanceof Error ? error.message : String(error)}`
-          );
-        })
-        .finally(() => {
-          this.running = false;
-        });
+      this.launchRun(this.tick({ advanceMaintenance: false }), 'nudge tick failed');
     }, debounceMs);
     this.nudgeTimer.unref?.();
   }
@@ -799,21 +875,12 @@ export class OperatorTriggerLoop {
    * The interval wrapper catches + logs tick errors so one bad tick does not kill the loop
    * (the error is still surfaced loudly in the log - not swallowed).
    */
-  start(): () => void {
+  start(): () => Promise<void> {
     const { config, log } = this.deps;
+    this.stopping = false;
+    this.schedulerActive = true;
     if ((this.pendingDelivery || this.pendingRequest) && !this.running) {
-      this.running = true;
-      void this.recoverPendingReportWork()
-        .catch((error: unknown) => {
-          log(
-            `[trigger-loop] startup report recovery failed: ${
-              error instanceof Error ? error.message : String(error)
-            }`
-          );
-        })
-        .finally(() => {
-          this.running = false;
-        });
+      this.launchRun(this.recoverPendingReportWork(), 'startup report recovery failed');
     }
     const handle = setInterval(() => {
       // The INTERVAL is the leg: it beats even while a long tick (full
@@ -821,29 +888,93 @@ export class OperatorTriggerLoop {
       // on live. A loop mid-tick is alive, not silent.
       getLegCadence()?.beat('trigger-loop');
       if (this.running) {
+        this.maintenancePending = true;
         log('[trigger-loop] tick skipped: previous tick still running');
         return;
       }
-      this.running = true;
-      void this.tick()
-        .catch((error: unknown) => {
-          log(
-            `[trigger-loop] tick failed: ${error instanceof Error ? error.message : String(error)}`
-          );
-        })
-        .finally(() => {
-          this.running = false;
-        });
+      this.launchRun(this.tick(), 'tick failed');
     }, config.tickMs);
     handle.unref?.();
     log(`[trigger-loop] started (tick every ${config.tickMs}ms)`);
+    let stopPromise: Promise<void> | undefined;
     return () => {
+      if (stopPromise) return stopPromise;
+      this.stopping = true;
+      this.schedulerActive = false;
+      this.maintenancePending = false;
       clearInterval(handle);
       if (this.nudgeTimer) {
         clearTimeout(this.nudgeTimer);
         this.nudgeTimer = null;
       }
-      log('[trigger-loop] stopped');
+      stopPromise = (async () => {
+        const activeRun = this.activeRunPromise;
+        if (activeRun) await activeRun;
+        log('[trigger-loop] stopped');
+      })();
+      return stopPromise;
     };
   }
+
+  private launchRun(work: Promise<unknown>, failureLabel: string): void {
+    this.running = true;
+    const tracked = work
+      .then(() => undefined)
+      .catch((error: unknown) => {
+        this.deps.log(
+          `[trigger-loop] ${failureLabel}: ${error instanceof Error ? error.message : String(error)}`
+        );
+      })
+      .finally(() => {
+        if (this.activeRunPromise === tracked) this.activeRunPromise = null;
+        this.finishRun();
+      });
+    this.activeRunPromise = tracked;
+  }
+
+  private finishRun(): void {
+    this.running = false;
+    if (!this.schedulerActive || !this.maintenancePending) return;
+    this.maintenancePending = false;
+    this.launchRun(this.tick(), 'deferred maintenance tick failed');
+  }
+}
+
+const REVIEW_CONTEXT_EVENT_CHARS = 500;
+const REVIEW_CONTEXT_TOTAL_CHARS = 8_000;
+
+function boundedReviewContext(events: OperatorChannelEvent[]): string[] {
+  const lines: string[] = [];
+  let used = 0;
+  for (const event of [...events].reverse()) {
+    const content = event.content
+      .trim()
+      .replace(/[\r\n]+/g, ' ')
+      .slice(0, REVIEW_CONTEXT_EVENT_CHARS);
+    const line = `[${event.channelId}] ${content}`;
+    if (used + line.length + 1 > REVIEW_CONTEXT_TOTAL_CHARS) break;
+    lines.push(line);
+    used += line.length + 1;
+  }
+  const omitted = events.length - lines.length;
+  lines.reverse();
+  if (omitted > 0) lines.unshift(`[... ${omitted} event(s) omitted by review input budget]`);
+  return lines;
+}
+
+function authorWindowFingerprint(events: OperatorChannelEvent[]): string {
+  const hash = createHash('sha256');
+  for (const event of events) {
+    hash.update(event.channel);
+    hash.update('\0');
+    hash.update(event.channelId);
+    hash.update('\0');
+    hash.update(String(event.eventIndexId ?? event.id));
+    hash.update('\0');
+    hash.update(String(event.createdAt));
+    hash.update('\0');
+    hash.update(event.content);
+    hash.update('\0');
+  }
+  return hash.digest('hex');
 }

--- a/packages/standalone/src/operator/trigger-author.ts
+++ b/packages/standalone/src/operator/trigger-author.ts
@@ -67,6 +67,7 @@ export interface TriggerAgentRuntime {
 
 export interface TriggerAgentRuntimeDependencies {
   askClaude?: AskAgent;
+  createClaudeAsk?: (options: { model?: string; signal?: AbortSignal }) => AskAgent;
   createCodexRuntime?: (options: CodexRuntimeProcessOptions) => TriggerCodexRunner;
   createClineRuntime?: (options: {
     command?: string;
@@ -82,13 +83,17 @@ export interface TriggerAgentRuntimeDependencies {
 export type ClaudeCliExecutor = (
   file: string,
   args: string[],
-  options: { maxBuffer: number }
+  options: { maxBuffer: number; signal?: AbortSignal }
 ) => Promise<{ stdout: string }>;
 
 const TRIGGER_CODEX_SYSTEM_PROMPT =
   'Return only the requested JSON value, with no prose or code fences.';
 const TRIGGER_AUTHOR_SESSION_KEY = 'operator:trigger-author';
 const TRIGGER_REVIEW_SESSION_KEY = 'operator:trigger-review';
+const AUTHOR_EVENT_CHARS = 500;
+const AUTHOR_EVENT_SECTION_CHARS = 10_000;
+const AUTHOR_TRIGGER_SUMMARY_CHARS = 300;
+const AUTHOR_TRIGGER_SECTION_CHARS = 12_000;
 
 export async function authorTriggers(
   events: OperatorChannelEvent[],
@@ -126,26 +131,34 @@ export async function authorTriggers(
   return created;
 }
 
-/**
- * How much of a trigger's memoryQuery the author pass needs to see.
- *
- * The list exists for ONE job, stated in the prompt itself: do not propose a variant of a
- * trigger that already exists. Keywords decide that; the full recall instruction does not.
- *
- * Measured on the live registry 2026-07-30: 162 active triggers, memoryQuery averaging 1,261
- * characters, 204 KB of the 240 KB prompt - and growing with every trigger the pass authors,
- * which is a loop that feeds itself. One call cost $1.33 at 126,667 cache-creation tokens and
- * took 41 seconds, every 30 minutes.
- */
-const EXISTING_TRIGGER_QUERY_CHARS = 160;
-
 function summarizeExistingTrigger(t: TriggerRecord): string {
-  const query = t.memoryQuery ?? '';
-  const gist =
-    query.length > EXISTING_TRIGGER_QUERY_CHARS
-      ? `${query.slice(0, EXISTING_TRIGGER_QUERY_CHARS).trimEnd()}...`
-      : query;
-  return `- ${t.id}: keywords=[${t.match.keywords.join(', ')}] gist="${gist}"`;
+  const scope = t.match.scopeChannelIds?.length ? t.match.scopeChannelIds.join(', ') : '*';
+  return `- kind=${t.kind} scope=[${scope}] mode=${t.match.keywordMode} keywords=[${t.match.keywords.join(', ')}]`;
+}
+
+function boundedLines(
+  lines: string[],
+  perLineChars: number,
+  sectionChars: number,
+  newestFirstBudget = false
+): string {
+  const selected: string[] = [];
+  let used = 0;
+  const candidates = newestFirstBudget ? [...lines].reverse() : lines;
+  for (const raw of candidates) {
+    const line = raw.replace(/[\r\n]+/g, ' ').slice(0, perLineChars);
+    if (used + line.length + 1 > sectionChars) break;
+    selected.push(line);
+    used += line.length + 1;
+  }
+  const omitted = lines.length - selected.length;
+  const ordered = newestFirstBudget ? selected.reverse() : selected;
+  if (omitted > 0) {
+    const note = `- [... ${omitted} item(s) omitted by input budget]`;
+    if (newestFirstBudget) ordered.unshift(note);
+    else ordered.push(note);
+  }
+  return ordered.join('\n');
 }
 
 export function buildAuthorPrompt(
@@ -153,9 +166,20 @@ export function buildAuthorPrompt(
   existing: TriggerRecord[]
 ): string {
   // English default. Personal phrasing overrides load from ~/.mama/operator/*.json (later refinement).
-  const window = events.map((e) => `- [${e.channelId}] ${e.content}`).join('\n');
+  const window = boundedLines(
+    events.map((e) => `- [${e.channelId}] ${e.content}`),
+    AUTHOR_EVENT_CHARS,
+    AUTHOR_EVENT_SECTION_CHARS,
+    true
+  );
   const existingList =
-    existing.length === 0 ? '(none yet)' : existing.map(summarizeExistingTrigger).join('\n');
+    existing.length === 0
+      ? '(none yet)'
+      : boundedLines(
+          existing.map(summarizeExistingTrigger),
+          AUTHOR_TRIGGER_SUMMARY_CHARS,
+          AUTHOR_TRIGGER_SECTION_CHARS
+        );
   return [
     "You maintain a personal operator's library of TRIGGERS. A trigger fires on future messages",
     'that match its keywords and then recalls a memory to help the operator intervene proactively.',
@@ -201,16 +225,24 @@ export function validateTriggerSpec(spec: unknown): TriggerSpec {
   if (!isObject(spec)) throw new Error('trigger spec must be an object');
   const nonEmptyString = (v: unknown): v is string => typeof v === 'string' && v.trim() !== '';
 
-  if (!nonEmptyString(spec.kind)) throw new Error('trigger.kind must be a non-empty string');
-  if (!nonEmptyString(spec.memoryQuery))
-    throw new Error('trigger.memoryQuery must be a non-empty string');
+  const boundedString = (label: string, value: unknown, maxChars: number): string => {
+    if (!nonEmptyString(value) || value.length > maxChars) {
+      throw new Error(`${label} must be a non-empty string of at most ${maxChars} characters`);
+    }
+    return value;
+  };
+
+  const id = spec.id === undefined ? undefined : boundedString('trigger.id', spec.id, 512);
+  const kind = boundedString('trigger.kind', spec.kind, 256);
+  const memoryQuery = boundedString('trigger.memoryQuery', spec.memoryQuery, 4_000);
 
   if (!isObject(spec.match)) throw new Error('trigger.match must be an object');
   const match = spec.match;
   if (
     !Array.isArray(match.keywords) ||
     match.keywords.length === 0 ||
-    !match.keywords.every(nonEmptyString)
+    match.keywords.length > 64 ||
+    !match.keywords.every((keyword) => nonEmptyString(keyword) && keyword.length <= 256)
   ) {
     throw new Error('trigger.match.keywords must be a non-empty string[]');
   }
@@ -222,31 +254,43 @@ export function validateTriggerSpec(spec: unknown): TriggerSpec {
   if (
     match.scopeChannelIds !== undefined &&
     (!Array.isArray(match.scopeChannelIds) ||
-      !match.scopeChannelIds.every((c) => typeof c === 'string'))
+      match.scopeChannelIds.length > 64 ||
+      !match.scopeChannelIds.every(
+        (channelId) => nonEmptyString(channelId) && channelId.length <= 256
+      ))
   ) {
     throw new Error('trigger.match.scopeChannelIds must be string[] when present');
   }
 
   if (
     !Array.isArray(spec.procedure) ||
+    spec.procedure.length > 64 ||
     !spec.procedure.every(
-      (p) => isObject(p) && typeof p.action === 'string' && typeof p.description === 'string'
+      (p) =>
+        isObject(p) &&
+        nonEmptyString(p.action) &&
+        p.action.length <= 256 &&
+        typeof p.description === 'string' &&
+        p.description.length <= 2_000
     )
   ) {
     throw new Error('trigger.procedure must be an array of {action, description}');
   }
   if (
     !Array.isArray(spec.requiredEvidence) ||
-    !spec.requiredEvidence.every((e) => typeof e === 'string')
+    spec.requiredEvidence.length > 64 ||
+    !spec.requiredEvidence.every(
+      (evidence) => typeof evidence === 'string' && evidence.length <= 1_000
+    )
   ) {
     throw new Error('trigger.requiredEvidence must be string[]');
   }
 
   // Deliberately NO check of kind/action VALUES against any catalog (G3 guard).
   return {
-    id: typeof spec.id === 'string' ? spec.id : undefined,
-    kind: spec.kind,
-    memoryQuery: spec.memoryQuery,
+    id,
+    kind,
+    memoryQuery,
     match: {
       keywords: match.keywords as string[],
       keywordMode: match.keywordMode,
@@ -258,9 +302,8 @@ export function validateTriggerSpec(spec: unknown): TriggerSpec {
   };
 }
 
-/** Build the legacy bare-Claude JSON runner while allowing command injection in tests. */
 /**
- * Effort for the bare-CLI structured-JSON calls, named rather than inherited.
+ * Effort for the isolated structured-JSON calls, named rather than inherited.
  *
  * Without this the call inherits `effortLevel` from ~/.claude/settings.json, which on the
  * owner's install is `xhigh` - and the daemon exports MAX_THINKING_TOKENS=0 (added
@@ -279,13 +322,31 @@ export function validateTriggerSpec(spec: unknown): TriggerSpec {
  */
 const TRIGGER_AUTHOR_EFFORT = 'high';
 
-export function createAskAgentCLI(execute: ClaudeCliExecutor = executeClaudeCLI): AskAgent {
+export function createAskAgentCLI(
+  execute: ClaudeCliExecutor = executeClaudeCLI,
+  options: { model?: string; signal?: AbortSignal } = {}
+): AskAgent {
   return async (prompt) => {
-    const { stdout } = await execute(
-      'claude',
-      ['-p', prompt, '--output-format', 'json', '--effort', TRIGGER_AUTHOR_EFFORT],
-      { maxBuffer: 16 * 1024 * 1024 }
-    );
+    const args = [
+      '-p',
+      prompt,
+      '--output-format',
+      'json',
+      '--effort',
+      TRIGGER_AUTHOR_EFFORT,
+      '--safe-mode',
+      '--tools',
+      '',
+      '--no-session-persistence',
+    ];
+    if (options.model) {
+      args.push('--model', options.model);
+    }
+    const executeOptions = {
+      maxBuffer: 16 * 1024 * 1024,
+      ...(options.signal ? { signal: options.signal } : {}),
+    };
+    const { stdout } = await execute('claude', args, executeOptions);
     const parsed = JSON.parse(stdout) as { type?: string; result?: unknown };
     if (parsed.type === 'result' && typeof parsed.result === 'string') return parsed.result;
     throw new Error('claude CLI did not return a text result');
@@ -298,7 +359,7 @@ export const askAgentCLI: AskAgent = createAskAgentCLI();
 /**
  * Provider boundary for trigger authoring and review.
  *
- * Claude keeps the historical bare CLI path. Codex shares one app-server
+ * Claude keeps an isolated JSON-only CLI path. Codex shares one app-server
  * connection, but every structured task starts a fresh, isolated, read-only
  * session and advertises no host tools.
  */
@@ -308,11 +369,41 @@ export function createTriggerAgentRuntime(
   dependencies: TriggerAgentRuntimeDependencies = {}
 ): TriggerAgentRuntime {
   if (backend === 'claude') {
-    const askClaude = dependencies.askClaude ?? askAgentCLI;
+    const controller = new AbortController();
+    const createClaudeAsk =
+      dependencies.createClaudeAsk ??
+      ((runtimeOptions: { model?: string; signal?: AbortSignal }) =>
+        createAskAgentCLI(executeClaudeCLI, runtimeOptions));
+    const askClaude =
+      dependencies.askClaude ??
+      createClaudeAsk({ model: options.model, signal: controller.signal });
+    const activeCalls = new Set<Promise<string>>();
+    let stopped = false;
+    let stopPromise: Promise<void> | undefined;
+    const askTracked: AskAgent = (prompt) => {
+      if (stopped) return Promise.reject(new Error('Claude trigger runtime has stopped'));
+      let call: Promise<string>;
+      try {
+        call = askClaude(prompt);
+      } catch (error) {
+        call = Promise.reject(error);
+      }
+      activeCalls.add(call);
+      return call.finally(() => {
+        activeCalls.delete(call);
+      });
+    };
     return {
-      askAuthor: askClaude,
-      askReview: askClaude,
-      stop: async () => undefined,
+      askAuthor: askTracked,
+      askReview: askTracked,
+      stop: () => {
+        stopPromise ??= Promise.resolve().then(async () => {
+          stopped = true;
+          controller.abort();
+          await Promise.allSettled([...activeCalls]);
+        });
+        return stopPromise;
+      },
     };
   }
 
@@ -414,7 +505,7 @@ const CLAUDE_CLI_TIMEOUT_MS = 240_000;
 async function executeClaudeCLI(
   file: string,
   args: string[],
-  options: { maxBuffer: number }
+  options: { maxBuffer: number; signal?: AbortSignal }
 ): Promise<{ stdout: string }> {
   try {
     const { stdout } = await execFileAsync(file, args, {

--- a/packages/standalone/src/operator/trigger-registry.ts
+++ b/packages/standalone/src/operator/trigger-registry.ts
@@ -46,7 +46,7 @@ export class TriggerRegistry {
   }
 
   private runMigration(): void {
-    this.db.prepare('PRAGMA busy_timeout = 5000').get();
+    this.db.pragma('busy_timeout = 5000');
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS operator_triggers (
         id TEXT PRIMARY KEY,

--- a/packages/standalone/src/operator/trigger-registry.ts
+++ b/packages/standalone/src/operator/trigger-registry.ts
@@ -29,7 +29,13 @@ interface TriggerRow {
   fired: number;
   succeeded: number;
   failed: number;
+  reviewed_fired: number;
 }
+
+const REVIEW_RETRY_BASE_MS = 6 * 60 * 60 * 1000;
+const REVIEW_RETRY_MAX_MS = 24 * 60 * 60 * 1000;
+const AUTHOR_RETRY_BASE_MS = 6 * 60 * 60 * 1000;
+const AUTHOR_RETRY_MAX_MS = 24 * 60 * 60 * 1000;
 
 export class TriggerRegistry {
   private db: SQLiteDatabase;
@@ -40,6 +46,7 @@ export class TriggerRegistry {
   }
 
   private runMigration(): void {
+    this.db.prepare('PRAGMA busy_timeout = 5000').get();
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS operator_triggers (
         id TEXT PRIMARY KEY,
@@ -56,10 +63,53 @@ export class TriggerRegistry {
         disabled_reason TEXT,
         fired INTEGER NOT NULL DEFAULT 0,
         succeeded INTEGER NOT NULL DEFAULT 0,
-        failed INTEGER NOT NULL DEFAULT 0
+        failed INTEGER NOT NULL DEFAULT 0,
+        reviewed_fired INTEGER NOT NULL DEFAULT 0,
+        review_failures INTEGER NOT NULL DEFAULT 0,
+        review_retry_after INTEGER
       );
       CREATE INDEX IF NOT EXISTS idx_operator_triggers_status ON operator_triggers(status);
+      CREATE TABLE IF NOT EXISTS operator_trigger_author_state (
+        singleton_id INTEGER PRIMARY KEY CHECK(singleton_id = 1),
+        window_fingerprint TEXT NOT NULL,
+        failures INTEGER NOT NULL,
+        retry_after INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
     `);
+    this.migrateReviewWatermark();
+  }
+
+  /**
+   * Existing fired rows were already reviewed repeatedly by the legacy loop. Baseline them at
+   * their current fire count so an upgrade cannot immediately fan out one review call per row.
+   */
+  private migrateReviewWatermark(): void {
+    this.db.exec('BEGIN IMMEDIATE');
+    try {
+      const columns = this.db.prepare(`PRAGMA table_info(operator_triggers)`).all() as Array<{
+        name: string;
+      }>;
+      const names = new Set(columns.map((column) => column.name));
+      if (!names.has('reviewed_fired')) {
+        this.db.exec(
+          `ALTER TABLE operator_triggers ADD COLUMN reviewed_fired INTEGER NOT NULL DEFAULT 0`
+        );
+        this.db.exec(`UPDATE operator_triggers SET reviewed_fired = fired`);
+      }
+      if (!names.has('review_failures')) {
+        this.db.exec(
+          `ALTER TABLE operator_triggers ADD COLUMN review_failures INTEGER NOT NULL DEFAULT 0`
+        );
+      }
+      if (!names.has('review_retry_after')) {
+        this.db.exec(`ALTER TABLE operator_triggers ADD COLUMN review_retry_after INTEGER`);
+      }
+      this.db.exec('COMMIT');
+    } catch (error) {
+      this.db.exec('ROLLBACK');
+      throw error;
+    }
   }
 
   /** Persist an agent-authored trigger. Self-activates (G4): status is 'active' at birth. */
@@ -100,6 +150,99 @@ export class TriggerRegistry {
       .prepare(`SELECT * FROM operator_triggers WHERE status = 'active' ORDER BY created_at DESC`)
       .all() as TriggerRow[];
     return rows.map(rowToRecord);
+  }
+
+  /** Active triggers with fire evidence that has not yet reached the review pass. */
+  listReviewCandidates(limit = Number.MAX_SAFE_INTEGER, nowMs = Date.now()): TriggerRecord[] {
+    if (!Number.isInteger(limit) || limit <= 0) {
+      throw new Error('listReviewCandidates: limit must be a positive integer');
+    }
+    if (!Number.isFinite(nowMs)) throw new Error('listReviewCandidates: nowMs must be finite');
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM operator_triggers
+         WHERE status = 'active' AND fired > reviewed_fired
+           AND (review_retry_after IS NULL OR review_retry_after <= ?)
+         ORDER BY updated_at ASC, created_at ASC, id ASC
+         LIMIT ?`
+      )
+      .all(nowMs, limit) as TriggerRow[];
+    return rows.map(rowToRecord);
+  }
+
+  /** Advance the durable review watermark only after a review decision was applied. */
+  markReviewed(id: string, fired: number): void {
+    if (!Number.isInteger(fired) || fired < 0) {
+      throw new Error(`markReviewed: fired must be a non-negative integer for ${id}`);
+    }
+    const result = this.db
+      .prepare(
+        `UPDATE operator_triggers
+         SET reviewed_fired = MAX(reviewed_fired, ?), review_failures = 0,
+             review_retry_after = NULL, updated_at = ?
+         WHERE id = ? AND status = 'active'`
+      )
+      .run(fired, Date.now(), id);
+    if (result.changes === 0) throw new Error(`markReviewed: no active trigger with id ${id}`);
+  }
+
+  /** Back off a failed provider/parse attempt without blocking later review candidates. */
+  recordReviewFailure(id: string, nowMs = Date.now()): void {
+    if (!Number.isFinite(nowMs))
+      throw new Error(`recordReviewFailure: nowMs must be finite for ${id}`);
+    const row = this.db
+      .prepare(`SELECT review_failures FROM operator_triggers WHERE id = ? AND status = 'active'`)
+      .get(id) as { review_failures: number } | undefined;
+    if (!row) throw new Error(`recordReviewFailure: no active trigger with id ${id}`);
+    const failures = row.review_failures + 1;
+    const retryDelay = Math.min(REVIEW_RETRY_BASE_MS * 2 ** (failures - 1), REVIEW_RETRY_MAX_MS);
+    const retryAfter = nowMs + retryDelay;
+    this.db
+      .prepare(
+        `UPDATE operator_triggers
+         SET review_failures = ?, review_retry_after = ?, updated_at = ?
+         WHERE id = ? AND status = 'active'`
+      )
+      .run(failures, retryAfter, nowMs, id);
+  }
+
+  /** A provider outage or poison author window must not be resent on every cadence. */
+  canAttemptAuthor(nowMs = Date.now()): boolean {
+    if (!Number.isFinite(nowMs)) throw new Error('canAttemptAuthor: nowMs must be finite');
+    const row = this.db
+      .prepare(`SELECT retry_after FROM operator_trigger_author_state WHERE singleton_id = 1`)
+      .get() as { retry_after: number } | undefined;
+    return row === undefined || row.retry_after <= nowMs;
+  }
+
+  /** Persist a process-independent exponential backoff for the structured author call. */
+  recordAuthorFailure(windowFingerprint: string, nowMs = Date.now()): void {
+    if (windowFingerprint.trim() === '') {
+      throw new Error('recordAuthorFailure: window fingerprint must be non-empty');
+    }
+    if (!Number.isFinite(nowMs)) throw new Error('recordAuthorFailure: nowMs must be finite');
+    const row = this.db
+      .prepare(`SELECT failures FROM operator_trigger_author_state WHERE singleton_id = 1`)
+      .get() as { failures: number } | undefined;
+    const failures = (row?.failures ?? 0) + 1;
+    const retryDelay = Math.min(AUTHOR_RETRY_BASE_MS * 2 ** (failures - 1), AUTHOR_RETRY_MAX_MS);
+    this.db
+      .prepare(
+        `INSERT INTO operator_trigger_author_state
+           (singleton_id, window_fingerprint, failures, retry_after, updated_at)
+         VALUES (1, ?, ?, ?, ?)
+         ON CONFLICT(singleton_id) DO UPDATE SET
+           window_fingerprint = excluded.window_fingerprint,
+           failures = excluded.failures,
+           retry_after = excluded.retry_after,
+           updated_at = excluded.updated_at`
+      )
+      .run(windowFingerprint, failures, nowMs + retryDelay, nowMs);
+  }
+
+  /** A successful author decision clears the provider/parse failure streak. */
+  clearAuthorFailure(): void {
+    this.db.prepare(`DELETE FROM operator_trigger_author_state WHERE singleton_id = 1`).run();
   }
 
   /** Every trigger regardless of status (owner tray view). id DESC breaks same-ms ties. */
@@ -153,6 +296,42 @@ export class TriggerRegistry {
     const record = this.getById(id);
     if (!record) throw new Error(`disable: trigger ${id} missing after update`);
     return record;
+  }
+
+  /** Agent retirement must never overwrite a durable owner disable that won the race (TG-06). */
+  retireActive(id: string, reason: string): TriggerRecord {
+    const result = this.db
+      .prepare(
+        `UPDATE operator_triggers
+         SET status = 'disabled', disabled_reason = ?, updated_at = ?
+         WHERE id = ? AND status = 'active'`
+      )
+      .run(reason, Date.now(), id);
+    if (result.changes === 0) throw new Error(`retireActive: no active trigger with id ${id}`);
+    const record = this.getById(id);
+    if (!record) throw new Error(`retireActive: trigger ${id} missing after update`);
+    return record;
+  }
+
+  /** Disable the original and insert its replacement as one rollback-safe decision. */
+  refine(id: string, reason: string, replacement: CreateTriggerInput): TriggerRecord {
+    this.db.exec('BEGIN IMMEDIATE');
+    try {
+      const result = this.db
+        .prepare(
+          `UPDATE operator_triggers
+           SET status = 'disabled', disabled_reason = ?, updated_at = ?
+           WHERE id = ? AND status = 'active'`
+        )
+        .run(reason, Date.now(), id);
+      if (result.changes === 0) throw new Error(`refine: no active trigger with id ${id}`);
+      const created = this.create(replacement);
+      this.db.exec('COMMIT');
+      return created;
+    } catch (error) {
+      this.db.exec('ROLLBACK');
+      throw error;
+    }
   }
 
   close(): void {

--- a/packages/standalone/src/operator/trigger-review.ts
+++ b/packages/standalone/src/operator/trigger-review.ts
@@ -18,6 +18,15 @@ import { validateTriggerSpec, askAgentCLI, type AskAgent } from './trigger-autho
 
 export type ReviewDecision = EvolutionDecision;
 
+const REVIEW_PROMPT_MAX_CHARS = 30_000;
+const REVIEW_TRIGGER_ID_CHARS = 512;
+const REVIEW_TRIGGER_KIND_CHARS = 512;
+const REVIEW_TRIGGER_KEYWORDS_CHARS = 8_000;
+const REVIEW_TRIGGER_KEYWORD_CHARS = 256;
+const REVIEW_MEMORY_QUERY_CHARS = 8_000;
+const REVIEW_CONTEXT_CHARS = 8_000;
+const REVIEW_CONTEXT_LINE_CHARS = 500;
+
 export function parseReviewDecision(text: string): ReviewDecision {
   const raw = extractJsonObject(stripCodeFences(text));
   if (raw === null) throw new Error('agent review output contained no JSON object');
@@ -51,13 +60,16 @@ export function parseReviewDecision(text: string): ReviewDecision {
 }
 
 /** Mechanically apply the agent's decision to the registry (mirror of evolveTrigger's apply, minus outcome recording). */
-export function applyReview(decision: ReviewDecision, triggerId: string, registry: TriggerRegistry): EvolutionAction {
+export function applyReview(
+  decision: ReviewDecision,
+  triggerId: string,
+  registry: TriggerRegistry
+): EvolutionAction {
   if (decision.action === 'retired') {
-    registry.disable(triggerId, decision.reason);
+    registry.retireActive(triggerId, decision.reason);
     return 'retired';
   }
   if (decision.action === 'refined') {
-    registry.disable(triggerId, `refined: ${decision.reason}`);
     const spec = decision.newSpec;
     const id = spec.id ?? `${triggerId}.r.${reviewHash(spec.kind, spec.match.keywords)}`;
     const input: CreateTriggerInput = {
@@ -70,26 +82,42 @@ export function applyReview(decision: ReviewDecision, triggerId: string, registr
       authoredBy: 'agent',
       provenance: { createdFrom: `refined-from:${triggerId}`, note: decision.reason },
     };
-    registry.create(input);
+    registry.refine(triggerId, `refined: ${decision.reason}`, input);
     return 'refined';
   }
   return 'kept';
 }
 
 export function buildReviewPrompt(trigger: TriggerRecord, recentContext: string[]): string {
-  return [
-    'You maintain a personal operator\'s library of TRIGGERS (keyword rules that recall a memory',
+  const triggerId = boundedPromptValue(trigger.id, REVIEW_TRIGGER_ID_CHARS);
+  const kind = boundedPromptValue(trigger.kind, REVIEW_TRIGGER_KIND_CHARS);
+  const memoryQuery = boundedPromptValue(trigger.memoryQuery, REVIEW_MEMORY_QUERY_CHARS);
+  const keywords = boundedPromptLines(
+    trigger.match.keywords,
+    REVIEW_TRIGGER_KEYWORD_CHARS,
+    REVIEW_TRIGGER_KEYWORDS_CHARS,
+    ', '
+  );
+  const context = boundedPromptLines(
+    recentContext,
+    REVIEW_CONTEXT_LINE_CHARS,
+    REVIEW_CONTEXT_CHARS,
+    '\n- ',
+    true
+  );
+  const prompt = [
+    "You maintain a personal operator's library of TRIGGERS (keyword rules that recall a memory",
     'when future messages match). Review ONE trigger and decide whether to keep, refine, or',
     'retire it, based on its spec, its fire activity, and recent messages.',
     '',
-    `Trigger id: ${trigger.id}`,
-    `kind: ${trigger.kind}`,
-    `keywords (${trigger.match.keywordMode}): ${trigger.match.keywords.join(', ')}`,
-    `memoryQuery: ${trigger.memoryQuery}`,
+    `Trigger id: ${triggerId}`,
+    `kind: ${kind}`,
+    `keywords (${trigger.match.keywordMode}): ${keywords}`,
+    `memoryQuery: ${memoryQuery}`,
     `stats: fired=${trigger.stats.fired} succeeded=${trigger.stats.succeeded} failed=${trigger.stats.failed}`,
     '',
     'Recent messages (context):',
-    ...recentContext.map((line) => `- ${line}`),
+    context === '' ? '(none)' : `- ${context}`,
     '',
     'Judge for yourself - there is no fixed rule. Firing a lot on irrelevant messages suggests',
     'refine (narrower keywords) or retire; firing usefully suggests keep; never firing may mean',
@@ -102,6 +130,44 @@ export function buildReviewPrompt(trigger: TriggerRecord, recentContext: string[
     '     "match": { "keywords": string[], "keywordMode": "any"|"every", "minConfidence": number },',
     '     "procedure": [{ "action": string, "description": string }], "requiredEvidence": string[] } }',
   ].join('\n');
+  if (prompt.length > REVIEW_PROMPT_MAX_CHARS) {
+    throw new Error(`review prompt exceeded ${REVIEW_PROMPT_MAX_CHARS} character budget`);
+  }
+  return prompt;
+}
+
+function boundedPromptValue(value: string, maxChars: number): string {
+  const sanitized = value.replace(/[\r\n]+/g, ' ');
+  if (sanitized.length <= maxChars) return sanitized;
+  return `${sanitized.slice(0, maxChars - 16)} [...truncated]`;
+}
+
+function boundedPromptLines(
+  values: string[],
+  perValueChars: number,
+  totalChars: number,
+  separator: string,
+  newestFirstBudget = false
+): string {
+  const selected: string[] = [];
+  let used = 0;
+  const candidates = newestFirstBudget ? [...values].reverse() : values;
+  for (const value of candidates) {
+    const bounded = boundedPromptValue(value, perValueChars);
+    const added = bounded.length + (selected.length === 0 ? 0 : separator.length);
+    if (used + added > totalChars) break;
+    selected.push(bounded);
+    used += added;
+  }
+  const ordered = newestFirstBudget ? selected.reverse() : selected;
+  if (selected.length < values.length) {
+    const omitted = `[... ${values.length - selected.length} item(s) omitted]`;
+    if (used + separator.length + omitted.length <= totalChars) {
+      if (newestFirstBudget) ordered.unshift(omitted);
+      else ordered.push(omitted);
+    }
+  }
+  return ordered.join(separator);
 }
 
 /** Real agent review via the local claude CLI. Exercised in the M1-T4 live smoke. */

--- a/packages/standalone/tests/operator/operator-trigger-loop.test.ts
+++ b/packages/standalone/tests/operator/operator-trigger-loop.test.ts
@@ -13,6 +13,7 @@ import { join } from 'node:path';
 import Database, { type SQLiteDatabase } from '../../src/sqlite.js';
 import { TriggerRegistry } from '../../src/operator/trigger-registry.js';
 import { OperatorTriggerLoop, type TickResult } from '../../src/operator/operator-trigger-loop.js';
+import { buildReviewPrompt } from '../../src/operator/trigger-review.js';
 import type {
   OperatorChannelEvent,
   OperatorMemoryPort,
@@ -296,6 +297,318 @@ describe('OperatorTriggerLoop', () => {
     expect(review.mock.calls[0][0].id).toBe('fired-one');
     expect(reg.getById('fired-one')?.status).toBe('disabled');
     expect(reg.getById('silent-one')?.status).toBe('active');
+  });
+
+  it('reviews a kept trigger only after a new fire, not forever on every cadence', async () => {
+    seedTrigger(reg, 'review-watermark', 'report');
+    const review = vi.fn(async () => ({ action: 'kept' as const }));
+    const loop = makeLoop({
+      review,
+      config: {
+        tickMs: 1000,
+        drainLimit: 50,
+        authorEveryNTicks: 99,
+        reviewEveryNTicks: 1,
+        authorWindowSize: 10,
+      },
+    });
+
+    delta.queue = [ev(1, 'ch-a', 'report one')];
+    await loop.tick();
+    expect(review).toHaveBeenCalledTimes(1);
+
+    await loop.tick();
+    expect(review).toHaveBeenCalledTimes(1);
+
+    delta.queue = [ev(2, 'ch-a', 'report two')];
+    await loop.tick();
+    expect(review).toHaveBeenCalledTimes(2);
+  });
+
+  it('authors a connector window once until a new event arrives (TG-05)', async () => {
+    const askAgent = vi.fn(async () => '[]');
+    const loop = makeLoop({
+      askAgent,
+      config: {
+        tickMs: 1000,
+        drainLimit: 50,
+        authorEveryNTicks: 1,
+        reviewEveryNTicks: 99,
+        authorWindowSize: 10,
+      },
+    });
+
+    delta.queue = [ev(1, 'ch-a', 'first window')];
+    await loop.tick();
+    await loop.tick();
+    expect(askAgent).toHaveBeenCalledTimes(1);
+
+    delta.queue = [ev(2, 'ch-a', 'new evidence')];
+    await loop.tick();
+    expect(askAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it('durably backs off a failed author window and consumes it only after success (TG-05)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    try {
+      const askAgent = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('provider malformed JSON'))
+        .mockResolvedValue('[]');
+      const loop = makeLoop({
+        askAgent,
+        config: {
+          tickMs: 1000,
+          drainLimit: 50,
+          authorEveryNTicks: 1,
+          reviewEveryNTicks: 99,
+          authorWindowSize: 10,
+        },
+      });
+
+      delta.queue = [ev(1, 'ch-a', 'poison author window')];
+      await expect(loop.tick()).resolves.toMatchObject({ authored: 0 });
+      expect(askAgent).toHaveBeenCalledTimes(1);
+
+      delta.queue = [ev(2, 'ch-a', 'new evidence during provider backoff')];
+      await loop.tick();
+      expect(askAgent).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1000);
+      await loop.tick();
+      expect(askAgent).toHaveBeenCalledTimes(2);
+      await loop.tick();
+      expect(askAgent).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('TG-05/TG-06 keeps newest review context through the final provider prompt', async () => {
+    seedTrigger(reg, 'latest-review', 'MATCH_NEWEST_REVIEW');
+    const contexts: string[][] = [];
+    const review = vi.fn(async (_trigger, context: string[]) => {
+      contexts.push(context);
+      return { action: 'kept' as const };
+    });
+    const loop = makeLoop({
+      review,
+      config: {
+        tickMs: 1000,
+        drainLimit: 50,
+        authorEveryNTicks: 99,
+        reviewEveryNTicks: 1,
+        authorWindowSize: 50,
+      },
+    });
+    delta.queue = Array.from({ length: 50 }, (_, index) => {
+      const marker =
+        index === 0
+          ? 'OLDEST_REVIEW_SENTINEL'
+          : index === 49
+            ? 'MATCH_NEWEST_REVIEW NEWEST_REVIEW_SENTINEL'
+            : `MIDDLE_REVIEW_${String(index).padStart(2, '0')}`;
+      return ev(index + 1, 'ch-a', marker.padEnd(151, 'x'));
+    });
+
+    await loop.tick();
+
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0].join('\n')).toContain('NEWEST_REVIEW_SENTINEL');
+    expect(contexts[0].join('\n').length).toBeLessThanOrEqual(8_100);
+    const trigger = reg.getById('latest-review');
+    if (!trigger) throw new Error('latest-review trigger missing');
+    const finalPrompt = buildReviewPrompt(trigger, contexts[0]);
+    expect(finalPrompt).toContain('NEWEST_REVIEW_SENTINEL');
+    expect(finalPrompt).not.toContain('OLDEST_REVIEW_SENTINEL');
+  });
+
+  it('isolates a poison review candidate and backs it off without starving the next one', async () => {
+    seedTrigger(reg, 'poison', 'poison');
+    seedTrigger(reg, 'healthy', 'healthy');
+    reg.recordFire('poison');
+    reg.recordFire('healthy');
+    const review = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('provider malformed JSON'))
+      .mockResolvedValue({ action: 'kept' as const });
+    const loop = makeLoop({
+      review,
+      config: {
+        tickMs: 1000,
+        drainLimit: 50,
+        authorEveryNTicks: 99,
+        reviewEveryNTicks: 1,
+        reviewBatchLimit: 2,
+        authorWindowSize: 10,
+      },
+    });
+
+    await expect(loop.tick()).resolves.toMatchObject({ reviewed: 1 });
+    expect(review).toHaveBeenCalledTimes(2);
+    await loop.tick();
+    expect(review).toHaveBeenCalledTimes(2);
+  });
+
+  it('continues review when owner state changes before failure backoff is recorded', async () => {
+    seedTrigger(reg, 'owner-disabled', 'disabled');
+    seedTrigger(reg, 'still-reviewable', 'healthy');
+    reg.recordFire('owner-disabled');
+    reg.recordFire('still-reviewable');
+    const review = vi.fn(async (trigger: { id: string }) => {
+      if (review.mock.calls.length === 1) {
+        reg.disable(trigger.id, 'owner veto during review');
+        throw new Error('provider failed after owner veto');
+      }
+      return { action: 'kept' as const };
+    });
+    const loop = makeLoop({
+      review,
+      config: {
+        tickMs: 1000,
+        drainLimit: 50,
+        authorEveryNTicks: 99,
+        reviewEveryNTicks: 1,
+        reviewBatchLimit: 2,
+        authorWindowSize: 10,
+      },
+    });
+
+    await expect(loop.tick()).resolves.toMatchObject({ reviewed: 1 });
+    expect(review).toHaveBeenCalledTimes(2);
+    expect(logs.some((line) => line.includes('state changed before backoff'))).toBe(true);
+  });
+
+  it('uses one review call per maintenance pass by default', async () => {
+    seedTrigger(reg, 'default-cap-a', 'a');
+    seedTrigger(reg, 'default-cap-b', 'b');
+    reg.recordFire('default-cap-a');
+    reg.recordFire('default-cap-b');
+    const review = vi.fn(async () => ({ action: 'kept' as const }));
+    const loop = makeLoop({
+      review,
+      config: {
+        tickMs: 1000,
+        drainLimit: 50,
+        authorEveryNTicks: 99,
+        reviewEveryNTicks: 1,
+        authorWindowSize: 10,
+      },
+    });
+
+    await loop.tick();
+    expect(review).toHaveBeenCalledTimes(1);
+    await loop.tick();
+    expect(review).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves a fire that arrives while a kept review is in flight', async () => {
+    seedTrigger(reg, 'concurrent-fire', 'report');
+    reg.recordFire('concurrent-fire');
+    let releaseReview: (() => void) | undefined;
+    const review = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ action: 'kept' }>((resolve) => {
+            releaseReview = () => resolve({ action: 'kept' });
+          })
+      )
+      .mockResolvedValue({ action: 'kept' as const });
+    const loop = makeLoop({
+      review,
+      config: {
+        tickMs: 1000,
+        drainLimit: 50,
+        authorEveryNTicks: 99,
+        reviewEveryNTicks: 1,
+        authorWindowSize: 10,
+      },
+    });
+
+    const firstTick = loop.tick();
+    await vi.waitFor(() => expect(review).toHaveBeenCalledTimes(1));
+    reg.recordFire('concurrent-fire');
+    releaseReview?.();
+    await firstTick;
+    await loop.tick();
+    expect(review).toHaveBeenCalledTimes(2);
+  });
+
+  it('migrates legacy fired rows as already reviewed before accepting a new fire', () => {
+    const legacyDb = new Database(':memory:');
+    legacyDb.exec(`
+      CREATE TABLE operator_triggers (
+        id TEXT PRIMARY KEY,
+        kind TEXT NOT NULL,
+        memory_query TEXT NOT NULL,
+        match_json TEXT NOT NULL,
+        procedure_json TEXT NOT NULL,
+        required_evidence_json TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'active',
+        authored_by TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        provenance_json TEXT NOT NULL,
+        disabled_reason TEXT,
+        fired INTEGER NOT NULL DEFAULT 0,
+        succeeded INTEGER NOT NULL DEFAULT 0,
+        failed INTEGER NOT NULL DEFAULT 0
+      );
+    `);
+    legacyDb
+      .prepare(`INSERT INTO operator_triggers VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+      .run(
+        'legacy-fired',
+        'legacy',
+        'query',
+        JSON.stringify({ keywords: ['legacy'], keywordMode: 'any', minConfidence: 0.5 }),
+        '[]',
+        '[]',
+        'active',
+        'agent',
+        1,
+        1,
+        JSON.stringify({ createdFrom: 'legacy', note: '' }),
+        null,
+        7,
+        0,
+        0
+      );
+
+    const migrated = new TriggerRegistry(legacyDb);
+    expect(migrated.listReviewCandidates()).toEqual([]);
+    migrated.recordFire('legacy-fired');
+    expect(migrated.listReviewCandidates().map((trigger) => trigger.id)).toEqual(['legacy-fired']);
+    migrated.close();
+  });
+
+  it('caps each review pass and defers remaining newly-fired triggers', async () => {
+    for (let index = 0; index < 5; index += 1) {
+      const id = `bounded-review-${index}`;
+      seedTrigger(reg, id, `keyword-${index}`);
+      reg.recordFire(id);
+    }
+    const review = vi.fn(async () => ({ action: 'kept' as const }));
+    const loop = makeLoop({
+      review,
+      config: {
+        tickMs: 1000,
+        drainLimit: 50,
+        authorEveryNTicks: 99,
+        reviewEveryNTicks: 1,
+        reviewBatchLimit: 2,
+        authorWindowSize: 10,
+      },
+    });
+
+    await loop.tick();
+    expect(review).toHaveBeenCalledTimes(2);
+    await loop.tick();
+    expect(review).toHaveBeenCalledTimes(4);
+    await loop.tick();
+    expect(review).toHaveBeenCalledTimes(5);
   });
 
   it('owner report: agent digest sent on cadence when fires accumulated (M1.5)', async () => {
@@ -614,6 +927,256 @@ describe('OperatorTriggerLoop', () => {
       expect(tickSpy).not.toHaveBeenCalled(); // debounced: nothing yet
       await vi.advanceTimersByTimeAsync(15_000);
       expect(tickSpy).toHaveBeenCalledTimes(1); // burst collapsed to a single tick
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('nudge drains fresh data without advancing author maintenance cadence (M2.4/TG-06)', async () => {
+    vi.useFakeTimers();
+    try {
+      const askAgent = vi.fn(async () => '[]');
+      const loop = makeLoop({
+        askAgent,
+        config: {
+          tickMs: 60_000,
+          drainLimit: 50,
+          authorEveryNTicks: 2,
+          reviewEveryNTicks: 99,
+          authorWindowSize: 10,
+          nudgeDebounceMs: 15_000,
+        },
+      });
+      delta.queue = [ev(1, 'ch-a', 'fresh connector event')];
+
+      loop.nudge();
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(askAgent).not.toHaveBeenCalled();
+
+      await loop.tick();
+      expect(askAgent).not.toHaveBeenCalled();
+      await loop.tick();
+      expect(askAgent).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('nudge does not advance review maintenance cadence (TG-05/TG-06)', async () => {
+    vi.useFakeTimers();
+    try {
+      seedTrigger(reg, 'nudge-review', 'report');
+      reg.recordFire('nudge-review');
+      const review = vi.fn(async () => ({ action: 'kept' as const }));
+      const loop = makeLoop({
+        review,
+        config: {
+          tickMs: 60_000,
+          drainLimit: 50,
+          authorEveryNTicks: 99,
+          reviewEveryNTicks: 2,
+          authorWindowSize: 10,
+          nudgeDebounceMs: 15_000,
+        },
+      });
+
+      loop.nudge();
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(review).not.toHaveBeenCalled();
+      await loop.tick();
+      expect(review).not.toHaveBeenCalled();
+      await loop.tick();
+      expect(review).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('TG-05/TG-06 collapses many missed intervals into one deferred maintenance tick', async () => {
+    vi.useFakeTimers();
+    let releaseRecall: (() => void) | undefined;
+    try {
+      seedTrigger(reg, 'slow-nudge', 'report');
+      const askAgent = vi.fn(async () => '[]');
+      const memory: OperatorMemoryPort = {
+        async save() {},
+        recall: vi.fn(
+          () =>
+            new Promise((resolve) => {
+              releaseRecall = () => resolve([]);
+            })
+        ),
+      };
+      const loop = makeLoop({
+        memory,
+        askAgent,
+        config: {
+          tickMs: 100,
+          drainLimit: 50,
+          authorEveryNTicks: 1,
+          reviewEveryNTicks: 99,
+          authorWindowSize: 10,
+          nudgeDebounceMs: 0,
+        },
+      });
+      const tickSpy = vi.spyOn(loop, 'tick');
+      const stop = loop.start();
+      delta.queue = [ev(1, 'ch-a', 'report is slow')];
+      loop.nudge();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(releaseRecall).toBeDefined();
+
+      await vi.advanceTimersByTimeAsync(500);
+      expect(askAgent).not.toHaveBeenCalled();
+      releaseRecall?.();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(askAgent).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(askAgent).toHaveBeenCalledTimes(1);
+      expect(tickSpy).toHaveBeenCalledTimes(2);
+      stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('TG-05/TG-06 stop waits for the active tick and suppresses deferred maintenance', async () => {
+    vi.useFakeTimers();
+    let releaseRecall: (() => void) | undefined;
+    try {
+      seedTrigger(reg, 'stop-slow-nudge', 'report');
+      const askAgent = vi.fn(async () => '[]');
+      const memory: OperatorMemoryPort = {
+        async save() {},
+        recall: vi.fn(
+          () =>
+            new Promise((resolve) => {
+              releaseRecall = () => resolve([]);
+            })
+        ),
+      };
+      const loop = makeLoop({
+        memory,
+        askAgent,
+        config: {
+          tickMs: 100,
+          drainLimit: 50,
+          authorEveryNTicks: 1,
+          reviewEveryNTicks: 99,
+          authorWindowSize: 10,
+          nudgeDebounceMs: 0,
+        },
+      });
+      const tickSpy = vi.spyOn(loop, 'tick');
+      const stop = loop.start();
+      delta.queue = [ev(1, 'ch-a', 'report is slow')];
+      loop.nudge();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(500);
+
+      let stopped = false;
+      const stopping = Promise.resolve(stop()).then(() => {
+        stopped = true;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(stopped).toBe(false);
+
+      releaseRecall?.();
+      await vi.advanceTimersByTimeAsync(0);
+      await stopping;
+
+      expect(askAgent).not.toHaveBeenCalled();
+      loop.nudge();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(tickSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('TG-05/TG-06 shutdown abort starts no later model leg or retry backoff', async () => {
+    vi.useFakeTimers();
+    let rejectAuthor: ((error: Error) => void) | undefined;
+    try {
+      const askAgent = vi.fn(
+        () =>
+          new Promise<string>((_resolve, reject) => {
+            rejectAuthor = reject;
+          })
+      );
+      const reportAsk = vi.fn(async () => 'must not run');
+      const loop = makeLoop({
+        askAgent,
+        reportAsk,
+        output: { send: vi.fn(async () => {}) },
+        config: {
+          tickMs: 100,
+          drainLimit: 50,
+          authorEveryNTicks: 1,
+          reviewEveryNTicks: 99,
+          authorWindowSize: 10,
+          reportEveryNTicks: 1,
+        },
+      });
+      delta.queue = [ev(1, 'ch-a', 'activity buffered for a digest')];
+      const stop = loop.start();
+      await vi.advanceTimersByTimeAsync(100);
+      expect(askAgent).toHaveBeenCalledTimes(1);
+
+      const stopping = stop();
+      rejectAuthor?.(new Error('intentional shutdown abort'));
+      await vi.advanceTimersByTimeAsync(0);
+      await stopping;
+
+      expect(reportAsk).not.toHaveBeenCalled();
+      expect(reg.canAttemptAuthor(0)).toBe(true);
+      expect(logs.some((line) => line.includes('cancelled by shutdown'))).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('TG-05/TG-06 review shutdown abort preserves the candidate without later model work', async () => {
+    vi.useFakeTimers();
+    let rejectReview: ((error: Error) => void) | undefined;
+    try {
+      seedTrigger(reg, 'shutdown-review', 'report');
+      const review = vi.fn(
+        () =>
+          new Promise<{ action: 'kept' }>((_resolve, reject) => {
+            rejectReview = reject;
+          })
+      );
+      const reportAsk = vi.fn(async () => 'must not run');
+      const loop = makeLoop({
+        review,
+        reportAsk,
+        output: { send: vi.fn(async () => {}) },
+        config: {
+          tickMs: 100,
+          drainLimit: 50,
+          authorEveryNTicks: 99,
+          reviewEveryNTicks: 1,
+          authorWindowSize: 10,
+          reportEveryNTicks: 1,
+        },
+      });
+      delta.queue = [ev(1, 'ch-a', 'report activity buffered for review')];
+      const stop = loop.start();
+      await vi.advanceTimersByTimeAsync(100);
+      expect(review).toHaveBeenCalledTimes(1);
+
+      const stopping = stop();
+      rejectReview?.(new Error('intentional review shutdown abort'));
+      await vi.advanceTimersByTimeAsync(0);
+      await stopping;
+
+      expect(reportAsk).not.toHaveBeenCalled();
+      expect(reg.listReviewCandidates().map((trigger) => trigger.id)).toEqual(['shutdown-review']);
+      expect(
+        logs.some((line) => line.includes('review trigger=shutdown-review cancelled by shutdown'))
+      ).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/standalone/tests/operator/report-carry.test.ts
+++ b/packages/standalone/tests/operator/report-carry.test.ts
@@ -317,6 +317,8 @@ describe('TG-06: versioned one-shot report carry', () => {
   ])(
     'TG-05/TG-06 quarantines an exact V1 carry %s before accepting a target-bound delivery',
     (_variant, legacyCarry) => {
+      vi.useFakeTimers();
+      vi.setSystemTime('2026-08-02T00:00:30.000Z');
       const path = tempCarryPath();
       const store = new FileReportCarryStore(path);
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
@@ -342,6 +344,7 @@ describe('TG-06: versioned one-shot report carry', () => {
         expect(store.peek(TARGET, Date.parse(DELIVERED_AT))).toBeNull();
       } finally {
         warn.mockRestore();
+        vi.useRealTimers();
       }
     }
   );

--- a/packages/standalone/tests/operator/trigger-author.test.ts
+++ b/packages/standalone/tests/operator/trigger-author.test.ts
@@ -144,18 +144,22 @@ describe('authorTriggers', () => {
     expect(prompt).toContain('proposing NOTHING over proposing a variant');
   });
 
-  // The list's job is dedup, and keywords decide that. Carrying the full recall instruction
-  // for every trigger made the prompt grow with every trigger the pass authored - a loop
-  // feeding itself. Measured live 2026-07-30: 162 active triggers, memoryQuery averaging
-  // 1,261 chars, 231 KB of prompt, $1.33 and 41s per call, every 30 minutes.
-  it('carries every existing trigger by keywords, and its recall query only as a gist', async () => {
+  // The list's job is dedup, and keywords + scope decide that. IDs grow on every refinement and
+  // recall queries do not help dedup, so neither belongs in the recurring author prompt.
+  it('carries existing trigger keywords without refinement IDs or recall queries', async () => {
     const { buildAuthorPrompt } = await import('../../src/operator/trigger-author.js');
-    const long = 'x'.repeat(4000);
+    const querySentinel = 'FORBIDDEN_QUERY_SENTINEL';
+    const long = `${querySentinel}${'x'.repeat(4000)}`;
     reg.create({
-      id: 'gist-probe',
+      id: `root${'.r.refinement'.repeat(80)}`,
       kind: 'k',
       memoryQuery: long,
-      match: { keywords: ['unmistakable-keyword'], keywordMode: 'any', minConfidence: 0.5 },
+      match: {
+        keywords: ['unmistakable-keyword'],
+        keywordMode: 'any',
+        minConfidence: 0.5,
+        scopeChannelIds: ['telegram:owner'],
+      },
       procedure: [{ action: 'a', description: 'd' }],
       requiredEvidence: [],
       authoredBy: 'agent',
@@ -166,12 +170,54 @@ describe('authorTriggers', () => {
 
     // Dedup still possible: the keyword is intact.
     expect(prompt).toContain('unmistakable-keyword');
-    // The instruction body is not.
-    expect(prompt).not.toContain(long);
-    expect(prompt).toContain('...');
-    // And the gist is bounded, not merely shorter.
-    const gist = /gist="([^"]*)"/.exec(prompt)?.[1] ?? '';
-    expect(gist.length).toBeLessThanOrEqual(200);
+    expect(prompt).toContain('telegram:owner');
+    // Prompt growth inputs are absent.
+    expect(prompt).not.toContain(querySentinel);
+    expect(prompt).not.toContain(long.slice(0, 160));
+    expect(prompt).not.toContain('.r.refinement');
+  });
+
+  it('TG-05 bounds recurring author input even when events and registry contain large text', async () => {
+    const { buildAuthorPrompt } = await import('../../src/operator/trigger-author.js');
+    for (let index = 0; index < 80; index += 1) {
+      reg.create({
+        id: `bounded-${index}`,
+        kind: `kind-${index}`,
+        memoryQuery: `query-${index}`,
+        match: {
+          keywords: [`keyword-${index}-${'k'.repeat(300)}`],
+          keywordMode: 'any',
+          minConfidence: 0.5,
+        },
+        procedure: [],
+        requiredEvidence: [],
+        authoredBy: 'agent',
+        provenance: { createdFrom: 'seed', note: '' },
+      });
+    }
+
+    const prompt = buildAuthorPrompt(
+      Array.from({ length: 50 }, (_, index) => ev(`event-${index}-${'e'.repeat(4000)}`, index + 1)),
+      reg.listActive()
+    );
+
+    expect(prompt.length).toBeLessThanOrEqual(30_000);
+    expect(prompt).toContain('omitted');
+  });
+
+  it('TG-05 keeps the newest author evidence when the budget omits older messages', async () => {
+    const { buildAuthorPrompt } = await import('../../src/operator/trigger-author.js');
+    const events = Array.from({ length: 30 }, (_, index) =>
+      ev(
+        `${index === 0 ? 'OLDEST_AUTHOR_SENTINEL' : index === 29 ? 'NEWEST_AUTHOR_SENTINEL' : `event-${index}`} ${'x'.repeat(600)}`,
+        index + 1
+      )
+    );
+
+    const prompt = buildAuthorPrompt(events, []);
+
+    expect(prompt).toContain('NEWEST_AUTHOR_SENTINEL');
+    expect(prompt).not.toContain('OLDEST_AUTHOR_SENTINEL');
   });
 
   // 193 failures over the log's lifetime recorded nothing but the 240 KB command line that
@@ -263,10 +309,98 @@ describe('authorTriggers', () => {
       })
     ).toThrow(); // empty kind + empty keywords = malformed shape
   });
+
+  it('TG-05 rejects oversized trigger fields and arrays before persistence', () => {
+    const valid = {
+      kind: 'recurring report',
+      memoryQuery: 'weekly report state',
+      match: { keywords: ['report'], keywordMode: 'any', minConfidence: 0.7 },
+      procedure: [],
+      requiredEvidence: [],
+    };
+
+    expect(() => validateTriggerSpec({ ...valid, memoryQuery: 'x'.repeat(4_001) })).toThrow(
+      /memoryQuery/
+    );
+    expect(() =>
+      validateTriggerSpec({
+        ...valid,
+        match: { ...valid.match, keywords: Array.from({ length: 65 }, () => 'report') },
+      })
+    ).toThrow(/keywords/);
+    expect(() =>
+      validateTriggerSpec({
+        ...valid,
+        procedure: Array.from({ length: 65 }, () => ({ action: 'recall', description: 'x' })),
+      })
+    ).toThrow(/procedure/);
+  });
+
+  it('TG-05 pins every trigger input boundary at max and max plus one', () => {
+    const atLimit = {
+      id: 'i'.repeat(512),
+      kind: 'k'.repeat(256),
+      memoryQuery: 'q'.repeat(4_000),
+      match: {
+        keywords: Array.from({ length: 64 }, () => 'w'.repeat(256)),
+        keywordMode: 'any',
+        minConfidence: 0.7,
+        scopeChannelIds: Array.from({ length: 64 }, () => 's'.repeat(256)),
+      },
+      procedure: Array.from({ length: 64 }, () => ({
+        action: 'a'.repeat(256),
+        description: 'd'.repeat(2_000),
+      })),
+      requiredEvidence: Array.from({ length: 64 }, () => 'e'.repeat(1_000)),
+    };
+    expect(() => validateTriggerSpec(atLimit)).not.toThrow();
+
+    const overLimit: Array<[string, unknown]> = [
+      ['id', { ...atLimit, id: 'i'.repeat(513) }],
+      ['kind', { ...atLimit, kind: 'k'.repeat(257) }],
+      ['memoryQuery', { ...atLimit, memoryQuery: 'q'.repeat(4_001) }],
+      [
+        'keyword count',
+        { ...atLimit, match: { ...atLimit.match, keywords: [...atLimit.match.keywords, 'x'] } },
+      ],
+      ['keyword length', { ...atLimit, match: { ...atLimit.match, keywords: ['w'.repeat(257)] } }],
+      [
+        'scope count',
+        {
+          ...atLimit,
+          match: {
+            ...atLimit.match,
+            scopeChannelIds: [...atLimit.match.scopeChannelIds, 'x'],
+          },
+        },
+      ],
+      [
+        'scope length',
+        { ...atLimit, match: { ...atLimit.match, scopeChannelIds: ['s'.repeat(257)] } },
+      ],
+      [
+        'procedure count',
+        {
+          ...atLimit,
+          procedure: [...atLimit.procedure, { action: 'a', description: 'd' }],
+        },
+      ],
+      ['action length', { ...atLimit, procedure: [{ action: 'a'.repeat(257), description: 'd' }] }],
+      [
+        'description length',
+        { ...atLimit, procedure: [{ action: 'a', description: 'd'.repeat(2_001) }] },
+      ],
+      ['evidence count', { ...atLimit, requiredEvidence: [...atLimit.requiredEvidence, 'x'] }],
+      ['evidence length', { ...atLimit, requiredEvidence: ['e'.repeat(1_001)] }],
+    ];
+    for (const [label, spec] of overLimit) {
+      expect(() => validateTriggerSpec(spec), label).toThrow();
+    }
+  });
 });
 
 describe('trigger agent provider boundary', () => {
-  it('keeps the Claude CLI command, arguments, and JSON result parsing unchanged', async () => {
+  it('uses a customization-free, tool-free, non-persistent Claude JSON session (TG-05)', async () => {
     const execute = vi.fn().mockResolvedValue({
       stdout: JSON.stringify({ type: 'result', result: '[{"kind":"k"}]' }),
     });
@@ -275,9 +409,52 @@ describe('trigger agent provider boundary', () => {
     await expect(askAgent('author prompt')).resolves.toBe('[{"kind":"k"}]');
     expect(execute).toHaveBeenCalledWith(
       'claude',
-      ['-p', 'author prompt', '--output-format', 'json', '--effort', 'high'],
+      [
+        '-p',
+        'author prompt',
+        '--output-format',
+        'json',
+        '--effort',
+        'high',
+        '--safe-mode',
+        '--tools',
+        '',
+        '--no-session-persistence',
+      ],
       { maxBuffer: 16 * 1024 * 1024 }
     );
+  });
+
+  it('constructs the Claude trigger runner with the configured model (TG-06)', async () => {
+    const askClaude = vi.fn().mockResolvedValue('[]');
+    const createClaudeAsk = vi.fn(() => askClaude);
+    const dependencies = { createClaudeAsk } as unknown as Parameters<
+      typeof createTriggerAgentRuntime
+    >[2];
+
+    const runtime = createTriggerAgentRuntime('claude', { model: 'claude-sonnet-5' }, dependencies);
+
+    expect(createClaudeAsk).toHaveBeenCalledWith({
+      model: 'claude-sonnet-5',
+      signal: expect.any(AbortSignal),
+    });
+    await expect(runtime.askAuthor('author')).resolves.toBe('[]');
+    await expect(runtime.askReview('review')).resolves.toBe('[]');
+    expect(askClaude).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes the configured model to the Claude CLI instead of inheriting user settings', async () => {
+    const execute = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({ type: 'result', result: '[]' }),
+    });
+    const askAgent = createAskAgentCLI(execute, { model: 'claude-sonnet-5' });
+
+    await askAgent('review prompt');
+
+    const args = execute.mock.calls[0][1];
+    const modelIndex = args.indexOf('--model');
+    expect(modelIndex).toBeGreaterThan(-1);
+    expect(args[modelIndex + 1]).toBe('claude-sonnet-5');
   });
 
   it('does not construct Codex for the Claude backend and propagates Claude failures', async () => {
@@ -289,6 +466,40 @@ describe('trigger agent provider boundary', () => {
     await expect(runtime.askAuthor('prompt')).rejects.toBe(failure);
     expect(createCodexRuntime).not.toHaveBeenCalled();
     await runtime.stop();
+  });
+
+  it('TG-05/TG-06 aborts and drains an in-flight Claude trigger call on stop', async () => {
+    let runtimeSignal: AbortSignal | undefined;
+    let rejectCall: ((error: Error) => void) | undefined;
+    let abortObserved = false;
+    const createClaudeAsk = vi.fn((options: { model?: string; signal?: AbortSignal }) => {
+      runtimeSignal = options.signal;
+      return async () =>
+        new Promise<string>((_resolve, reject) => {
+          rejectCall = reject;
+          options.signal?.addEventListener('abort', () => {
+            abortObserved = true;
+          });
+        });
+    });
+    const runtime = createTriggerAgentRuntime('claude', {}, { createClaudeAsk });
+    const pending = runtime.askAuthor('long author prompt');
+    const rejection = expect(pending).rejects.toThrow('aborted');
+
+    let stopResolved = false;
+    const stopping = Promise.all([runtime.stop(), runtime.stop()]).then(() => {
+      stopResolved = true;
+    });
+    await Promise.resolve();
+    expect(abortObserved).toBe(true);
+    expect(stopResolved).toBe(false);
+
+    rejectCall?.(new Error('claude trigger call aborted after child cleanup'));
+    await stopping;
+    await rejection;
+
+    expect(runtimeSignal?.aborted).toBe(true);
+    expect(createClaudeAsk).toHaveBeenCalledTimes(1);
   });
 
   it('uses one read-only Codex app-server runner with isolated fresh author and review lanes', async () => {

--- a/packages/standalone/tests/operator/trigger-registry.test.ts
+++ b/packages/standalone/tests/operator/trigger-registry.test.ts
@@ -3,6 +3,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import Database, { type SQLiteDatabase } from '../../src/sqlite.js';
 import { TriggerRegistry } from '../../src/operator/trigger-registry.js';
 import type { CreateTriggerInput } from '../../src/operator/trigger-types.js';
@@ -87,5 +90,81 @@ describe('TriggerRegistry', () => {
     expect(all[0].status).toBe('disabled');
     expect(all[0].disabledReason).toBe('noisy');
     expect(all[1].disabledReason).toBeUndefined();
+  });
+
+  it('acquires the migration write lock before inspecting legacy columns', () => {
+    const source = readFileSync(
+      new URL('../../src/operator/trigger-registry.ts', import.meta.url),
+      'utf8'
+    );
+    const migration = source.slice(
+      source.indexOf('private migrateReviewWatermark'),
+      source.indexOf('/** Persist an agent-authored trigger')
+    );
+    expect(migration.indexOf("this.db.exec('BEGIN IMMEDIATE')")).toBeGreaterThan(-1);
+    expect(migration.indexOf("this.db.exec('BEGIN IMMEDIATE')")).toBeLessThan(
+      migration.indexOf('PRAGMA table_info(operator_triggers)')
+    );
+  });
+
+  it('persists the review watermark across a registry restart', () => {
+    const path = join(mkdtempSync(join(tmpdir(), 'mama-trigger-watermark-')), 'triggers.db');
+    const first = new TriggerRegistry(new Database(path));
+    first.create(sampleInput('durable'));
+    first.recordFire('durable');
+    first.markReviewed('durable', 1);
+    first.close();
+
+    const restarted = new TriggerRegistry(new Database(path));
+    expect(restarted.listReviewCandidates()).toEqual([]);
+    restarted.recordFire('durable');
+    expect(restarted.listReviewCandidates().map((trigger) => trigger.id)).toEqual(['durable']);
+    restarted.close();
+  });
+
+  it('TG-06 persists failed review backoff and successful clear across restarts', () => {
+    const path = join(mkdtempSync(join(tmpdir(), 'mama-trigger-review-retry-')), 'triggers.db');
+    const first = new TriggerRegistry(new Database(path));
+    first.create(sampleInput('retry'));
+    first.recordFire('retry');
+    first.recordReviewFailure('retry', 1_000);
+    first.close();
+
+    const backedOff = new TriggerRegistry(new Database(path));
+    expect(backedOff.listReviewCandidates(8, 1_000 + 60 * 60 * 1000)).toEqual([]);
+    expect(backedOff.listReviewCandidates(8, 1_000 + 6 * 60 * 60 * 1000)).toHaveLength(1);
+    backedOff.markReviewed('retry', 1);
+    backedOff.recordFire('retry');
+    backedOff.close();
+
+    const cleared = new TriggerRegistry(new Database(path));
+    expect(cleared.listReviewCandidates(8, 1_001).map((trigger) => trigger.id)).toEqual(['retry']);
+    cleared.close();
+  });
+
+  it('TG-05 persists author provider backoff across a registry restart', () => {
+    const path = join(mkdtempSync(join(tmpdir(), 'mama-trigger-author-retry-')), 'triggers.db');
+    const first = new TriggerRegistry(new Database(path));
+    first.recordAuthorFailure('window-a', 1_000);
+    first.close();
+
+    const restarted = new TriggerRegistry(new Database(path));
+    expect(restarted.canAttemptAuthor(1_000 + 60 * 60 * 1000)).toBe(false);
+    expect(restarted.canAttemptAuthor(1_000 + 6 * 60 * 60 * 1000)).toBe(true);
+    restarted.clearAuthorFailure();
+    restarted.close();
+
+    const cleared = new TriggerRegistry(new Database(path));
+    expect(cleared.canAttemptAuthor(1_001)).toBe(true);
+    cleared.close();
+  });
+
+  it('validates review queue boundaries and rejects inactive failure updates', () => {
+    expect(() => reg.listReviewCandidates(0)).toThrow(/positive integer/);
+    expect(() => reg.listReviewCandidates(1, Number.NaN)).toThrow(/finite/);
+    expect(() => reg.markReviewed('missing', -1)).toThrow(/non-negative integer/);
+    reg.create(sampleInput('disabled-review'));
+    reg.disable('disabled-review', 'owner veto');
+    expect(() => reg.recordReviewFailure('disabled-review')).toThrow(/no active trigger/);
   });
 });

--- a/packages/standalone/tests/operator/trigger-review.test.ts
+++ b/packages/standalone/tests/operator/trigger-review.test.ts
@@ -5,9 +5,16 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import Database, { type SQLiteDatabase } from '../../src/sqlite.js';
 import { TriggerRegistry } from '../../src/operator/trigger-registry.js';
-import { parseReviewDecision, applyReview } from '../../src/operator/trigger-review.js';
+import {
+  parseReviewDecision,
+  applyReview,
+  buildReviewPrompt,
+} from '../../src/operator/trigger-review.js';
 import type { CreateTriggerInput } from '../../src/operator/trigger-types.js';
 
 function seed(reg: TriggerRegistry, id = 't1'): void {
@@ -27,7 +34,9 @@ function seed(reg: TriggerRegistry, id = 't1'): void {
 describe('parseReviewDecision', () => {
   it('parses kept / retired / refined decisions (prose tolerated)', () => {
     expect(parseReviewDecision('{"action":"kept"}')).toEqual({ action: 'kept' });
-    expect(parseReviewDecision('Verdict:\n{"action":"retired","reason":"never useful"}\ndone')).toEqual({
+    expect(
+      parseReviewDecision('Verdict:\n{"action":"retired","reason":"never useful"}\ndone')
+    ).toEqual({
       action: 'retired',
       reason: 'never useful',
     });
@@ -77,6 +86,33 @@ describe('applyReview', () => {
     expect(reg.getById('t1')?.status).toBe('disabled');
   });
 
+  it('TG-06 preserves owner veto when late retired review lands from another connection', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'mama-trigger-review-'));
+    const databasePath = join(directory, 'triggers.db');
+    const reviewRegistry = new TriggerRegistry(new Database(databasePath));
+    const ownerRegistry = new TriggerRegistry(new Database(databasePath));
+    try {
+      seed(reviewRegistry, 'owner-race');
+      ownerRegistry.disable('owner-race', 'owner veto during review');
+
+      expect(() =>
+        applyReview(
+          { action: 'retired', reason: 'late agent retirement' },
+          'owner-race',
+          reviewRegistry
+        )
+      ).toThrow(/no active trigger/);
+      expect(reviewRegistry.getById('owner-race')).toMatchObject({
+        status: 'disabled',
+        disabledReason: 'owner veto during review',
+      });
+    } finally {
+      ownerRegistry.close();
+      reviewRegistry.close();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   it('refined supersedes: old disabled, new active with the agent spec', () => {
     seed(reg);
     const result = applyReview(
@@ -100,5 +136,63 @@ describe('applyReview', () => {
     expect(active).toHaveLength(1);
     expect(active[0].match.keywords).toEqual(['weekly report']);
     expect(active[0].authoredBy).toBe('agent');
+  });
+
+  it('rolls back the original trigger when a refined replacement ID collides', () => {
+    seed(reg, 't1');
+    seed(reg, 'existing');
+
+    expect(() =>
+      applyReview(
+        {
+          action: 'refined',
+          reason: 'narrow it',
+          newSpec: {
+            id: 'existing',
+            kind: 'k2',
+            memoryQuery: 'q2',
+            match: { keywords: ['weekly report'], keywordMode: 'any', minConfidence: 0.75 },
+            procedure: [],
+            requiredEvidence: [],
+          },
+        },
+        't1',
+        reg
+      )
+    ).toThrow();
+    expect(reg.getById('t1')?.status).toBe('active');
+    expect(reg.getById('existing')?.status).toBe('active');
+  });
+});
+
+describe('buildReviewPrompt input budget', () => {
+  it('TG-05/TG-06 bounds legacy trigger fields and context to a fixed prompt ceiling', () => {
+    const giant = 'x'.repeat(50_000);
+    const trigger = {
+      id: giant,
+      kind: giant,
+      memoryQuery: giant,
+      match: {
+        keywords: Array.from({ length: 100 }, () => giant),
+        keywordMode: 'any' as const,
+        minConfidence: 0.7,
+      },
+      procedure: [],
+      requiredEvidence: [],
+      status: 'active' as const,
+      authoredBy: 'agent' as const,
+      createdAt: 1,
+      updatedAt: 1,
+      provenance: { createdFrom: 'legacy', note: '' },
+      stats: { fired: 1, succeeded: 0, failed: 0 },
+    };
+
+    const prompt = buildReviewPrompt(
+      trigger,
+      Array.from({ length: 100 }, () => giant)
+    );
+
+    expect(prompt.length).toBeLessThanOrEqual(30_000);
+    expect(prompt).toContain('Return ONLY one JSON object');
   });
 });

--- a/packages/standalone/tests/operator/trigger-runtime-wiring.test.ts
+++ b/packages/standalone/tests/operator/trigger-runtime-wiring.test.ts
@@ -17,10 +17,12 @@ describe('trigger runtime provider wiring', () => {
     );
   });
 
-  it('registers the selected trigger runtime for daemon shutdown', () => {
+  it('TG-06 awaits loop drain and trigger runtime abort together during shutdown', () => {
     const startSource = readFileSync(join(__dirname, '../../src/cli/commands/start.ts'), 'utf-8');
 
-    expect(startSource).toContain('await triggerAgentRuntime.stop()');
+    expect(startSource).toContain(
+      'await Promise.all([stopTriggerLoop(), triggerAgentRuntime.stop()])'
+    );
   });
 
   it('uses one resolved workspace for host policy and the trigger runtime', () => {


### PR DESCRIPTION
## Summary

- Bound trigger-author and trigger-review prompts to the newest relevant evidence so maintenance runs cannot replay unbounded task or review history.
- Persist per-trigger exponential backoff, collapse missed intervals, deduplicate pending work, and isolate poison review items to prevent retry storms and token leakage.
- Pin non-persistent Claude maintenance calls to the configured model, disable unnecessary tools for those calls, and abort/drain active work during shutdown.
- Prepare and document MAMA OS `0.32.3`; this PR changes only `@jungjaehoon/mama-os` and its documentation.

## Telegram parity

- **TG-05:** preserves conversation/session continuity while keeping maintenance/report lanes stateless and bounded.
- **TG-06:** keeps operator-report delivery autonomous without hard-coding Kagemusha-specific task behavior; author/review maintenance now uses durable backoff and bounded evidence.
- Updated `docs/development/kagemusha-telegram-parity.md` with implementation and regression evidence.

## Test coverage

### Coverage map — 42/48 flows (88%)

- ✅ Prompt/input caps, newest evidence, model pinning, tool-free Claude CLI
- ✅ Author dedupe, durable backoff, review watermark/batching, poison isolation
- ✅ Nudge cadence, missed-interval collapse, active-run drain, author/review shutdown cancellation
- ⚠️ Remaining lower-priority direct-test gaps cover repeated 24-hour backoff caps and redundant shutdown guards; the production paths are covered by integration regressions.

## Verification

- `pnpm test` — 7/7 workspace tasks passed; MAMA OS 344 files and 4,600 tests passed (4 files / 7 tests skipped).
- `pnpm build` — passed; 48 gateway tools generated and UI bundle built.
- `pnpm typecheck` — passed.
- `pnpm lint` — passed.
- `pnpm sync-versions --check` — passed for MAMA OS 0.32.3.
- Prettier, `git diff --check`, PII/secret scan — passed.

## Review

- Independent testing, maintainability, performance, security, data-migration, and red-team reviews: **0 unresolved findings**.
- Final adversarial review: **ship as-is**.
- No new TODO/FIXME markers and no unrelated scope changes.

## Release plan

After merge, dispatch the existing `release.yml` workflow for `mama-os` with patch version `0.32.3`, verify the GitHub release and package registry publication, then install the exact version and restart the production agent with its existing Claude Sonnet 5 configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trigger authoring and review reliability with failure backoff, progress tracking, bounded batches, and safer recovery.
  * Prevented duplicate or outdated processing by preserving scheduling progress and limiting context sent to AI providers.
  * Improved shutdown behavior by cancelling and draining active trigger work cleanly.
  * Added safer trigger updates and protections against conflicting changes.

* **Documentation**
  * Updated release documentation, package metadata, and version references to 0.32.3.
  * Expanded documentation of trigger-loop safeguards and verification coverage.

* **Tests**
  * Added comprehensive coverage for backoff, scheduling, prompt limits, persistence, concurrency, and shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->