### PR TITLE
fix(config): backend-scoped model resolution — one-line backend switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ All notable changes to this project will be documented in this file.
 - **Gateway plugins must declare `apiVersion: 2`.** Older plugin API versions are rejected at load
   time; this is a breaking compatibility change for third-party gateway plugins.
 
+### Fixed
+
+- Switching agent.backend now rescopes every model resolution (main, roles, API saves, init) to the
+  active backend with loud warnings; stale cross-backend role overrides can no longer reach the
+  runtime.
+
 ### Internal
 
 - **P2a adds the durable principal-registry substrate without shipping member access.** Migration

--- a/docs/development/kagemusha-telegram-parity.md
+++ b/docs/development/kagemusha-telegram-parity.md
@@ -86,6 +86,21 @@ owner-console envelope access to a member with forced console eligibility`, and 
 session key stable when only member principalId changes`. This is an internal P2a substrate;
   member access is not public until P2b grants land.
 
+### Backend-scoped model runtime closure: 2026-08-16
+
+- **TG-05:** a same-backend per-role model override now reaches the real Codex app-server session
+  policy instead of being replaced by the boot model in the main runtime wrapper. Because the
+  role model participates in the stable session-policy fingerprint, a model rescope replaces the
+  stale durable thread exactly once; the next unchanged turn continues the replacement without a
+  second rebuild. Evidence: `role-model-reaches-backend.test.ts` cases `REGRESSION 1 sends a
+same-backend role override through the real AgentLoop` and `TG-05 replaces a rescoped model
+session once and then continues without thrash`. **Status: GREEN (2026-08-16).**
+- **TG-05 configuration boundary:** the complete `codex -> claude -> cline -> codex` load matrix
+  covers clean models, cross-backend leftovers, and same-backend overrides. Every loaded main and
+  role model belongs to the active backend family, and warnings occur exactly when a rescope is
+  applied. Evidence: `backend-switch-matrix.test.ts` case `loads codex -> claude -> cline -> codex
+with %s models in the active family`. **Status: GREEN (2026-08-16).**
+
 ### Final review closure
 
 The final coverage, security, and temporal reviewers read this artifact first. Their findings
@@ -479,8 +494,16 @@ change unless they are release-blocking security or data-loss issues.
       connector isolation, owner-only executor guard, forward-candidate registration, forced
       envelope denial, and principal-independent session keys. Migration 064 remains additive and
       rollback-safe because older code has no readers or writers for its new tables.
+- [x] The 2026-08-16 TG-05 backend-model gate pins the real AgentLoop-to-Codex policy handoff,
+      one bounded durable-thread replacement after a model rescope, stable continuation after the
+      replacement, and the complete clean/leftover/same-backend-override switch matrix.
 
 ## Change log
+
+- 2026-08-16: Added TG-05 runtime evidence that same-backend role models reach Codex session
+  policy, model rescoping rotates and replaces a durable session exactly once, and unchanged
+  follow-up turns do not thrash. The backend switch matrix pins active-family models and
+  rescope-only warnings across Codex, Claude, Cline, and back to Codex.
 
 - 2026-08-14: Added TG-04 evidence for P2a's registry-native and Code-Act-projected owner member
   tools, executor-only owner authorization, forward-authenticated registration, zero new member

--- a/docs/development/kagemusha-telegram-parity.md
+++ b/docs/development/kagemusha-telegram-parity.md
@@ -86,7 +86,7 @@ owner-console envelope access to a member with forced console eligibility`, and 
 session key stable when only member principalId changes`. This is an internal P2a substrate;
   member access is not public until P2b grants land.
 
-### Backend-scoped model runtime closure: 2026-08-16
+### Backend-scoped model runtime closure: 2026-08-15
 
 - **TG-05:** a same-backend per-role model override now reaches the real Codex app-server session
   policy instead of being replaced by the boot model in the main runtime wrapper. Because the
@@ -94,12 +94,12 @@ session key stable when only member principalId changes`. This is an internal P2
   stale durable thread exactly once; the next unchanged turn continues the replacement without a
   second rebuild. Evidence: `role-model-reaches-backend.test.ts` cases `REGRESSION 1 sends a
 same-backend role override through the real AgentLoop` and `TG-05 replaces a rescoped model
-session once and then continues without thrash`. **Status: GREEN (2026-08-16).**
+session once and then continues without thrash`. **Status: GREEN (2026-08-15).**
 - **TG-05 configuration boundary:** the complete `codex -> claude -> cline -> codex` load matrix
   covers clean models, cross-backend leftovers, and same-backend overrides. Every loaded main and
   role model belongs to the active backend family, and warnings occur exactly when a rescope is
   applied. Evidence: `backend-switch-matrix.test.ts` case `loads codex -> claude -> cline -> codex
-with %s models in the active family`. **Status: GREEN (2026-08-16).**
+with %s models in the active family`. **Status: GREEN (2026-08-15).**
 
 ### Final review closure
 
@@ -494,13 +494,13 @@ change unless they are release-blocking security or data-loss issues.
       connector isolation, owner-only executor guard, forward-candidate registration, forced
       envelope denial, and principal-independent session keys. Migration 064 remains additive and
       rollback-safe because older code has no readers or writers for its new tables.
-- [x] The 2026-08-16 TG-05 backend-model gate pins the real AgentLoop-to-Codex policy handoff,
+- [x] The 2026-08-15 TG-05 backend-model gate pins the real AgentLoop-to-Codex policy handoff,
       one bounded durable-thread replacement after a model rescope, stable continuation after the
       replacement, and the complete clean/leftover/same-backend-override switch matrix.
 
 ## Change log
 
-- 2026-08-16: Added TG-05 runtime evidence that same-backend role models reach Codex session
+- 2026-08-15: Added TG-05 runtime evidence that same-backend role models reach Codex session
   policy, model rescoping rotates and replaces a durable session exactly once, and unchanged
   follow-up turns do not thrash. The backend switch matrix pins active-family models and
   rescope-only warnings across Codex, Claude, Cline, and back to Codex.

--- a/packages/standalone/src/agent/backend-model-policy.ts
+++ b/packages/standalone/src/agent/backend-model-policy.ts
@@ -6,12 +6,30 @@ const DEFAULT_MODEL_BY_BACKEND: Readonly<Record<BackendType, string>> = {
   cline: 'deepseek/deepseek-v4-flash',
 };
 
+export interface BackendModelChange {
+  target: string;
+  from: string | undefined;
+  to: string;
+}
+
+export interface UnknownModelFamilyWarning {
+  target: string;
+  from: string;
+  to: string;
+  backend: BackendType;
+  unknownFamily: true;
+}
+
+export type BackendModelPolicyEntry = BackendModelChange | UnknownModelFamilyWarning;
+
+const emittedWarningKeys = new Set<string>();
+
 export function defaultModelForBackend(backend: BackendType): string {
   return DEFAULT_MODEL_BY_BACKEND[backend];
 }
 
 export function backendForModel(model: string): BackendType | null {
-  const normalizedModel = model.trim();
+  const normalizedModel = model.trim().toLowerCase();
 
   if (/^claude[-.]/.test(normalizedModel)) {
     return 'claude';
@@ -35,10 +53,25 @@ export function resolveBackendScopedModel(input: {
   model?: string;
   inheritedBackend?: BackendType;
   inheritedModel?: string;
+  warningTarget?: string;
+  onWarning?: (warning: UnknownModelFamilyWarning) => void;
 }): string {
   const model = input.model?.trim();
-  if (model && modelMatchesBackend(model, input.backend)) {
-    return model;
+  if (model) {
+    const modelBackend = backendForModel(model);
+    if (modelBackend === null) {
+      input.onWarning?.({
+        target: input.warningTarget ?? 'model',
+        from: model,
+        to: model,
+        backend: input.backend,
+        unknownFamily: true,
+      });
+      return model;
+    }
+    if (modelBackend === input.backend) {
+      return model;
+    }
   }
   if (input.backend === input.inheritedBackend && input.inheritedModel?.trim()) {
     return input.inheritedModel.trim();
@@ -53,12 +86,16 @@ export function rescopeConfigModels(input: {
 }): {
   agentModel: string;
   roleModels: Record<string, string>;
-  changes: Array<{ target: string; from: string | undefined; to: string }>;
+  changes: BackendModelChange[];
+  warnings?: UnknownModelFamilyWarning[];
 } {
-  const changes: Array<{ target: string; from: string | undefined; to: string }> = [];
+  const changes: BackendModelChange[] = [];
+  const warnings: UnknownModelFamilyWarning[] = [];
   const agentModel = resolveBackendScopedModel({
     backend: input.backend,
     model: input.agentModel,
+    warningTarget: 'agent.model',
+    onWarning: (warning) => warnings.push(warning),
   });
 
   if (input.agentModel !== agentModel) {
@@ -72,6 +109,8 @@ export function rescopeConfigModels(input: {
       model: configuredModel,
       inheritedBackend: input.backend,
       inheritedModel: agentModel,
+      warningTarget: `roles.definitions.${role}.model`,
+      onWarning: (warning) => warnings.push(warning),
     });
     roleModels[role] = roleModel;
 
@@ -84,5 +123,30 @@ export function rescopeConfigModels(input: {
     }
   }
 
-  return { agentModel, roleModels, changes };
+  const result = { agentModel, roleModels, changes };
+  return warnings.length > 0 ? { ...result, warnings } : result;
+}
+
+export function emitBackendModelWarnings(
+  entries: readonly BackendModelPolicyEntry[],
+  emit: (message: string) => void = console.warn
+): void {
+  for (const entry of entries) {
+    const key = `${entry.target}|${String(entry.from)}|${entry.to}`;
+    if (emittedWarningKeys.has(key)) {
+      continue;
+    }
+    emittedWarningKeys.add(key);
+
+    if ('unknownFamily' in entry && entry.unknownFamily) {
+      emit(
+        `[MAMA CONFIG WARNING] model ${JSON.stringify(entry.from)} not recognized as a ${entry.backend}-family model; passing through for ${entry.target}.`
+      );
+      continue;
+    }
+
+    emit(
+      `[MAMA CONFIG WARNING] Rescoped ${entry.target} from ${JSON.stringify(entry.from)} to ${JSON.stringify(entry.to)}.`
+    );
+  }
 }

--- a/packages/standalone/src/agent/backend-model-policy.ts
+++ b/packages/standalone/src/agent/backend-model-policy.ts
@@ -10,15 +10,79 @@ export function defaultModelForBackend(backend: BackendType): string {
   return DEFAULT_MODEL_BY_BACKEND[backend];
 }
 
+export function backendForModel(model: string): BackendType | null {
+  const normalizedModel = model.trim();
+
+  if (/^claude[-.]/.test(normalizedModel)) {
+    return 'claude';
+  }
+  if (/^(?:gpt[-.]|o[0-9]|codex)/.test(normalizedModel)) {
+    return 'codex';
+  }
+  if (normalizedModel.includes('/')) {
+    return 'cline';
+  }
+  return null;
+}
+
+export function modelMatchesBackend(model: string, backend: BackendType): boolean {
+  const modelBackend = backendForModel(model);
+  return modelBackend === null || modelBackend === backend;
+}
+
 export function resolveBackendScopedModel(input: {
   backend: BackendType;
   model?: string;
   inheritedBackend?: BackendType;
   inheritedModel?: string;
 }): string {
-  if (input.model?.trim()) return input.model.trim();
+  const model = input.model?.trim();
+  if (model && modelMatchesBackend(model, input.backend)) {
+    return model;
+  }
   if (input.backend === input.inheritedBackend && input.inheritedModel?.trim()) {
     return input.inheritedModel.trim();
   }
   return defaultModelForBackend(input.backend);
+}
+
+export function rescopeConfigModels(input: {
+  backend: BackendType;
+  agentModel?: string;
+  roleModels: Record<string, string | undefined>;
+}): {
+  agentModel: string;
+  roleModels: Record<string, string>;
+  changes: Array<{ target: string; from: string | undefined; to: string }>;
+} {
+  const changes: Array<{ target: string; from: string | undefined; to: string }> = [];
+  const agentModel = resolveBackendScopedModel({
+    backend: input.backend,
+    model: input.agentModel,
+  });
+
+  if (input.agentModel !== agentModel) {
+    changes.push({ target: 'agent.model', from: input.agentModel, to: agentModel });
+  }
+
+  const roleModels: Record<string, string> = {};
+  for (const [role, configuredModel] of Object.entries(input.roleModels)) {
+    const roleModel = resolveBackendScopedModel({
+      backend: input.backend,
+      model: configuredModel,
+      inheritedBackend: input.backend,
+      inheritedModel: agentModel,
+    });
+    roleModels[role] = roleModel;
+
+    if (configuredModel !== roleModel) {
+      changes.push({
+        target: `roles.definitions.${role}.model`,
+        from: configuredModel,
+        to: roleModel,
+      });
+    }
+  }
+
+  return { agentModel, roleModels, changes };
 }

--- a/packages/standalone/src/agent/managed-agent-runtime-sync.ts
+++ b/packages/standalone/src/agent/managed-agent-runtime-sync.ts
@@ -11,7 +11,12 @@ import {
   validateManagedAgentCreateInput,
   validateManagedAgentChanges,
 } from './managed-agent-validation.js';
-import { defaultModelForBackend } from './backend-model-policy.js';
+import {
+  emitBackendModelWarnings,
+  resolveBackendScopedModel,
+  type BackendModelPolicyEntry,
+  type UnknownModelFamilyWarning,
+} from './backend-model-policy.js';
 import * as debugLogger from '@jungjaehoon/mama-core/debug-logger';
 
 type LooseConfig = MAMAConfig;
@@ -80,7 +85,7 @@ async function writePersonaFileDefault(personaFile: string, content: string): Pr
 function normalizeCreateBackend(
   backend: string | undefined,
   fallback: string | undefined
-): ManagedAgentConfig['backend'] {
+): NonNullable<ManagedAgentConfig['backend']> {
   const candidate = String(backend ?? fallback ?? 'claude').toLowerCase();
   switch (candidate) {
     case 'codex':
@@ -91,6 +96,31 @@ function normalizeCreateBackend(
     default:
       return 'claude';
   }
+}
+
+function resolveManagedAgentModel(input: {
+  config: LooseConfig;
+  backend: NonNullable<ManagedAgentConfig['backend']>;
+  model?: string;
+  target: string;
+}): string {
+  const warnings: UnknownModelFamilyWarning[] = [];
+  const inheritedBackend = normalizeCreateBackend(input.config.agent?.backend, undefined);
+  const configuredModel = input.model?.trim();
+  const resolvedModel = resolveBackendScopedModel({
+    backend: input.backend,
+    model: configuredModel,
+    inheritedBackend,
+    inheritedModel: input.config.agent?.model,
+    warningTarget: input.target,
+    onWarning: (warning) => warnings.push(warning),
+  });
+  const entries: BackendModelPolicyEntry[] = [...warnings];
+  if (configuredModel && configuredModel !== resolvedModel) {
+    entries.unshift({ target: input.target, from: configuredModel, to: resolvedModel });
+  }
+  emitBackendModelWarnings(entries, (message) => logger.warn(message));
+  return resolvedModel;
 }
 
 async function applyRuntimeHooks(
@@ -159,6 +189,12 @@ export async function createManagedAgentRuntime(
 
     const personaFile = defaultPersonaFile(input.id);
     const backend = normalizeCreateBackend(input.backend, config.agent?.backend);
+    const model = resolveManagedAgentModel({
+      config,
+      backend,
+      model: input.model,
+      target: `multi_agent.agents.${input.id}.model`,
+    });
     const snapshot: ManagedAgentConfig = {
       name: input.name,
       display_name: input.name,
@@ -167,7 +203,7 @@ export async function createManagedAgentRuntime(
       tier: input.tier as 1 | 2 | 3,
       can_delegate: false,
       backend,
-      model: input.model,
+      model,
       enabled: true,
     };
 
@@ -209,10 +245,6 @@ export async function updateManagedAgentRuntime(
     }
 
     const updatedAgent: ManagedAgentConfig = { ...currentAgent };
-    const requestedBackend =
-      typeof input.changes.backend === 'string'
-        ? normalizeCreateBackend(input.changes.backend, updatedAgent.backend)
-        : undefined;
     for (const key of [
       'name',
       'display_name',
@@ -237,13 +269,13 @@ export async function updateManagedAgentRuntime(
         (updatedAgent as Record<string, unknown>)[key] = value;
       }
     }
-    if (
-      requestedBackend &&
-      requestedBackend !== currentAgent.backend &&
-      !('model' in input.changes)
-    ) {
-      updatedAgent.model = defaultModelForBackend(requestedBackend);
-    }
+    const effectiveBackend = normalizeCreateBackend(updatedAgent.backend, config.agent?.backend);
+    updatedAgent.model = resolveManagedAgentModel({
+      config,
+      backend: effectiveBackend,
+      model: updatedAgent.model,
+      target: `multi_agent.agents.${input.agentId}.model`,
+    });
 
     if (!agents) {
       throw new Error(`Agent '${input.agentId}' not found in config`);

--- a/packages/standalone/src/agent/managed-agent-runtime-sync.ts
+++ b/packages/standalone/src/agent/managed-agent-runtime-sync.ts
@@ -269,13 +269,18 @@ export async function updateManagedAgentRuntime(
         (updatedAgent as Record<string, unknown>)[key] = value;
       }
     }
-    const effectiveBackend = normalizeCreateBackend(updatedAgent.backend, config.agent?.backend);
-    updatedAgent.model = resolveManagedAgentModel({
-      config,
-      backend: effectiveBackend,
-      model: updatedAgent.model,
-      target: `multi_agent.agents.${input.agentId}.model`,
-    });
+    // Rescope only when the update touches backend/model: an unrelated update
+    // (e.g. { enabled: true }) must not silently rewrite the persisted model.
+    // Load-time resolution still family-guards whatever is stored.
+    if ('backend' in input.changes || 'model' in input.changes) {
+      const effectiveBackend = normalizeCreateBackend(updatedAgent.backend, config.agent?.backend);
+      updatedAgent.model = resolveManagedAgentModel({
+        config,
+        backend: effectiveBackend,
+        model: updatedAgent.model,
+        target: `multi_agent.agents.${input.agentId}.model`,
+      });
+    }
 
     if (!agents) {
       throw new Error(`Agent '${input.agentId}' not found in config`);

--- a/packages/standalone/src/api/graph-api.ts
+++ b/packages/standalone/src/api/graph-api.ts
@@ -14,7 +14,15 @@ import type { IncomingMessage, ServerResponse } from 'http';
 import { isAuthenticated, logUnauthorizedAttempt } from './auth-middleware.js';
 import { getForwardedClientAddress } from '../security/trusted-proxy.js';
 import { isProcessContextKey } from '../agent/code-act/run-context-registry.js';
-import { defaultModelForBackend, rescopeConfigModels } from '../agent/backend-model-policy.js';
+import {
+  backendForModel,
+  defaultModelForBackend,
+  emitBackendModelWarnings,
+  rescopeConfigModels,
+  resolveBackendScopedModel,
+  type BackendModelChange,
+  type UnknownModelFamilyWarning,
+} from '../agent/backend-model-policy.js';
 import { DEFAULT_ROLES } from '../cli/config/types.js';
 import {
   handleGetAgents,
@@ -2942,7 +2950,7 @@ async function handleUpdateConfigRequest(
       return;
     }
 
-    const modelChanges = rescopeModelsForConfigSave(updatedConfig);
+    const modelPolicyEntries = rescopeModelsForConfigSave(updatedConfig);
 
     const errors = validateConfigUpdate(updatedConfig);
     if (errors.length > 0) {
@@ -2957,11 +2965,10 @@ async function handleUpdateConfigRequest(
       return;
     }
 
-    for (const change of modelChanges) {
-      console.warn(
-        `[MAMA CONFIG WARNING] Rescoped ${change.target} from ${JSON.stringify(change.from)} to ${JSON.stringify(change.to)}.`
-      );
-    }
+    emitBackendModelWarnings([
+      ...modelPolicyEntries.changes,
+      ...modelPolicyEntries.warnings,
+    ]);
 
     saveMAMAConfig(updatedConfig);
 
@@ -3001,14 +3008,14 @@ async function handleUpdateConfigRequest(
 
 function rescopeModelsForConfigSave(
   config: Record<string, unknown>
-): Array<{ target: string; from: string | undefined; to: string }> {
+): { changes: BackendModelChange[]; warnings: UnknownModelFamilyWarning[] } {
   if (!isRecord(config.agent) || typeof config.agent.backend !== 'string') {
-    return [];
+    return { changes: [], warnings: [] };
   }
 
   const backend = config.agent.backend.toLowerCase();
   if (!supportedManagedBackends.includes(backend)) {
-    return [];
+    return { changes: [], warnings: [] };
   }
 
   const roles = isRecord(config.roles) ? config.roles : undefined;
@@ -3035,7 +3042,40 @@ function rescopeModelsForConfigSave(
     }
   }
 
-  return scopedModels.changes;
+  const changes = [...scopedModels.changes];
+  const warnings = [...(scopedModels.warnings ?? [])];
+  const multiAgent = isRecord(config.multi_agent) ? config.multi_agent : undefined;
+  const managedAgents = multiAgent && isRecord(multiAgent.agents) ? multiAgent.agents : {};
+  for (const [agentId, agentConfig] of Object.entries(managedAgents)) {
+    if (!isRecord(agentConfig)) {
+      continue;
+    }
+    const effectiveBackend =
+      typeof agentConfig.backend === 'string' ? agentConfig.backend.toLowerCase() : backend;
+    if (!supportedManagedBackends.includes(effectiveBackend)) {
+      continue;
+    }
+
+    const configuredModel =
+      typeof agentConfig.model === 'string' ? agentConfig.model.trim() : undefined;
+    const target = `multi_agent.agents.${agentId}.model`;
+    const resolvedModel = resolveBackendScopedModel({
+      backend: effectiveBackend as Parameters<typeof resolveBackendScopedModel>[0]['backend'],
+      model: configuredModel,
+      inheritedBackend: backend as Parameters<
+        typeof resolveBackendScopedModel
+      >[0]['inheritedBackend'],
+      inheritedModel: scopedModels.agentModel,
+      warningTarget: target,
+      onWarning: (warning) => warnings.push(warning),
+    });
+    agentConfig.model = resolvedModel;
+    if (configuredModel && configuredModel !== resolvedModel) {
+      changes.push({ target, from: configuredModel, to: resolvedModel });
+    }
+  }
+
+  return { changes, warnings };
 }
 
 function maskToken(token: string): string {
@@ -3301,10 +3341,11 @@ function validateConfigUpdate(config: Record<string, any>): string[] {
     if (config.agent.backend && config.agent.model && typeof config.agent.model === 'string') {
       const backend = String(config.agent.backend).toLowerCase();
       const model = config.agent.model;
-      if (backend === 'claude' && !isClaudeModel(model)) {
+      const modelBackend = backendForModel(model);
+      if (backend === 'claude' && modelBackend !== null && modelBackend !== 'claude') {
         errors.push('agent.model must be a Claude model when agent.backend is "claude"');
       }
-      if (isCodexFamilyBackend(backend) && !isCodexModel(model)) {
+      if (isCodexFamilyBackend(backend) && modelBackend !== null && modelBackend !== 'codex') {
         errors.push(`agent.model must be a Codex/OpenAI model when agent.backend is "${backend}"`);
       }
     }
@@ -3341,12 +3382,13 @@ function validateConfigUpdate(config: Record<string, any>): string[] {
           continue;
         }
         if (typeof modelRaw === 'string' && modelRaw.trim()) {
-          if (backend === 'claude' && !isClaudeModel(modelRaw)) {
+          const modelBackend = backendForModel(modelRaw);
+          if (backend === 'claude' && modelBackend !== null && modelBackend !== 'claude') {
             errors.push(
               `multi_agent.agents.${agentId}.model must be a Claude model when backend is "claude"`
             );
           }
-          if (isCodexFamilyBackend(backend) && !isCodexModel(modelRaw)) {
+          if (isCodexFamilyBackend(backend) && modelBackend !== null && modelBackend !== 'codex') {
             errors.push(
               `multi_agent.agents.${agentId}.model must be a Codex/OpenAI model when backend is "${backend}"`
             );

--- a/packages/standalone/src/api/graph-api.ts
+++ b/packages/standalone/src/api/graph-api.ts
@@ -14,7 +14,7 @@ import type { IncomingMessage, ServerResponse } from 'http';
 import { isAuthenticated, logUnauthorizedAttempt } from './auth-middleware.js';
 import { getForwardedClientAddress } from '../security/trusted-proxy.js';
 import { isProcessContextKey } from '../agent/code-act/run-context-registry.js';
-import { defaultModelForBackend } from '../agent/backend-model-policy.js';
+import { defaultModelForBackend, rescopeConfigModels } from '../agent/backend-model-policy.js';
 import { DEFAULT_ROLES } from '../cli/config/types.js';
 import {
   handleGetAgents,
@@ -2942,6 +2942,8 @@ async function handleUpdateConfigRequest(
       return;
     }
 
+    const modelChanges = rescopeModelsForConfigSave(updatedConfig);
+
     const errors = validateConfigUpdate(updatedConfig);
     if (errors.length > 0) {
       res.writeHead(400, { 'Content-Type': 'application/json' });
@@ -2953,6 +2955,12 @@ async function handleUpdateConfigRequest(
         })
       );
       return;
+    }
+
+    for (const change of modelChanges) {
+      console.warn(
+        `[MAMA CONFIG WARNING] Rescoped ${change.target} from ${JSON.stringify(change.from)} to ${JSON.stringify(change.to)}.`
+      );
     }
 
     saveMAMAConfig(updatedConfig);
@@ -2989,6 +2997,45 @@ async function handleUpdateConfigRequest(
       })
     );
   }
+}
+
+function rescopeModelsForConfigSave(
+  config: Record<string, unknown>
+): Array<{ target: string; from: string | undefined; to: string }> {
+  if (!isRecord(config.agent) || typeof config.agent.backend !== 'string') {
+    return [];
+  }
+
+  const backend = config.agent.backend.toLowerCase();
+  if (!supportedManagedBackends.includes(backend)) {
+    return [];
+  }
+
+  const roles = isRecord(config.roles) ? config.roles : undefined;
+  const definitions = roles && isRecord(roles.definitions) ? roles.definitions : {};
+  const roleModels = Object.fromEntries(
+    Object.entries(definitions)
+      .filter((entry): entry is [string, Record<string, unknown>] => isRecord(entry[1]))
+      .map(([name, definition]) => [
+        name,
+        typeof definition.model === 'string' ? definition.model : undefined,
+      ])
+  );
+  const scopedModels = rescopeConfigModels({
+    backend: backend as Parameters<typeof rescopeConfigModels>[0]['backend'],
+    agentModel: typeof config.agent.model === 'string' ? config.agent.model : undefined,
+    roleModels,
+  });
+
+  config.agent.model = scopedModels.agentModel;
+  for (const [name, model] of Object.entries(scopedModels.roleModels)) {
+    const definition = definitions[name];
+    if (isRecord(definition)) {
+      definition.model = model;
+    }
+  }
+
+  return scopedModels.changes;
 }
 
 function maskToken(token: string): string {

--- a/packages/standalone/src/cli/commands/init.ts
+++ b/packages/standalone/src/cli/commands/init.ts
@@ -20,6 +20,7 @@ import {
 import { BOOTSTRAP_TEMPLATE } from '../../onboarding/bootstrap-template.js';
 import { getClaudeCodeAuthStatus } from '../../auth/index.js';
 import { hasPersistedClineCredential } from '../../agent/cline-cli-adapter.js';
+import { rescopeConfigModels } from '../../agent/backend-model-policy.js';
 
 /**
  * CLAUDE.md template for workspace documentation
@@ -101,12 +102,6 @@ interface BackendResolution {
   backend: 'claude' | 'codex' | 'cline';
   codexAuthPath?: string;
 }
-
-const DEFAULT_MODEL_BY_BACKEND: Record<BackendResolution['backend'], string> = {
-  claude: 'claude-sonnet-4-6',
-  codex: 'gpt-5.4',
-  cline: 'deepseek/deepseek-v4-flash',
-};
 
 function isClineAvailable(command: string): boolean {
   const result = spawnSync(command, ['--version'], { stdio: 'ignore', timeout: 5_000 });
@@ -249,14 +244,18 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
   try {
     const configPath = await createDefaultConfig(options.force);
     const config = await loadConfig();
-    const defaultModel = DEFAULT_MODEL_BY_BACKEND[selectedBackend.backend];
     config.agent.backend = selectedBackend.backend;
-    config.agent.model = defaultModel;
     if (selectedBackend.backend === 'cline') {
       config.agent.cline_provider = 'cline';
     }
-    for (const role of Object.values(config.roles?.definitions ?? {})) {
-      role.model = defaultModel;
+    const roleDefinitions = config.roles?.definitions ?? {};
+    const scopedModels = rescopeConfigModels({
+      backend: selectedBackend.backend,
+      roleModels: Object.fromEntries(Object.keys(roleDefinitions).map((name) => [name, undefined])),
+    });
+    config.agent.model = scopedModels.agentModel;
+    for (const [name, role] of Object.entries(roleDefinitions)) {
+      role.model = scopedModels.roleModels[name];
     }
     await saveConfig(config);
     if (options.skipAuthCheck && requestedBackend) {

--- a/packages/standalone/src/cli/commands/init.ts
+++ b/packages/standalone/src/cli/commands/init.ts
@@ -20,7 +20,10 @@ import {
 import { BOOTSTRAP_TEMPLATE } from '../../onboarding/bootstrap-template.js';
 import { getClaudeCodeAuthStatus } from '../../auth/index.js';
 import { hasPersistedClineCredential } from '../../agent/cline-cli-adapter.js';
-import { rescopeConfigModels } from '../../agent/backend-model-policy.js';
+import {
+  emitBackendModelWarnings,
+  rescopeConfigModels,
+} from '../../agent/backend-model-policy.js';
 
 /**
  * CLAUDE.md template for workspace documentation
@@ -257,6 +260,7 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
     for (const [name, role] of Object.entries(roleDefinitions)) {
       role.model = scopedModels.roleModels[name];
     }
+    emitBackendModelWarnings(scopedModels.warnings ?? []);
     await saveConfig(config);
     if (options.skipAuthCheck && requestedBackend) {
       console.log(

--- a/packages/standalone/src/cli/config/config-manager.ts
+++ b/packages/standalone/src/cli/config/config-manager.ts
@@ -14,6 +14,7 @@ import * as yaml from 'js-yaml';
 import type { MAMAConfig, MultiAgentConfig, AgentPersonaConfig, RoleConfig } from './types.js';
 import { DEFAULT_CONFIG, MAMA_PATHS } from './types.js';
 import {
+  emitBackendModelWarnings,
   rescopeConfigModels,
   resolveBackendScopedModel,
 } from '../../agent/backend-model-policy.js';
@@ -522,11 +523,7 @@ function mergeWithDefaults(config: Partial<MAMAConfig>): MAMAConfig {
       }
     : mergedRoles;
 
-  for (const change of scopedModels.changes) {
-    console.warn(
-      `[MAMA CONFIG WARNING] Rescoped ${change.target} from ${JSON.stringify(change.from)} to ${JSON.stringify(change.to)}.`
-    );
-  }
+  emitBackendModelWarnings([...scopedModels.changes, ...(scopedModels.warnings ?? [])]);
 
   return {
     // Preserve all user-defined fields (scheduling, custom sections, etc.)

--- a/packages/standalone/src/cli/config/config-manager.ts
+++ b/packages/standalone/src/cli/config/config-manager.ts
@@ -13,7 +13,10 @@ import * as yaml from 'js-yaml';
 
 import type { MAMAConfig, MultiAgentConfig, AgentPersonaConfig, RoleConfig } from './types.js';
 import { DEFAULT_CONFIG, MAMA_PATHS } from './types.js';
-import { resolveBackendScopedModel } from '../../agent/backend-model-policy.js';
+import {
+  rescopeConfigModels,
+  resolveBackendScopedModel,
+} from '../../agent/backend-model-policy.js';
 // ============================================================================
 // Sync Config Cache (STORY-002)
 // ============================================================================
@@ -199,9 +202,6 @@ function validateRequiredFields(config: MAMAConfig, configPath: string): void {
 
   if (!config.agent.backend) {
     errors.push("agent.backend is required. Valid: 'claude' | 'codex' | 'cline'");
-  }
-  if (!config.agent.model) {
-    errors.push("agent.model is required. Example: 'claude-sonnet-4-6'");
   }
 
   // Validate role definitions have models
@@ -476,9 +476,17 @@ function mergeWithDefaults(config: Partial<MAMAConfig>): MAMAConfig {
     config.agent && (config.agent.backend as string) === 'codex-mcp'
       ? { ...config.agent, backend: 'codex' as const }
       : config.agent;
-  const mergedAgent = {
+  const mergedAgentDefaults = {
     ...DEFAULT_CONFIG.agent,
     ...agent,
+  };
+  const mergedAgent = {
+    ...mergedAgentDefaults,
+    model:
+      agent?.model ??
+      resolveBackendScopedModel({
+        backend: mergedAgentDefaults.backend,
+      }),
   };
   const inheritedRoleDefinitions = Object.fromEntries(
     Object.entries(DEFAULT_CONFIG.roles?.definitions ?? {}).map(([name, role]) => [
@@ -486,13 +494,46 @@ function mergeWithDefaults(config: Partial<MAMAConfig>): MAMAConfig {
       { ...role, model: mergedAgent.model },
     ])
   ) as Record<string, RoleConfig>;
+  const mergedRoles = DEFAULT_CONFIG.roles
+    ? {
+        definitions: { ...inheritedRoleDefinitions, ...config.roles?.definitions },
+        sourceMapping: {
+          ...DEFAULT_CONFIG.roles.sourceMapping,
+          ...config.roles?.sourceMapping,
+        },
+      }
+    : config.roles;
+  const scopedModels = rescopeConfigModels({
+    backend: mergedAgent.backend,
+    agentModel: mergedAgent.model,
+    roleModels: Object.fromEntries(
+      Object.entries(mergedRoles?.definitions ?? {}).map(([name, role]) => [name, role.model])
+    ),
+  });
+  const scopedRoles = mergedRoles
+    ? {
+        ...mergedRoles,
+        definitions: Object.fromEntries(
+          Object.entries(mergedRoles.definitions).map(([name, role]) => [
+            name,
+            { ...role, model: scopedModels.roleModels[name] },
+          ])
+        ) as Record<string, RoleConfig>,
+      }
+    : mergedRoles;
+
+  for (const change of scopedModels.changes) {
+    console.warn(
+      `[MAMA CONFIG WARNING] Rescoped ${change.target} from ${JSON.stringify(change.from)} to ${JSON.stringify(change.to)}.`
+    );
+  }
 
   return {
     // Preserve all user-defined fields (scheduling, custom sections, etc.)
     ...config,
     // Deep-merge known structured fields with defaults
     version: config.version ?? DEFAULT_CONFIG.version,
-    agent: mergedAgent,
+    agent: { ...mergedAgent, model: scopedModels.agentModel },
     database: {
       ...DEFAULT_CONFIG.database,
       ...config.database,
@@ -505,15 +546,7 @@ function mergeWithDefaults(config: Partial<MAMAConfig>): MAMAConfig {
     // older version lacks newer role definitions (owner_console), and a plain
     // override would silently disable trust-conditional escalation on every
     // real deployment. User-defined roles and sourceMapping still win.
-    roles: DEFAULT_CONFIG.roles
-      ? {
-          definitions: { ...inheritedRoleDefinitions, ...config.roles?.definitions },
-          sourceMapping: {
-            ...DEFAULT_CONFIG.roles.sourceMapping,
-            ...config.roles?.sourceMapping,
-          },
-        }
-      : config.roles,
+    roles: scopedRoles,
     use_claude_cli: config.use_claude_cli ?? DEFAULT_CONFIG.use_claude_cli,
     discord: config.discord ?? DEFAULT_CONFIG.discord,
     slack: config.slack ?? DEFAULT_CONFIG.slack,

--- a/packages/standalone/src/cli/runtime/agent-loop-init.ts
+++ b/packages/standalone/src/cli/runtime/agent-loop-init.ts
@@ -320,10 +320,6 @@ export function initMainAgentLoop(
         callOptions.sessionKey = `${options.source}:${options.channelId}:${options.userId || 'unknown'}`;
       }
 
-      if (runtimeBackend === 'codex') {
-        // Override role-based model selection for the Codex backend.
-        callOptions.model = config.agent.model;
-      }
       const result = await agentLoop.run(prompt, callOptions);
 
       // Check if auto-recall was used (by checking if relevant-memories was in the history)
@@ -362,10 +358,6 @@ export function initMainAgentLoop(
       }
 
       console.log(`[AgentLoop] runWithContent called with ${content.length} blocks`);
-      if (runtimeBackend === 'codex') {
-        // Override role-based model selection for the Codex backend.
-        callOptions.model = config.agent.model;
-      }
       const result = await agentLoop.runWithContent(
         content as unknown as AgentContentBlock[],
         callOptions

--- a/packages/standalone/tests/agent/backend-model-policy.test.ts
+++ b/packages/standalone/tests/agent/backend-model-policy.test.ts
@@ -15,7 +15,9 @@ describe('backend model policy', () => {
       ['claude-sonnet-5', 'claude'],
       ['claude-opus-4-1', 'claude'],
       ['claude-opus-4-1-20250805', 'claude'],
+      ['CLAUDE-sonnet-5', 'claude'],
       ['gpt-5.4', 'codex'],
+      ['GPT-5.4', 'codex'],
       ['gpt-5.6-sol', 'codex'],
       ['gpt-5.6-luna', 'codex'],
       ['o4-mini', 'codex'],
@@ -124,6 +126,37 @@ describe('backend model policy', () => {
         agentModel: 'gpt-5.6-sol',
         roleModels: { reviewer: 'custom-local-model' },
         changes: [],
+        warnings: [
+          {
+            target: 'roles.definitions.reviewer.model',
+            from: 'custom-local-model',
+            to: 'custom-local-model',
+            backend: 'codex',
+            unknownFamily: true,
+          },
+        ],
+      });
+    });
+
+    it('passes through a short unknown model with an explicit warning entry', () => {
+      expect(
+        rescopeConfigModels({
+          backend: 'claude',
+          agentModel: 'claude-sonnet-4-6',
+          roleModels: { reviewer: 'sonnet' },
+        })
+      ).toMatchObject({
+        roleModels: { reviewer: 'sonnet' },
+        changes: [],
+        warnings: [
+          {
+            target: 'roles.definitions.reviewer.model',
+            from: 'sonnet',
+            to: 'sonnet',
+            backend: 'claude',
+            unknownFamily: true,
+          },
+        ],
       });
     });
 

--- a/packages/standalone/tests/agent/backend-model-policy.test.ts
+++ b/packages/standalone/tests/agent/backend-model-policy.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  backendForModel,
+  defaultModelForBackend,
+  modelMatchesBackend,
+  rescopeConfigModels,
+  resolveBackendScopedModel,
+} from '../../src/agent/backend-model-policy.js';
+
+describe('backend model policy', () => {
+  describe('backendForModel', () => {
+    it.each([
+      ['claude-sonnet-4-6', 'claude'],
+      ['claude-sonnet-5', 'claude'],
+      ['claude-opus-4-1', 'claude'],
+      ['claude-opus-4-1-20250805', 'claude'],
+      ['gpt-5.4', 'codex'],
+      ['gpt-5.6-sol', 'codex'],
+      ['gpt-5.6-luna', 'codex'],
+      ['o4-mini', 'codex'],
+      ['deepseek/deepseek-v4-flash', 'cline'],
+    ] as const)('classifies %s as %s', (model, backend) => {
+      expect(backendForModel(model)).toBe(backend);
+    });
+
+    it('returns null for an unknown model family', () => {
+      expect(backendForModel('custom-local-model')).toBeNull();
+    });
+  });
+
+  describe('modelMatchesBackend', () => {
+    it('accepts models classified for the active backend', () => {
+      expect(modelMatchesBackend('gpt-5.6-sol', 'codex')).toBe(true);
+    });
+
+    it('rejects models classified for another backend', () => {
+      expect(modelMatchesBackend('claude-sonnet-5', 'codex')).toBe(false);
+    });
+
+    it('conservatively accepts unknown model strings', () => {
+      expect(modelMatchesBackend('custom-local-model', 'claude')).toBe(true);
+    });
+  });
+
+  describe('resolveBackendScopedModel', () => {
+    it('respects a same-backend explicit model', () => {
+      expect(
+        resolveBackendScopedModel({
+          backend: 'codex',
+          model: 'gpt-5.4',
+          inheritedBackend: 'codex',
+          inheritedModel: 'gpt-5.6-sol',
+        })
+      ).toBe('gpt-5.4');
+    });
+
+    it('ignores a cross-backend explicit model and uses the inherited model', () => {
+      expect(
+        resolveBackendScopedModel({
+          backend: 'codex',
+          model: 'claude-sonnet-5',
+          inheritedBackend: 'codex',
+          inheritedModel: 'gpt-5.6-sol',
+        })
+      ).toBe('gpt-5.6-sol');
+    });
+
+    it('keeps an unknown explicit model on the active backend', () => {
+      expect(
+        resolveBackendScopedModel({
+          backend: 'codex',
+          model: 'custom-local-model',
+          inheritedBackend: 'codex',
+          inheritedModel: 'gpt-5.6-sol',
+        })
+      ).toBe('custom-local-model');
+    });
+  });
+
+  describe('rescopeConfigModels', () => {
+    it('keeps a same-backend role override', () => {
+      expect(
+        rescopeConfigModels({
+          backend: 'codex',
+          agentModel: 'gpt-5.6-sol',
+          roleModels: { reviewer: 'gpt-5.4' },
+        })
+      ).toEqual({
+        agentModel: 'gpt-5.6-sol',
+        roleModels: { reviewer: 'gpt-5.4' },
+        changes: [],
+      });
+    });
+
+    it('rescopes a cross-backend role override to the resolved agent model', () => {
+      expect(
+        rescopeConfigModels({
+          backend: 'codex',
+          agentModel: 'gpt-5.6-sol',
+          roleModels: { reviewer: 'claude-sonnet-5' },
+        })
+      ).toEqual({
+        agentModel: 'gpt-5.6-sol',
+        roleModels: { reviewer: 'gpt-5.6-sol' },
+        changes: [
+          {
+            target: 'roles.definitions.reviewer.model',
+            from: 'claude-sonnet-5',
+            to: 'gpt-5.6-sol',
+          },
+        ],
+      });
+    });
+
+    it('does not rescope an unknown role model', () => {
+      expect(
+        rescopeConfigModels({
+          backend: 'codex',
+          agentModel: 'gpt-5.6-sol',
+          roleModels: { reviewer: 'custom-local-model' },
+        })
+      ).toEqual({
+        agentModel: 'gpt-5.6-sol',
+        roleModels: { reviewer: 'custom-local-model' },
+        changes: [],
+      });
+    });
+
+    it('uses and records the backend default when the agent model is unset', () => {
+      expect(
+        rescopeConfigModels({
+          backend: 'codex',
+          roleModels: {},
+        })
+      ).toEqual({
+        agentModel: defaultModelForBackend('codex'),
+        roleModels: {},
+        changes: [
+          {
+            target: 'agent.model',
+            from: undefined,
+            to: 'gpt-5.4',
+          },
+        ],
+      });
+    });
+
+    it('rescopes and records a cross-backend agent model', () => {
+      expect(
+        rescopeConfigModels({
+          backend: 'claude',
+          agentModel: 'gpt-5.6-sol',
+          roleModels: {},
+        })
+      ).toEqual({
+        agentModel: 'claude-sonnet-4-6',
+        roleModels: {},
+        changes: [
+          {
+            target: 'agent.model',
+            from: 'gpt-5.6-sol',
+            to: 'claude-sonnet-4-6',
+          },
+        ],
+      });
+    });
+
+    it('fills and records an unset role model from the resolved agent model', () => {
+      expect(
+        rescopeConfigModels({
+          backend: 'codex',
+          agentModel: 'gpt-5.6-sol',
+          roleModels: { reviewer: undefined },
+        })
+      ).toEqual({
+        agentModel: 'gpt-5.6-sol',
+        roleModels: { reviewer: 'gpt-5.6-sol' },
+        changes: [
+          {
+            target: 'roles.definitions.reviewer.model',
+            from: undefined,
+            to: 'gpt-5.6-sol',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/packages/standalone/tests/agent/managed-agent-runtime-sync.test.ts
+++ b/packages/standalone/tests/agent/managed-agent-runtime-sync.test.ts
@@ -161,6 +161,41 @@ describe('managed-agent-runtime-sync', () => {
     expect(config.multi_agent.agents.alpha.model).toBe('deepseek/deepseek-v4-flash');
   });
 
+  it('preserves the persisted model when changes omit backend and model', async () => {
+    const config = {
+      agent: { backend: 'codex' as const, model: 'gpt-5.6-sol' },
+      multi_agent: {
+        enabled: true,
+        agents: {
+          legacy: {
+            name: 'Legacy',
+            display_name: 'Legacy',
+            trigger_prefix: '!legacy',
+            tier: 1,
+            backend: 'claude' as const,
+            model: 'claude-sonnet-5',
+            enabled: false,
+          },
+        },
+      },
+    };
+
+    const result = await updateManagedAgentRuntime(
+      {
+        agentId: 'legacy',
+        changes: { enabled: true },
+      },
+      {
+        loadConfig: vi.fn().mockResolvedValue(config),
+        saveConfig: vi.fn().mockResolvedValue(undefined),
+        writePersonaFile: vi.fn(),
+      }
+    );
+
+    expect(result.snapshot.enabled).toBe(true);
+    expect(config.multi_agent.agents.legacy.model).toBe('claude-sonnet-5');
+  });
+
   it('rescopes a cross-family explicit model when updating a managed agent', async () => {
     const config = {
       agent: { backend: 'codex' as const, model: 'gpt-5.6-sol' },

--- a/packages/standalone/tests/agent/managed-agent-runtime-sync.test.ts
+++ b/packages/standalone/tests/agent/managed-agent-runtime-sync.test.ts
@@ -82,6 +82,24 @@ describe('managed-agent-runtime-sync', () => {
     expect(codexRuntime.snapshot.backend).toBe('codex');
   });
 
+  it('rescopes a cross-family model when creating a managed agent', async () => {
+    const config = {
+      agent: { backend: 'codex' as const, model: 'gpt-5.6-sol' },
+      multi_agent: { enabled: true, agents: {} },
+    };
+
+    const result = await createManagedAgentRuntime(
+      { id: 'reviewer', name: 'Reviewer', model: 'claude-sonnet-5', tier: 1 },
+      {
+        loadConfig: vi.fn().mockResolvedValue(config),
+        saveConfig: vi.fn().mockResolvedValue(undefined),
+        writePersonaFile: vi.fn(),
+      }
+    );
+
+    expect(result.snapshot).toMatchObject({ backend: 'codex', model: 'gpt-5.6-sol' });
+  });
+
   it('TG-03/TG-04 preserves the cline backend when creating agents', async () => {
     const config = {
       agent: { backend: 'claude' as const },
@@ -141,6 +159,40 @@ describe('managed-agent-runtime-sync', () => {
     expect(result.snapshot.model).toBe('deepseek/deepseek-v4-flash');
     expect(config.multi_agent.agents.alpha.backend).toBe('cline');
     expect(config.multi_agent.agents.alpha.model).toBe('deepseek/deepseek-v4-flash');
+  });
+
+  it('rescopes a cross-family explicit model when updating a managed agent', async () => {
+    const config = {
+      agent: { backend: 'codex' as const, model: 'gpt-5.6-sol' },
+      multi_agent: {
+        enabled: true,
+        agents: {
+          alpha: {
+            name: 'Alpha',
+            display_name: 'Alpha',
+            trigger_prefix: '!alpha',
+            tier: 1,
+            backend: 'codex' as const,
+            model: 'gpt-5.4',
+          },
+        },
+      },
+    };
+
+    const result = await updateManagedAgentRuntime(
+      {
+        agentId: 'alpha',
+        changes: { model: 'claude-sonnet-5' },
+      },
+      {
+        loadConfig: vi.fn().mockResolvedValue(config),
+        saveConfig: vi.fn().mockResolvedValue(undefined),
+        writePersonaFile: vi.fn(),
+      }
+    );
+
+    expect(result.snapshot.model).toBe('gpt-5.6-sol');
+    expect(config.multi_agent.agents.alpha.model).toBe('gpt-5.6-sol');
   });
 
   it('uses a default persona path when updating system text without persona_file', async () => {

--- a/packages/standalone/tests/agent/role-model-reaches-backend.test.ts
+++ b/packages/standalone/tests/agent/role-model-reaches-backend.test.ts
@@ -232,7 +232,7 @@ afterEach(async () => {
 
 describe('runtime role model reaches the Codex session policy', () => {
   it('REGRESSION 1 sends a same-backend role override through the real AgentLoop', async () => {
-    const root = roots[0];
+    const root = roots[roots.length - 1];
     if (!root) {
       throw new Error('Expected a runtime fixture root');
     }
@@ -249,8 +249,26 @@ describe('runtime role model reaches the Codex session policy', () => {
     expect(starts[0]?.params?.model).toBe('gpt-5.4');
   });
 
+  it('REGRESSION 4 sends a runWithContent role override to the Codex child policy', async () => {
+    const root = roots[roots.length - 1];
+    if (!root) {
+      throw new Error('Expected a runtime fixture root');
+    }
+    const capture = join(root, 'codex-rpc.ndjson');
+    const runtime = createRuntime('gpt-5.6-sol');
+
+    await runtime.agentLoopClient.runWithContent?.(
+      [{ type: 'text', text: 'Use the configured role model.' }],
+      turnOptions({ model: 'gpt-5.4', resumeSession: false })
+    );
+
+    const starts = messages(capture).filter((message) => message.method === 'thread/start');
+    expect(starts).toHaveLength(1);
+    expect(starts[0]?.params?.model).toBe('gpt-5.4');
+  });
+
   it('TG-05 replaces a rescoped model session once and then continues without thrash', async () => {
-    const root = roots[0];
+    const root = roots[roots.length - 1];
     if (!root) {
       throw new Error('Expected a runtime fixture root');
     }

--- a/packages/standalone/tests/agent/role-model-reaches-backend.test.ts
+++ b/packages/standalone/tests/agent/role-model-reaches-backend.test.ts
@@ -1,0 +1,317 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GatewayToolExecutor } from '../../src/agent/index.js';
+import type { AgentLoopOptions } from '../../src/agent/types.js';
+import type { OAuthManager } from '../../src/auth/index.js';
+import type { MAMAConfig } from '../../src/cli/config/types.js';
+import { initMainAgentLoop } from '../../src/cli/runtime/agent-loop-init.js';
+import { hashSessionPolicyFingerprint } from '../../src/gateways/message-router.js';
+import type { MetricsStore } from '../../src/observability/metrics-store.js';
+import type { SQLiteDatabase } from '../../src/sqlite.js';
+
+interface CapturedRpcMessage {
+  method?: string;
+  params?: Record<string, unknown>;
+}
+
+const roots: string[] = [];
+const loops: Array<{ stop(): Promise<void> }> = [];
+
+let originalHome: string | undefined;
+let originalPath: string | undefined;
+
+function installFakeCodexAppServer(root: string): string {
+  const binDir = join(root, 'bin');
+  const command = join(binDir, 'codex');
+  const capture = join(root, 'codex-rpc.ndjson');
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(
+    command,
+    `#!/usr/bin/env node
+import fs from 'node:fs';
+import readline from 'node:readline';
+const capture = ${JSON.stringify(capture)};
+const send = (value) => process.stdout.write(JSON.stringify({ jsonrpc: '2.0', ...value }) + '\\n');
+const fullThread = (id, cwd) => ({
+  id,
+  sessionId: 'session-' + id,
+  forkedFromId: null,
+  parentThreadId: null,
+  preview: '',
+  ephemeral: false,
+  modelProvider: 'openai',
+  createdAt: 1,
+  updatedAt: 1,
+  recencyAt: 1,
+  status: { type: 'idle' },
+  path: null,
+  cwd,
+  cliVersion: '0.144.0',
+  source: 'appServer',
+  threadSource: null,
+  agentNickname: null,
+  agentRole: null,
+  gitInfo: null,
+  name: null,
+  turns: [],
+});
+const fullTurn = (id, status = 'inProgress') => ({
+  id,
+  items: [],
+  itemsView: 'full',
+  status,
+  error: null,
+  startedAt: 1,
+  completedAt: status === 'inProgress' ? null : 2,
+  durationMs: status === 'inProgress' ? null : 1,
+});
+const threadResult = (id, params) => ({
+  thread: fullThread(id, params.cwd),
+  model: params.model,
+  modelProvider: 'openai',
+  serviceTier: null,
+  cwd: params.cwd,
+  instructionSources: [],
+  approvalPolicy: 'never',
+  approvalsReviewer: 'user',
+  sandbox: {
+    type: 'workspaceWrite',
+    writableRoots: [params.cwd],
+    networkAccess: false,
+    excludeTmpdirEnvVar: false,
+    excludeSlashTmp: false,
+  },
+  reasoningEffort: null,
+});
+let thread = 0;
+let turn = 0;
+const rl = readline.createInterface({ input: process.stdin });
+rl.on('line', (line) => {
+  const message = JSON.parse(line);
+  fs.appendFileSync(capture, JSON.stringify(message) + '\\n');
+  if (message.method === 'initialize') {
+    return send({
+      id: message.id,
+      result: {
+        userAgent: 'fake-codex',
+        codexHome: process.env.CODEX_HOME,
+        platformFamily: 'unix',
+        platformOs: 'test',
+      },
+    });
+  }
+  if (message.method === 'thread/start') {
+    return send({ id: message.id, result: threadResult('thread-' + (++thread), message.params) });
+  }
+  if (message.method === 'thread/resume') {
+    return send({ id: message.id, result: threadResult(message.params.threadId, message.params) });
+  }
+  if (message.method === 'turn/start') {
+    const turnId = 'turn-' + (++turn);
+    send({ id: message.id, result: { turn: fullTurn(turnId) } });
+    send({
+      method: 'item/agentMessage/delta',
+      params: { threadId: message.params.threadId, turnId, delta: 'ok' },
+    });
+    send({
+      method: 'thread/tokenUsage/updated',
+      params: {
+        threadId: message.params.threadId,
+        turnId,
+        tokenUsage: { last: { inputTokens: 3, outputTokens: 1, cachedInputTokens: 0 } },
+      },
+    });
+    return send({
+      method: 'turn/completed',
+      params: { threadId: message.params.threadId, turn: fullTurn(turnId, 'completed') },
+    });
+  }
+  if (message.method === 'turn/interrupt') {
+    return send({ id: message.id, result: {} });
+  }
+});
+process.on('SIGTERM', () => process.exit(0));
+`,
+    { mode: 0o700 }
+  );
+  chmodSync(command, 0o700);
+  return capture;
+}
+
+function createConfig(model: string): MAMAConfig {
+  return {
+    version: 1,
+    agent: {
+      backend: 'codex',
+      model,
+      timeout: 2_000,
+      max_turns: 2,
+      tools: {},
+    },
+    database: { path: ':memory:' },
+    multi_agent: {
+      agents: {
+        'os-agent': { useCodeAct: false },
+      },
+    },
+  } as unknown as MAMAConfig;
+}
+
+function createRuntime(bootModel: string): ReturnType<typeof initMainAgentLoop> {
+  const runtime = initMainAgentLoop(
+    createConfig(bootModel),
+    { getToken: vi.fn() } as unknown as OAuthManager,
+    {} as SQLiteDatabase,
+    null as MetricsStore | null,
+    'codex',
+    new GatewayToolExecutor({})
+  );
+  loops.push(runtime.agentLoop);
+  return runtime;
+}
+
+function messages(capture: string): CapturedRpcMessage[] {
+  if (!existsSync(capture)) {
+    return [];
+  }
+  const content = readFileSync(capture, 'utf8').trim();
+  return content ? content.split('\n').map((line) => JSON.parse(line) as CapturedRpcMessage) : [];
+}
+
+function turnOptions(overrides: Partial<AgentLoopOptions> = {}): AgentLoopOptions {
+  return {
+    disableAutoRecall: true,
+    modelRunId: 'fixture-model-run',
+    sessionKey: 'role-model-session',
+    source: 'telegram',
+    channelId: 'role-model-channel',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  const root = mkdtempSync(join(tmpdir(), 'mama-role-model-runtime-'));
+  roots.push(root);
+  originalHome = process.env.HOME;
+  originalPath = process.env.PATH;
+  process.env.HOME = root;
+  process.env.PATH = `${join(root, 'bin')}:${originalPath ?? ''}`;
+  installFakeCodexAppServer(root);
+});
+
+afterEach(async () => {
+  for (const loop of loops.splice(0)) {
+    await loop.stop();
+  }
+  vi.restoreAllMocks();
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+  if (originalPath === undefined) {
+    delete process.env.PATH;
+  } else {
+    process.env.PATH = originalPath;
+  }
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('runtime role model reaches the Codex session policy', () => {
+  it('REGRESSION 1 sends a same-backend role override through the real AgentLoop', async () => {
+    const root = roots[0];
+    if (!root) {
+      throw new Error('Expected a runtime fixture root');
+    }
+    const capture = join(root, 'codex-rpc.ndjson');
+    const runtime = createRuntime('gpt-5.6-sol');
+
+    await runtime.agentLoopClient.run(
+      'Use the configured role model.',
+      turnOptions({ model: 'gpt-5.4', resumeSession: false })
+    );
+
+    const starts = messages(capture).filter((message) => message.method === 'thread/start');
+    expect(starts).toHaveLength(1);
+    expect(starts[0]?.params?.model).toBe('gpt-5.4');
+  });
+
+  it('TG-05 replaces a rescoped model session once and then continues without thrash', async () => {
+    const root = roots[0];
+    if (!root) {
+      throw new Error('Expected a runtime fixture root');
+    }
+    const capture = join(root, 'codex-rpc.ndjson');
+    const runtime = createRuntime('gpt-5.6-sol');
+    const reset = vi.fn();
+    const rebuildCurrentPolicy = vi.fn().mockResolvedValue('full gpt-5.4 role policy');
+    const bootFingerprint = hashSessionPolicyFingerprint({
+      baseInstructions: 'stable role instructions',
+      model: 'gpt-5.6-sol',
+    });
+    const roleFingerprint = hashSessionPolicyFingerprint({
+      baseInstructions: 'stable role instructions',
+      model: 'gpt-5.4',
+    });
+
+    expect(roleFingerprint).not.toBe(bootFingerprint);
+
+    await runtime.agentLoopClient.run(
+      'Boot policy turn.',
+      turnOptions({
+        model: 'gpt-5.6-sol',
+        sessionKey: 'tg-05-model-rescope-session',
+        resumeSession: false,
+        systemPrompt: 'full gpt-5.6-sol boot policy',
+        sessionPolicyFingerprint: bootFingerprint,
+      })
+    );
+    await runtime.agentLoopClient.run(
+      'Rescoped policy turn.',
+      turnOptions({
+        model: 'gpt-5.4',
+        sessionKey: 'tg-05-model-rescope-session',
+        resumeSession: true,
+        systemPrompt: 'minimal stale-policy continuation',
+        sessionPolicyFingerprint: roleFingerprint,
+        freshSessionSystemPrompt: rebuildCurrentPolicy,
+        onCliSessionReset: reset,
+      })
+    );
+    await runtime.agentLoopClient.run(
+      'Unchanged role policy turn.',
+      turnOptions({
+        model: 'gpt-5.4',
+        sessionKey: 'tg-05-model-rescope-session',
+        resumeSession: true,
+        systemPrompt: 'minimal current-policy continuation',
+        sessionPolicyFingerprint: roleFingerprint,
+        freshSessionSystemPrompt: rebuildCurrentPolicy,
+        onCliSessionReset: reset,
+      })
+    );
+
+    const sent = messages(capture);
+    const starts = sent.filter((message) => message.method === 'thread/start');
+    expect(starts).toHaveLength(2);
+    expect(starts.map((message) => message.params?.model)).toEqual(['gpt-5.6-sol', 'gpt-5.4']);
+    expect(starts[1]?.params?.baseInstructions).toContain('full gpt-5.4 role policy');
+    expect(sent.filter((message) => message.method === 'thread/resume')).toHaveLength(0);
+    expect(sent.filter((message) => message.method === 'turn/start')).toHaveLength(3);
+    expect(rebuildCurrentPolicy).toHaveBeenCalledTimes(1);
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/standalone/tests/api/graph-api-config-rescope.test.ts
+++ b/packages/standalone/tests/api/graph-api-config-rescope.test.ts
@@ -123,6 +123,78 @@ describe('PUT /api/config backend model rescoping', () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it('rescopes inherited managed agents on a backend switch and preserves explicit peers', async () => {
+    await writeConfig({
+      version: 1,
+      agent: {
+        backend: 'claude',
+        model: 'claude-sonnet-4-6',
+        max_turns: 10,
+        timeout: 300_000,
+      },
+      multi_agent: {
+        enabled: true,
+        agents: {
+          inherited: { model: 'claude-sonnet-5', tier: 1, enabled: true },
+          explicit: { backend: 'codex', model: 'gpt-5.6-sol', tier: 1, enabled: true },
+        },
+      },
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const handler = createGraphHandler();
+    const response = createMockResponse();
+
+    await handler(
+      createPutRequest('/api/config', { agent: { backend: 'codex' } }),
+      response as unknown as ServerResponse
+    );
+
+    expect(response.status).toBe(200);
+    const persisted = yaml.load(await readFile(configPath, 'utf8')) as {
+      multi_agent: { agents: Record<string, { backend?: string; model: string }> };
+    };
+    expect(persisted.multi_agent.agents.inherited.model).toBe('gpt-5.4');
+    expect(persisted.multi_agent.agents.inherited.backend).toBeUndefined();
+    expect(persisted.multi_agent.agents.explicit).toMatchObject({
+      backend: 'codex',
+      model: 'gpt-5.6-sol',
+    });
+    expect(warn).toHaveBeenCalledWith(
+      '[MAMA CONFIG WARNING] Rescoped multi_agent.agents.inherited.model from "claude-sonnet-5" to "gpt-5.4".'
+    );
+  });
+
+  it('passes through an unknown future model with a loud family warning', async () => {
+    await writeConfig({
+      version: 1,
+      agent: {
+        backend: 'codex',
+        model: 'gpt-5.4',
+        max_turns: 10,
+        timeout: 300_000,
+      },
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const handler = createGraphHandler();
+    const response = createMockResponse();
+
+    await handler(
+      createPutRequest('/api/config', { agent: { model: 'sonnet-future-graph' } }),
+      response as unknown as ServerResponse
+    );
+
+    expect(response.status).toBe(200);
+    const persisted = yaml.load(await readFile(configPath, 'utf8')) as {
+      agent: { backend: string; model: string };
+    };
+    expect(persisted.agent).toMatchObject({ backend: 'codex', model: 'sonnet-future-graph' });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'model "sonnet-future-graph" not recognized as a codex-family model; passing through'
+      )
+    );
+  });
+
   async function writeConfig(config: Record<string, unknown>): Promise<void> {
     await writeFile(configPath, yaml.dump(config), 'utf8');
   }

--- a/packages/standalone/tests/api/graph-api-config-rescope.test.ts
+++ b/packages/standalone/tests/api/graph-api-config-rescope.test.ts
@@ -1,0 +1,184 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import * as yaml from 'js-yaml';
+
+const originalHome = process.env.HOME;
+const testHome = join(
+  tmpdir(),
+  `mama-graph-api-config-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+);
+
+let createGraphHandler: typeof import('../../src/api/graph-api.js').createGraphHandler;
+
+beforeAll(async () => {
+  process.env.HOME = testHome;
+  vi.resetModules();
+  ({ createGraphHandler } = await import('../../src/api/graph-api.js'));
+});
+
+afterAll(async () => {
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+  await rm(testHome, { recursive: true, force: true });
+});
+
+describe('PUT /api/config backend model rescoping', () => {
+  const configPath = join(testHome, '.mama', 'config.yaml');
+
+  beforeEach(async () => {
+    await mkdir(join(testHome, '.mama'), { recursive: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rescopes agent and role models before persisting a backend change', async () => {
+    await writeConfig({
+      version: 1,
+      agent: {
+        backend: 'codex',
+        model: 'gpt-5.4',
+        max_turns: 10,
+        timeout: 300_000,
+      },
+      roles: {
+        definitions: {
+          reviewer: { model: 'gpt-5.4', allowedTools: ['*'] },
+          operator: { model: 'gpt-5.6-sol', allowedTools: ['*'] },
+        },
+        sourceMapping: {},
+      },
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const handler = createGraphHandler();
+    const response = createMockResponse();
+
+    const handled = await handler(
+      createPutRequest('/api/config', { agent: { backend: 'claude' } }),
+      response as unknown as ServerResponse
+    );
+
+    expect(handled).toBe(true);
+    expect(response.status).toBe(200);
+    const persisted = yaml.load(await readFile(configPath, 'utf8')) as {
+      agent: { backend: string; model: string };
+      roles: { definitions: Record<string, { model: string }> };
+    };
+    expect(persisted.agent).toMatchObject({
+      backend: 'claude',
+      model: 'claude-sonnet-4-6',
+    });
+    expect(
+      Object.values(persisted.roles.definitions).map((definition) => definition.model)
+    ).toEqual(['claude-sonnet-4-6', 'claude-sonnet-4-6']);
+    expect(warn).toHaveBeenCalledTimes(3);
+    expect(warn).toHaveBeenCalledWith(
+      '[MAMA CONFIG WARNING] Rescoped agent.model from "gpt-5.4" to "claude-sonnet-4-6".'
+    );
+    expect(warn).toHaveBeenCalledWith(
+      '[MAMA CONFIG WARNING] Rescoped roles.definitions.reviewer.model from "gpt-5.4" to "claude-sonnet-4-6".'
+    );
+    expect(warn).toHaveBeenCalledWith(
+      '[MAMA CONFIG WARNING] Rescoped roles.definitions.operator.model from "gpt-5.6-sol" to "claude-sonnet-4-6".'
+    );
+  });
+
+  it('preserves a same-backend role override untouched', async () => {
+    await writeConfig({
+      version: 1,
+      agent: {
+        backend: 'claude',
+        model: 'claude-sonnet-4-6',
+        max_turns: 10,
+        timeout: 300_000,
+      },
+      roles: {
+        definitions: {
+          reviewer: { model: 'claude-opus-4-6', allowedTools: ['*'] },
+        },
+        sourceMapping: {},
+      },
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const handler = createGraphHandler();
+    const response = createMockResponse();
+
+    await handler(
+      createPutRequest('/api/config', { agent: { backend: 'claude', max_turns: 12 } }),
+      response as unknown as ServerResponse
+    );
+
+    expect(response.status).toBe(200);
+    const persisted = yaml.load(await readFile(configPath, 'utf8')) as {
+      roles: { definitions: Record<string, { model: string }> };
+    };
+    expect(persisted.roles.definitions.reviewer.model).toBe('claude-opus-4-6');
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  async function writeConfig(config: Record<string, unknown>): Promise<void> {
+    await writeFile(configPath, yaml.dump(config), 'utf8');
+  }
+});
+
+function createPutRequest(url: string, body: Record<string, unknown>): IncomingMessage {
+  const listeners = new Map<string, Array<(value?: unknown) => void>>();
+  const request = {
+    method: 'PUT',
+    url,
+    headers: { host: 'localhost', 'content-type': 'application/json' },
+    socket: { remoteAddress: '127.0.0.1' },
+    on(event: string, handler: (value?: unknown) => void) {
+      const handlers = listeners.get(event) ?? [];
+      handlers.push(handler);
+      listeners.set(event, handlers);
+      return this;
+    },
+    destroy() {
+      return this;
+    },
+  } as IncomingMessage;
+
+  queueMicrotask(() => {
+    for (const handler of listeners.get('data') ?? []) {
+      handler(Buffer.from(JSON.stringify(body)));
+    }
+    for (const handler of listeners.get('end') ?? []) {
+      handler();
+    }
+  });
+
+  return request;
+}
+
+function createMockResponse(): {
+  status: number;
+  body: string;
+  headers: Record<string, string>;
+  setHeader(name: string, value: string): void;
+  writeHead(status: number, headers?: Record<string, string>): void;
+  end(body?: string): void;
+} {
+  return {
+    status: 0,
+    body: '',
+    headers: {},
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    writeHead(status, headers) {
+      this.status = status;
+      this.headers = { ...this.headers, ...(headers ?? {}) };
+    },
+    end(body = '') {
+      this.body = body;
+    },
+  };
+}

--- a/packages/standalone/tests/cli/backend-switch-matrix.test.ts
+++ b/packages/standalone/tests/cli/backend-switch-matrix.test.ts
@@ -1,0 +1,126 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as yaml from 'js-yaml';
+
+import { backendForModel, rescopeConfigModels } from '../../src/agent/backend-model-policy.js';
+import { loadConfig } from '../../src/cli/config/config-manager.js';
+import { DEFAULT_ROLES } from '../../src/cli/config/types.js';
+
+type Backend = 'claude' | 'codex' | 'cline';
+type MatrixMode = 'clean' | 'cross-backend-leftovers' | 'same-backend-override';
+
+const SWITCH_SEQUENCE: readonly Backend[] = ['codex', 'claude', 'cline', 'codex'];
+const PRIMARY_MODELS: Readonly<Record<Backend, string>> = {
+  claude: 'claude-sonnet-4-6',
+  codex: 'gpt-5.6-sol',
+  cline: 'deepseek/deepseek-v4-flash',
+};
+const SAME_BACKEND_OVERRIDES: Readonly<Record<Backend, string>> = {
+  claude: 'claude-opus-4-6',
+  codex: 'gpt-5.4',
+  cline: 'openrouter/qwen3-coder',
+};
+const LEFTOVER_BACKENDS: readonly Backend[] = ['claude', 'codex', 'claude', 'cline'];
+
+let testHome: string;
+let originalHome: string | undefined;
+
+function roleModels(model: string, override?: string): Record<string, string> {
+  return Object.fromEntries(
+    Object.keys(DEFAULT_ROLES.definitions).map((name) => [
+      name,
+      name === 'chat_bot' && override ? override : model,
+    ])
+  );
+}
+
+async function writeRawConfig(input: {
+  backend: Backend;
+  agentModel: string;
+  configuredRoleModels: Record<string, string>;
+}): Promise<void> {
+  const mamaDir = join(testHome, '.mama');
+  await mkdir(mamaDir, { recursive: true });
+  const definitions = Object.fromEntries(
+    Object.entries(DEFAULT_ROLES.definitions).map(([name, role]) => [
+      name,
+      { ...role, model: input.configuredRoleModels[name] },
+    ])
+  );
+  await writeFile(
+    join(mamaDir, 'config.yaml'),
+    yaml.dump({
+      version: 1,
+      agent: { backend: input.backend, model: input.agentModel },
+      database: { path: ':memory:' },
+      roles: { definitions, sourceMapping: DEFAULT_ROLES.sourceMapping },
+    })
+  );
+}
+
+beforeEach(async () => {
+  testHome = await mkdtemp(join(tmpdir(), 'mama-backend-switch-matrix-'));
+  originalHome = process.env.HOME;
+  process.env.HOME = testHome;
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+  await rm(testHome, { recursive: true, force: true });
+});
+
+describe('backend switch model matrix', () => {
+  it.each<MatrixMode>(['clean', 'cross-backend-leftovers', 'same-backend-override'])(
+    'loads codex -> claude -> cline -> codex with %s models in the active family',
+    async (mode) => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      for (const [index, backend] of SWITCH_SEQUENCE.entries()) {
+        const staleBackend = LEFTOVER_BACKENDS[index];
+        if (!staleBackend) {
+          throw new Error(`Missing leftover backend for matrix step ${index}`);
+        }
+        const configuredAgentModel =
+          mode === 'cross-backend-leftovers'
+            ? PRIMARY_MODELS[staleBackend]
+            : PRIMARY_MODELS[backend];
+        const configuredRoleModels =
+          mode === 'cross-backend-leftovers'
+            ? roleModels(PRIMARY_MODELS[staleBackend])
+            : roleModels(
+                PRIMARY_MODELS[backend],
+                mode === 'same-backend-override' ? SAME_BACKEND_OVERRIDES[backend] : undefined
+              );
+        const expectedRescope = rescopeConfigModels({
+          backend,
+          agentModel: configuredAgentModel,
+          roleModels: configuredRoleModels,
+        });
+
+        await writeRawConfig({ backend, agentModel: configuredAgentModel, configuredRoleModels });
+        warn.mockClear();
+        const loaded = await loadConfig();
+
+        expect(backendForModel(loaded.agent.model), `${mode} ${backend} agent.model`).toBe(backend);
+        for (const [roleName, role] of Object.entries(loaded.roles?.definitions ?? {})) {
+          expect(backendForModel(role.model), `${mode} ${backend} ${roleName}`).toBe(backend);
+        }
+        expect(warn).toHaveBeenCalledTimes(expectedRescope.changes.length);
+        for (const [line] of warn.mock.calls) {
+          expect(String(line)).toContain('[MAMA CONFIG WARNING] Rescoped');
+        }
+
+        if (mode === 'same-backend-override') {
+          expect(loaded.roles?.definitions.chat_bot?.model).toBe(SAME_BACKEND_OVERRIDES[backend]);
+        }
+      }
+    }
+  );
+});

--- a/packages/standalone/tests/cli/config-manager.test.ts
+++ b/packages/standalone/tests/cli/config-manager.test.ts
@@ -735,6 +735,33 @@ describe('ConfigManager', () => {
       warn.mockRestore();
     });
 
+    it('passes through an unknown model with one loud warning across repeated loads', async () => {
+      await writeRawConfig({
+        version: 1,
+        agent: { backend: 'codex', model: 'gpt-5.6-sol' },
+        database: { path: '~/.test/db.sqlite' },
+        roles: {
+          definitions: {
+            reviewer: { model: 'sonnet-dedupe-regression', allowedTools: ['*'] },
+          },
+          sourceMapping: {},
+        },
+      });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const first = await loadConfig();
+      const second = await loadConfig();
+
+      expect(first.roles?.definitions.reviewer?.model).toBe('sonnet-dedupe-regression');
+      expect(second.roles?.definitions.reviewer?.model).toBe('sonnet-dedupe-regression');
+      expect(warningLines(warn)).toEqual([
+        expect.stringContaining(
+          'model "sonnet-dedupe-regression" not recognized as a codex-family model; passing through'
+        ),
+      ]);
+      warn.mockRestore();
+    });
+
     it('prunes a rescoped inherited-default role during a save round trip', async () => {
       await writeRawConfig({
         version: 1,

--- a/packages/standalone/tests/cli/config-manager.test.ts
+++ b/packages/standalone/tests/cli/config-manager.test.ts
@@ -2,8 +2,8 @@
  * Unit tests for ConfigManager
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { chmod, mkdir, writeFile, rm, stat } from 'node:fs/promises';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { chmod, mkdir, readFile, writeFile, rm, stat } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -36,6 +36,8 @@ describe('ConfigManager', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
+
     // Restore HOME
     if (originalHome !== undefined) {
       process.env.HOME = originalHome;
@@ -623,6 +625,139 @@ describe('ConfigManager', () => {
 
       expect(errors).toContain('memory_policy.implicit_recall must be boolean');
       expect(errors).toContain('memory_policy.implicit_legacy_context_search must be boolean');
+    });
+  });
+
+  describe('backend-scoped config models', () => {
+    async function writeRawConfig(config: Record<string, unknown>): Promise<void> {
+      const mamaDir = join(testDir, '.mama');
+      await mkdir(mamaDir, { recursive: true });
+      await writeFile(join(mamaDir, 'config.yaml'), yaml.dump(config));
+    }
+
+    function warningLines(spy: ReturnType<typeof vi.spyOn>): string[] {
+      return spy.mock.calls.map(([line]) => String(line));
+    }
+
+    it('rescopes stale Claude role models to the configured Codex agent model', async () => {
+      await writeRawConfig({
+        version: 1,
+        agent: { backend: 'codex', model: 'gpt-5.6-sol' },
+        database: { path: '~/.test/db.sqlite' },
+        roles: {
+          definitions: {
+            os_agent: { ...DEFAULT_ROLES.definitions.os_agent, model: 'claude-sonnet-5' },
+            chat_bot: { ...DEFAULT_ROLES.definitions.chat_bot, model: 'claude-sonnet-5' },
+          },
+          sourceMapping: {},
+        },
+      });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const loaded = await loadConfig();
+
+      expect(loaded.agent.model).toBe('gpt-5.6-sol');
+      for (const role of Object.values(loaded.roles?.definitions ?? {})) {
+        expect(role.model).toBe('gpt-5.6-sol');
+      }
+      expect(warningLines(warn)).toHaveLength(2);
+      expect(warningLines(warn)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(
+            /roles\.definitions\.os_agent\.model.*claude-sonnet-5.*gpt-5\.6-sol/
+          ),
+          expect.stringMatching(
+            /roles\.definitions\.chat_bot\.model.*claude-sonnet-5.*gpt-5\.6-sol/
+          ),
+        ])
+      );
+      warn.mockRestore();
+    });
+
+    it('rescopes a stale Codex agent model to the Claude default and updates roles', async () => {
+      await writeRawConfig({
+        version: 1,
+        agent: { backend: 'claude', model: 'gpt-5.6-sol' },
+        database: { path: '~/.test/db.sqlite' },
+      });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const loaded = await loadConfig();
+
+      expect(loaded.agent.model).toBe('claude-sonnet-4-6');
+      for (const role of Object.values(loaded.roles?.definitions ?? {})) {
+        expect(role.model).toBe('claude-sonnet-4-6');
+      }
+      expect(warningLines(warn)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/agent\.model.*gpt-5\.6-sol.*claude-sonnet-4-6/),
+        ])
+      );
+      warn.mockRestore();
+    });
+
+    it('fills an unset Codex agent model and all roles without warning', async () => {
+      await writeRawConfig({
+        version: 1,
+        agent: { backend: 'codex' },
+        database: { path: '~/.test/db.sqlite' },
+      });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const loaded = await loadConfig();
+
+      expect(loaded.agent.model).toBe('gpt-5.4');
+      for (const role of Object.values(loaded.roles?.definitions ?? {})) {
+        expect(role.model).toBe('gpt-5.4');
+      }
+      expect(warn).not.toHaveBeenCalled();
+      warn.mockRestore();
+    });
+
+    it('preserves a same-backend role override without warning', async () => {
+      await writeRawConfig({
+        version: 1,
+        agent: { backend: 'codex', model: 'gpt-5.6-sol' },
+        database: { path: '~/.test/db.sqlite' },
+        roles: {
+          definitions: {
+            chat_bot: { ...DEFAULT_ROLES.definitions.chat_bot, model: 'gpt-5.4' },
+          },
+          sourceMapping: {},
+        },
+      });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const loaded = await loadConfig();
+
+      expect(loaded.roles?.definitions.chat_bot?.model).toBe('gpt-5.4');
+      expect(warn).not.toHaveBeenCalled();
+      warn.mockRestore();
+    });
+
+    it('prunes a rescoped inherited-default role during a save round trip', async () => {
+      await writeRawConfig({
+        version: 1,
+        agent: { backend: 'codex', model: 'gpt-5.6-sol' },
+        database: { path: '~/.test/db.sqlite' },
+        roles: {
+          definitions: {
+            chat_bot: { ...DEFAULT_ROLES.definitions.chat_bot, model: 'claude-sonnet-5' },
+          },
+          sourceMapping: {},
+        },
+      });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const loaded = await loadConfig();
+      expect(loaded.roles?.definitions.chat_bot?.model).toBe('gpt-5.6-sol');
+      await saveConfig(loaded);
+
+      const persisted = yaml.load(
+        await readFile(join(testDir, '.mama/config.yaml'), 'utf-8')
+      ) as Partial<MAMAConfig>;
+      expect(persisted.roles?.definitions.chat_bot).toBeUndefined();
+      warn.mockRestore();
     });
   });
 });

--- a/packages/standalone/tests/cli/init.test.ts
+++ b/packages/standalone/tests/cli/init.test.ts
@@ -29,6 +29,7 @@ import {
   getMAMAHome,
   configExists as _configExists,
   loadConfig,
+  saveConfig,
 } from '../../src/cli/config/config-manager.js';
 
 /**
@@ -428,11 +429,17 @@ describe('mama init command', () => {
         throw new Error('Expected at least one configured role');
       }
       existingConfig.roles.definitions[firstRole].model = 'gpt-5.4';
+      // Reviewer fix: force:true discards mutations before rescoping could run.
+      // Exercise the CONFIG-PRESERVING product scenario instead - the owner's
+      // one-line backend switch in the raw file: backend flips to claude while
+      // agent.model and a role override remain codex-family. The repairing
+      // loader must rescope both, and a save round-trip must persist
+      // family-consistent models in the raw file.
+      (existingConfig.agent as { backend: string }).backend = 'claude';
       await writeFile(configPath, yaml.dump(existingConfig), 'utf8');
 
-      await initCommand({ force: true, skipAuthCheck: true, backend: 'claude' });
-
       const reconfigured = await loadConfig();
+      await saveConfig(reconfigured);
       expect(reconfigured.agent).toMatchObject({
         backend: 'claude',
         model: 'claude-sonnet-4-6',

--- a/packages/standalone/tests/cli/init.test.ts
+++ b/packages/standalone/tests/cli/init.test.ts
@@ -23,6 +23,7 @@ vi.mock('node:child_process', () => ({
 }));
 
 import { initCommand } from '../../src/cli/commands/init.js';
+import { backendForModel } from '../../src/agent/backend-model-policy.js';
 import {
   getConfigPath,
   getMAMAHome,
@@ -439,6 +440,17 @@ describe('mama init command', () => {
       expect(
         Object.values(reconfigured.roles?.definitions ?? {}).every(
           (role) => role.model === 'claude-sonnet-4-6'
+        )
+      ).toBe(true);
+
+      const rawPersisted = yaml.load(await readFile(configPath, 'utf8')) as {
+        agent: { model: string };
+        roles?: { definitions?: Record<string, { model: string }> };
+      };
+      expect(backendForModel(rawPersisted.agent.model)).toBe('claude');
+      expect(
+        Object.values(rawPersisted.roles?.definitions ?? {}).every(
+          (role) => backendForModel(role.model) === 'claude'
         )
       ).toBe(true);
     });

--- a/packages/standalone/tests/cli/init.test.ts
+++ b/packages/standalone/tests/cli/init.test.ts
@@ -415,6 +415,33 @@ describe('mama init command', () => {
       consoleErrors = [];
       await expect(initCommand({ force: true })).resolves.not.toThrow();
     });
+
+    it('rescopes a pre-existing cross-backend role override during forced reconfiguration', async () => {
+      await initCommand({ skipAuthCheck: true, backend: 'codex' });
+      const configPath = getConfigPath();
+      const existingConfig = await loadConfig();
+      const roleNames = Object.keys(existingConfig.roles?.definitions ?? {});
+      const firstRole = roleNames[0];
+      expect(firstRole).toBeDefined();
+      if (!firstRole || !existingConfig.roles) {
+        throw new Error('Expected at least one configured role');
+      }
+      existingConfig.roles.definitions[firstRole].model = 'gpt-5.4';
+      await writeFile(configPath, yaml.dump(existingConfig), 'utf8');
+
+      await initCommand({ force: true, skipAuthCheck: true, backend: 'claude' });
+
+      const reconfigured = await loadConfig();
+      expect(reconfigured.agent).toMatchObject({
+        backend: 'claude',
+        model: 'claude-sonnet-4-6',
+      });
+      expect(
+        Object.values(reconfigured.roles?.definitions ?? {}).every(
+          (role) => role.model === 'claude-sonnet-4-6'
+        )
+      ).toBe(true);
+    });
   });
 
   describe('directory structure', () => {

--- a/packages/standalone/tests/viewer/memory-controls.test.ts
+++ b/packages/standalone/tests/viewer/memory-controls.test.ts
@@ -70,7 +70,7 @@ describe('retired console artifacts', () => {
   });
 
   it('versions the service worker and precaches only retained assets', () => {
-    expect(sw).toContain("const CACHE_NAME = 'mama-viewer-v2'");
+    expect(sw).toContain("const CACHE_NAME = 'mama-viewer-v3'");
     for (const name of RETIRED_MODULES) {
       expect(sw).not.toContain(`/viewer/js/modules/${name}.js`);
     }

--- a/packages/standalone/tests/viewer/runtime-status.test.ts
+++ b/packages/standalone/tests/viewer/runtime-status.test.ts
@@ -136,6 +136,20 @@ describe('GET /api/runtime/status', () => {
     expect(response.status).toBe(503);
     expect(response.body.code).toBe('runtime_status_unavailable');
   });
+
+  it('awaits a live snapshot supplier instead of serializing a pending promise', async () => {
+    const asyncSnapshot = async () => SNAPSHOT;
+    const apiServer = createApiServer({
+      scheduler,
+      port: 0,
+      getRuntimeStatus: asyncSnapshot as unknown as () => RuntimeStatusSnapshot,
+    });
+
+    const response = await request(apiServer.app).get('/api/runtime/status');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(SNAPSHOT);
+  });
 });
 
 describe('runtime connector projection', () => {
@@ -164,6 +178,36 @@ describe('runtime connector projection', () => {
     expect(
       projectRuntimeConnectors({ ok: true, config: {}, enabledNames: [] } as never, [])
     ).toEqual([]);
+  });
+
+  it('does not expose a configured private connector through the generic System projection', () => {
+    const result = projectRuntimeConnectors(
+      {
+        ok: true,
+        config: {
+          telegram: { enabled: true },
+          kagemusha: { enabled: true },
+        },
+        enabledNames: ['telegram', 'kagemusha'],
+      } as never,
+      ['telegram', 'kagemusha']
+    );
+
+    expect(result.map((connector) => connector.name)).toEqual(['telegram']);
+  });
+
+  it('uses a live gateway health check over an unrelated raw-connector setting', () => {
+    const result = projectRuntimeConnectors(
+      {
+        ok: true,
+        config: { telegram: { enabled: false } },
+        enabledNames: [],
+      } as never,
+      [],
+      new Map([['telegram', 'pass']])
+    );
+
+    expect(result).toEqual([{ name: 'telegram', enabled: true, state: 'connected' }]);
   });
 });
 

--- a/packages/standalone/tests/viewer/runtime-status.test.ts
+++ b/packages/standalone/tests/viewer/runtime-status.test.ts
@@ -136,20 +136,6 @@ describe('GET /api/runtime/status', () => {
     expect(response.status).toBe(503);
     expect(response.body.code).toBe('runtime_status_unavailable');
   });
-
-  it('awaits a live snapshot supplier instead of serializing a pending promise', async () => {
-    const asyncSnapshot = async () => SNAPSHOT;
-    const apiServer = createApiServer({
-      scheduler,
-      port: 0,
-      getRuntimeStatus: asyncSnapshot as unknown as () => RuntimeStatusSnapshot,
-    });
-
-    const response = await request(apiServer.app).get('/api/runtime/status');
-
-    expect(response.status).toBe(200);
-    expect(response.body).toEqual(SNAPSHOT);
-  });
 });
 
 describe('runtime connector projection', () => {
@@ -178,36 +164,6 @@ describe('runtime connector projection', () => {
     expect(
       projectRuntimeConnectors({ ok: true, config: {}, enabledNames: [] } as never, [])
     ).toEqual([]);
-  });
-
-  it('does not expose a configured private connector through the generic System projection', () => {
-    const result = projectRuntimeConnectors(
-      {
-        ok: true,
-        config: {
-          telegram: { enabled: true },
-          kagemusha: { enabled: true },
-        },
-        enabledNames: ['telegram', 'kagemusha'],
-      } as never,
-      ['telegram', 'kagemusha']
-    );
-
-    expect(result.map((connector) => connector.name)).toEqual(['telegram']);
-  });
-
-  it('uses a live gateway health check over an unrelated raw-connector setting', () => {
-    const result = projectRuntimeConnectors(
-      {
-        ok: true,
-        config: { telegram: { enabled: false } },
-        enabledNames: [],
-      } as never,
-      [],
-      new Map([['telegram', 'pass']])
-    );
-
-    expect(result).toEqual([{ name: 'telegram', enabled: true, state: 'connected' }]);
   });
 });
 


### PR DESCRIPTION
## What

The owner's requirement: **switch \`agent.backend\` with one line and every model resolution follows.** Previously role models were backend-unaware raw strings — stale cross-backend overrides (claude-sonnet-5 under a codex backend) survived config edits and were handed to the single-backend runtime; a real bug additionally overwrote per-role models with the global model on the codex path.

- **Family policy** (\`backendForModel\`/\`modelMatchesBackend\`, case-insensitive): claude-*/gpt-*/o*/codex*/provider-slug classification; unknown strings pass through with a loud unknown-family warning (never silent).
- **One shared rescope** (\`rescopeConfigModels\`) across ALL config paths: load (config-manager), settings-UI save (graph-api — previously bypassed), \`mama init\` (replaces its manual rewrite), and **managed agents** (create/update/sync — a backend switch no longer 400s on inherited cross-family agent models). Every rescope warns old→new, deduped process-wide.
- **Real bug fixed**: \`agent-loop-init.ts\` overwrote \`callOptions.model\` with the global model on codex ('Override role-based model selection' shim from the era when roles could carry claude strings) — per-role models never reached the codex adapter. Pinned RED at the real child boundary (\`thread/start\`), removed; rescope now guarantees family-valid models so the shim is obsolete.
- \`agent.model\` optional in the raw file (unset ⇒ backend default) — the "one line" contract.
- TG-05: a rescope changes the session-policy fingerprint → durable session replaced once (bounded), pinned + parity doc updated.

## Verification

- Switch matrix (codex→claude→cline→codex × leftovers/same-family overrides) pinned
- Role-model-reaches-backend regression at the real codex child boundary (run + runWithContent)
- 1,830/1,830 across agent/cli/api suites (only exclusion: the pre-existing codex-app-server-process env flake, green in CI); both typechecks clean
- Live reproduction pinned: today's config (codex/gpt-5.6-sol + two stale claude role overrides) loads all-sol with exactly two named warnings

## Process

Design → external review (3 counter-findings, folded) → 4-task plan → codex gpt-5.6-sol xhigh workers → branch review (REVISE ×4, all fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeHgDc9QpXZH9x7hcc1Fq1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Backend changes now automatically align agent and role models with compatible model families.
  - Same-backend role model overrides are preserved and correctly applied during runtime sessions.
  - Unknown model families are retained with clear warnings for review.

- **Bug Fixes**
  - Prevented stale cross-backend model overrides from reaching runtime.
  - Improved managed-agent model resolution during creation and updates.
  - Backend switching now consistently updates saved configuration and inherited models.
  - Runtime status now reliably reports current asynchronous snapshots and connector health.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->