### PR TITLE
perf(standalone): coalesce owner-event Board refreshes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node Version](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org)
 [![LongMemEval 100Q](https://img.shields.io/badge/LongMemEval%20100Q-93%25-blue)](packages/memorybench/)
-[![Tests](https://img.shields.io/badge/tests-6080%20passing-success)](https://github.com/jungjaehoon-lifegamez/MAMA)
+[![Tests](https://img.shields.io/badge/tests-6205%20passing-success)](https://github.com/jungjaehoon-lifegamez/MAMA)
 
 > Right now, you read every channel yourself so nothing slips past you.
 > MAMA reads them instead, and sends you the few things that need you.
@@ -133,7 +133,7 @@ running, and skips quietly when it is not:
 
 | Package                                       | What it is                                                                                                     | You run it?          |
 | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------------- |
-| [mama-os](packages/standalone/) 0.37.0        | The always-on server: connectors, trigger loop, reports, task board, web UI. 92k lines. "MAMA" means this.     | `mama start`         |
+| [mama-os](packages/standalone/) 0.38.0        | The always-on server: connectors, trigger loop, reports, task board, web UI. 92k lines. "MAMA" means this.     | `mama start`         |
 | [mama-core](packages/mama-core/) 2.2.0        | The library underneath: memory, provenance, graph, embeddings. Everything imports it; it imports nothing here. | No binary            |
 | [mama-server](packages/mcp-server/) 1.15.0    | A deliberately thin MCP adapter over the core — 3.7k lines, no logic of its own.                               | As an MCP server     |
 | [plugin](packages/claude-code-plugin/) 1.11.0 | Claude Code hooks + slash commands. No background process.                                                     | Installed, not run   |
@@ -196,10 +196,10 @@ Each "Next" item comes from a measurement, or from a competitor doing it better:
 ```bash
 git clone https://github.com/jungjaehoon-lifegamez/MAMA.git
 cd MAMA && pnpm install && pnpm build
-pnpm test     # 6,080 passing tests across five packages
+pnpm test     # 6,205 passing tests across five packages
 ```
 
-Guidelines in [CLAUDE.md](CLAUDE.md). _Last updated: 2026-08-19_
+Guidelines in [CLAUDE.md](CLAUDE.md). _Last updated: 2026-08-26_
 
 ## License
 

--- a/docs/development/kagemusha-telegram-parity.md
+++ b/docs/development/kagemusha-telegram-parity.md
@@ -83,6 +83,30 @@ scenario IDs from this document.
   passed with 4 files/7 tests skipped. Root typecheck and production build both passed.
 - **Status:** CODE GREEN; release cutover and a real owner Telegram feedback event remain pending.
 
+### Owner-event Board coalescing evidence: 2026-08-26
+
+- **TG-03/TG-04:** MAMA still decides whether to delegate Board work through
+  `workorder_request`; the host does not prescribe the model's tool sequence. The gateway derives
+  owner-event batch identity only from host execution state, while direct owner requests keep the
+  distinct manual forced-refresh contract.
+- **TG-05:** each connector batch still receives one fresh, self-contained owner-event model run.
+  Coalescing begins only after MAMA chooses Board delegation: twenty exact batches persist twenty
+  receipts but share one open non-force Board workorder.
+- **TG-06:** `owner_event_board_refresh_intents` atomically binds each retained inbox batch to its
+  repair generation and shared workorder. A persisted acceptance ACKs the exact batch before a
+  replayed model run, including after runner failure. Only a verified full Board effect with a
+  complete receipt applies captured generations. Later generations schedule one post-terminal
+  non-force repair; unverified or failed effects do not hot-loop. Pending intents survive restart,
+  seed a higher boot generation, and reattach to one repair.
+- **Flag boundary:** `BoardRefreshGate` is always present. `MAMA_BOARD_RECONCILE=1` controls only
+  debounced connector-delta reconcile and its operator route; boot, scheduled, manual, and
+  owner-event full repair retain the host gate with the flag off.
+- **Verification:** the PR-A focused gate passed eight files and 197 tests. The complete standalone
+  suite passed 382 files and 5,165 tests, with four files and seven tests skipped. Root typecheck,
+  build, and all seven Turbo test tasks passed. This is code/test evidence only.
+- **Status:** CODE GREEN; PR-A review/merge, the PR-B Temporal change, release cutover, and a real
+  owner-event canary remain pending.
+
 ### Sender-boundary completion evidence: 2026-08-13
 
 | ID    | Evidence update                                                                                                                                                                                                                                                                                      | Verification                                                                                                                                                                                                                                                       | Status                     |
@@ -191,11 +215,13 @@ Source paths below are relative to `packages/standalone/src`; test paths are rel
   contract carries `repairGeneration`, the exact `noUpdateScope`, the canonical wrapped
   `report_publish` call, and the force/no-update distinction. Evidence: `operator/briefs.ts` and
   `tests/operator/briefs.test.ts`.
-- **TG-06 generation-aware Board repair gate:** when `MAMA_BOARD_RECONCILE=1`, one host-owned
-  `BoardRefreshGate` spans boot and scheduled full repair, debounced reconcile deltas,
-  `/api/report/agent-refresh`, and direct owner workorder requests. Dirt is marked before
-  validation/enqueue; a completion clears only the generation captured by that attempt, so later
-  deltas survive. A full attempt clears only after an attempt-bound accepted all-four-slot publish,
+- **TG-06 generation-aware Board repair gate:** one host-owned `BoardRefreshGate` always spans boot
+  and scheduled full repair, `/api/report/agent-refresh`, owner workorder requests, and completion
+  verification.
+  `MAMA_BOARD_RECONCILE=1` additionally enables debounced reconcile deltas and the explicit
+  reconcile route. Dirt is marked before validation/enqueue; a completion clears only the
+  generation captured by that attempt, so later deltas survive. A full attempt clears only after
+  an attempt-bound accepted all-four-slot publish,
   or after an exact `contract_no_update` proof for the captured scope on a non-force scheduled
   repair. Manual and owner `force: true` paths cannot discharge dirt with no-update prose. Open
   scheduled repair retries share one idempotency key.
@@ -651,10 +677,18 @@ change unless they are release-blocking security or data-loss issues.
       No earlier Board aggregate is reused after the later publisher changes.
 - [x] A clean detached checkout of the staged PR index passed 376 files and 5,033 tests, with four
       files and nine tests skipped (5,042 total); typecheck and build passed.
-- [ ] Rebuild/restart the release, confirm the `0.37.0` runtime cutover, complete a real owner
-      Telegram turn, and observe visible Telegram report delivery.
+- [x] The 2026-08-26 owner-event Board coalescing gate passed eight focused files / 197 tests, the
+      complete standalone suite (382 files / 5,165 tests; four files / seven tests skipped), root
+      typecheck and build, and all seven root Turbo test tasks. This does not claim live behavior.
+- [ ] Merge both Slice A PRs, rebuild/restart the next release, complete a real owner-event turn,
+      and compare visible delivery plus 24-hour model-work cost against the saved baseline.
 
 ## Change log
+
+- 2026-08-26: Recorded TG-03/TG-04/TG-05/TG-06 code evidence for durable exact-batch Board
+  acceptance, many-to-one non-force coalescing, verified-generation application, post-terminal
+  follow-up, crash recovery, and flag semantics. The focused, standalone, and root gates passed.
+  PR-A review/merge, PR-B, release cutover, and a real owner-event canary remain pending.
 
 - 2026-08-19: Recorded the uncommitted operator stabilization patch for TG-03/TG-04/TG-05/TG-06:
   named-object Code-Act declarations with wrapped/legacy report compatibility, actual

--- a/docs/development/kagemusha-telegram-parity.md
+++ b/docs/development/kagemusha-telegram-parity.md
@@ -88,7 +88,8 @@ scenario IDs from this document.
 - **TG-03/TG-04:** MAMA still decides whether to delegate Board work through
   `workorder_request`; the host does not prescribe the model's tool sequence. The gateway derives
   owner-event batch identity only from host execution state, while direct owner requests keep the
-  distinct manual forced-refresh contract.
+  distinct manual forced-refresh contract. An explicitly disabled `dashboard-agent` refuses Board
+  delegation before creating an intent; the always-on repair gate is not execution authority.
 - **TG-05:** each connector batch still receives one fresh, self-contained owner-event model run.
   Coalescing begins only after MAMA chooses Board delegation: twenty exact batches persist twenty
   receipts but share one open non-force Board workorder.

--- a/docs/development/kagemusha-telegram-parity.md
+++ b/docs/development/kagemusha-telegram-parity.md
@@ -88,8 +88,8 @@ scenario IDs from this document.
 - **TG-03/TG-04:** MAMA still decides whether to delegate Board work through
   `workorder_request`; the host does not prescribe the model's tool sequence. The gateway derives
   owner-event batch identity only from host execution state, while direct owner requests keep the
-  distinct manual forced-refresh contract. An explicitly disabled `dashboard-agent` refuses Board
-  delegation before creating an intent; the always-on repair gate is not execution authority.
+  distinct manual forced-refresh contract. The optional legacy `dashboard-agent` persona setting
+  does not disable the independent Stage-2 Board publisher/verifier runtime.
 - **TG-05:** each connector batch still receives one fresh, self-contained owner-event model run.
   Coalescing begins only after MAMA chooses Board delegation: twenty exact batches persist twenty
   receipts but share one open non-force Board workorder.

--- a/docs/development/kagemusha-telegram-parity.md
+++ b/docs/development/kagemusha-telegram-parity.md
@@ -102,8 +102,8 @@ scenario IDs from this document.
 - **Flag boundary:** `BoardRefreshGate` is always present. `MAMA_BOARD_RECONCILE=1` controls only
   debounced connector-delta reconcile and its operator route; boot, scheduled, manual, and
   owner-event full repair retain the host gate with the flag off.
-- **Verification:** the PR-A focused gate passed eight files and 197 tests. The complete standalone
-  suite passed 382 files and 5,165 tests, with four files and seven tests skipped. Root typecheck,
+- **Verification:** the PR-A focused gate passed eight files and 198 tests. The complete standalone
+  suite passed 382 files and 5,166 tests, with four files and seven tests skipped. Root typecheck,
   build, and all seven Turbo test tasks passed. This is code/test evidence only.
 - **Status:** CODE GREEN; PR-A review/merge, the PR-B Temporal change, release cutover, and a real
   owner-event canary remain pending.
@@ -678,8 +678,8 @@ change unless they are release-blocking security or data-loss issues.
       No earlier Board aggregate is reused after the later publisher changes.
 - [x] A clean detached checkout of the staged PR index passed 376 files and 5,033 tests, with four
       files and nine tests skipped (5,042 total); typecheck and build passed.
-- [x] The 2026-08-26 owner-event Board coalescing gate passed eight focused files / 197 tests, the
-      complete standalone suite (382 files / 5,165 tests; four files / seven tests skipped), root
+- [x] The 2026-08-26 owner-event Board coalescing gate passed eight focused files / 198 tests, the
+      complete standalone suite (382 files / 5,166 tests; four files / seven tests skipped), root
       typecheck and build, and all seven root Turbo test tasks. This does not claim live behavior.
 - [ ] Merge both Slice A PRs, rebuild/restart the next release, complete a real owner-event turn,
       and compare visible delivery plus 24-hour model-work cost against the saved baseline.

--- a/docs/development/runtime-overhead-board-coalescing-plan.md
+++ b/docs/development/runtime-overhead-board-coalescing-plan.md
@@ -95,7 +95,7 @@ export class OwnerEventBoardRefreshLedger {
 }
 ```
 
-- [ ] **Step 1: Write failing acceptance and duplicate tests**
+- [x] **Step 1: Write failing acceptance and duplicate tests**
 
 ```ts
 it('atomically binds one exact batch to one shared non-force Board workorder', () => {
@@ -121,7 +121,7 @@ it('returns the same acceptance for the same batch without enqueueing again', ()
 });
 ```
 
-- [ ] **Step 2: Run the focused test and verify RED**
+- [x] **Step 2: Run the focused test and verify RED**
 
 ```bash
 pnpm --dir packages/standalone exec vitest run tests/operator/owner-event-board-refresh.test.ts
@@ -129,7 +129,7 @@ pnpm --dir packages/standalone exec vitest run tests/operator/owner-event-board-
 
 Expected: FAIL because the module does not exist.
 
-- [ ] **Step 3: Implement the additive migration and atomic accept**
+- [x] **Step 3: Implement the additive migration and atomic accept**
 
 ```sql
 CREATE TABLE IF NOT EXISTS owner_event_board_refresh_intents (
@@ -151,7 +151,7 @@ Validate the batch ID, event IDs, generation, and scope. In one `db.transaction(
 Add a source-wiring assertion in `owner-event-wiring.test.ts` during Task 4 so daemon boot must construct
 the ledger, whose constructor invokes the migration after both referenced parent tables exist.
 
-- [ ] **Step 4: Add burst, rollback, cleanup, and generation tests**
+- [x] **Step 4: Add burst, rollback, cleanup, and generation tests**
 
 ```ts
 it('coalesces twenty batches onto one open workorder', () => {
@@ -174,11 +174,11 @@ it('applies only captured generations and emits one follow-up signal', () => {
 
 Also assert rollback leaves neither new task nor intent, FK cleanup removes the intent, `maxPendingGeneration()` ignores applied rows, `attachPendingToWorkOrder()` changes only pending rows, and no `markVerified()` means no follow-up signal.
 
-- [ ] **Step 5: Run the focused test and verify GREEN**
+- [x] **Step 5: Run the focused test and verify GREEN**
 
 Run Step 2. Expected: PASS.
 
-- [ ] **Step 6: Commit Task 1**
+- [x] **Step 6: Commit Task 1**
 
 ```bash
 git add packages/standalone/src/db/migrations/owner-event-board-refresh.ts packages/standalone/src/operator/owner-event-board-refresh.ts packages/standalone/tests/operator/owner-event-board-refresh.test.ts
@@ -208,7 +208,7 @@ export type WorkOrderRequestOrigin =
   | { kind: 'owner_event'; batchId: number; eventIds: readonly string[] };
 ```
 
-- [ ] **Step 1: Write failing origin tests**
+- [x] **Step 1: Write failing origin tests**
 
 ```ts
 expect(handler).toHaveBeenCalledWith('board', {
@@ -220,7 +220,7 @@ expect(handler).toHaveBeenCalledWith('board', {
 
 Assert chat produces `owner_manual`, model-supplied identity fields are ignored, and `source: 'owner-event'` without host `ownerEventEffects` plus non-empty causes fails closed.
 
-- [ ] **Step 2: Run gateway and handler tests and verify RED**
+- [x] **Step 2: Run gateway and handler tests and verify RED**
 
 ```bash
 pnpm --dir packages/standalone exec vitest run tests/agent/gateway-tool-executor.test.ts tests/cli/start-board-refresh-gate.test.ts
@@ -228,7 +228,7 @@ pnpm --dir packages/standalone exec vitest run tests/agent/gateway-tool-executor
 
 Expected: FAIL on the old handler signature and forced owner-event payload.
 
-- [ ] **Step 3: Derive the closed origin from trusted execution state**
+- [x] **Step 3: Derive the closed origin from trusted execution state**
 
 Owner-event origin requires:
 
@@ -242,7 +242,7 @@ state.source === 'owner-event' &&
 
 Never read origin from tool input. Pass `owner_manual` for other admitted owner requests.
 
-- [ ] **Step 4: Route only owner-event Board through the ledger**
+- [x] **Step 4: Route only owner-event Board through the ledger**
 
 ```ts
 const generation = deps.boardRefreshGate.markChannelDirty(OWNER_BOARD_FULL_REPAIR_CHANNEL);
@@ -256,11 +256,11 @@ deps.ownerEventBoardRefreshLedger.accept({
 
 Use one captured generation. Manual Board, Wiki, and memory-curation keep their existing keys; Wiki/memory take host event IDs from `origin.eventIds`.
 
-- [ ] **Step 5: Add behavior regressions and verify GREEN**
+- [x] **Step 5: Add behavior regressions and verify GREEN**
 
 Assert 20 requests yield 20 intents/one non-force task, same-batch retry yields no task, manual remains forced, missing ledger fails without old-path fallback, and Wiki/memory permanent keys are unchanged. Run Step 2 plus Task 1 test. Expected: PASS.
 
-- [ ] **Step 6: Commit Task 2**
+- [x] **Step 6: Commit Task 2**
 
 ```bash
 git add packages/standalone/src/agent/types.ts packages/standalone/src/agent/gateway-tool-executor.ts packages/standalone/src/cli/commands/start.ts packages/standalone/tests/agent/gateway-tool-executor.test.ts packages/standalone/tests/cli/start-board-refresh-gate.test.ts
@@ -284,7 +284,7 @@ git commit -m "fix(standalone): coalesce owner-event board requests"
 - Consumes: ledger `markVerified()`, `attachPendingToWorkOrder()`, `consumePostTerminalFollowup()`.
 - Produces: `ApiRoutesHandle.requestBoardRepair(): void`.
 
-- [ ] **Step 1: Write failing verified-only hook tests**
+- [x] **Step 1: Write failing verified-only hook tests**
 
 ```ts
 it('marks intents only after a verified full repair', () => {
@@ -298,11 +298,11 @@ it('does not mark intents after unverified or failed results', () => {
 });
 ```
 
-- [ ] **Step 2: Write failing terminal-order route tests**
+- [x] **Step 2: Write failing terminal-order route tests**
 
 Assert accepted-intent nudge bypasses only watermark skip, never sets force, attaches pending rows to the returned task, runs after current task terminal, and unverified/failed/exhausted events never nudge.
 
-- [ ] **Step 3: Run hook/route tests and verify RED**
+- [x] **Step 3: Run hook/route tests and verify RED**
 
 ```bash
 pnpm --dir packages/standalone exec vitest run tests/operator/workorder-hooks.test.ts tests/cli/runtime/api-routes-init-reconcile.test.ts
@@ -310,7 +310,7 @@ pnpm --dir packages/standalone exec vitest run tests/operator/workorder-hooks.te
 
 Expected: FAIL because no intent port or nudge exists.
 
-- [ ] **Step 4: Implement verified application and terminal nudge**
+- [x] **Step 4: Implement verified application and terminal nudge**
 
 Change `runDashboardAgent` options to `{ force?: boolean; acceptedIntent?: boolean }`. `acceptedIntent` requires a pending intent, bypasses only `delta.enqueue === false`, uses `boardRepairKey()` without force, and calls `attachPendingToWorkOrder(newId)`. Make `enqueueWorkOrderOrThrow()` return the workorder.
 
@@ -332,11 +332,11 @@ return {
 
 In WorkOrderConsumer `onEvent`, consume the ledger set only for `complete` Board events, then call `boardRepairNudge.current?.()`. Assign the ref from `apiRoutesHandle.requestBoardRepair` before consumer boot recovery/start.
 
-- [ ] **Step 5: Run focused tests and verify GREEN**
+- [x] **Step 5: Run focused tests and verify GREEN**
 
 Run Step 3 plus Task 1 test. Expected: PASS.
 
-- [ ] **Step 6: Commit Task 3**
+- [x] **Step 6: Commit Task 3**
 
 ```bash
 git add packages/standalone/src/operator/workorder-hooks.ts packages/standalone/src/cli/runtime/api-routes-init.ts packages/standalone/src/cli/commands/start.ts packages/standalone/tests/operator/workorder-hooks.test.ts packages/standalone/tests/cli/runtime/api-routes-init-reconcile.test.ts
@@ -360,7 +360,7 @@ git commit -m "fix(standalone): schedule verified board follow-ups"
 - Consumes: `maxPendingGeneration()`, `findAcceptance(batchId)`, always-on gate.
 - Produces: exact batch terminal recovery without another model run.
 
-- [ ] **Step 1: Write failing boot and recovery behavior tests**
+- [x] **Step 1: Write failing boot and recovery behavior tests**
 
 ```ts
 it('ACKs a persisted Board acceptance after restart without waking the model', async () => {
@@ -389,7 +389,7 @@ it('ACKs a persisted Board acceptance after restart without waking the model', a
 
 Also prove the same lookup wins after a simulated runner error and that no intent leaves the batch pending.
 
-- [ ] **Step 2: Run wiring/config tests and verify RED**
+- [x] **Step 2: Run wiring/config tests and verify RED**
 
 ```bash
 pnpm --dir packages/standalone exec vitest run tests/cli/owner-event-wiring.test.ts tests/cli/start-board-refresh-gate.test.ts tests/cli/runtime/api-routes-init-reconcile.test.ts
@@ -397,7 +397,7 @@ pnpm --dir packages/standalone exec vitest run tests/cli/owner-event-wiring.test
 
 Expected: FAIL because the Board intent ledger and acceptance lookup do not exist.
 
-- [ ] **Step 3: Reorder boot construction and make the gate unconditional**
+- [x] **Step 3: Reorder boot construction and make the gate unconditional**
 
 ```ts
 const taskLedger = new TaskLedger(operatorDb);
@@ -415,7 +415,7 @@ Define `resolveInitialBoardRepairGeneration(now, pendingGeneration)` as a tested
 `Math.max(now, (pendingGeneration ?? -1) + 1)`. Keep the env flag only around `ReconcileScheduler`
 and its explicit reconcile route.
 
-- [ ] **Step 4: Add exact batch terminal recovery**
+- [x] **Step 4: Add exact batch terminal recovery**
 
 ```ts
 const boardAcceptance = ownerEventBoardRefreshLedger.findAcceptance(batch.id);
@@ -426,11 +426,11 @@ if (boardAcceptance) {
 
 Keep external effects, Wiki, memory-curation, and exact no-update lookup unchanged.
 
-- [ ] **Step 5: Add boot and flag matrix assertions and verify GREEN**
+- [x] **Step 5: Add boot and flag matrix assertions and verify GREEN**
 
 Using real ledger/gate/route components, assert pending intents seed a greater boot generation and reattach to one boot repair, no pending intent preserves normal boot behavior, flag off disables only delta reconcile, and no owner-event path sets force. Run Step 2 plus ledger/hook tests. Expected: PASS.
 
-- [ ] **Step 6: Commit Task 4**
+- [x] **Step 6: Commit Task 4**
 
 ```bash
 git add packages/standalone/src/cli/commands/start.ts packages/standalone/src/cli/runtime/api-routes-init.ts packages/standalone/tests/cli/owner-event-wiring.test.ts packages/standalone/tests/cli/start-board-refresh-gate.test.ts packages/standalone/tests/cli/runtime/api-routes-init-reconcile.test.ts
@@ -451,11 +451,11 @@ git commit -m "fix(standalone): recover owner-event board acceptance"
 - Consumes: committed PR-A code/test evidence.
 - Produces: TG evidence and exact verification record.
 
-- [ ] **Step 1: Record TG evidence without claiming live behavior**
+- [x] **Step 1: Record TG evidence without claiming live behavior**
 
 Add a dated section stating: TG-03/TG-04 preserve the agent's workorder choice; TG-05 keeps the fresh owner-event run and coalesces only downstream Board work; TG-06 atomically binds exact batch acceptance, recovers it after crash, and follows verified generations. Status: `CODE GREEN; release and real-event canary pending`.
 
-- [ ] **Step 2: Run focused PR-A tests**
+- [x] **Step 2: Run focused PR-A tests**
 
 ```bash
 pnpm --dir packages/standalone exec vitest run \
@@ -471,7 +471,7 @@ pnpm --dir packages/standalone exec vitest run \
 
 Expected: all selected tests PASS.
 
-- [ ] **Step 3: Run package and root gates**
+- [x] **Step 3: Run package and root gates**
 
 ```bash
 pnpm --dir packages/standalone typecheck
@@ -484,7 +484,7 @@ pnpm test
 
 Expected: every command exits 0.
 
-- [ ] **Step 4: Run changed-file format and whitespace gates**
+- [x] **Step 4: Run changed-file format and whitespace gates**
 
 ```bash
 pnpm exec prettier --check docs/development/kagemusha-telegram-parity.md docs/development/runtime-overhead-reduction-design.md packages/standalone/src/db/migrations/owner-event-board-refresh.ts packages/standalone/src/operator/owner-event-board-refresh.ts packages/standalone/src/operator/workorder-hooks.ts packages/standalone/src/agent/types.ts packages/standalone/src/agent/gateway-tool-executor.ts packages/standalone/src/cli/commands/start.ts packages/standalone/src/cli/runtime/api-routes-init.ts packages/standalone/tests/operator/owner-event-board-refresh.test.ts packages/standalone/tests/operator/workorder-hooks.test.ts packages/standalone/tests/agent/gateway-tool-executor.test.ts packages/standalone/tests/cli/start-board-refresh-gate.test.ts packages/standalone/tests/cli/runtime/api-routes-init-reconcile.test.ts packages/standalone/tests/cli/owner-event-wiring.test.ts
@@ -493,13 +493,13 @@ git diff --check
 
 Expected: exit 0. Report unrelated root format debt separately.
 
-- [ ] **Step 5: Commit evidence**
+- [x] **Step 5: Commit evidence**
 
 ```bash
 git add docs/development/kagemusha-telegram-parity.md docs/development/runtime-overhead-reduction-design.md
 git commit -m "docs: record owner-event board coalescing evidence"
 ```
 
-- [ ] **Step 6: Run the diff-scoped review gate**
+- [x] **Step 6: Run the diff-scoped review gate**
 
 Invoke `review` before `ship`. Fix every P0-P3 finding with a RED→GREEN regression, rerun affected focused suites, and commit coherent corrections. Create the PR only after the review log is CLEAN.

--- a/docs/development/runtime-overhead-board-coalescing-plan.md
+++ b/docs/development/runtime-overhead-board-coalescing-plan.md
@@ -69,6 +69,11 @@ export interface OwnerEventBoardRefreshAcceptance {
   appliedAt: number | null;
 }
 
+export function resolveInitialBoardRepairGeneration(
+  now: number,
+  pendingGeneration: number | null
+): number;
+
 export class OwnerEventBoardRefreshLedger {
   constructor(db: SQLiteDatabase, taskLedger: BoardWorkOrderPort, clock?: () => number);
   maxPendingGeneration(): number | null;
@@ -355,17 +360,34 @@ git commit -m "fix(standalone): schedule verified board follow-ups"
 - Consumes: `maxPendingGeneration()`, `findAcceptance(batchId)`, always-on gate.
 - Produces: exact batch terminal recovery without another model run.
 
-- [ ] **Step 1: Write failing production-wiring tests**
+- [ ] **Step 1: Write failing boot and recovery behavior tests**
 
 ```ts
-expect(startSource).toContain('new OwnerEventBoardRefreshLedger(operatorDb, taskLedger)');
-expect(startSource).toContain('ownerEventBoardRefreshLedger.findAcceptance(batch.id)');
-expect(startSource).not.toContain(
-  "process.env.MAMA_BOARD_RECONCILE === '1' ? new BoardRefreshGate() : null"
-);
+it('ACKs a persisted Board acceptance after restart without waking the model', async () => {
+  const accepted = boardIntents.accept({
+    batchId,
+    eventIds: ['evt-1'],
+    repair: { repairGeneration: 20, noUpdateScope: 'full:20' },
+  });
+  expect(accepted.workOrderId).toBeGreaterThan(0);
+
+  const runner = { run: vi.fn(() => Promise.reject(new Error('must not run'))) };
+  const loop = new OwnerEventLoop({
+    ...ownerLoopDeps,
+    runner,
+    getTerminalReceipt: (batch) =>
+      boardIntents.findAcceptance(batch.id)
+        ? { status: 'delegated', tools: ['workorder_request'] }
+        : null,
+  });
+
+  expect(await loop.tick()).toBe('processed');
+  expect(runner.run).not.toHaveBeenCalled();
+  expect(inbox.depth()).toEqual({ pending: 0, claimed: 0, dead: 0 });
+});
 ```
 
-Also prove persisted acceptance wins before model execution and after runner error.
+Also prove the same lookup wins after a simulated runner error and that no intent leaves the batch pending.
 
 - [ ] **Step 2: Run wiring/config tests and verify RED**
 
@@ -373,7 +395,7 @@ Also prove persisted acceptance wins before model execution and after runner err
 pnpm --dir packages/standalone exec vitest run tests/cli/owner-event-wiring.test.ts tests/cli/start-board-refresh-gate.test.ts tests/cli/runtime/api-routes-init-reconcile.test.ts
 ```
 
-Expected: FAIL on conditional gate construction and exact-key-only recovery.
+Expected: FAIL because the Board intent ledger and acceptance lookup do not exist.
 
 - [ ] **Step 3: Reorder boot construction and make the gate unconditional**
 
@@ -381,14 +403,17 @@ Expected: FAIL on conditional gate construction and exact-key-only recovery.
 const taskLedger = new TaskLedger(operatorDb);
 const ownerEventInbox = new OwnerEventInbox(operatorDb);
 const ownerEventBoardRefreshLedger = new OwnerEventBoardRefreshLedger(operatorDb, taskLedger);
-const initialBoardGeneration = Math.max(
+const initialBoardGeneration = resolveInitialBoardRepairGeneration(
   Date.now(),
-  (ownerEventBoardRefreshLedger.maxPendingGeneration() ?? -1) + 1
+  ownerEventBoardRefreshLedger.maxPendingGeneration()
 );
 const boardRefreshGate = new BoardRefreshGate({ initialGeneration: initialBoardGeneration });
 ```
 
-Keep the env flag only around `ReconcileScheduler` and its explicit reconcile route.
+Define `resolveInitialBoardRepairGeneration(now, pendingGeneration)` as a tested pure function in
+`owner-event-board-refresh.ts`: it validates safe non-negative integers and returns
+`Math.max(now, (pendingGeneration ?? -1) + 1)`. Keep the env flag only around `ReconcileScheduler`
+and its explicit reconcile route.
 
 - [ ] **Step 4: Add exact batch terminal recovery**
 
@@ -403,7 +428,7 @@ Keep external effects, Wiki, memory-curation, and exact no-update lookup unchang
 
 - [ ] **Step 5: Add boot and flag matrix assertions and verify GREEN**
 
-Assert pending intents seed a greater boot generation and reattach to one boot repair, no pending intent preserves normal boot behavior, flag off disables only delta reconcile, and no owner-event path sets force. Run Step 2 plus ledger/hook tests. Expected: PASS.
+Using real ledger/gate/route components, assert pending intents seed a greater boot generation and reattach to one boot repair, no pending intent preserves normal boot behavior, flag off disables only delta reconcile, and no owner-event path sets force. Run Step 2 plus ledger/hook tests. Expected: PASS.
 
 - [ ] **Step 6: Commit Task 4**
 

--- a/docs/development/runtime-overhead-board-coalescing-plan.md
+++ b/docs/development/runtime-overhead-board-coalescing-plan.md
@@ -1,0 +1,480 @@
+# Owner-Event Board Coalescing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace event-by-event forced Board full runs with one receipt-backed non-force repair plus at most one post-terminal follow-up obligation.
+
+**Architecture:** Add one `OwnerEventBoardRefreshLedger` on the existing operator SQLite connection. It atomically binds each exact owner-event batch to the existing shared Board workorder, records verified application by repair generation, and exposes a run-local post-terminal follow-up signal. Keep `BoardRefreshGate`, `boardRepairKey()`, TaskLedger, effect verification, and OwnerEventLoop as the authorities they already are.
+
+**Tech Stack:** TypeScript, better-sqlite3 through `SQLiteDatabase`, Vitest single-fork configuration, pnpm workspace, launchd runtime.
+
+**Spec:** `docs/development/runtime-overhead-reduction-design.md`
+
+## Global Constraints
+
+- Preserve TG-03, TG-04, TG-05, and TG-06; update `docs/development/kagemusha-telegram-parity.md` with PR-A evidence.
+- Preserve sender, role, envelope, scope, destination, path, idempotency, and durable receipt checks.
+- Never derive batch identity, event IDs, repair generation, force, or idempotency key from model input.
+- Manual owner Board refresh remains `mode: 'full', force: true` with a unique manual key.
+- Owner-event Board refresh is `mode: 'full', force: false` with the shared `boardRepairKey()`.
+- `BoardRefreshGate` is always constructed; `MAMA_BOARD_RECONCILE` controls only the delta reconcile scheduler.
+- Do not add a model session, worker, queue, external dependency, append-only telemetry table, or fallback data path.
+- New SQLite schema is additive and fail-loud; keep Vitest in its current single-fork configuration.
+- Do not edit the three parked skip-worktree Viewer files.
+
+---
+
+## File Map
+
+| File                                                                      | Responsibility                                              |
+| ------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| `packages/standalone/src/db/migrations/owner-event-board-refresh.ts`      | Additive intent table/index migration                       |
+| `packages/standalone/src/operator/owner-event-board-refresh.ts`           | Durable batch-to-workorder ledger and post-terminal signal  |
+| `packages/standalone/tests/operator/owner-event-board-refresh.test.ts`    | DDL, atomicity, duplicate/burst, cleanup, generation tests  |
+| `packages/standalone/src/agent/types.ts`                                  | Closed `WorkOrderRequestOrigin` host contract               |
+| `packages/standalone/src/agent/gateway-tool-executor.ts`                  | Derive origin from trusted execution state                  |
+| `packages/standalone/src/cli/commands/start.ts`                           | Construct and wire ledger/gate, receipt recovery, nudge ref |
+| `packages/standalone/src/operator/workorder-hooks.ts`                     | Apply intents only after verified full repair               |
+| `packages/standalone/src/cli/runtime/api-routes-init.ts`                  | Always-on full gate and terminal-safe repair nudge          |
+| `packages/standalone/tests/cli/start-board-refresh-gate.test.ts`          | Manual/owner-event request matrix                           |
+| `packages/standalone/tests/agent/gateway-tool-executor.test.ts`           | Trusted origin and forged-input cases                       |
+| `packages/standalone/tests/operator/workorder-hooks.test.ts`              | Verified-only generation application                        |
+| `packages/standalone/tests/cli/runtime/api-routes-init-reconcile.test.ts` | Flag, nudge, no-hot-loop, boot cases                        |
+| `packages/standalone/tests/cli/owner-event-wiring.test.ts`                | Production assembly pin                                     |
+| `docs/development/kagemusha-telegram-parity.md`                           | TG evidence                                                 |
+
+---
+
+### Task 1: Durable Owner-Event Board Refresh Ledger
+
+**Files:**
+
+- Create: `packages/standalone/src/db/migrations/owner-event-board-refresh.ts`
+- Create: `packages/standalone/src/operator/owner-event-board-refresh.ts`
+- Create: `packages/standalone/tests/operator/owner-event-board-refresh.test.ts`
+
+**Interfaces:**
+
+- Consumes: `SQLiteDatabase`, `TaskLedger.enqueueWorkOrder()`, `boardRepairKey()`, `FullRepairCapture`.
+- Migration produces `applyOwnerEventBoardRefreshMigration(db: SQLiteDatabase): void`; the ledger
+  constructor invokes it after TaskLedger and OwnerEventInbox have created the referenced parent tables.
+- Produces:
+
+```ts
+export interface OwnerEventBoardRefreshAcceptance {
+  batchId: number;
+  batchKey: string;
+  repairGeneration: number;
+  workOrderId: number;
+  appliedAt: number | null;
+}
+
+export class OwnerEventBoardRefreshLedger {
+  constructor(db: SQLiteDatabase, taskLedger: BoardWorkOrderPort, clock?: () => number);
+  maxPendingGeneration(): number | null;
+  accept(input: {
+    batchId: number;
+    eventIds: readonly string[];
+    repair: FullRepairCapture;
+  }): OwnerEventBoardRefreshAcceptance;
+  findAcceptance(batchId: number): OwnerEventBoardRefreshAcceptance | null;
+  attachPendingToWorkOrder(workOrderId: number): number;
+  markVerified(
+    workOrderId: number,
+    capturedGeneration: number
+  ): {
+    applied: number;
+    followupPending: boolean;
+  };
+  consumePostTerminalFollowup(workOrderId: number): boolean;
+}
+```
+
+- [ ] **Step 1: Write failing acceptance and duplicate tests**
+
+```ts
+it('atomically binds one exact batch to one shared non-force Board workorder', () => {
+  const accepted = ledger.accept({
+    batchId: 1,
+    eventIds: ['evt-b', 'evt-a'],
+    repair: { repairGeneration: 11, noUpdateScope: 'full:11' },
+  });
+  expect(accepted).toMatchObject({ batchId: 1, repairGeneration: 11, appliedAt: null });
+  expect(enqueued).toEqual([
+    expect.objectContaining({
+      workKind: 'board',
+      idempotencyKey: 'board:full:repair',
+      input: expect.objectContaining({ mode: 'full', force: false, repairGeneration: 11 }),
+    }),
+  ]);
+});
+
+it('returns the same acceptance for the same batch without enqueueing again', () => {
+  const first = ledger.accept(input);
+  expect(ledger.accept(input)).toEqual(first);
+  expect(enqueued).toHaveLength(1);
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+```bash
+pnpm --dir packages/standalone exec vitest run tests/operator/owner-event-board-refresh.test.ts
+```
+
+Expected: FAIL because the module does not exist.
+
+- [ ] **Step 3: Implement the additive migration and atomic accept**
+
+```sql
+CREATE TABLE IF NOT EXISTS owner_event_board_refresh_intents (
+  batch_id INTEGER PRIMARY KEY REFERENCES owner_event_inbox(id) ON DELETE CASCADE,
+  batch_key TEXT NOT NULL UNIQUE,
+  repair_generation INTEGER NOT NULL CHECK (repair_generation >= 0),
+  workorder_id INTEGER NOT NULL REFERENCES operator_tasks(id),
+  applied_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_owner_event_board_refresh_pending
+  ON owner_event_board_refresh_intents(repair_generation, batch_id)
+  WHERE applied_at IS NULL;
+```
+
+Validate the batch ID, event IDs, generation, and scope. In one `db.transaction()` callback: return a matching existing row, otherwise call `taskLedger.enqueueWorkOrder()` and insert the intent with that workorder ID. Conflicting reuse of a batch ID or batch key throws.
+
+Add a source-wiring assertion in `owner-event-wiring.test.ts` during Task 4 so daemon boot must construct
+the ledger, whose constructor invokes the migration after both referenced parent tables exist.
+
+- [ ] **Step 4: Add burst, rollback, cleanup, and generation tests**
+
+```ts
+it('coalesces twenty batches onto one open workorder', () => {
+  const rows = Array.from({ length: 20 }, (_, index) =>
+    ledger.accept({
+      batchId: index + 1,
+      eventIds: [`evt-${index + 1}`],
+      repair: { repairGeneration: 20 + index, noUpdateScope: `full:${20 + index}` },
+    })
+  );
+  expect(new Set(rows.map((row) => row.workOrderId)).size).toBe(1);
+});
+
+it('applies only captured generations and emits one follow-up signal', () => {
+  expect(ledger.markVerified(workOrderId, 25)).toEqual({ applied: 6, followupPending: true });
+  expect(ledger.consumePostTerminalFollowup(workOrderId)).toBe(true);
+  expect(ledger.consumePostTerminalFollowup(workOrderId)).toBe(false);
+});
+```
+
+Also assert rollback leaves neither new task nor intent, FK cleanup removes the intent, `maxPendingGeneration()` ignores applied rows, `attachPendingToWorkOrder()` changes only pending rows, and no `markVerified()` means no follow-up signal.
+
+- [ ] **Step 5: Run the focused test and verify GREEN**
+
+Run Step 2. Expected: PASS.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add packages/standalone/src/db/migrations/owner-event-board-refresh.ts packages/standalone/src/operator/owner-event-board-refresh.ts packages/standalone/tests/operator/owner-event-board-refresh.test.ts
+git commit -m "feat(standalone): add durable owner-event board intents"
+```
+
+---
+
+### Task 2: Host-Bound Origin and Request Coalescing
+
+**Files:**
+
+- Modify: `packages/standalone/src/agent/types.ts`
+- Modify: `packages/standalone/src/agent/gateway-tool-executor.ts`
+- Modify: `packages/standalone/src/cli/commands/start.ts`
+- Modify: `packages/standalone/tests/agent/gateway-tool-executor.test.ts`
+- Modify: `packages/standalone/tests/cli/start-board-refresh-gate.test.ts`
+
+**Interfaces:**
+
+- Consumes: `OwnerEventEffectAuthority.batchId`, trusted `causeEventIds`, ledger `accept()`.
+- Produces:
+
+```ts
+export type WorkOrderRequestOrigin =
+  | { kind: 'owner_manual' }
+  | { kind: 'owner_event'; batchId: number; eventIds: readonly string[] };
+```
+
+- [ ] **Step 1: Write failing origin tests**
+
+```ts
+expect(handler).toHaveBeenCalledWith('board', {
+  kind: 'owner_event',
+  batchId: 42,
+  eventIds: ['evt-1'],
+});
+```
+
+Assert chat produces `owner_manual`, model-supplied identity fields are ignored, and `source: 'owner-event'` without host `ownerEventEffects` plus non-empty causes fails closed.
+
+- [ ] **Step 2: Run gateway and handler tests and verify RED**
+
+```bash
+pnpm --dir packages/standalone exec vitest run tests/agent/gateway-tool-executor.test.ts tests/cli/start-board-refresh-gate.test.ts
+```
+
+Expected: FAIL on the old handler signature and forced owner-event payload.
+
+- [ ] **Step 3: Derive the closed origin from trusted execution state**
+
+Owner-event origin requires:
+
+```ts
+state.source === 'owner-event' &&
+  Number.isSafeInteger(state.ownerEventEffects?.batchId) &&
+  state.ownerEventEffects!.batchId > 0 &&
+  Array.isArray(state.causeEventIds) &&
+  state.causeEventIds.length > 0;
+```
+
+Never read origin from tool input. Pass `owner_manual` for other admitted owner requests.
+
+- [ ] **Step 4: Route only owner-event Board through the ledger**
+
+```ts
+const generation = deps.boardRefreshGate.markChannelDirty(OWNER_BOARD_FULL_REPAIR_CHANNEL);
+const repair = deps.boardRefreshGate.captureFullRepair();
+deps.ownerEventBoardRefreshLedger.accept({
+  batchId: origin.batchId,
+  eventIds: origin.eventIds,
+  repair: { ...repair, repairGeneration: generation },
+});
+```
+
+Use one captured generation. Manual Board, Wiki, and memory-curation keep their existing keys; Wiki/memory take host event IDs from `origin.eventIds`.
+
+- [ ] **Step 5: Add behavior regressions and verify GREEN**
+
+Assert 20 requests yield 20 intents/one non-force task, same-batch retry yields no task, manual remains forced, missing ledger fails without old-path fallback, and Wiki/memory permanent keys are unchanged. Run Step 2 plus Task 1 test. Expected: PASS.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add packages/standalone/src/agent/types.ts packages/standalone/src/agent/gateway-tool-executor.ts packages/standalone/src/cli/commands/start.ts packages/standalone/tests/agent/gateway-tool-executor.test.ts packages/standalone/tests/cli/start-board-refresh-gate.test.ts
+git commit -m "fix(standalone): coalesce owner-event board requests"
+```
+
+---
+
+### Task 3: Verified Application and Post-Terminal Follow-Up
+
+**Files:**
+
+- Modify: `packages/standalone/src/operator/workorder-hooks.ts`
+- Modify: `packages/standalone/src/cli/runtime/api-routes-init.ts`
+- Modify: `packages/standalone/src/cli/commands/start.ts`
+- Modify: `packages/standalone/tests/operator/workorder-hooks.test.ts`
+- Modify: `packages/standalone/tests/cli/runtime/api-routes-init-reconcile.test.ts`
+
+**Interfaces:**
+
+- Consumes: ledger `markVerified()`, `attachPendingToWorkOrder()`, `consumePostTerminalFollowup()`.
+- Produces: `ApiRoutesHandle.requestBoardRepair(): void`.
+
+- [ ] **Step 1: Write failing verified-only hook tests**
+
+```ts
+it('marks intents only after a verified full repair', () => {
+  applyBoardRefreshVerdict(workOrder, true, { disposition: 'complete' }, gate, intents);
+  expect(intents.markVerified).toHaveBeenCalledWith(workOrder.id, 12);
+});
+
+it('does not mark intents after unverified or failed results', () => {
+  applyBoardRefreshVerdict(workOrder, false, { disposition: 'complete' }, gate, intents);
+  expect(intents.markVerified).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Write failing terminal-order route tests**
+
+Assert accepted-intent nudge bypasses only watermark skip, never sets force, attaches pending rows to the returned task, runs after current task terminal, and unverified/failed/exhausted events never nudge.
+
+- [ ] **Step 3: Run hook/route tests and verify RED**
+
+```bash
+pnpm --dir packages/standalone exec vitest run tests/operator/workorder-hooks.test.ts tests/cli/runtime/api-routes-init-reconcile.test.ts
+```
+
+Expected: FAIL because no intent port or nudge exists.
+
+- [ ] **Step 4: Implement verified application and terminal nudge**
+
+Change `runDashboardAgent` options to `{ force?: boolean; acceptedIntent?: boolean }`. `acceptedIntent` requires a pending intent, bypasses only `delta.enqueue === false`, uses `boardRepairKey()` without force, and calls `attachPendingToWorkOrder(newId)`. Make `enqueueWorkOrderOrThrow()` return the workorder.
+
+Expose:
+
+```ts
+return {
+  requestBoardRepair: () => runDashboardAgent({ acceptedIntent: true }),
+  stop: () => {
+    if (boardBootTimeout) clearTimeout(boardBootTimeout);
+    boardBootTimeout = null;
+    if (boardInterval) clearInterval(boardInterval);
+    boardInterval = null;
+    boardReconcileScheduler?.stop();
+    boardReconcileScheduler = null;
+  },
+};
+```
+
+In WorkOrderConsumer `onEvent`, consume the ledger set only for `complete` Board events, then call `boardRepairNudge.current?.()`. Assign the ref from `apiRoutesHandle.requestBoardRepair` before consumer boot recovery/start.
+
+- [ ] **Step 5: Run focused tests and verify GREEN**
+
+Run Step 3 plus Task 1 test. Expected: PASS.
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git add packages/standalone/src/operator/workorder-hooks.ts packages/standalone/src/cli/runtime/api-routes-init.ts packages/standalone/src/cli/commands/start.ts packages/standalone/tests/operator/workorder-hooks.test.ts packages/standalone/tests/cli/runtime/api-routes-init-reconcile.test.ts
+git commit -m "fix(standalone): schedule verified board follow-ups"
+```
+
+---
+
+### Task 4: Boot Recovery, Terminal Receipt, and Flag Semantics
+
+**Files:**
+
+- Modify: `packages/standalone/src/cli/commands/start.ts`
+- Modify: `packages/standalone/src/cli/runtime/api-routes-init.ts`
+- Modify: `packages/standalone/tests/cli/owner-event-wiring.test.ts`
+- Modify: `packages/standalone/tests/cli/runtime/api-routes-init-reconcile.test.ts`
+- Modify: `packages/standalone/tests/cli/start-board-refresh-gate.test.ts`
+
+**Interfaces:**
+
+- Consumes: `maxPendingGeneration()`, `findAcceptance(batchId)`, always-on gate.
+- Produces: exact batch terminal recovery without another model run.
+
+- [ ] **Step 1: Write failing production-wiring tests**
+
+```ts
+expect(startSource).toContain('new OwnerEventBoardRefreshLedger(operatorDb, taskLedger)');
+expect(startSource).toContain('ownerEventBoardRefreshLedger.findAcceptance(batch.id)');
+expect(startSource).not.toContain(
+  "process.env.MAMA_BOARD_RECONCILE === '1' ? new BoardRefreshGate() : null"
+);
+```
+
+Also prove persisted acceptance wins before model execution and after runner error.
+
+- [ ] **Step 2: Run wiring/config tests and verify RED**
+
+```bash
+pnpm --dir packages/standalone exec vitest run tests/cli/owner-event-wiring.test.ts tests/cli/start-board-refresh-gate.test.ts tests/cli/runtime/api-routes-init-reconcile.test.ts
+```
+
+Expected: FAIL on conditional gate construction and exact-key-only recovery.
+
+- [ ] **Step 3: Reorder boot construction and make the gate unconditional**
+
+```ts
+const taskLedger = new TaskLedger(operatorDb);
+const ownerEventInbox = new OwnerEventInbox(operatorDb);
+const ownerEventBoardRefreshLedger = new OwnerEventBoardRefreshLedger(operatorDb, taskLedger);
+const initialBoardGeneration = Math.max(
+  Date.now(),
+  (ownerEventBoardRefreshLedger.maxPendingGeneration() ?? -1) + 1
+);
+const boardRefreshGate = new BoardRefreshGate({ initialGeneration: initialBoardGeneration });
+```
+
+Keep the env flag only around `ReconcileScheduler` and its explicit reconcile route.
+
+- [ ] **Step 4: Add exact batch terminal recovery**
+
+```ts
+const boardAcceptance = ownerEventBoardRefreshLedger.findAcceptance(batch.id);
+if (boardAcceptance) {
+  return { status: 'delegated' as const, tools: ['workorder_request'] };
+}
+```
+
+Keep external effects, Wiki, memory-curation, and exact no-update lookup unchanged.
+
+- [ ] **Step 5: Add boot and flag matrix assertions and verify GREEN**
+
+Assert pending intents seed a greater boot generation and reattach to one boot repair, no pending intent preserves normal boot behavior, flag off disables only delta reconcile, and no owner-event path sets force. Run Step 2 plus ledger/hook tests. Expected: PASS.
+
+- [ ] **Step 6: Commit Task 4**
+
+```bash
+git add packages/standalone/src/cli/commands/start.ts packages/standalone/src/cli/runtime/api-routes-init.ts packages/standalone/tests/cli/owner-event-wiring.test.ts packages/standalone/tests/cli/start-board-refresh-gate.test.ts packages/standalone/tests/cli/runtime/api-routes-init-reconcile.test.ts
+git commit -m "fix(standalone): recover owner-event board acceptance"
+```
+
+---
+
+### Task 5: Documentation and Verification Gate
+
+**Files:**
+
+- Modify: `docs/development/kagemusha-telegram-parity.md`
+- Modify: `docs/development/runtime-overhead-reduction-design.md`
+
+**Interfaces:**
+
+- Consumes: committed PR-A code/test evidence.
+- Produces: TG evidence and exact verification record.
+
+- [ ] **Step 1: Record TG evidence without claiming live behavior**
+
+Add a dated section stating: TG-03/TG-04 preserve the agent's workorder choice; TG-05 keeps the fresh owner-event run and coalesces only downstream Board work; TG-06 atomically binds exact batch acceptance, recovers it after crash, and follows verified generations. Status: `CODE GREEN; release and real-event canary pending`.
+
+- [ ] **Step 2: Run focused PR-A tests**
+
+```bash
+pnpm --dir packages/standalone exec vitest run \
+  tests/operator/owner-event-board-refresh.test.ts \
+  tests/operator/workorder-hooks.test.ts \
+  tests/cli/start-board-refresh-gate.test.ts \
+  tests/cli/runtime/api-routes-init-reconcile.test.ts \
+  tests/cli/owner-event-wiring.test.ts \
+  tests/agent/gateway-tool-executor.test.ts \
+  tests/operator/owner-event-loop.test.ts \
+  tests/operator/owner-event-outcome.test.ts
+```
+
+Expected: all selected tests PASS.
+
+- [ ] **Step 3: Run package and root gates**
+
+```bash
+pnpm --dir packages/standalone typecheck
+pnpm --dir packages/standalone build
+pnpm --dir packages/standalone test
+pnpm typecheck
+pnpm build
+pnpm test
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 4: Run changed-file format and whitespace gates**
+
+```bash
+pnpm exec prettier --check docs/development/kagemusha-telegram-parity.md docs/development/runtime-overhead-reduction-design.md packages/standalone/src/db/migrations/owner-event-board-refresh.ts packages/standalone/src/operator/owner-event-board-refresh.ts packages/standalone/src/operator/workorder-hooks.ts packages/standalone/src/agent/types.ts packages/standalone/src/agent/gateway-tool-executor.ts packages/standalone/src/cli/commands/start.ts packages/standalone/src/cli/runtime/api-routes-init.ts packages/standalone/tests/operator/owner-event-board-refresh.test.ts packages/standalone/tests/operator/workorder-hooks.test.ts packages/standalone/tests/agent/gateway-tool-executor.test.ts packages/standalone/tests/cli/start-board-refresh-gate.test.ts packages/standalone/tests/cli/runtime/api-routes-init-reconcile.test.ts packages/standalone/tests/cli/owner-event-wiring.test.ts
+git diff --check
+```
+
+Expected: exit 0. Report unrelated root format debt separately.
+
+- [ ] **Step 5: Commit evidence**
+
+```bash
+git add docs/development/kagemusha-telegram-parity.md docs/development/runtime-overhead-reduction-design.md
+git commit -m "docs: record owner-event board coalescing evidence"
+```
+
+- [ ] **Step 6: Run the diff-scoped review gate**
+
+Invoke `review` before `ship`. Fix every P0-P3 finding with a RED→GREEN regression, rerun affected focused suites, and commit coherent corrections. Create the PR only after the review log is CLEAN.

--- a/docs/development/runtime-overhead-reduction-design.md
+++ b/docs/development/runtime-overhead-reduction-design.md
@@ -1,0 +1,475 @@
+# MAMA Runtime Overhead Reduction — 검증을 보존하고 모델 낭비를 제거하는 설계
+
+> **상태:** 오너 검토 대기
+>
+> **작성일:** 2026-08-26
+>
+> **선택안:** A — 위험과 검증 방법이 다른 세 슬라이스를 독립 출하한다. 첫 구현은
+> `Slice A: Model-work control`이다. 감사 저장 수명주기와 daemon 로그 회전은 각각 별도 설계·승인 후
+> 진행한다.
+>
+> **패리티 계약:** 이 설계는 `TG-03`, `TG-04`, `TG-05`, `TG-06`을 따른다. 특히 모델이 안전한
+> 도구를 자유롭게 조합하는 능력은 유지하고, 호스트는 권한·중복 방지·durable receipt·복구만
+> 소유한다.
+
+## 1. 문제 정의
+
+MAMA의 운영 오버헤드는 “검증 함수가 너무 많아서” 발생하지 않았다. 실측상 sender, role,
+envelope, destination, path, receipt, input validation 같은 로컬 검증은 대부분 마이크로초에서 수
+밀리초 수준이었다. 실제 비용의 중심은 다음 두 경로였다.
+
+1. connector owner-event가 Board 작업을 요청할 때마다 `force: true` 전체 수리를 새로 실행한다.
+2. Temporal worker가 동일한 결정적 도구 계약 오류를 형태만 바꿔 반복하고, 실패한 generation을
+   다시 모델에 맡긴다.
+
+이 둘은 안전 검증의 비용이 아니라 모델 호출 횟수와 컨텍스트 크기의 비용이다. 따라서 검증을
+삭제하면 보안과 복구 성질만 잃고 비용 원인은 남는다.
+
+## 2. 관측 기준선
+
+아래 수치는 2026-08-25의 현재 릴리스 이후 약 9.7시간 운영 창에서 로컬 DB, Codex rollout 파일,
+daemon 로그와 소스 코드를 읽어 측정한 기준선이다. rollout 파일을 전체 토큰의 권위 있는 출처로
+사용하고, DB 수치는 lane별 상대 분해에 사용했다.
+
+| 항목                             |           관측값 | 해석                                       |
+| -------------------------------- | ---------------: | ------------------------------------------ |
+| Codex 세션                       |               80 | 같은 운영 창의 전체 세션                   |
+| 전체 토큰                        |       22,825,582 | 입력+출력 합계                             |
+| Board                            | 23회 / 8,487,359 | 세션당 평균 369,016                        |
+| owner-event Board 강제 전체 수리 | 20회 / 7,204,986 | owner-event Board 요청 전부 `full + force` |
+| Temporal                         |  3회 / 5,179,840 | 한 generation이 3회 재시도 후 소진         |
+| 두 낭비 경로 합계                |       12,384,826 | 전체 토큰의 54.3%                          |
+| Temporal 실패 trace              |   486 / 전체 565 | `context_compile` scope 계약 오류가 다수   |
+| Board 실제 실행 시간             |  평균 약 250.5초 | owner-event 요청은 평균 약 86.6초          |
+| Temporal 실제 실행 시간          |  평균 약 411.7초 | 같은 결정적 실패를 장시간 반복             |
+
+로컬 검증 기준선은 다음과 같다.
+
+| 검증                           |              관측 비용 |
+| ------------------------------ | ---------------------: |
+| envelope 구조 검사             |  호출당 약 0.16–0.36µs |
+| live boundary config 읽기+파싱 |         호출당 약 47µs |
+| 시간별 결정적 code audit       |         약 5–21ms/시간 |
+| 빠른 gateway 도구 + 감사 기록  |        대체로 약 1–4ms |
+| idle daemon                    | CPU 0.0%, RSS 약 135MB |
+
+## 3. 목표
+
+1. owner-event burst가 Board 전체 강제 수리를 이벤트 수만큼 생성하지 않게 한다.
+2. 같은 결정적 Temporal 도구 계약 실패가 한 generation에서 무한 변형되거나 새 모델 run으로
+   재시도되지 않게 한다.
+3. owner-event 입력 배치가 durable acceptance, 외부 effect, 또는 정확한 no-update receipt 중 하나와
+   계속 연결되게 한다.
+4. 현재의 sender/role/envelope/scope/destination/path/idempotency/receipt 검증을 유지한다.
+5. 모델 비용, 실행 시간, 중복 작업 감소를 릴리스 후 24시간 운영 지표로 입증한다.
+
+## 4. 비목표와 불변식
+
+### 비목표
+
+- 일반적인 검증 함수 삭제나 단일 “fast mode” 추가
+- `xhigh`를 전역으로 낮춰 원인을 숨기는 변경
+- 모델이 수행할 도구 순서를 호스트 코드에 하드코딩
+- Board, Wiki, memory-curation을 하나의 거대 오케스트레이터로 합치기
+- 기존 Telegram 앱/UI를 이용한 검증
+- Slice A에서 기존 감사 데이터를 삭제하거나 daemon 로그를 회전하기
+
+### 반드시 유지할 안전 불변식
+
+- ingress principal 분류와 owner/external 경계
+- role 및 tool 권한, host-issued envelope, scope와 destination 검증
+- 외부 effect의 pending-before-send, receipt-first recovery와 멱등성
+- mutation의 committed/unknown 결과에 대한 비재시도 정책
+- input validation, secret filtering, 경로 containment, 결과 sanitization
+- 시간별 deterministic code audit
+- `TG-03/TG-04`: coherent primitive와 agent freedom
+- `TG-05`: bounded context restoration과 같은 정책 세션의 최소 continuation
+- `TG-06`: prose가 아닌 durable receipt가 완료 권위
+
+## 5. 검토한 접근
+
+### A. 독립 슬라이스로 비용 원인을 제거 — 선택
+
+1. 모델 작업 제어
+2. 감사 저장 수명주기
+3. daemon 로그 회전
+
+장점은 각 변경이 별도 실패 도메인과 되돌리기 단위를 갖는다는 점이다. 첫 슬라이스는 삭제 없는
+additive migration과 호스트 상태 기계만 사용한다. 운영 효과를 먼저 측정한 뒤 저장 정책을 결정할
+수 있다.
+
+### B. 한 PR에서 모델·DB·로그를 모두 정리 — 기각
+
+토큰 절감과 디스크 회수를 한 번에 얻지만, 성능 회귀·receipt 회귀·데이터 삭제 문제를 분리해
+판단할 수 없다. 실패 시 어떤 변경을 되돌려야 하는지도 불명확하다.
+
+### C. 검증과 감사 기록을 광범위하게 비활성화 — 기각
+
+실측 비용이 작은 경로를 제거하면서 principal, scope, destination, mutation recovery 불변식을
+깨뜨린다. 모델 호출의 54.3% 낭비 원인도 해결하지 못한다.
+
+## 6. 프로그램 구조
+
+```text
+Slice A — Model-work control
+  A1. owner-event Board coalescing + durable acceptance
+  A2. Temporal host-bound context contract
+  A3. deterministic failure circuit breaker + retry classification
+  A4. 24-hour canary and cost comparison
+
+Slice B — Audit storage lifecycle
+  별도 보존 정책 승인 → additive archive/compaction → 온라인 정리
+
+Slice C — launchd-safe daemon log rotation
+  별도 회전 정책 승인 → reopen 가능한 writer → size/time rotation
+```
+
+Slice A가 정상 출하되어도 B와 C는 자동 승인되지 않는다. B는 데이터 보존이라는 파괴적 결정을,
+C는 launchd와 열린 file descriptor의 수명주기 결정을 각각 요구한다.
+
+## 7. Slice A 상세 설계
+
+### A1. Owner-event Board refresh coordinator
+
+#### 현재 결함
+
+`buildOwnerWorkOrderRequestHandler()`는 owner chat과 owner-event가 공유한다. `kind === 'board'`이고
+`causeEventIds`가 있으면 이를 `mode: 'full', force: true`와 고유 `boardBatchKey()`로 변환한다.
+따라서 connector event batch마다 새로운 전체 수리가 만들어진다. 한편 `OwnerEventLoop`의 terminal
+receipt는 같은 exact batch key의 workorder를 찾아야만 배치를 ACK한다. 단순히 enqueue를 생략하거나
+공용 key로 바꾸면 receipt 계약이 끊어진다.
+
+#### 새 경계
+
+`workorder_request`의 호출 출처를 데이터 유무로 추측하지 않는다. 호스트 실행 컨텍스트가 다음
+origin을 명시한다.
+
+```ts
+type WorkOrderRequestOrigin =
+  | { kind: 'owner_manual' }
+  | { kind: 'owner_event'; batchId: number; eventIds: readonly string[] };
+```
+
+- `owner_manual`: 기존 `full + force: true` 의미와 고유 manual key를 유지한다.
+- `owner_event`: `causeEventIds`를 모델 입력에서 받지 않고 host-bound batch에서 파생한다.
+  모델은 batch ID, event ID, force 여부 또는 idempotency key를 선택하거나 넓힐 수 없다.
+
+#### Durable intent
+
+operator DB에 additive 테이블 `owner_event_board_refresh_intents`를 추가한다.
+
+| 열                         | 의미                                                 |
+| -------------------------- | ---------------------------------------------------- |
+| `batch_id` PK/FK           | owner-event batch와 1:1                              |
+| `batch_key` UNIQUE         | 기존 event ID 정렬 해시로 만든 retry-stable identity |
+| `repair_generation`        | 해당 요청이 더럽힌 Board generation                  |
+| `status`                   | `accepted`, `attached`, `applied`, `failed`          |
+| `workorder_id` nullable    | 실제 수리에 연결된 workorder                         |
+| `last_error` nullable      | bounded operator 진단 문자열                         |
+| `created_at`, `updated_at` | 복구와 retention 기준                                |
+
+트랜잭션 순서:
+
+1. `batch_id`로 intent를 `INSERT OR IGNORE`한다.
+2. Board gate를 dirty로 만들고 generation을 intent에 고정한다.
+3. 기존의 열린 non-force Board repair가 있으면 intent를 그 workorder에 `attached`한다.
+4. 없으면 공용 `boardRepairKey()`로 `mode: 'full', force: false` 작업 하나를 enqueue하고 연결한다.
+5. durable intent가 최소 `accepted` 상태가 된 뒤에만 `workorder_request` 성공을 반환한다.
+
+동일 batch retry는 같은 intent를 읽는다. 새 batch가 활성 수리 중 도착하면 그 수리에 연결하되 새
+generation은 남긴다. 여기서 `attached`는 “요청이 수리 coordinator에 접수됐다”는 뜻이지 현재
+attempt가 그 generation까지 처리했다는 뜻이 아니다. 활성 수리가 자기 captured generation까지만
+지우므로, 이후 generation이 남으면 완료 hook이 기존 terminal row가 공용 key를 놓은 뒤 후속 수리를
+하나 enqueue하고 아직 적용되지 않은 intent를 새 workorder에 다시 연결한다. 결과적으로 burst는
+`1 open repair + 1 durable follow-up obligation`으로 수렴한다.
+
+#### 완료와 ACK
+
+- owner-event terminal receipt는 더 이상 Board task의 exact occurrence key만 찾지 않는다.
+- 해당 `batch_id`의 intent가 `accepted` 이상이고 연결된 workorder가 존재하면 `delegated` receipt를
+  반환한다. 이는 기존 `accepted workorder` 의미를 유지한다. Board 수리 완료를 기다려 owner-event
+  inbox를 붙잡는 계약으로 바꾸지 않는다.
+- workorder 완료 hook은 captured generation 이하 intent를 `applied`로 전환한다.
+- 수리 실패는 intent를 삭제하지 않는다. gate dirt와 intent를 남기고 기존 Board 경보/자기회복
+  경로가 후속 수리를 맡는다.
+- boot recovery는 `accepted/attached` intent의 최대 generation보다 큰 값으로 Board gate를
+  초기화하고 boot-dirty full repair 하나에 미적용 intent를 다시 연결한다. 메모리 gate만 보고 수리
+  완료를 추정하지 않는다.
+- `owner_event_inbox` 삭제 시 intent도 FK/trigger로 정리한다. ACK된 inbox의 기존 retention과 같은
+  수명을 따르며, durable receipt가 필요한 동안 먼저 삭제하지 않는다.
+
+#### 패리티 영향
+
+- **TG-03/TG-04:** 모델은 여전히 Board/Wiki/memory 도구를 자유롭게 선택한다. 호스트는 Board 요청을
+  하나의 안전한 primitive로 접수할 뿐, Board 내부 행동 순서를 지시하지 않는다.
+- **TG-05:** 이벤트별 fresh owner-event 판단은 유지하지만, 판단 이후 같은 Board 전체 컨텍스트를
+  반복 실행하는 비용을 합친다.
+- **TG-06:** exact batch는 durable intent와 연결되고, prose만으로 ACK되지 않는다. crash 후에도 같은
+  batch가 새 강제 전체 수리를 만들지 않는다.
+
+### A2. Temporal context contract를 host-bound로 만든다
+
+#### 현재 결함
+
+Temporal brief는 `context_compile`을 요구하지만, 도구 설명은 `mama_search`와 `mama_recall`에 있는
+“scope를 생략하면 호스트가 기본값을 적용한다”는 계약을 충분히 노출하지 않는다. 모델이 scope와
+connector를 직접 만들면 executor가 `memory_scope_out_of_scope`, `connector_out_of_scope`,
+`context_compile_input_invalid`로 거부한다. 거부는 맞지만 같은 선택을 모델이 반복한다.
+
+#### 변경
+
+1. canonical tool registry와 HostBridge가 동일한 `context_compile` 설명을 생성한다.
+2. Temporal managed brief는 다음 계약을 명시한다.
+   - `scopes`, `connectors`를 모델이 공급하지 않는다.
+   - host-bound execution context가 현재 generation의 project, connector, memory grant를 적용한다.
+   - 모델은 `task`, `range`, `as_of`, strictness와 bounded compile budget만 선택한다. active temporal
+     task의 raw seed는 호스트가 추가한다.
+3. executor의 기존 경계를 유지한다. 필드 누락 시 trusted envelope snapshot을 적용하고, 명시
+   필드는 기존 subset/authorization 검증을 통과해야 한다. widening은 계속 거부한다.
+4. prompt와 registry의 문구가 달라지지 않도록 coherence test를 추가한다.
+
+이 변경은 검증 완화가 아니다. 모델 선택 영역에서 권한 필드를 제거하고, 기존 fail-closed executor를
+그대로 유지한다.
+
+### A3. Deterministic failure circuit breaker
+
+#### 현재 결함
+
+AgentLoop의 반복 방지는 outer Code-Act code 문자열을 키로 사용한다. 모델이 코드를 조금씩 바꾸면
+같은 host failure도 다른 호출로 보이며 50-call emergency cap까지 진행할 수 있다. Temporal
+WorkOrderConsumer는 generation을 최대 3회 모델 run으로 재시도해 같은 계약 실패를 확대한다.
+
+#### 구조화 fingerprint
+
+HostBridge가 이미 생산하는 trusted `hostToolExecutions`만 사용해 fingerprint를 만든다. 모델 prose,
+sandbox console, 코드 문자열은 분류 권위가 아니다.
+
+```text
+fingerprint = sha256(
+  outerTool + nestedTool + normalizedFailureCode + authorityBoundary
+)
+```
+
+`authorityBoundary`는 scope/destination/principal 계열을 구분하지만 실제 ID나 민감한 입력은 포함하지
+않는다. 오류 메시지 전체를 hash하지 않아 숫자·정렬·표현 차이로 회피되지 않게 한다.
+
+결정적 오류 집합은 명시적 allowlist로 시작한다.
+
+- `memory_scope_out_of_scope`
+- `connector_out_of_scope`
+- `context_compile_input_invalid`
+- `invalid_memory_scope`
+- `role_denied`, `tool_denied`, `destination_out_of_scope`
+- schema/argument contract 위반
+
+provider 429/5xx, capacity, transport disconnect는 이 집합에 넣지 않는다. mutation outcome unknown,
+committed-after-abort, missing result는 기존 구조적 비재시도 정책을 그대로 우선한다.
+
+#### 차단 규칙
+
+- 같은 Temporal run에서 같은 결정적 fingerprint가 연속 3회 나오면 즉시
+  `TOOL_CONTRACT_REPEAT`로 종료한다.
+- 추가 안전망으로 Temporal run의 outer Code-Act 호출은 최대 8회다. 일반 owner turn과 다른 lane은
+  기존 50-call ceiling을 유지한다.
+- 종료 결과는 `retryable: false`, `failureClass: 'deterministic_contract'`, fingerprint의 짧은
+  비민감 prefix를 갖는다.
+- WorkOrderConsumer는 trusted structured result만 보고 `allowRetry: false`로 generation을 실패
+  처리한다. 응답 prose에서 “재시도하지 마라”를 파싱하지 않는다.
+- provider/transient failure는 현재 retry 정책을 유지한다.
+
+#### 패리티 영향
+
+- **TG-03/TG-04:** 정상적으로 서로 다른 Code-Act 프로그램을 조합하는 자유는 유지된다. 단지 같은
+  trusted host denial을 반복하는 경우만 차단한다.
+- **TG-06:** mutation의 불확실 결과와 완료 영수증이 circuit breaker보다 우선한다. 이미 시작된
+  side effect를 안전하다고 추측해 재시도하지 않는다.
+
+## 8. 데이터 흐름
+
+### Owner-event Board
+
+```text
+connector batch persisted
+  → owner AgentLoop chooses workorder_request(board)
+  → host derives owner_event origin
+  → durable refresh intent INSERT/lookup
+  → attach to one open repair OR enqueue one non-force repair
+  → durable acceptance returned
+  → OwnerEventLoop ACKs exact batch
+  → Board completion clears captured generation only
+  → newer dirt schedules at most one follow-up
+```
+
+### Temporal failure
+
+```text
+temporal generation claimed
+  → host-bound context_compile defaults
+  → Code-Act nested executions recorded
+  → deterministic fingerprints accumulated
+  → 3 equal failures OR 8 outer calls
+  → structured non-retryable TOOL_CONTRACT_REPEAT
+  → generation exhausted once, no replacement model run
+  → operator evidence + bounded alarm
+```
+
+## 9. 오류 처리와 복구
+
+| 실패 지점                       | 처리                                                 |
+| ------------------------------- | ---------------------------------------------------- |
+| intent INSERT 실패              | workorder 요청 실패, owner-event retry; ACK 금지     |
+| intent 저장 후 enqueue 전 crash | boot recovery가 intent로 repair를 재생성             |
+| enqueue 후 ACK 전 crash         | 동일 batch intent/workorder를 찾아 ACK; 새 작업 금지 |
+| Board 실행 중 새 event          | 새 generation 유지, 현재 완료 후 follow-up 최대 하나 |
+| Board publish 검증 실패         | dirt와 intent 유지, existing alarm/self-heal 사용    |
+| context_compile 권한 위반       | fail-closed + fingerprint 카운트                     |
+| 결정적 실패 3회                 | 비재시도 generation 실패                             |
+| provider 429/5xx                | 기존 transient retry                                 |
+| mutation outcome unknown        | 기존 no-retry receipt-first recovery 우선            |
+| daemon shutdown                 | 기존 active workorder drain/boot recovery 계약 유지  |
+
+## 10. Migration과 호환성
+
+- `owner_event_board_refresh_intents`는 operator DB에 additive `CREATE TABLE IF NOT EXISTS` migration으로
+  추가한다.
+- 기존 `owner_event_inbox`, `operator_tasks`, `owner_event_effects` 행은 수정하지 않는다.
+- 구버전은 새 테이블을 읽지 않으므로 rollback-safe다. 단, 새 버전이 만든 non-force repair는 기존
+  Board payload schema와 호환되어야 한다.
+- migration 실패 시 daemon은 owner-event 처리를 시작하지 않고 fail loudly 한다. 메모리-only
+  fallback은 금지한다.
+- 기존 `boardBatchKey()`는 historical lookup과 batch identity 생성에 유지할 수 있지만, 더 이상
+  owner-event마다 독립 full-force workorder occurrence를 만드는 데 사용하지 않는다.
+
+## 11. 테스트 전략 — TDD
+
+구현은 아래 RED 테스트부터 시작한다.
+
+### A1 Board/receipt
+
+1. `TG-06`: 동일 owner-event batch retry가 intent와 workorder 하나만 만든다.
+2. `TG-06`: 서로 다른 20개 batch burst가 open repair 하나에 attach되고 follow-up은 최대 하나다.
+3. `TG-06`: enqueue 후 ACK 전 crash가 새 workorder 없이 durable acceptance를 복구한다.
+4. `TG-06`: 새 generation은 오래된 repair 완료로 지워지지 않는다.
+5. `TG-06`: prose-only 또는 intent 없는 성공은 ACK되지 않는다.
+6. `TG-03/TG-04`: owner manual Board 요청은 여전히 `force: true`; owner-event는 `force: false`다.
+7. migration I/O 실패는 fail-closed하고 기존 DB bytes를 보존한다.
+
+### A2 Temporal context
+
+1. `TG-03/TG-04`: Temporal `context_compile`은 host scope를 기본 적용한다.
+2. 명시적으로 scope를 넓히면 기존과 같이 거부한다.
+3. registry, HostBridge, managed brief의 계약 문구가 일치한다.
+4. trusted grant snapshot은 한 호출 안에서 변하지 않고 다음 호출에서 revoke를 반영한다.
+
+### A3 Circuit breaker/retry
+
+1. 코드 문자열이 다른 3개 Code-Act가 같은 nested failure를 내면 한 run에서 차단된다.
+2. 서로 다른 정상 프로그램은 차단되지 않는다.
+3. provider 429/5xx는 deterministic fingerprint로 분류되지 않는다.
+4. mutation outcome unknown은 기존 no-retry 결과를 유지한다.
+5. Temporal 8-call ceiling이 그 lane에만 적용된다.
+6. `retryable: false` generation은 WorkOrderConsumer가 새 model run을 만들지 않는다.
+7. 구조화 결과 없이 같은 문구만 출력한 model prose는 retry 분류 권위가 아니다.
+
+### 회귀 게이트
+
+- 관련 standalone focused suites
+- standalone typecheck와 build
+- 전체 standalone test
+- root typecheck, build, test
+- 변경 파일 Prettier와 `git diff --check`
+- `docs/development/kagemusha-telegram-parity.md`의 TG-03/TG-04/TG-05/TG-06 evidence/status 갱신
+
+## 12. 출시와 운영 검증
+
+### 단계 1 — shadow 계측
+
+한 릴리스 동안 기존 동작을 바꾸지 않고 다음 counter를 추가한다.
+
+- owner-event Board intents accepted/attached/applied/failed
+- Board repair open/follow-up/coalesced batch 수
+- Temporal deterministic fingerprint count와 breaker termination
+- workorder별 model runs, tokens, duration, retry class
+
+민감한 event ID, connector payload, chat ID, scope ID는 로그에 기록하지 않는다.
+
+### 단계 2 — Slice A 활성화
+
+- 기능 플래그는 rollback용으로만 두며 기본값은 새 경로다.
+- old path를 fallback으로 호출하지 않는다. 새 durable path가 실패하면 fail loudly 한다.
+- build/install/restart는 별도 단계로 구분하고 launchd 단일 인스턴스를 확인한다.
+
+### 단계 3 — 24시간 canary
+
+UI나 synthetic connector event를 사용하지 않는다. 실제 운영 이벤트와 로컬 DB/rollout/receipt/log만
+읽는다.
+
+완료 조건:
+
+1. owner-event가 만든 `full + force` Board workorder가 0건이다.
+2. owner-event Board 토큰이 기준선 대비 최소 60% 감소한다. 이벤트 수가 너무 적으면 비율 판정을
+   보류하고 최소 10개 실제 batch가 쌓일 때까지 기다린다.
+3. burst가 `1 open repair + 1 follow-up` 상한을 넘지 않는다.
+4. 결정적 Temporal 오류 하나가 3회를 넘는 Code-Act 또는 1회를 넘는 model run을 만들지 않는다.
+5. 정상 Temporal generation 하나가 완료 receipt까지 성공한다.
+6. owner-event batch가 durable effect, accepted intent/workorder, exact no-update 중 하나 없이 ACK된
+   사례가 0건이다.
+7. TG-03/TG-04 권한, TG-05 session continuity, TG-06 delivery/receipt 회귀가 0건이다.
+8. provider 오류, Telegram 409, 중복 전송, 본문 잘림, 내부 메타 노출이 0건이다.
+
+실제 이벤트가 없으면 성공으로 추정하지 않고 canary를 계속 기다린다.
+
+## 13. Slice B — Audit storage lifecycle 후속 설계 경계
+
+현재 DB에는 보존 정책이 없는 대형 append-only 표면이 있다.
+
+| 표면                  |       관측 크기/행수 | 현재 판단                             |
+| --------------------- | -------------------: | ------------------------------------- |
+| `context_packets`     |    약 261MB / 10,642 | payload가 크고 retention 없음         |
+| `envelopes`           |  약 159.8MB / 54,959 | 관측 시점에 모두 expired              |
+| `agent_activity`      | 약 144.5MB / 255,855 | workorder verifier가 현재 권위로 사용 |
+| `model_runs`          |   약 57.3MB / 72,958 | 운영/비용 분석에 필요                 |
+| `tool_traces`         |  약 45.9MB / 174,060 | 상세 nested execution 근거            |
+| `validation_sessions` |   약 13.5MB / 12,462 | 현재 boot 이후 신규 없음              |
+
+Slice B는 다음 결정을 별도 문서에서 승인받은 뒤에만 시작한다.
+
+- durable business receipt, task, decision, provenance를 영구 보존 대상으로 분류
+- `tool_traces`를 canonical detail로 할지 `agent_activity`를 canonical projection으로 할지 결정
+- workorder verifier가 compact projection으로 전환된 뒤에만 원본 retention 적용
+- age + terminal status + receipt reachability를 함께 사용하는 삭제 조건
+- dry-run count/bytes, `VACUUM INTO` backup, batch delete, WAL checkpoint, rollback 검증
+
+단순 행수 기준 삭제나 `agent_activity` 즉시 제거는 금지한다.
+
+## 14. Slice C — launchd-safe daemon log rotation 후속 설계 경계
+
+`daemon.log`는 관측 시 약 141MB였고 audit warning 기준은 50MB였다. 현재 daemon과 watchdog은 append
+file descriptor를 오래 유지하므로 외부 rename만 하면 실행 중인 프로세스가 이전 inode에 계속 쓸 수
+있다.
+
+Slice C는 다음을 별도 설계한다.
+
+- writer가 회전 후 file descriptor를 명시적으로 reopen하는 계약
+- size/time trigger와 한 번에 하나의 rotation lock
+- bounded generation 수와 비동기 gzip
+- launchd 재시작 없이 회전되는 integration test
+- crash 중 temp 파일/부분 gzip 복구
+- secret redaction을 rotation 전후 동일하게 유지
+
+## 15. 성공 정의
+
+이 프로그램의 성공은 “검증 코드 줄 수 감소”가 아니다.
+
+- 안전 검증과 receipt 불변식은 그대로다.
+- 실제 모델 호출과 토큰이 줄어든다.
+- 동일한 실패는 더 빨리, 구조적으로, 비재시도 상태로 끝난다.
+- connector burst가 하나의 수리 의도로 수렴한다.
+- 저장과 로그는 승인된 수명주기 안에서만 줄어든다.
+- 각 슬라이스는 독립적으로 검증·출하·롤백할 수 있다.
+
+## 16. 승인 후 다음 단계
+
+이 문서 승인 후에만 `Slice A` 구현 계획을 작성한다. 구현 계획은 파일·테스트·migration 순서를
+구체화하고, RED→GREEN 단위로 나눈다. Slice B와 Slice C는 Slice A의 24시간 canary 결과와 무관하게
+각각 별도 설계 승인 게이트를 거친다.

--- a/docs/development/runtime-overhead-reduction-design.md
+++ b/docs/development/runtime-overhead-reduction-design.md
@@ -699,7 +699,7 @@ Slice B와 C는 본 문서에 이미 이유·범위·승인 게이트가 있어 
 
 검증 결과:
 
-- PR-A 집중 gate: 8 files, 197 tests passed.
-- Standalone: 382 files, 5,165 tests passed; 4 files / 7 tests skipped.
+- PR-A 집중 gate: 8 files, 198 tests passed.
+- Standalone: 382 files, 5,166 tests passed; 4 files / 7 tests skipped.
 - Root: typecheck exit 0, build exit 0, test 7/7 Turbo tasks passed.
 - 릴리즈, 실제 owner-event canary, 24시간 비용 비교는 아직 수행하지 않았다.

--- a/docs/development/runtime-overhead-reduction-design.md
+++ b/docs/development/runtime-overhead-reduction-design.md
@@ -1,6 +1,6 @@
 # MAMA Runtime Overhead Reduction — 검증을 보존하고 모델 낭비를 제거하는 설계
 
-> **상태:** Eng review CLEAR, 구현 계획 작성 가능
+> **상태:** Eng review CLEAR, PR-A CODE GREEN, PR-B 구현 대기
 >
 > **작성일:** 2026-08-26
 >
@@ -681,3 +681,25 @@ Slice B와 C는 본 문서에 이미 이유·범위·승인 게이트가 있어 
 
 - **UNRESOLVED:** 0
 - **VERDICT:** ENG CLEARED, ready to write the implementation plan.
+
+## 24. PR-A implementation evidence
+
+2026-08-26 기준 PR-A는 코드와 테스트가 완료됐고, 아직 운영 릴리즈는 하지 않았다.
+
+- exact owner-event batch마다 durable intent를 한 행 저장하고 열린 Board repair 하나로
+  coalesce한다. 직접 owner 요청만 기존 `force: true` 계약을 유지한다.
+- intent acceptance와 workorder enqueue는 같은 SQLite transaction이다. 재시작 시 미적용 최대
+  generation보다 높은 gate를 만들고 pending intent를 새 non-force repair에 재연결한다.
+- full Board의 action verifier와 receipt가 모두 성공한 경우만 captured generation까지 적용한다.
+  실행 중 들어온 더 최신 generation은 현재 workorder terminal 뒤 한 번만 follow-up한다.
+- owner-event terminal receipt는 external effect 다음으로 durable Board acceptance를 확인하고,
+  Wiki/memory permanent key와 exact no-update 경로를 그대로 보존한다.
+- `MAMA_BOARD_RECONCILE`은 delta reconcile scheduler와 route만 제어한다. full repair gate는 항상
+  존재한다.
+
+검증 결과:
+
+- PR-A 집중 gate: 8 files, 197 tests passed.
+- Standalone: 382 files, 5,165 tests passed; 4 files / 7 tests skipped.
+- Root: typecheck exit 0, build exit 0, test 7/7 Turbo tasks passed.
+- 릴리즈, 실제 owner-event canary, 24시간 비용 비교는 아직 수행하지 않았다.

--- a/docs/development/runtime-overhead-reduction-design.md
+++ b/docs/development/runtime-overhead-reduction-design.md
@@ -1,6 +1,6 @@
 # MAMA Runtime Overhead Reduction — 검증을 보존하고 모델 낭비를 제거하는 설계
 
-> **상태:** 오너 검토 대기
+> **상태:** Eng review CLEAR, 구현 계획 작성 가능
 >
 > **작성일:** 2026-08-26
 >
@@ -112,9 +112,9 @@ additive migration과 호스트 상태 기계만 사용한다. 운영 효과를 
 
 ```text
 Slice A — Model-work control
-  A1. owner-event Board coalescing + durable acceptance
-  A2. Temporal host-bound context contract
-  A3. deterministic failure circuit breaker + retry classification
+  PR-A. owner-event Board coalescing + durable acceptance
+  PR-B. Temporal host-bound context contract
+        + deterministic failure circuit breaker + retry classification
   A4. 24-hour canary and cost comparison
 
 Slice B — Audit storage lifecycle
@@ -126,6 +126,10 @@ Slice C — launchd-safe daemon log rotation
 
 Slice A가 정상 출하되어도 B와 C는 자동 승인되지 않는다. B는 데이터 보존이라는 파괴적 결정을,
 C는 launchd와 열린 file descriptor의 수명주기 결정을 각각 요구한다.
+
+Slice A 자체도 한 거대 PR로 만들지 않는다. Board와 Temporal은 실패 도메인과 회귀 테스트가 다르므로
+`PR-A → PR-B → 릴리즈 1회`로 진행한다. PR-A가 main에 머지된 뒤 PR-B를 최신 main에서 시작하고, 두
+PR이 모두 clear된 뒤 한 릴리즈로 운영에 반영한다.
 
 ## 7. Slice A 상세 설계
 
@@ -156,6 +160,15 @@ type WorkOrderRequestOrigin =
 
 #### Durable intent
 
+`OwnerEventBoardRefreshLedger` 하나가 기존 `operatorDb`, `TaskLedger`, `BoardRefreshGate`를 조합한다.
+Board 수리 자체는 기존 `boardRepairKey()`와 TaskLedger의 open-row dedupe를 그대로 사용한다. 새
+테이블은 여러 owner-event batch가 workorder 하나를 공유할 때 필요한 many-to-one receipt 관계만
+보관한다.
+
+`BoardRefreshGate`는 full-repair coordination을 위해 항상 생성한다. 기존
+`MAMA_BOARD_RECONCILE=1`은 connector delta reconcile scheduler만 제어하고, owner-event coalescing이나
+scheduled full repair의 안전성을 끄지 않는다.
+
 operator DB에 additive 테이블 `owner_event_board_refresh_intents`를 추가한다.
 
 | 열                         | 의미                                                 |
@@ -163,38 +176,51 @@ operator DB에 additive 테이블 `owner_event_board_refresh_intents`를 추가�
 | `batch_id` PK/FK           | owner-event batch와 1:1                              |
 | `batch_key` UNIQUE         | 기존 event ID 정렬 해시로 만든 retry-stable identity |
 | `repair_generation`        | 해당 요청이 더럽힌 Board generation                  |
-| `status`                   | `accepted`, `attached`, `applied`, `failed`          |
-| `workorder_id` nullable    | 실제 수리에 연결된 workorder                         |
-| `last_error` nullable      | bounded operator 진단 문자열                         |
+| `workorder_id` FK          | 실제 수리에 연결된 workorder                         |
+| `applied_at` nullable      | verified repair가 해당 generation을 처리한 시각      |
 | `created_at`, `updated_at` | 복구와 retention 기준                                |
+
+`applied_at IS NULL` 행만 `(repair_generation, batch_id)`로 찾는 partial index를 둔다. owner-event
+inbox가 삭제될 때 intent도 `ON DELETE CASCADE`로 삭제한다. `TaskLedger`가 같은 DB connection에서 이미
+`foreign_keys = ON`을 설정하므로 별도 cleanup timer나 두 번째 retention 정책은 만들지 않는다.
 
 트랜잭션 순서:
 
-1. `batch_id`로 intent를 `INSERT OR IGNORE`한다.
-2. Board gate를 dirty로 만들고 generation을 intent에 고정한다.
-3. 기존의 열린 non-force Board repair가 있으면 intent를 그 workorder에 `attached`한다.
-4. 없으면 공용 `boardRepairKey()`로 `mode: 'full', force: false` 작업 하나를 enqueue하고 연결한다.
-5. durable intent가 최소 `accepted` 상태가 된 뒤에만 `workorder_request` 성공을 반환한다.
+1. DB transaction 전에 Board gate를 dirty로 만든다. 이후 DB가 실패해도 안전한 extra repair만 남고
+   work loss는 생기지 않는다.
+2. 같은 operator DB transaction 안에서 `batch_id` intent를 조회한다. 이미 있으면 같은 durable
+   acceptance를 반환한다.
+3. 새 batch라면 기존의 열린 non-force Board repair를 찾고, 없으면 공용 `boardRepairKey()`로
+   `mode: 'full', force: false` 작업 하나를 enqueue한다.
+4. 선택된 workorder ID와 generation을 가진 intent를 삽입한다.
+5. intent와 workorder가 함께 commit된 뒤에만 `workorder_request` 성공을 반환한다.
 
 동일 batch retry는 같은 intent를 읽는다. 새 batch가 활성 수리 중 도착하면 그 수리에 연결하되 새
-generation은 남긴다. 여기서 `attached`는 “요청이 수리 coordinator에 접수됐다”는 뜻이지 현재
+generation은 남긴다. 여기서 workorder 연결은 “요청이 수리 coordinator에 접수됐다”는 뜻이지 현재
 attempt가 그 generation까지 처리했다는 뜻이 아니다. 활성 수리가 자기 captured generation까지만
 지우므로, 이후 generation이 남으면 완료 hook이 기존 terminal row가 공용 key를 놓은 뒤 후속 수리를
 하나 enqueue하고 아직 적용되지 않은 intent를 새 workorder에 다시 연결한다. 결과적으로 burst는
-`1 open repair + 1 durable follow-up obligation`으로 수렴한다.
+`1 open repair + 1 durable follow-up obligation`으로 수렴한다. 별도 `status` state machine은 만들지
+않는다. `applied_at IS NULL`이 유일한 미적용 상태다.
 
 #### 완료와 ACK
 
 - owner-event terminal receipt는 더 이상 Board task의 exact occurrence key만 찾지 않는다.
-- 해당 `batch_id`의 intent가 `accepted` 이상이고 연결된 workorder가 존재하면 `delegated` receipt를
-  반환한다. 이는 기존 `accepted workorder` 의미를 유지한다. Board 수리 완료를 기다려 owner-event
-  inbox를 붙잡는 계약으로 바꾸지 않는다.
-- workorder 완료 hook은 captured generation 이하 intent를 `applied`로 전환한다.
+- 해당 `batch_id` intent와 연결된 workorder가 존재하면 `delegated` receipt를 반환한다. 이는 기존
+  `accepted workorder` 의미를 유지한다. Board 수리 완료를 기다려 owner-event inbox를 붙잡는 계약으로
+  바꾸지 않는다.
+- verified workorder hook만 captured generation 이하 intent에 `applied_at`을 기록한다.
+- verified hook 뒤에 더 높은 미적용 generation이 남으면 현재 workorder ID를 run-local follow-up set에
+  넣는다. WorkOrderConsumer가 그 row를 terminal로 commit한 뒤 내보내는 기존 `onEvent(complete)`가 set을
+  consume해 non-force repair를 즉시 요청한다. 이 요청은 accepted intent가 있으므로 delta-skip을
+  우회하지만 `force: true`가 아니며, exact no-update receipt로 안전하게 끝날 수 있다.
+- unverified completion과 failed/exhausted event는 즉시 follow-up을 만들지 않는다. dirt와 intent를
+  유지하고 기존 scheduled self-heal과 경보를 사용해 hot loop를 막는다.
 - 수리 실패는 intent를 삭제하지 않는다. gate dirt와 intent를 남기고 기존 Board 경보/자기회복
   경로가 후속 수리를 맡는다.
-- boot recovery는 `accepted/attached` intent의 최대 generation보다 큰 값으로 Board gate를
-  초기화하고 boot-dirty full repair 하나에 미적용 intent를 다시 연결한다. 메모리 gate만 보고 수리
-  완료를 추정하지 않는다.
+- boot recovery는 미적용 intent의 최대 generation보다 큰 값으로 Board gate를 초기화하고 boot-dirty
+  full repair 하나에 미적용 intent를 다시 연결한다. verified hook 이후 process death가 나도 다음 boot가
+  같은 의무를 복구한다. 메모리 gate만 보고 수리 완료를 추정하지 않는다.
 - `owner_event_inbox` 삭제 시 intent도 FK/trigger로 정리한다. ACK된 inbox의 기존 retention과 같은
   수명을 따르며, durable receipt가 필요한 동안 먼저 삭제하지 않는다.
 
@@ -218,7 +244,8 @@ connector를 직접 만들면 executor가 `memory_scope_out_of_scope`, `connecto
 
 #### 변경
 
-1. canonical tool registry와 HostBridge가 동일한 `context_compile` 설명을 생성한다.
+1. 작은 shared contract constant에서 canonical tool registry와 HostBridge가 동일한
+   `context_compile` 설명을 읽는다. 문구를 두 파일에 복사하지 않는다.
 2. Temporal managed brief는 다음 계약을 명시한다.
    - `scopes`, `connectors`를 모델이 공급하지 않는다.
    - host-bound execution context가 현재 generation의 project, connector, memory grant를 적용한다.
@@ -246,12 +273,13 @@ sandbox console, 코드 문자열은 분류 권위가 아니다.
 
 ```text
 fingerprint = sha256(
-  outerTool + nestedTool + normalizedFailureCode + authorityBoundary
+  ordered(failedNestedTool + normalizedFailureCode)
 )
 ```
 
-`authorityBoundary`는 scope/destination/principal 계열을 구분하지만 실제 ID나 민감한 입력은 포함하지
-않는다. 오류 메시지 전체를 hash하지 않아 숫자·정렬·표현 차이로 회피되지 않게 한다.
+fingerprint는 기존 trusted `hostToolExecutions`의 실패한 `{name, code}`만 사용한다. principal, scope,
+destination ID 또는 오류 메시지 전체를 새 audit surface에 추가하지 않는다. 동일 run 안에서만 비교하므로
+권한 identity를 fingerprint에 중복 포함할 필요가 없다.
 
 결정적 오류 집합은 명시적 allowlist로 시작한다.
 
@@ -267,14 +295,19 @@ committed-after-abort, missing result는 기존 구조적 비재시도 정책을
 
 #### 차단 규칙
 
+- `RunScope`에 Temporal run 전용 `codeActCalls`, `lastDeterministicFingerprint`,
+  `consecutiveDeterministicFailures`만 추가한다. AgentLoop instance state나 session state에 저장하지
+  않는다.
 - 같은 Temporal run에서 같은 결정적 fingerprint가 연속 3회 나오면 즉시
-  `TOOL_CONTRACT_REPEAT`로 종료한다.
-- 추가 안전망으로 Temporal run의 outer Code-Act 호출은 최대 8회다. 일반 owner turn과 다른 lane은
-  기존 50-call ceiling을 유지한다.
+  `TOOL_CONTRACT_REPEAT`로 종료한다. 성공하거나 다른 fingerprint가 나오면 연속 카운터를 reset한다.
+- 추가 안전망으로 Temporal run의 outer Code-Act 호출은 실행 전 최대 8회다. 일반 owner turn과 다른
+  lane은 기존 50-call ceiling을 유지한다.
 - 종료 결과는 `retryable: false`, `failureClass: 'deterministic_contract'`, fingerprint의 짧은
   비민감 prefix를 갖는다.
-- WorkOrderConsumer는 trusted structured result만 보고 `allowRetry: false`로 generation을 실패
-  처리한다. 응답 prose에서 “재시도하지 마라”를 파싱하지 않는다.
+- `TOOL_CONTRACT_REPEAT`를 `HostToolTerminalCode`와 `AgentErrorCode`의 닫힌 vocabulary에 추가한다.
+  WorkOrderConsumer는 그 exact `AgentError.code`만 보고 `allowRetry: false`로 generation을 실패 처리한다.
+  응답 prose나 일반적인 `retryable: false`를 넓게 해석하지 않는다.
+- mutation terminal code가 있으면 circuit breaker보다 먼저 반환한다.
 - provider/transient failure는 현재 retry 정책을 유지한다.
 
 #### 패리티 영향
@@ -315,24 +348,26 @@ temporal generation claimed
 
 ## 9. 오류 처리와 복구
 
-| 실패 지점                       | 처리                                                 |
-| ------------------------------- | ---------------------------------------------------- |
-| intent INSERT 실패              | workorder 요청 실패, owner-event retry; ACK 금지     |
-| intent 저장 후 enqueue 전 crash | boot recovery가 intent로 repair를 재생성             |
-| enqueue 후 ACK 전 crash         | 동일 batch intent/workorder를 찾아 ACK; 새 작업 금지 |
-| Board 실행 중 새 event          | 새 generation 유지, 현재 완료 후 follow-up 최대 하나 |
-| Board publish 검증 실패         | dirt와 intent 유지, existing alarm/self-heal 사용    |
-| context_compile 권한 위반       | fail-closed + fingerprint 카운트                     |
-| 결정적 실패 3회                 | 비재시도 generation 실패                             |
-| provider 429/5xx                | 기존 transient retry                                 |
-| mutation outcome unknown        | 기존 no-retry receipt-first recovery 우선            |
-| daemon shutdown                 | 기존 active workorder drain/boot recovery 계약 유지  |
+| 실패 지점                         | 처리                                                   |
+| --------------------------------- | ------------------------------------------------------ |
+| intent INSERT 실패                | workorder 요청 실패, owner-event retry; ACK 금지       |
+| intent/workorder transaction 실패 | 전체 rollback, dirty gate가 다음 repair를 보장         |
+| enqueue 후 ACK 전 crash           | 동일 batch intent/workorder를 찾아 ACK; 새 작업 금지   |
+| Board 실행 중 새 event            | 새 generation 유지, 현재 완료 후 follow-up 최대 하나   |
+| Board publish 검증 실패           | dirt와 intent 유지, 즉시 loop 없이 scheduled self-heal |
+| context_compile 권한 위반         | fail-closed + fingerprint 카운트                       |
+| 결정적 실패 3회                   | 비재시도 generation 실패                               |
+| provider 429/5xx                  | 기존 transient retry                                   |
+| mutation outcome unknown          | 기존 no-retry receipt-first recovery 우선              |
+| daemon shutdown                   | 기존 active workorder drain/boot recovery 계약 유지    |
 
 ## 10. Migration과 호환성
 
 - `owner_event_board_refresh_intents`는 operator DB에 additive `CREATE TABLE IF NOT EXISTS` migration으로
   추가한다.
 - 기존 `owner_event_inbox`, `operator_tasks`, `owner_event_effects` 행은 수정하지 않는다.
+- 기존 `MAMA_BOARD_RECONCILE` 설정은 delta reconcile scheduler만 제어한다. full repair gate와
+  owner-event intent 접수는 항상 활성이다.
 - 구버전은 새 테이블을 읽지 않으므로 rollback-safe다. 단, 새 버전이 만든 non-force repair는 기존
   Board payload schema와 호환되어야 한다.
 - migration 실패 시 daemon은 owner-event 처리를 시작하지 않고 fail loudly 한다. 메모리-only
@@ -347,12 +382,16 @@ temporal generation claimed
 ### A1 Board/receipt
 
 1. `TG-06`: 동일 owner-event batch retry가 intent와 workorder 하나만 만든다.
-2. `TG-06`: 서로 다른 20개 batch burst가 open repair 하나에 attach되고 follow-up은 최대 하나다.
+2. `TG-06`: 서로 다른 20개 batch burst가 open repair 하나에 연결되고 durable follow-up obligation은
+   최대 하나다.
 3. `TG-06`: enqueue 후 ACK 전 crash가 새 workorder 없이 durable acceptance를 복구한다.
 4. `TG-06`: 새 generation은 오래된 repair 완료로 지워지지 않는다.
 5. `TG-06`: prose-only 또는 intent 없는 성공은 ACK되지 않는다.
 6. `TG-03/TG-04`: owner manual Board 요청은 여전히 `force: true`; owner-event는 `force: false`다.
-7. migration I/O 실패는 fail-closed하고 기존 DB bytes를 보존한다.
+7. verified completion만 terminal 이후 immediate follow-up을 만들고, unverified/failed completion은 hot
+   loop를 만들지 않는다.
+8. `MAMA_BOARD_RECONCILE`이 꺼져도 owner-event coalescing과 scheduled full gate는 유지된다.
+9. migration I/O 실패는 fail-closed하고 기존 DB bytes를 보존한다.
 
 ### A2 Temporal context
 
@@ -382,24 +421,27 @@ temporal generation claimed
 
 ## 12. 출시와 운영 검증
 
-### 단계 1 — shadow 계측
+### 단계 1 — 릴리즈 내 계측
 
-한 릴리스 동안 기존 동작을 바꾸지 않고 다음 counter를 추가한다.
+별도 shadow 릴리스를 만들지 않는다. 이미 확보한 운영 기준선을 before 값으로 고정한다. 새 append-only
+telemetry table도 만들지 않고 durable intent, 기존 `operator_tasks`, `agent_activity`, `model_runs`, Codex
+rollout에서 아래 값을 계산한다. 코드에 새로 필요한 것은 기존 metric sink의 breaker termination counter
+하나다.
 
-- owner-event Board intents accepted/attached/applied/failed
+- owner-event Board intents accepted/applied/pending
 - Board repair open/follow-up/coalesced batch 수
 - Temporal deterministic fingerprint count와 breaker termination
 - workorder별 model runs, tokens, duration, retry class
 
 민감한 event ID, connector payload, chat ID, scope ID는 로그에 기록하지 않는다.
 
-### 단계 2 — Slice A 활성화
+### 단계 2 — PR-A/PR-B 머지 후 Slice A 활성화
 
 - 기능 플래그는 rollback용으로만 두며 기본값은 새 경로다.
 - old path를 fallback으로 호출하지 않는다. 새 durable path가 실패하면 fail loudly 한다.
 - build/install/restart는 별도 단계로 구분하고 launchd 단일 인스턴스를 확인한다.
 
-### 단계 3 — 24시간 canary
+### 단계 3 — 단일 릴리즈와 24시간 canary
 
 UI나 synthetic connector event를 사용하지 않는다. 실제 운영 이벤트와 로컬 DB/rollout/receipt/log만
 읽는다.
@@ -473,3 +515,168 @@ Slice C는 다음을 별도 설계한다.
 이 문서 승인 후에만 `Slice A` 구현 계획을 작성한다. 구현 계획은 파일·테스트·migration 순서를
 구체화하고, RED→GREEN 단위로 나눈다. Slice B와 Slice C는 Slice A의 24시간 canary 결과와 무관하게
 각각 별도 설계 승인 게이트를 거친다.
+
+## 17. What already exists
+
+| 문제                            | 기존 권위/코드                                       | 재사용 결정                       |
+| ------------------------------- | ---------------------------------------------------- | --------------------------------- |
+| full Board dirt와 generation    | `BoardRefreshGate`                                   | 항상 생성하고 그대로 사용         |
+| 열린 full repair dedupe         | `boardRepairKey()` + TaskLedger partial unique index | 새 queue를 만들지 않음            |
+| workorder durable acceptance    | `operator_tasks`                                     | 실제 repair row 권위 유지         |
+| owner-event batch 수명주기      | `OwnerEventInbox`                                    | intent FK/retention의 부모로 사용 |
+| owner-event terminal recovery   | `getTerminalReceipt()`                               | exact batch intent lookup을 추가  |
+| Board effect verification       | `applyBoardRefreshVerdict()`                         | verified generation만 적용 처리   |
+| Temporal envelope defaults      | `ContextCompileService.coerceCompileInput()`         | 실행 의미 변경 없이 설명만 정합화 |
+| trusted nested tool audit       | `hostToolExecutions`                                 | fingerprint의 유일한 입력         |
+| run-local concurrency isolation | `RunScope`                                           | breaker counter를 여기에만 저장   |
+| Temporal retry suppression      | `failTemporalWorkOrder(..., allowRetry)`             | exact terminal code만 연결        |
+| backend terminal propagation    | `HostToolTerminalCode` → `AgentErrorCode`            | 닫힌 vocabulary 확장              |
+
+새 queue, 새 worker, 새 model session, 새 외부 서비스는 필요 없다. 새 stateful class는
+`OwnerEventBoardRefreshLedger` 하나다. Temporal breaker는 `RunScope`와 pure helper로 구현한다.
+
+## 18. Code path and user-flow coverage plan
+
+```text
+PR-A: OWNER-EVENT BOARD
+=======================
+workorder_request(board)
+  ├─ owner_manual
+  │   └─ [★★★ EXISTING+REGRESSION] force:true, unique manual key
+  └─ owner_event
+      ├─ [★★★ NEW] same batch already linked → same durable receipt
+      ├─ [★★★ NEW] no open repair → dirty → atomic intent+repair insert
+      ├─ [★★★ NEW] open repair → dirty → atomic intent attach
+      └─ [★★★ NEW] transaction error → no ACK, dirty remains safe
+
+verified Board completion
+  ├─ [★★★ NEW] no newer generation → apply intents, no follow-up
+  ├─ [★★★ NEW] newer generation → terminal commit → one immediate follow-up
+  ├─ [★★★ NEW] process dies before follow-up → boot repair recovers pending intent
+  └─ [★★★ NEW] unverified/failed → no immediate hot loop, scheduled self-heal
+
+owner-event recovery
+  ├─ [★★★ NEW] enqueue committed, ACK missing → intent receipt ACKs without model
+  ├─ [★★★ NEW] prose only / missing intent → retry
+  └─ [★★★ NEW] inbox retention deletes intent through FK cascade
+
+configuration
+  ├─ [★★★ NEW] MAMA_BOARD_RECONCILE=1 → delta reconcile + full gate
+  └─ [★★★ NEW] MAMA_BOARD_RECONCILE off → no delta reconcile, full gate still active
+
+PR-B: TEMPORAL
+==============
+context_compile projection
+  ├─ [★★★ NEW] registry + HostBridge use one description constant
+  ├─ [★★★ NEW] Temporal brief requires omitted scopes/connectors
+  ├─ [★★★ EXISTING+REGRESSION] omitted fields use trusted envelope
+  └─ [★★★ EXISTING+REGRESSION] explicit widening remains denied
+
+outer Code-Act call
+  ├─ non-Temporal → [★★★ REGRESSION] existing 50-call behavior unchanged
+  └─ Temporal
+      ├─ [★★★ NEW] call 1..8 counted before execution
+      ├─ [★★★ NEW] successful/different result resets consecutive fingerprint
+      ├─ [★★★ NEW] same deterministic {tool,code} x3 → TOOL_CONTRACT_REPEAT
+      ├─ [★★★ NEW] call 9 attempted → TOOL_CONTRACT_REPEAT before host execution
+      ├─ [★★★ NEW] provider/transport/no-code failure → not fingerprinted
+      ├─ [★★★ NEW] mutation terminal result → existing terminal code wins
+      └─ [★★★ NEW] concurrent/next run → independent zeroed RunScope
+
+terminal propagation [→EVAL: real Temporal canary]
+  ├─ [★★★ NEW] Claude parsed tool path preserves exact code
+  ├─ [★★★ NEW] Codex native host bridge preserves exact code
+  ├─ [★★★ NEW] Cline custom tool path preserves exact code
+  └─ [★★★ NEW] WorkOrderConsumer suppresses only TOOL_CONTRACT_REPEAT retry
+```
+
+모든 새 branch는 RED 테스트를 먼저 작성한다. prompt 품질의 최종 eval은 synthetic connector traffic이
+아니라 실제 Temporal generation이 `context_compile → task_temporal_reconcile receipt`를 완주하는
+24시간 canary다.
+
+## 19. Production failure modes
+
+| 실패                                    | 방어                             | 테스트                            | 사용자/운영자 표면               |
+| --------------------------------------- | -------------------------------- | --------------------------------- | -------------------------------- |
+| intent insert와 task enqueue 사이 crash | 같은 SQLite transaction          | crash-boundary integration        | batch 재시도, silent ACK 없음    |
+| gate dirty 후 DB rollback               | safe extra dirt                  | transaction failure unit          | 다음 scheduled repair, error log |
+| 여러 batch 동시 접수                    | single writer + unique batch/key | duplicate/concurrency integration | workorder 한 개                  |
+| verified hook 뒤 terminal 전 crash      | 미적용 intent boot scan          | boot recovery integration         | 다음 boot repair                 |
+| verified terminal 뒤 nudge 전 crash     | boot-dirty + pending intent      | boot recovery integration         | 다음 boot repair                 |
+| unverified Board가 즉시 반복            | verified-only follow-up signal   | unverified completion regression  | 기존 경보, scheduled retry       |
+| flag off에서 coalescing 비활성          | gate unconditional               | config matrix                     | 동일 owner-event 계약            |
+| model이 failure audit를 위조            | executor-returned audit만 사용   | forged prose/result regression    | 위조는 breaker 권위 없음         |
+| mutation과 contract failure가 함께 존재 | mutation terminal 우선           | precedence regression             | receipt-first no-retry           |
+| provider outage를 결정적 오류로 오분류  | closed code allowlist            | 429/5xx/transport matrix          | 기존 backoff/retry               |
+| breaker state가 다른 run에 누출         | RunScope local state             | concurrent-run regression         | 정상 owner/chat 영향 없음        |
+| backend가 terminal code를 잃음          | closed transport vocabulary      | Claude/Codex/Cline matrix         | workorder 1회 실패, 재실행 없음  |
+
+테스트와 오류 처리가 모두 없는 silent failure는 설계상 0개다.
+
+## 20. Performance review
+
+- owner-event마다 작은 intent row 한 개가 추가되지만 기존 7일 inbox retention과 함께 삭제된다.
+- 미적용 scan은 partial index만 읽는다. 전체 acked history scan은 없다.
+- 첫/중복 접수는 같은 SQLite connection의 짧은 write transaction 하나다. 모델 실행 시간과 비교하면
+  미미하며, 외부 I/O를 transaction 안에서 수행하지 않는다.
+- fingerprint는 최대 8회, 작은 `{name, code}` 배열만 hash한다. payload나 connector text를 hash하지
+  않는다.
+- 새 append-only telemetry row를 만들지 않는다. canary는 durable intent와 기존 운영 기록을 집계한다.
+- 기대 효과는 기준선 owner-event Board 7,204,986 tokens와 Temporal 5,179,840 tokens의 반복 부분을
+  직접 줄이는 것이다. 로컬 검증 마이크로초 경로는 그대로다.
+
+## 21. NOT in scope
+
+- Slice B 감사 데이터 삭제/압축: retention 권위와 backup 정책을 별도 승인해야 한다.
+- Slice C daemon 로그 회전: launchd open-file lifecycle을 별도 검증해야 한다.
+- 전역 reasoning effort 변경: 원인 제어가 아니라 품질/비용 정책 변경이다.
+- owner-event AgentLoop 호출 자체 제거: 이벤트의 의미 판단은 MAMA의 일이다.
+- Board 내부 tool sequence 하드코딩: TG-03/TG-04 agent freedom을 위반한다.
+- Telegram/브라우저 synthetic canary: 실제 이벤트가 없으면 완료를 보류한다.
+- 기존 대형 파일 일반 리팩터링: 이번 변경에 필요한 seam만 추출한다.
+
+Slice B와 C는 본 문서에 이미 이유·범위·승인 게이트가 있어 `TODOS.md`에 중복 항목을 추가하지 않는다.
+
+## 22. Implementation and PR structure
+
+| 단계                           | 모듈                              | 의존성                                 |
+| ------------------------------ | --------------------------------- | -------------------------------------- |
+| PR-A intent ledger             | `operator/`                       | 기존 inbox/task ledger/gate            |
+| PR-A wiring and recovery       | `cli/`, `operator/`               | PR-A intent ledger                     |
+| PR-A focused/full verification | `tests/operator/`, `tests/cli/`   | PR-A 구현                              |
+| PR-B context contract          | `agent/`, `operator/`             | PR-A 머지 후 최신 main                 |
+| PR-B circuit breaker           | `agent/`, `operator/`             | PR-B context contract와 병렬 작성 가능 |
+| PR-B focused/full verification | `tests/agent/`, `tests/operator/` | PR-B 구현                              |
+| release/canary                 | release + local runtime           | PR-A와 PR-B 머지                       |
+
+기술적으로 PR-A와 PR-B 구현은 병렬 가능하지만, 본 작업은 순차 진행한다. 두 PR 모두 패리티 문서를
+수정하고 최종 릴리즈가 하나이므로, PR-A의 실제 review 결과를 PR-B 계획에 반영하는 편이 merge conflict와
+동일한 실수를 줄인다.
+
+## 23. Eng review completion summary
+
+- Step 0 Scope Challenge: 두 PR, 한 릴리즈로 scope 분리
+- Architecture Review: 4 issues found, 4 resolved
+- Code Quality Review: 3 issues found, 3 resolved
+- Test Review: coverage diagram produced, 30개 path를 RED/regression test requirement로 반영
+- Performance Review: 2 issues found, 2 resolved
+- NOT in scope: 작성 완료
+- What already exists: 작성 완료
+- TODOS.md updates: 0, 기존 설계와 중복이라 추가하지 않음
+- Failure modes: 12개 검토, critical silent gap 0
+- Outside voice: skipped, 별도 agent 요청 없음
+- Parallelization: 2개 구현 lane을 의도적으로 순차 실행
+- Lake Score: 9/9 교정에서 complete option 선택
+
+## GSTACK REVIEW REPORT
+
+| Review        | Trigger               | Why                             | Runs | Status       | Findings                                  |
+| ------------- | --------------------- | ------------------------------- | ---: | ------------ | ----------------------------------------- |
+| CEO Review    | `/plan-ceo-review`    | Scope & strategy                |    0 | —            | Backend cost-control change라 생략        |
+| Codex Review  | `/codex review`       | Independent 2nd opinion         |    0 | —            | Nested Codex 금지, 별도 agent 요청 없음   |
+| Eng Review    | `/plan-eng-review`    | Architecture & tests (required) |    1 | CLEAR (PLAN) | 39 issues/paths reviewed, 0 critical gaps |
+| Design Review | `/plan-design-review` | UI/UX gaps                      |    0 | —            | UI 변경 없음                              |
+| DX Review     | `/plan-devex-review`  | Developer experience gaps       |    0 | —            | 공개 API/SDK 변경 없음                    |
+
+- **UNRESOLVED:** 0
+- **VERDICT:** ENG CLEARED, ready to write the implementation plan.

--- a/docs/development/runtime-overhead-reduction-design.md
+++ b/docs/development/runtime-overhead-reduction-design.md
@@ -437,8 +437,9 @@ rollout에서 아래 값을 계산한다. 코드에 새로 필요한 것은 기�
 
 ### 단계 2 — PR-A/PR-B 머지 후 Slice A 활성화
 
-- 기능 플래그는 rollback용으로만 두며 기본값은 새 경로다.
 - old path를 fallback으로 호출하지 않는다. 새 durable path가 실패하면 fail loudly 한다.
+- rollback은 이전 패키지로 재설치하고 launchd를 재시작한다. schema는 additive이고 구버전이 새 테이블을
+  읽지 않으므로 별도 장기 기능 플래그를 유지하지 않는다.
 - build/install/restart는 별도 단계로 구분하고 launchd 단일 인스턴스를 확인한다.
 
 ### 단계 3 — 단일 릴리즈와 24시간 canary

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,9 +157,9 @@ _Contributing, testing, and development guidelines_
 
 ---
 
-**Status:** MAMA OS v0.37.0 — Claude CLI, Codex app-server, and Cline Hub are equivalent supported
+**Status:** MAMA OS v0.38.0 — Claude CLI, Codex app-server, and Cline Hub are equivalent supported
 backends with backend-owned durable context, role-scoped Code-Act projection, bounded recovery,
 and explicit non-replayable mutation outcomes. MAMA itself owns connector-event work as
 stateless fresh runs per batch on durable per-channel lane keys; configured private connectors
 remain installation-local and are never promoted into generic catalogs or prompts.
-**Last Updated:** 2026-08-19
+**Last Updated:** 2026-08-26

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -70,6 +70,7 @@ import type {
   ExternalBindingToolInput,
   ExternalLifecycleReconcileToolInput,
   PrincipalRepository,
+  WorkOrderRequestOrigin,
 } from './types.js';
 import { asUntrustedDriveEvidence, DriveToolService } from './drive-tools.js';
 import { ImageTranslationToolService } from './image-translation-tools.js';
@@ -662,7 +663,7 @@ export class GatewayToolExecutor {
   private workOrderRequestHandler:
     | ((
         kind: 'board' | 'wiki' | 'memory-curation',
-        causeEventIds?: readonly string[]
+        origin: WorkOrderRequestOrigin
       ) => { accepted: boolean; reason?: string })
     | null = null;
   private reportReader: (() => Record<string, { html: string; updatedAt?: string | null }>) | null =
@@ -884,7 +885,7 @@ export class GatewayToolExecutor {
   setWorkOrderRequestHandler(
     fn: (
       kind: 'board' | 'wiki' | 'memory-curation',
-      causeEventIds?: readonly string[]
+      origin: WorkOrderRequestOrigin
     ) => { accepted: boolean; reason?: string }
   ): void {
     this.workOrderRequestHandler = fn;
@@ -2666,12 +2667,30 @@ export class GatewayToolExecutor {
             };
           }
           // The batch rides from HOST execution state, never from tool input -
-          // an agent-supplied cause is forgeable (S2 review #14). Conductor
-          // runs carry their inbox batch here; chat runs carry nothing.
-          const enqueued = this.workOrderRequestHandler(
-            requestedKind,
-            this.getExecutionState().causeEventIds
-          );
+          // an agent-supplied cause is forgeable (S2 review #14).
+          const state = this.getExecutionState();
+          let origin: WorkOrderRequestOrigin;
+          if (state.source === 'owner-event') {
+            const batchId = state.ownerEventEffects?.batchId;
+            const eventIds = state.causeEventIds;
+            if (
+              !Number.isSafeInteger(batchId) ||
+              Number(batchId) <= 0 ||
+              !Array.isArray(eventIds) ||
+              eventIds.length === 0 ||
+              eventIds.some((eventId) => typeof eventId !== 'string' || eventId.trim().length === 0)
+            ) {
+              return {
+                success: false,
+                code: 'workorder_owner_event_authority_missing',
+                error: 'Owner-event workorder request requires host-issued batch authority.',
+              };
+            }
+            origin = { kind: 'owner_event', batchId: Number(batchId), eventIds };
+          } else {
+            origin = { kind: 'owner_manual' };
+          }
+          const enqueued = this.workOrderRequestHandler(requestedKind, origin);
           if (!enqueued.accepted) {
             return {
               success: false,

--- a/packages/standalone/src/agent/types.ts
+++ b/packages/standalone/src/agent/types.ts
@@ -176,6 +176,11 @@ export interface OwnerEventEffectAuthority {
   }>;
 }
 
+/** Host-derived origin for an owner workorder request; never accepted from model input. */
+export type WorkOrderRequestOrigin =
+  | { kind: 'owner_manual' }
+  | { kind: 'owner_event'; batchId: number; eventIds: readonly string[] };
+
 export type GatewayToolExecutionContext = {
   agentContext?: AgentContext;
   agentId?: string;

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -1658,6 +1658,9 @@ export async function runAgentLoop(
   // Durable MAMA owner-event journal. It uses new tables rather than replaying
   // the legacy default-off Conductor shadow backlog on cutover.
   const ownerEventInbox = new OwnerEventInbox(operatorDb);
+  const ownerEventBoardRefreshLedgerRef: { current: OwnerEventBoardRefreshLedger | null } = {
+    current: null,
+  };
   const ownerEventEffectLedger = new OwnerEventEffectLedger(operatorDb);
   toolExecutor.setOwnerEventEffectLedger(ownerEventEffectLedger);
   let stopOwnerEventRuntime: (() => Promise<void>) | null = null;
@@ -1707,6 +1710,7 @@ export async function runAgentLoop(
   resolveWorkerRequestTimeoutMs();
   let workOrderConsumer: import('../../operator/workorder-consumer.js').WorkOrderConsumer | null =
     null;
+  const boardRepairNudge: { current: (() => void) | null } = { current: null };
   let temporalRuntime: TemporalRuntime | null = null;
 
   gateways.push({
@@ -1895,6 +1899,13 @@ export async function runAgentLoop(
         } catch {
           /* telemetry only */
         }
+        if (
+          event.type === 'complete' &&
+          event.workKind === 'board' &&
+          ownerEventBoardRefreshLedgerRef.current?.consumePostTerminalFollowup(event.workOrderId)
+        ) {
+          boardRepairNudge.current?.();
+        }
       },
     });
     // (Consumer stop is folded into the operator-DB gateway above - ordering.)
@@ -1902,7 +1913,13 @@ export async function runAgentLoop(
     // Owner-issued workorders (workorder_request tool): enqueue+ack only.
     // Wired here - NOT inside any trigger-loop block (plan C11 class).
     toolExecutor.setWorkOrderRequestHandler(
-      buildOwnerWorkOrderRequestHandler({ taskLedger, boardRefreshGate })
+      buildOwnerWorkOrderRequestHandler({
+        taskLedger,
+        boardRefreshGate,
+        ...(ownerEventBoardRefreshLedgerRef.current
+          ? { ownerEventBoardRefreshLedger: ownerEventBoardRefreshLedgerRef.current }
+          : {}),
+      })
     );
   }
   const temporalTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -2400,7 +2417,11 @@ export async function runAgentLoop(
     sessionsDb: db,
     workOrderConsumer: workOrderConsumer ?? undefined,
     boardRefreshGate,
+    ...(ownerEventBoardRefreshLedgerRef.current
+      ? { ownerEventBoardRefreshLedger: ownerEventBoardRefreshLedgerRef.current }
+      : {}),
   });
+  boardRepairNudge.current = apiRoutesHandle.requestBoardRepair;
   gateways.push({ stop: async () => apiRoutesHandle.stop() });
 
   // ── Stage-2 boot pass (plan S2-T3): runtime assembly registered hooks;

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -26,6 +26,7 @@ import type {
   AgentContext,
   GatewayToolExecutionContext,
   PrincipalRepository,
+  WorkOrderRequestOrigin,
 } from '../../agent/types.js';
 import { ToolRegistry } from '../../agent/tool-registry.js';
 import { PromptEnhancer } from '../../agent/prompt-enhancer.js';
@@ -121,6 +122,7 @@ import {
 } from '../../operator/workorder-publishers.js';
 import { OwnerEventInbox } from '../../operator/owner-event-inbox.js';
 import { OwnerEventEffectLedger } from '../../operator/owner-event-effects.js';
+import { OwnerEventBoardRefreshLedger } from '../../operator/owner-event-board-refresh.js';
 import { OwnerEventLoop, closeOwnerEventBeforeDatabase } from '../../operator/owner-event-loop.js';
 import { buildOwnerEventPrompt } from '../../operator/owner-event-prompt.js';
 import {
@@ -853,6 +855,7 @@ const OWNER_BOARD_FULL_REPAIR_CHANNEL = 'host:owner-workorder:board-full';
 export interface OwnerWorkOrderRequestHandlerDeps {
   taskLedger: TaskLedger;
   boardRefreshGate: BoardRefreshGate | null;
+  ownerEventBoardRefreshLedger?: OwnerEventBoardRefreshLedger;
   now?: () => number;
   log?: (line: string) => void;
   logError?: (line: string, detail: unknown) => void;
@@ -863,51 +866,58 @@ export function buildOwnerWorkOrderRequestHandler(
   deps: OwnerWorkOrderRequestHandlerDeps
 ): (
   kind: 'board' | 'wiki' | 'memory-curation',
-  causeEventIds?: readonly string[]
+  origin?: WorkOrderRequestOrigin
 ) => { accepted: boolean; reason?: string } {
   const now = deps.now ?? Date.now;
   const log = deps.log ?? ((line: string) => ownerWorkOrderLogger.info(line));
   const logError =
     deps.logError ?? ((line: string, detail: unknown) => ownerWorkOrderLogger.error(line, detail));
 
-  return (kind, causeEventIds) => {
+  return (kind, origin = { kind: 'owner_manual' }) => {
     try {
       const requestedAt = now();
       let idempotencyKey: string;
       let payload: Record<string, unknown>;
       if (kind === 'board') {
+        if (!deps.boardRefreshGate) {
+          throw new Error('Board refresh gate is unavailable');
+        }
+        if (origin.kind === 'owner_event') {
+          if (!deps.ownerEventBoardRefreshLedger) {
+            throw new Error('Owner-event Board refresh ledger is unavailable');
+          }
+          const existing = deps.ownerEventBoardRefreshLedger.findAcceptance(origin.batchId);
+          if (existing) {
+            log(`[stage2] owner workorder already accepted: board#${existing.workOrderId}`);
+            return { accepted: true };
+          }
+          deps.boardRefreshGate.markChannelDirty(OWNER_BOARD_FULL_REPAIR_CHANNEL);
+          const accepted = deps.ownerEventBoardRefreshLedger.accept({
+            batchId: origin.batchId,
+            eventIds: origin.eventIds,
+            repair: deps.boardRefreshGate.captureFullRepair(),
+          });
+          log(`[stage2] owner workorder accepted: board#${accepted.workOrderId}`);
+          return { accepted: true };
+        }
         // TG-06: host dirt is recorded before validation or enqueue can fail.
         // The fixed synthetic channel never trusts model/event identifiers.
-        const repair = deps.boardRefreshGate
-          ? (() => {
-              deps.boardRefreshGate.markChannelDirty(OWNER_BOARD_FULL_REPAIR_CHANNEL);
-              return deps.boardRefreshGate.captureFullRepair();
-            })()
-          : null;
-        if (causeEventIds && causeEventIds.length > 0) {
-          idempotencyKey = boardBatchKey(causeEventIds);
-          payload = {
-            mode: 'full',
-            force: true,
-            eventIds: [...causeEventIds],
-            ...(repair ?? {}),
-          };
-        } else {
-          idempotencyKey = boardManualKey(requestedAt);
-          payload = { mode: 'full', force: true, ...(repair ?? {}) };
-        }
+        deps.boardRefreshGate.markChannelDirty(OWNER_BOARD_FULL_REPAIR_CHANNEL);
+        const repair = deps.boardRefreshGate.captureFullRepair();
+        idempotencyKey = boardManualKey(requestedAt);
+        payload = { mode: 'full', force: true, ...repair };
       } else if (kind === 'wiki') {
-        if (causeEventIds && causeEventIds.length > 0) {
-          idempotencyKey = ownerEventWorkOrderKey('wiki', causeEventIds);
-          payload = { batchId: idempotencyKey, events: [...causeEventIds] };
+        if (origin.kind === 'owner_event') {
+          idempotencyKey = ownerEventWorkOrderKey('wiki', origin.eventIds);
+          payload = { batchId: idempotencyKey, events: [...origin.eventIds] };
         } else {
           idempotencyKey = wikiBatchKey('manual', requestedAt);
           payload = { batchId: `${requestedAt}-manual`, events: ['manual'] };
         }
       } else {
         idempotencyKey =
-          causeEventIds && causeEventIds.length > 0
-            ? ownerEventWorkOrderKey('memory-curation', causeEventIds)
+          origin.kind === 'owner_event'
+            ? ownerEventWorkOrderKey('memory-curation', origin.eventIds)
             : promotionManualKey(requestedAt);
         payload = { scheduledAt: new Date(requestedAt).toISOString() };
       }

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -918,8 +918,6 @@ export interface OwnerWorkOrderRequestHandlerDeps {
   taskLedger: TaskLedger;
   boardRefreshGate: BoardRefreshGate | null;
   ownerEventBoardRefreshLedger?: OwnerEventBoardRefreshLedger;
-  /** Explicit per-agent config gate; an always-on repair gate is not execution authority. */
-  boardWorkOrderEnabled?: boolean;
   now?: () => number;
   log?: (line: string) => void;
   logError?: (line: string, detail: unknown) => void;
@@ -943,9 +941,6 @@ export function buildOwnerWorkOrderRequestHandler(
       let idempotencyKey: string;
       let payload: Record<string, unknown>;
       if (kind === 'board') {
-        if (deps.boardWorkOrderEnabled === false) {
-          throw new Error('Board workorder agent is disabled');
-        }
         if (!deps.boardRefreshGate) {
           throw new Error('Board refresh gate is unavailable');
         }
@@ -1730,10 +1725,6 @@ export async function runAgentLoop(
     operatorDb,
     taskLedger
   );
-  const boardWorkOrderEnabled = Boolean(
-    config.multi_agent?.agents?.['dashboard-agent'] &&
-    config.multi_agent.agents['dashboard-agent'].enabled !== false
-  );
   const ownerEventEffectLedger = new OwnerEventEffectLedger(operatorDb);
   toolExecutor.setOwnerEventEffectLedger(ownerEventEffectLedger);
   let stopOwnerEventRuntime: (() => Promise<void>) | null = null;
@@ -1990,7 +1981,6 @@ export async function runAgentLoop(
         taskLedger,
         boardRefreshGate,
         ownerEventBoardRefreshLedger,
-        boardWorkOrderEnabled,
       })
     );
   }

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -47,7 +47,7 @@ import type {
   CodeActResult,
   GraphHandlerOptions,
 } from '../../api/graph-api-types.js';
-import Database from '../../sqlite.js';
+import Database, { type SQLiteDatabase } from '../../sqlite.js';
 import { existsSync, readFileSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { minimatch } from 'minimatch';
@@ -120,9 +120,12 @@ import {
   validateWorkOrderPayload,
   wikiBatchKey,
 } from '../../operator/workorder-publishers.js';
-import { OwnerEventInbox } from '../../operator/owner-event-inbox.js';
+import { OwnerEventInbox, type OwnerEventBatch } from '../../operator/owner-event-inbox.js';
 import { OwnerEventEffectLedger } from '../../operator/owner-event-effects.js';
-import { OwnerEventBoardRefreshLedger } from '../../operator/owner-event-board-refresh.js';
+import {
+  OwnerEventBoardRefreshLedger,
+  resolveInitialBoardRepairGeneration,
+} from '../../operator/owner-event-board-refresh.js';
 import { OwnerEventLoop, closeOwnerEventBeforeDatabase } from '../../operator/owner-event-loop.js';
 import { buildOwnerEventPrompt } from '../../operator/owner-event-prompt.js';
 import {
@@ -851,6 +854,65 @@ export function buildSystemAgentProcessDefaults(config: {
 }
 
 const OWNER_BOARD_FULL_REPAIR_CHANNEL = 'host:owner-workorder:board-full';
+
+export function buildOwnerEventBoardRefreshRuntime(
+  operatorDb: SQLiteDatabase,
+  taskLedger: TaskLedger,
+  now: () => number = Date.now
+): {
+  ownerEventBoardRefreshLedger: OwnerEventBoardRefreshLedger;
+  boardRefreshGate: BoardRefreshGate;
+} {
+  const ownerEventBoardRefreshLedger = new OwnerEventBoardRefreshLedger(
+    operatorDb,
+    taskLedger,
+    now
+  );
+  const initialGeneration = resolveInitialBoardRepairGeneration(
+    now(),
+    ownerEventBoardRefreshLedger.maxPendingGeneration()
+  );
+  return {
+    ownerEventBoardRefreshLedger,
+    boardRefreshGate: new BoardRefreshGate({ initialGeneration }),
+  };
+}
+
+export function resolveOwnerEventTerminalReceipt(
+  batch: OwnerEventBatch,
+  deps: {
+    ownerEventEffectLedger: Pick<OwnerEventEffectLedger, 'confirmedKinds'>;
+    ownerEventBoardRefreshLedger: Pick<OwnerEventBoardRefreshLedger, 'findAcceptance'>;
+    taskLedger: Pick<TaskLedger, 'findWorkOrderByOccurrence' | 'maxNoUpdateId'>;
+  }
+):
+  | { status: 'acted'; tools: string[] }
+  | { status: 'delegated'; tools: ['workorder_request'] }
+  | { status: 'no_update'; tools: [] }
+  | null {
+  const confirmedEffects = deps.ownerEventEffectLedger.confirmedKinds(batch.id);
+  if (confirmedEffects.length > 0) {
+    return { status: 'acted', tools: confirmedEffects };
+  }
+  const acceptedWorkOrder =
+    deps.ownerEventBoardRefreshLedger.findAcceptance(batch.id) ??
+    deps.taskLedger.findWorkOrderByOccurrence('board', boardBatchKey(batch.eventIds)) ??
+    deps.taskLedger.findWorkOrderByOccurrence(
+      'wiki',
+      ownerEventWorkOrderKey('wiki', batch.eventIds)
+    ) ??
+    deps.taskLedger.findWorkOrderByOccurrence(
+      'memory-curation',
+      ownerEventWorkOrderKey('memory-curation', batch.eventIds)
+    );
+  if (acceptedWorkOrder) {
+    return { status: 'delegated', tools: ['workorder_request'] };
+  }
+  if (deps.taskLedger.maxNoUpdateId(`owner-event:${batch.id}`) > 0) {
+    return { status: 'no_update', tools: [] };
+  }
+  return null;
+}
 
 export interface OwnerWorkOrderRequestHandlerDeps {
   taskLedger: TaskLedger;
@@ -1652,15 +1714,17 @@ export async function runAgentLoop(
     operatorDb.close();
     throw err;
   }
-  // One host-owned gate spans owner workorder requests, route scheduling,
-  // delta ingestion, and completion verification for this boot.
-  const boardRefreshGate = process.env.MAMA_BOARD_RECONCILE === '1' ? new BoardRefreshGate() : null;
   // Durable MAMA owner-event journal. It uses new tables rather than replaying
   // the legacy default-off Conductor shadow backlog on cutover.
   const ownerEventInbox = new OwnerEventInbox(operatorDb);
-  const ownerEventBoardRefreshLedgerRef: { current: OwnerEventBoardRefreshLedger | null } = {
-    current: null,
-  };
+  // The host-owned gate is always present. MAMA_BOARD_RECONCILE controls only
+  // delta reconcile scheduling; exact owner-event Board acceptance, boot
+  // recovery, manual refresh, and full verification share this runtime in all
+  // configurations.
+  const { ownerEventBoardRefreshLedger, boardRefreshGate } = buildOwnerEventBoardRefreshRuntime(
+    operatorDb,
+    taskLedger
+  );
   const ownerEventEffectLedger = new OwnerEventEffectLedger(operatorDb);
   toolExecutor.setOwnerEventEffectLedger(ownerEventEffectLedger);
   let stopOwnerEventRuntime: (() => Promise<void>) | null = null;
@@ -1902,7 +1966,7 @@ export async function runAgentLoop(
         if (
           event.type === 'complete' &&
           event.workKind === 'board' &&
-          ownerEventBoardRefreshLedgerRef.current?.consumePostTerminalFollowup(event.workOrderId)
+          ownerEventBoardRefreshLedger.consumePostTerminalFollowup(event.workOrderId)
         ) {
           boardRepairNudge.current?.();
         }
@@ -1916,9 +1980,7 @@ export async function runAgentLoop(
       buildOwnerWorkOrderRequestHandler({
         taskLedger,
         boardRefreshGate,
-        ...(ownerEventBoardRefreshLedgerRef.current
-          ? { ownerEventBoardRefreshLedger: ownerEventBoardRefreshLedgerRef.current }
-          : {}),
+        ownerEventBoardRefreshLedger,
       })
     );
   }
@@ -2301,29 +2363,12 @@ export async function runAgentLoop(
             }),
           issueEnvelope: ownerEventIssueEnvelope,
           getNoUpdateMaxId: (scope) => taskLedger.maxNoUpdateId(scope),
-          getTerminalReceipt: (batch) => {
-            const confirmedEffects = ownerEventEffectLedger.confirmedKinds(batch.id);
-            if (confirmedEffects.length > 0) {
-              return { status: 'acted' as const, tools: confirmedEffects };
-            }
-            const acceptedWorkOrder =
-              taskLedger.findWorkOrderByOccurrence('board', boardBatchKey(batch.eventIds)) ??
-              taskLedger.findWorkOrderByOccurrence(
-                'wiki',
-                ownerEventWorkOrderKey('wiki', batch.eventIds)
-              ) ??
-              taskLedger.findWorkOrderByOccurrence(
-                'memory-curation',
-                ownerEventWorkOrderKey('memory-curation', batch.eventIds)
-              );
-            if (acceptedWorkOrder) {
-              return { status: 'delegated' as const, tools: ['workorder_request'] };
-            }
-            if (taskLedger.maxNoUpdateId(`owner-event:${batch.id}`) > 0) {
-              return { status: 'no_update' as const, tools: [] };
-            }
-            return null;
-          },
+          getTerminalReceipt: (batch) =>
+            resolveOwnerEventTerminalReceipt(batch, {
+              ownerEventEffectLedger,
+              ownerEventBoardRefreshLedger,
+              taskLedger,
+            }),
           recordTriggerOutcome: (triggerId, outcome) =>
             triggerRegistry.recordOutcome(triggerId, outcome),
           onDead: async (message) => {
@@ -2417,9 +2462,7 @@ export async function runAgentLoop(
     sessionsDb: db,
     workOrderConsumer: workOrderConsumer ?? undefined,
     boardRefreshGate,
-    ...(ownerEventBoardRefreshLedgerRef.current
-      ? { ownerEventBoardRefreshLedger: ownerEventBoardRefreshLedgerRef.current }
-      : {}),
+    ownerEventBoardRefreshLedger,
   });
   boardRepairNudge.current = apiRoutesHandle.requestBoardRepair;
   gateways.push({ stop: async () => apiRoutesHandle.stop() });

--- a/packages/standalone/src/cli/commands/start.ts
+++ b/packages/standalone/src/cli/commands/start.ts
@@ -918,6 +918,8 @@ export interface OwnerWorkOrderRequestHandlerDeps {
   taskLedger: TaskLedger;
   boardRefreshGate: BoardRefreshGate | null;
   ownerEventBoardRefreshLedger?: OwnerEventBoardRefreshLedger;
+  /** Explicit per-agent config gate; an always-on repair gate is not execution authority. */
+  boardWorkOrderEnabled?: boolean;
   now?: () => number;
   log?: (line: string) => void;
   logError?: (line: string, detail: unknown) => void;
@@ -941,6 +943,9 @@ export function buildOwnerWorkOrderRequestHandler(
       let idempotencyKey: string;
       let payload: Record<string, unknown>;
       if (kind === 'board') {
+        if (deps.boardWorkOrderEnabled === false) {
+          throw new Error('Board workorder agent is disabled');
+        }
         if (!deps.boardRefreshGate) {
           throw new Error('Board refresh gate is unavailable');
         }
@@ -1725,6 +1730,10 @@ export async function runAgentLoop(
     operatorDb,
     taskLedger
   );
+  const boardWorkOrderEnabled = Boolean(
+    config.multi_agent?.agents?.['dashboard-agent'] &&
+    config.multi_agent.agents['dashboard-agent'].enabled !== false
+  );
   const ownerEventEffectLedger = new OwnerEventEffectLedger(operatorDb);
   toolExecutor.setOwnerEventEffectLedger(ownerEventEffectLedger);
   let stopOwnerEventRuntime: (() => Promise<void>) | null = null;
@@ -1981,6 +1990,7 @@ export async function runAgentLoop(
         taskLedger,
         boardRefreshGate,
         ownerEventBoardRefreshLedger,
+        boardWorkOrderEnabled,
       })
     );
   }

--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -509,14 +509,20 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
   }
 
   if (dashboardAgentConfigured) {
-    // ── Dashboard board publisher ─────────────────────────────────────
     // Persona seeding stays: the optional legacy dashboard-agent config is
-    // still usable via multi-agent delegation; only its RUN path here was
-    // replaced by board workorders (consumer lane, brief-owned prompt).
+    // still usable via multi-agent delegation. It does not own the Stage-2
+    // Board worker runtime below.
     const { ensureDashboardPersona } = await import('../../multi-agent/dashboard-agent-persona.js');
     ensureDashboardPersona();
     routesLogger.debug('[Dashboard Agent] Persona ensured at ~/.mama/personas/dashboard.md');
+  } else {
+    routesLogger.debug(
+      '[Dashboard Agent] Optional legacy persona disabled; Stage-2 Board runtime remains enabled'
+    );
+  }
 
+  {
+    // ── Stage-2 Board publisher and verifier ───────────────────────────
     // Schedule/boot/manual all funnel here: one occurrence-keyed board
     // workorder per entry. An enqueue failure is logged loudly and the next
     // occurrence retries - there is no fallback run path.
@@ -875,8 +881,6 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
       });
       console.log('[reconcile] Board reconcile leg enabled (MAMA_BOARD_RECONCILE=1)');
     }
-  } else {
-    routesLogger.debug('[Dashboard Agent] Skipped; dashboard-agent is not configured');
   }
 
   // ── Wiki Agent ──────────────────────────────────────────────────────

--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -287,7 +287,7 @@ export interface RegisterApiRoutesParams {
   sessionsDb?: SQLiteDatabase;
   /** Stage-2 consumer: per-kind completion hooks register here (started by start.ts AFTER this returns). */
   workOrderConsumer?: WorkOrderConsumer;
-  /** Shared host-owned Board repair gate; null preserves reconcile-disabled legacy behavior. */
+  /** Shared host-owned Board repair gate. Production passes it unconditionally. */
   boardRefreshGate: BoardRefreshGate | null;
   /** Durable exact-batch intents coalesced onto shared non-force Board repairs. */
   ownerEventBoardRefreshLedger?: OwnerEventBoardRefreshLedger;

--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -296,6 +296,7 @@ export interface RegisterApiRoutesParams {
 }
 
 export interface ApiRoutesHandle {
+  readonly boardReconcileEnabled: boolean;
   requestBoardRepair(): void;
   stop(): void;
 }
@@ -326,6 +327,7 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
   let boardReconcileScheduler:
     | import('../../operator/board-reconcile.js').ReconcileScheduler
     | null = null;
+  let boardReconcileEnabled = false;
   let requestBoardRepair = (): void => {
     routesLogger.error('[stage2] Board repair nudge ignored: dashboard-agent is not configured');
   };
@@ -518,7 +520,8 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
     // Schedule/boot/manual all funnel here: one occurrence-keyed board
     // workorder per entry. An enqueue failure is logged loudly and the next
     // occurrence retries - there is no fallback run path.
-    const reconcileEnabled = boardRefreshGate !== null;
+    const reconcileEnabled = process.env.MAMA_BOARD_RECONCILE === '1';
+    boardReconcileEnabled = reconcileEnabled;
     // Evidence that a board was actually WRITTEN, not just that a run reached
     // 'done'. An unverified full run reaches 'done' too, so the delta gate
     // requires a publish at or after the baseline run's enqueue time.
@@ -623,7 +626,7 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
             ...(opts?.acceptedIntent ? { force: false } : {}),
             ...(opts?.force ? { force: true } : {}),
           },
-          opts?.force ? 'high' : undefined
+          opts?.force || opts?.acceptedIntent ? 'high' : undefined
         );
         if (acceptedIntentLedger) {
           acceptedIntentLedger.attachPendingToWorkOrder(workOrder.id);
@@ -641,7 +644,16 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
     // ONE constant feeds both the timer and the declared cadence - if they
     // drift apart the watchdog pages on a schedule nobody is running.
     const DASHBOARD_AGENT_INTERVAL_MS = 30 * 60 * 1000;
-    boardBootTimeout = setTimeout(runDashboardAgent, 10_000);
+    boardBootTimeout = setTimeout(() => {
+      if (
+        ownerEventBoardRefreshLedger &&
+        ownerEventBoardRefreshLedger.maxPendingGeneration() !== null
+      ) {
+        requestBoardRepair();
+        return;
+      }
+      runDashboardAgent();
+    }, 10_000);
     getLegCadence()?.declare('dashboard-agent', DASHBOARD_AGENT_INTERVAL_MS);
     boardInterval = setInterval(() => {
       getLegCadence()?.beat('dashboard-agent');
@@ -1938,6 +1950,7 @@ Keep the report under 2000 characters as it will be sent to Discord.`;
   console.log('✓ Viewer UI available at /viewer');
   console.log('✓ Setup wizard available at /setup');
   return {
+    boardReconcileEnabled,
     requestBoardRepair,
     stop: () => {
       if (boardBootTimeout) clearTimeout(boardBootTimeout);

--- a/packages/standalone/src/cli/runtime/api-routes-init.ts
+++ b/packages/standalone/src/cli/runtime/api-routes-init.ts
@@ -50,6 +50,7 @@ import {
   promotionManualKey,
 } from '../../operator/workorder-publishers.js';
 import type { BoardRefreshGate } from '../../operator/board-refresh-gate.js';
+import type { OwnerEventBoardRefreshLedger } from '../../operator/owner-event-board-refresh.js';
 import { REQUIRED_FULL_BOARD_SLOTS } from '../../operator/workorder-hooks.js';
 import {
   agentNoticeTerm,
@@ -58,7 +59,12 @@ import {
   evaluateBoardFullDelta,
   memoryRecencyTerm,
 } from '../../operator/board-delta-gate.js';
-import type { TaskLedger, WorkOrderKind, TaskPriority } from '../../operator/task-ledger.js';
+import type {
+  TaskLedger,
+  WorkOrderKind,
+  WorkOrderRecord,
+  TaskPriority,
+} from '../../operator/task-ledger.js';
 import type { WorkOrderConsumer } from '../../operator/workorder-consumer.js';
 import type { ExternalLifecycleCandidateSet } from '../../operator/external-lifecycle.js';
 import {
@@ -283,11 +289,14 @@ export interface RegisterApiRoutesParams {
   workOrderConsumer?: WorkOrderConsumer;
   /** Shared host-owned Board repair gate; null preserves reconcile-disabled legacy behavior. */
   boardRefreshGate: BoardRefreshGate | null;
+  /** Durable exact-batch intents coalesced onto shared non-force Board repairs. */
+  ownerEventBoardRefreshLedger?: OwnerEventBoardRefreshLedger;
   /** TG-05/TG-06: owner-report context store for the operator recovery surface. */
   reportContextStore?: import('../../gateways/telegram-report-context-store.js').TelegramReportContextStore;
 }
 
 export interface ApiRoutesHandle {
+  requestBoardRepair(): void;
   stop(): void;
 }
 
@@ -310,12 +319,16 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
     sessionsDb,
     workOrderConsumer,
     boardRefreshGate,
+    ownerEventBoardRefreshLedger,
   } = params;
   let boardBootTimeout: ReturnType<typeof setTimeout> | null = null;
   let boardInterval: ReturnType<typeof setInterval> | null = null;
   let boardReconcileScheduler:
     | import('../../operator/board-reconcile.js').ReconcileScheduler
     | null = null;
+  let requestBoardRepair = (): void => {
+    routesLogger.error('[stage2] Board repair nudge ignored: dashboard-agent is not configured');
+  };
 
   // ── Stage-2 workorder publishers ──────────────────────────────────────
   // The ONLY system run path since v0.28.0: every scheduled/boot/manual run
@@ -327,7 +340,7 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
     idempotencyKey: string,
     payload: Record<string, unknown>,
     priority?: TaskPriority
-  ): void => {
+  ): WorkOrderRecord => {
     const ledger = toolExecutor.getTaskLedger();
     if (!ledger) {
       throw new Error(`[stage2] TaskLedger unavailable - cannot enqueue ${workKind} workorder`);
@@ -335,6 +348,7 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
     validateWorkOrderPayload(workKind, payload);
     const wo = ledger.enqueueWorkOrder({ workKind, idempotencyKey, input: payload, priority });
     console.log(`[stage2] enqueued workorder ${workKind}#${wo.id} key=${idempotencyKey}`);
+    return wo;
   };
 
   // Wire EventBus to tool executor for agent_notices tool
@@ -518,9 +532,25 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
       }
       return Number.isFinite(oldest) ? oldest : 0;
     };
-    const runDashboardAgent = (opts?: { force?: boolean }): void => {
+    const runDashboardAgent = (opts?: { force?: boolean; acceptedIntent?: boolean }): void => {
       try {
-        if (!opts?.force && boardRefreshGate && !boardRefreshGate.needsFullRepair()) {
+        const acceptedIntentLedger = opts?.acceptedIntent
+          ? ownerEventBoardRefreshLedger
+          : undefined;
+        if (opts?.acceptedIntent) {
+          if (!acceptedIntentLedger || !boardRefreshGate) {
+            throw new Error('Owner-event Board repair runtime unavailable for accepted intent');
+          }
+          if (acceptedIntentLedger.maxPendingGeneration() === null) {
+            return;
+          }
+        }
+        if (
+          !opts?.force &&
+          !opts?.acceptedIntent &&
+          boardRefreshGate &&
+          !boardRefreshGate.needsFullRepair()
+        ) {
           return;
         }
         // Cheap host-side delta gate (Fix E). It runs in BOTH configs, because
@@ -565,7 +595,7 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
             `[stage2] board delta gate unavailable (${delta.warning}); enqueueing the full board anyway`
           );
         }
-        if (!opts?.force && !delta.enqueue) {
+        if (!opts?.force && !opts?.acceptedIntent && !delta.enqueue) {
           routesLogger.info(
             `[stage2] board full skipped: ${delta.reason} - nothing the board reads has moved since the last published full run`
           );
@@ -578,7 +608,7 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
         }
         const now = Date.now();
         const repair = boardRefreshGate?.captureFullRepair();
-        enqueueWorkOrderOrThrow(
+        const workOrder = enqueueWorkOrderOrThrow(
           'board',
           opts?.force
             ? boardManualKey(now)
@@ -590,10 +620,14 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
             ...(repair ?? {}),
             // Carried so this run's completion becomes the next tick's baseline.
             ...(delta.watermark === null ? {} : { deltaWatermark: delta.watermark }),
+            ...(opts?.acceptedIntent ? { force: false } : {}),
             ...(opts?.force ? { force: true } : {}),
           },
           opts?.force ? 'high' : undefined
         );
+        if (acceptedIntentLedger) {
+          acceptedIntentLedger.attachPendingToWorkOrder(workOrder.id);
+        }
       } catch (err) {
         routesLogger.error(
           '[stage2] board enqueue failed:',
@@ -601,6 +635,7 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
         );
       }
     };
+    requestBoardRepair = () => runDashboardAgent({ acceptedIntent: true });
 
     // First run after 10s (let connectors poll first), then every 30 min
     // ONE constant feeds both the timer and the declared cadence - if they
@@ -733,7 +768,13 @@ export async function registerApiRoutes(params: RegisterApiRoutesParams): Promis
                 target: isReconcile ? String(wo.payload.channelKey) : scope,
               });
             }
-            return applyBoardRefreshVerdict(wo, effectVerified, receiptVerdict, boardRefreshGate);
+            return applyBoardRefreshVerdict(
+              wo,
+              effectVerified,
+              receiptVerdict,
+              boardRefreshGate,
+              ownerEventBoardRefreshLedger
+            );
           },
         });
       }
@@ -1897,6 +1938,7 @@ Keep the report under 2000 characters as it will be sent to Discord.`;
   console.log('✓ Viewer UI available at /viewer');
   console.log('✓ Setup wizard available at /setup');
   return {
+    requestBoardRepair,
     stop: () => {
       if (boardBootTimeout) clearTimeout(boardBootTimeout);
       boardBootTimeout = null;

--- a/packages/standalone/src/db/migrations/owner-event-board-refresh.ts
+++ b/packages/standalone/src/db/migrations/owner-event-board-refresh.ts
@@ -1,0 +1,25 @@
+import type { SQLiteDatabase } from '../../sqlite.js';
+
+/**
+ * Additive receipt relation for coalesced owner-event Board requests.
+ *
+ * TaskLedger enables foreign keys before this migration runs. The relation
+ * deliberately inherits OwnerEventInbox retention through ON DELETE CASCADE;
+ * it has no independent cleanup timer or second retention policy.
+ */
+export function applyOwnerEventBoardRefreshMigration(db: SQLiteDatabase): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS owner_event_board_refresh_intents (
+      batch_id INTEGER PRIMARY KEY REFERENCES owner_event_inbox(id) ON DELETE CASCADE,
+      batch_key TEXT NOT NULL UNIQUE,
+      repair_generation INTEGER NOT NULL CHECK (repair_generation >= 0),
+      workorder_id INTEGER NOT NULL REFERENCES operator_tasks(id),
+      applied_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_owner_event_board_refresh_pending
+      ON owner_event_board_refresh_intents(repair_generation, batch_id)
+      WHERE applied_at IS NULL;
+  `);
+}

--- a/packages/standalone/src/operator/owner-event-board-refresh.ts
+++ b/packages/standalone/src/operator/owner-event-board-refresh.ts
@@ -1,7 +1,7 @@
 import type { SQLiteDatabase } from '../sqlite.js';
 import { applyOwnerEventBoardRefreshMigration } from '../db/migrations/owner-event-board-refresh.js';
 import { boardFullNoUpdateScope, type FullRepairCapture } from './board-refresh-gate.js';
-import { boardBatchKey, boardRepairKey } from './workorder-publishers.js';
+import { boardBatchKey, boardRepairKey, validateWorkOrderPayload } from './workorder-publishers.js';
 import type { EnqueueWorkOrderInput, WorkOrderRecord } from './task-ledger.js';
 
 export interface OwnerEventBoardRefreshAcceptance {
@@ -144,15 +144,17 @@ export class OwnerEventBoardRefreshLedger {
         }
         return existing;
       }
+      const payload = {
+        mode: 'full' as const,
+        force: false,
+        repairGeneration: input.repair.repairGeneration,
+        noUpdateScope: input.repair.noUpdateScope,
+      };
+      validateWorkOrderPayload('board', payload);
       const workOrder = this.taskLedger.enqueueWorkOrder({
         workKind: 'board',
         idempotencyKey: boardRepairKey(),
-        input: {
-          mode: 'full',
-          force: false,
-          repairGeneration: input.repair.repairGeneration,
-          noUpdateScope: input.repair.noUpdateScope,
-        },
+        input: payload,
         priority: 'high',
       });
       const now = this.clock();

--- a/packages/standalone/src/operator/owner-event-board-refresh.ts
+++ b/packages/standalone/src/operator/owner-event-board-refresh.ts
@@ -1,0 +1,245 @@
+import type { SQLiteDatabase } from '../sqlite.js';
+import { applyOwnerEventBoardRefreshMigration } from '../db/migrations/owner-event-board-refresh.js';
+import { boardFullNoUpdateScope, type FullRepairCapture } from './board-refresh-gate.js';
+import { boardBatchKey, boardRepairKey } from './workorder-publishers.js';
+import type { EnqueueWorkOrderInput, WorkOrderRecord } from './task-ledger.js';
+
+export interface OwnerEventBoardRefreshAcceptance {
+  batchId: number;
+  batchKey: string;
+  repairGeneration: number;
+  workOrderId: number;
+  appliedAt: number | null;
+}
+
+interface StoredAcceptanceRow {
+  batch_id: number;
+  batch_key: string;
+  repair_generation: number;
+  workorder_id: number;
+  applied_at: number | null;
+}
+
+interface StoredInboxIdentityRow {
+  event_ids_json: string;
+}
+
+export interface BoardWorkOrderPort {
+  enqueueWorkOrder(order: EnqueueWorkOrderInput): WorkOrderRecord;
+}
+
+function assertNonNegativeSafeInteger(value: number, field: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${field} must be a non-negative safe integer`);
+  }
+}
+
+function canonicalEventIds(value: readonly string[], field: string): string[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`${field} must contain at least one event id`);
+  }
+  const normalized = value.map((eventId) => {
+    if (typeof eventId !== 'string' || eventId.trim().length === 0) {
+      throw new Error(`${field} must contain only non-empty event ids`);
+    }
+    return eventId;
+  });
+  const unique = [...new Set(normalized)].sort();
+  if (unique.length !== normalized.length) {
+    throw new Error(`${field} must not contain duplicate event ids`);
+  }
+  return unique;
+}
+
+function acceptanceFromRow(row: StoredAcceptanceRow): OwnerEventBoardRefreshAcceptance {
+  return {
+    batchId: row.batch_id,
+    batchKey: row.batch_key,
+    repairGeneration: row.repair_generation,
+    workOrderId: row.workorder_id,
+    appliedAt: row.applied_at,
+  };
+}
+
+export function resolveInitialBoardRepairGeneration(
+  now: number,
+  pendingGeneration: number | null
+): number {
+  assertNonNegativeSafeInteger(now, 'board repair wall time');
+  if (pendingGeneration === null) return now;
+  assertNonNegativeSafeInteger(pendingGeneration, 'pending board repair generation');
+  if (pendingGeneration >= Number.MAX_SAFE_INTEGER) {
+    throw new Error('pending board repair generation exhausted');
+  }
+  return Math.max(now, pendingGeneration + 1);
+}
+
+/**
+ * Durable many-to-one relation between exact owner-event batches and the
+ * shared Board repair workorder (TG-06).
+ *
+ * SQLite owns acceptance. The in-memory set owns only a best-effort wakeup
+ * after the current workorder becomes terminal; unapplied rows recover it on
+ * the next boot if the process dies in that narrow window.
+ */
+export class OwnerEventBoardRefreshLedger {
+  private readonly postTerminalFollowups = new Set<number>();
+
+  constructor(
+    private readonly db: SQLiteDatabase,
+    private readonly taskLedger: BoardWorkOrderPort,
+    private readonly clock: () => number = () => Date.now()
+  ) {
+    applyOwnerEventBoardRefreshMigration(this.db);
+  }
+
+  maxPendingGeneration(): number | null {
+    const row = this.db
+      .prepare(
+        `SELECT MAX(repair_generation) AS generation
+           FROM owner_event_board_refresh_intents
+          WHERE applied_at IS NULL`
+      )
+      .get() as { generation: number | null } | undefined;
+    return row?.generation ?? null;
+  }
+
+  accept(input: {
+    batchId: number;
+    eventIds: readonly string[];
+    repair: FullRepairCapture;
+  }): OwnerEventBoardRefreshAcceptance {
+    if (!Number.isSafeInteger(input.batchId) || input.batchId <= 0) {
+      throw new Error('owner-event Board batchId must be a positive safe integer');
+    }
+    assertNonNegativeSafeInteger(input.repair.repairGeneration, 'board repair generation');
+    if (input.repair.noUpdateScope !== boardFullNoUpdateScope(input.repair.repairGeneration)) {
+      throw new Error('owner-event Board no-update scope does not match its repair generation');
+    }
+    const requestedEventIds = canonicalEventIds(input.eventIds, 'owner-event Board eventIds');
+    const inboxRow = this.db
+      .prepare(`SELECT event_ids_json FROM owner_event_inbox WHERE id = ?`)
+      .get(input.batchId) as StoredInboxIdentityRow | undefined;
+    if (!inboxRow) {
+      throw new Error(`owner-event Board batch ${input.batchId} does not exist`);
+    }
+    const storedEventIds = canonicalEventIds(
+      JSON.parse(inboxRow.event_ids_json) as string[],
+      'stored owner-event Board eventIds'
+    );
+    const batchKey = boardBatchKey(requestedEventIds);
+    if (boardBatchKey(storedEventIds) !== batchKey) {
+      throw new Error(
+        `owner-event Board batch ${input.batchId} conflicts with its stored event identity`
+      );
+    }
+
+    const transaction = this.db.transaction(() => {
+      const existing = this.readAcceptance(input.batchId);
+      if (existing) {
+        if (existing.batchKey !== batchKey) {
+          throw new Error(
+            `owner-event Board batch ${input.batchId} conflicts with its durable acceptance`
+          );
+        }
+        return existing;
+      }
+      const workOrder = this.taskLedger.enqueueWorkOrder({
+        workKind: 'board',
+        idempotencyKey: boardRepairKey(),
+        input: {
+          mode: 'full',
+          force: false,
+          repairGeneration: input.repair.repairGeneration,
+          noUpdateScope: input.repair.noUpdateScope,
+        },
+        priority: 'high',
+      });
+      const now = this.clock();
+      assertNonNegativeSafeInteger(now, 'owner-event Board intent time');
+      this.db
+        .prepare(
+          `INSERT INTO owner_event_board_refresh_intents
+             (batch_id, batch_key, repair_generation, workorder_id,
+              applied_at, created_at, updated_at)
+           VALUES (?, ?, ?, ?, NULL, ?, ?)`
+        )
+        .run(input.batchId, batchKey, input.repair.repairGeneration, workOrder.id, now, now);
+      const inserted = this.readAcceptance(input.batchId);
+      if (!inserted) {
+        throw new Error('owner-event Board acceptance disappeared after insert');
+      }
+      return inserted;
+    });
+    return transaction();
+  }
+
+  findAcceptance(batchId: number): OwnerEventBoardRefreshAcceptance | null {
+    if (!Number.isSafeInteger(batchId) || batchId <= 0) return null;
+    return this.readAcceptance(batchId);
+  }
+
+  attachPendingToWorkOrder(workOrderId: number): number {
+    this.assertBoardWorkOrder(workOrderId);
+    const result = this.db
+      .prepare(
+        `UPDATE owner_event_board_refresh_intents
+            SET workorder_id = ?, updated_at = ?
+          WHERE applied_at IS NULL AND workorder_id <> ?`
+      )
+      .run(workOrderId, this.clock(), workOrderId);
+    return result.changes;
+  }
+
+  markVerified(
+    workOrderId: number,
+    capturedGeneration: number
+  ): { applied: number; followupPending: boolean } {
+    this.assertBoardWorkOrder(workOrderId);
+    assertNonNegativeSafeInteger(capturedGeneration, 'captured Board repair generation');
+    const now = this.clock();
+    assertNonNegativeSafeInteger(now, 'owner-event Board application time');
+    const applied = this.db
+      .prepare(
+        `UPDATE owner_event_board_refresh_intents
+            SET applied_at = ?, updated_at = ?
+          WHERE applied_at IS NULL AND repair_generation <= ?`
+      )
+      .run(now, now, capturedGeneration).changes;
+    const followupPending = this.maxPendingGeneration() !== null;
+    if (followupPending) {
+      this.postTerminalFollowups.add(workOrderId);
+    }
+    return { applied, followupPending };
+  }
+
+  consumePostTerminalFollowup(workOrderId: number): boolean {
+    if (!this.postTerminalFollowups.delete(workOrderId)) return false;
+    return this.maxPendingGeneration() !== null;
+  }
+
+  private readAcceptance(batchId: number): OwnerEventBoardRefreshAcceptance | null {
+    const row = this.db
+      .prepare(
+        `SELECT batch_id, batch_key, repair_generation, workorder_id, applied_at
+           FROM owner_event_board_refresh_intents WHERE batch_id = ?`
+      )
+      .get(batchId) as StoredAcceptanceRow | undefined;
+    return row ? acceptanceFromRow(row) : null;
+  }
+
+  private assertBoardWorkOrder(workOrderId: number): void {
+    if (!Number.isSafeInteger(workOrderId) || workOrderId <= 0) {
+      throw new Error('Board workorder id must be a positive safe integer');
+    }
+    const row = this.db
+      .prepare(
+        `SELECT id FROM operator_tasks
+          WHERE id = ? AND kind = 'system' AND source_channel = 'workorder:board'`
+      )
+      .get(workOrderId) as { id: number } | undefined;
+    if (!row) {
+      throw new Error(`Board workorder ${workOrderId} does not exist`);
+    }
+  }
+}

--- a/packages/standalone/src/operator/workorder-hooks.ts
+++ b/packages/standalone/src/operator/workorder-hooks.ts
@@ -33,6 +33,13 @@ export interface BoardRefreshGatePort {
   completeVerifiedFull(capturedGeneration: number): void;
 }
 
+export interface OwnerEventBoardRefreshIntentPort {
+  markVerified(
+    workOrderId: number,
+    capturedGeneration: number
+  ): { applied: number; followupPending: boolean };
+}
+
 /**
  * Clear repair dirt only when both independent authorities agree: the
  * run-bound action verifier observed an effect and candidate receipts (when
@@ -44,7 +51,8 @@ export function applyBoardRefreshVerdict(
   workOrder: WorkOrderRecord,
   actionVerified: boolean,
   receiptVerdict: WorkOrderEffectVerdict,
-  gate: BoardRefreshGatePort
+  gate: BoardRefreshGatePort,
+  intents?: OwnerEventBoardRefreshIntentPort
 ): WorkOrderEffectVerdict {
   if (!actionVerified || receiptVerdict.disposition !== 'complete') {
     return receiptVerdict;
@@ -59,6 +67,10 @@ export function applyBoardRefreshVerdict(
       gate.completeVerifiedReconcile(channelKey, generation as number);
     }
   } else if (workOrder.payload.mode === 'full') {
+    // Persist application before clearing the in-memory repair gate. If the
+    // durable write fails, the required verdict hook fails closed and the
+    // gate remains dirty for recovery.
+    intents?.markVerified(workOrder.id, generation as number);
     gate.completeVerifiedFull(generation as number);
   }
   return receiptVerdict;

--- a/packages/standalone/tests/agent/gateway-tool-executor.test.ts
+++ b/packages/standalone/tests/agent/gateway-tool-executor.test.ts
@@ -2394,6 +2394,108 @@ describe('STORY-V019 - GatewayToolExecutor', () => {
       });
     });
 
+    describe('TG-06 host-bound workorder origin', () => {
+      it('derives owner-event identity from trusted execution state and ignores model fields', async () => {
+        const executor = new GatewayToolExecutor({ mamaApi: createMockApi() });
+        const handler = vi.fn(() => ({ accepted: true }));
+        executor.setWorkOrderRequestHandler(handler);
+        executor.setAgentContext({
+          ...createOwnerContext(),
+          source: 'owner-event',
+          platform: 'cli',
+          role: {
+            ...DEFAULT_ROLES.definitions.owner_console,
+            allowedTools: ['workorder_request'],
+          },
+        });
+
+        const result = await executor.execute(
+          'workorder_request',
+          { kind: 'board', batchId: 999, eventIds: ['model-forged'] } as never,
+          {
+            agentId: 'owner_console',
+            source: 'owner-event',
+            channelId: 'chatwork:feedback',
+            sourceMessageRef: 'owner-event:42',
+            modelRunId: 'mr-owner-event-workorder',
+            executionSurface: 'direct',
+            causeEventIds: ['evt-host'],
+            ownerEventEffects: {
+              batchId: 42,
+              effectKeys: {
+                telegram_send: 'telegram-delivery',
+                drive_upload: 'drive-upload',
+              },
+            },
+          }
+        );
+
+        expect(result).toMatchObject({ success: true });
+        expect(handler).toHaveBeenCalledWith('board', {
+          kind: 'owner_event',
+          batchId: 42,
+          eventIds: ['evt-host'],
+        });
+      });
+
+      it('uses owner_manual for a direct owner chat request', async () => {
+        const executor = new GatewayToolExecutor({ mamaApi: createMockApi() });
+        const handler = vi.fn(() => ({ accepted: true }));
+        executor.setWorkOrderRequestHandler(handler);
+        executor.setAgentContext(createOwnerContext());
+
+        const result = await executor.execute(
+          'workorder_request',
+          { kind: 'board' },
+          {
+            agentId: 'owner_console',
+            source: 'telegram',
+            channelId: 'owner-chat',
+            modelRunId: 'mr-owner-manual-workorder',
+            executionSurface: 'direct',
+          }
+        );
+
+        expect(result).toMatchObject({ success: true });
+        expect(handler).toHaveBeenCalledWith('board', { kind: 'owner_manual' });
+      });
+
+      it('fails closed when an owner-event run lacks its host-issued batch authority', async () => {
+        const executor = new GatewayToolExecutor({ mamaApi: createMockApi() });
+        const handler = vi.fn(() => ({ accepted: true }));
+        executor.setWorkOrderRequestHandler(handler);
+        executor.setAgentContext({
+          ...createOwnerContext(),
+          source: 'owner-event',
+          platform: 'cli',
+          role: {
+            ...DEFAULT_ROLES.definitions.owner_console,
+            allowedTools: ['workorder_request'],
+          },
+        });
+
+        const result = await executor.execute(
+          'workorder_request',
+          { kind: 'board' },
+          {
+            agentId: 'owner_console',
+            source: 'owner-event',
+            channelId: 'chatwork:feedback',
+            sourceMessageRef: 'owner-event:42',
+            modelRunId: 'mr-owner-event-missing-authority',
+            executionSurface: 'direct',
+            causeEventIds: ['evt-host'],
+          }
+        );
+
+        expect(result).toMatchObject({
+          success: false,
+          code: 'workorder_owner_event_authority_missing',
+        });
+        expect(handler).not.toHaveBeenCalled();
+      });
+    });
+
     describe('Story GT-SEC-1: Bash safety checks', () => {
       describe('AC #1: dangerous Bash commands are blocked', () => {
         it.each([

--- a/packages/standalone/tests/agent/temporal-work-context.test.ts
+++ b/packages/standalone/tests/agent/temporal-work-context.test.ts
@@ -575,6 +575,14 @@ describe('Story A2 Task 7: trusted temporal work context', () => {
         envelope,
         modelRunId: 'mr_wo_inherit',
         causeEventIds: ['evi_host_1', 'evi_host_2'],
+        ownerEventEffects: {
+          batchId: 42,
+          effectKeys: {
+            telegram_send: 'telegram-delivery',
+            drive_upload: 'drive-upload',
+          },
+        },
+        source: 'owner-event',
         agentContext: {
           ...executionContext.agentContext!,
           role: {
@@ -588,7 +596,11 @@ describe('Story A2 Task 7: trusted temporal work context', () => {
         },
       }
     );
-    expect(handler).toHaveBeenCalledWith('board', ['evi_host_1', 'evi_host_2']);
+    expect(handler).toHaveBeenCalledWith('board', {
+      kind: 'owner_event',
+      batchId: 42,
+      eventIds: ['evi_host_1', 'evi_host_2'],
+    });
   });
 
   it('the HOST seeds the compile with the bound source - the agent never restates it (S2)', async () => {

--- a/packages/standalone/tests/cli/owner-event-wiring.test.ts
+++ b/packages/standalone/tests/cli/owner-event-wiring.test.ts
@@ -1,15 +1,38 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import Database from '../../src/sqlite.js';
 import { OperatorTriggerLoop } from '../../src/operator/operator-trigger-loop.js';
 import { TriggerRegistry } from '../../src/operator/trigger-registry.js';
 import { OwnerEventInbox } from '../../src/operator/owner-event-inbox.js';
+import { OwnerEventBoardRefreshLedger } from '../../src/operator/owner-event-board-refresh.js';
+import { OwnerEventEffectLedger } from '../../src/operator/owner-event-effects.js';
 import { OwnerEventLoop } from '../../src/operator/owner-event-loop.js';
+import { TaskLedger } from '../../src/operator/task-ledger.js';
+import { resolveOwnerEventTerminalReceipt } from '../../src/cli/commands/start.js';
 import { buildOwnerEventAgentContext } from '../../src/operator/owner-event-policy.js';
 import { DEFAULT_ROLES } from '../../src/cli/config/types.js';
 import { resolvePrivateConnectorPolicy } from '../../src/connectors/private-connector-policy.js';
 import type { Envelope } from '../../src/envelope/types.js';
 
 describe('TG-03/TG-04/TG-05/TG-06 production owner-event seam', () => {
+  function ownerContext() {
+    return buildOwnerEventAgentContext({
+      backend: 'codex',
+      model: 'gpt-5.6-sol',
+      ownerRole: DEFAULT_ROLES.definitions.owner_console,
+      privateConnectorPolicy: resolvePrivateConnectorPolicy({
+        ok: true,
+        config: { kagemusha: { enabled: true } },
+        enabledNames: ['kagemusha'],
+      }),
+    });
+  }
+
+  function envelope(): Envelope {
+    return {
+      scope: { allowed_destinations: [{ kind: 'telegram', id: 'owner-chat' }] },
+    } as Envelope;
+  }
+
   it('moves one connector event from durable intake to a receipted MAMA owner turn', async () => {
     const db = new Database(':memory:');
     const registry = new TriggerRegistry(db);
@@ -134,5 +157,92 @@ describe('TG-03/TG-04/TG-05/TG-06 production owner-event seam', () => {
       failed: 0,
     });
     registry.close();
+  });
+
+  it('ACKs a persisted Board acceptance after restart without waking the model', async () => {
+    const db = new Database(':memory:');
+    const taskLedger = new TaskLedger(db);
+    const inbox = new OwnerEventInbox(db);
+    const effects = new OwnerEventEffectLedger(db);
+    const boardIntents = new OwnerEventBoardRefreshLedger(db, taskLedger);
+    const batchId = inbox.enqueue({
+      channelKey: 'chatwork:feedback',
+      eventIds: ['evt-restart'],
+      lines: ['feedback arrived'],
+      activations: [],
+    });
+    if (batchId === null) throw new Error('test batch unexpectedly deduplicated');
+    boardIntents.accept({
+      batchId,
+      eventIds: ['evt-restart'],
+      repair: { repairGeneration: 20, noUpdateScope: 'full:20' },
+    });
+    const runner = { run: vi.fn(() => Promise.reject(new Error('must not run'))) };
+    const loop = new OwnerEventLoop({
+      inbox,
+      runner,
+      agentContext: ownerContext(),
+      buildPrompt: () => 'must not build',
+      issueEnvelope: async () => envelope(),
+      getNoUpdateMaxId: (scope) => taskLedger.maxNoUpdateId(scope),
+      getTerminalReceipt: (batch) =>
+        resolveOwnerEventTerminalReceipt(batch, {
+          ownerEventEffectLedger: effects,
+          ownerEventBoardRefreshLedger: boardIntents,
+          taskLedger,
+        }),
+      log: () => undefined,
+    });
+
+    expect(await loop.tick()).toBe('processed');
+    expect(runner.run).not.toHaveBeenCalled();
+    expect(inbox.depth()).toEqual({ pending: 0, claimed: 0, dead: 0 });
+    db.close();
+  });
+
+  it('lets a durable Board acceptance win after the accepting runner throws', async () => {
+    const db = new Database(':memory:');
+    const taskLedger = new TaskLedger(db);
+    const inbox = new OwnerEventInbox(db);
+    const effects = new OwnerEventEffectLedger(db);
+    const boardIntents = new OwnerEventBoardRefreshLedger(db, taskLedger);
+    const batchId = inbox.enqueue({
+      channelKey: 'chatwork:feedback',
+      eventIds: ['evt-error'],
+      lines: ['feedback arrived'],
+      activations: [],
+    });
+    if (batchId === null) throw new Error('test batch unexpectedly deduplicated');
+    const runner = {
+      run: vi.fn(async () => {
+        boardIntents.accept({
+          batchId,
+          eventIds: ['evt-error'],
+          repair: { repairGeneration: 21, noUpdateScope: 'full:21' },
+        });
+        throw new Error('runner transport failed after acceptance');
+      }),
+    };
+    const loop = new OwnerEventLoop({
+      inbox,
+      runner,
+      agentContext: ownerContext(),
+      buildPrompt: () => 'handle feedback',
+      issueEnvelope: async () => envelope(),
+      getNoUpdateMaxId: (scope) => taskLedger.maxNoUpdateId(scope),
+      getTerminalReceipt: (batch) =>
+        resolveOwnerEventTerminalReceipt(batch, {
+          ownerEventEffectLedger: effects,
+          ownerEventBoardRefreshLedger: boardIntents,
+          taskLedger,
+        }),
+      log: () => undefined,
+    });
+
+    expect(await loop.tick()).toBe('processed');
+    expect(runner.run).toHaveBeenCalledTimes(1);
+    expect(inbox.depth()).toEqual({ pending: 0, claimed: 0, dead: 0 });
+    expect(boardIntents.findAcceptance(batchId)).not.toBeNull();
+    db.close();
   });
 });

--- a/packages/standalone/tests/cli/runtime/api-routes-init-reconcile.test.ts
+++ b/packages/standalone/tests/cli/runtime/api-routes-init-reconcile.test.ts
@@ -43,7 +43,7 @@ const enabledConnectorConfig: ConnectorConfigLoadResult = {
   enabledNames: ['kagemusha'],
 };
 
-function createConfig(): MAMAConfig {
+function createConfig(dashboardEnabled = true): MAMAConfig {
   return {
     ...DEFAULT_CONFIG,
     agent: { ...DEFAULT_CONFIG.agent },
@@ -62,7 +62,7 @@ function createConfig(): MAMAConfig {
           display_name: 'Dashboard',
           trigger_prefix: '@dashboard',
           persona_file: 'dashboard.md',
-          enabled: true,
+          enabled: dashboardEnabled,
         },
       },
     },
@@ -100,6 +100,7 @@ function publishBoardSlots(apiServer: { reportStore: ReportStore }): void {
 async function registerReconcileRuntime(input: {
   db: Database;
   connectorConfigLoadResult: ConnectorConfigLoadResult;
+  config?: MAMAConfig;
   ledger?: TaskLedger;
   boardRefreshGate?: BoardRefreshGate | null;
   ownerEventBoardRefreshLedger?: OwnerEventBoardRefreshLedger;
@@ -135,7 +136,7 @@ async function registerReconcileRuntime(input: {
   });
 
   const routeHandle = await registerApiRoutes({
-    config: createConfig(),
+    config: input.config ?? createConfig(),
     apiServer,
     eventBus,
     oauthManager: {} as OAuthManager,
@@ -349,6 +350,30 @@ describe('TG-04 Task 7: registered reconcile callback private lifecycle isolatio
 
       await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
       expect(ledger.claimNextWorkOrder()).toBeNull();
+    } finally {
+      db.close();
+    }
+  });
+
+  it('TG-04 keeps the Stage-2 Board runtime independent of disabled legacy persona config', async () => {
+    const db = new Database(':memory:');
+    try {
+      createBoardInputTables(db);
+      const { ledger, routeHandle } = await registerReconcileRuntime({
+        db,
+        connectorConfigLoadResult: enabledConnectorConfig,
+        config: createConfig(false),
+      });
+
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(ledger.claimNextWorkOrder()).toMatchObject({
+        workKind: 'board',
+        idempotencyKey: 'board:full:repair',
+        payload: { mode: 'full', repairGeneration: expect.any(Number) },
+      });
+      expect(routeHandle.boardReconcileEnabled).toBe(true);
+      routeHandle.stop();
     } finally {
       db.close();
     }

--- a/packages/standalone/tests/cli/runtime/api-routes-init-reconcile.test.ts
+++ b/packages/standalone/tests/cli/runtime/api-routes-init-reconcile.test.ts
@@ -19,6 +19,8 @@ import { BoardRefreshGate } from '../../../src/operator/board-refresh-gate.js';
 import { REQUIRED_FULL_BOARD_SLOTS } from '../../../src/operator/workorder-hooks.js';
 import type { ReportStore } from '../../../src/api/report-handler.js';
 import { WorkOrderConsumer } from '../../../src/operator/workorder-consumer.js';
+import { OwnerEventInbox } from '../../../src/operator/owner-event-inbox.js';
+import { OwnerEventBoardRefreshLedger } from '../../../src/operator/owner-event-board-refresh.js';
 import { buildOwnerWorkOrderRequestHandler } from '../../../src/cli/commands/start.js';
 import { CronScheduler } from '../../../src/scheduler/cron-scheduler.js';
 import Database from '../../../src/sqlite.js';
@@ -161,6 +163,10 @@ async function registerOwnerFullRuntime(effect: 'report' | 'no-update' | 'failed
   });
   const ledger = new TaskLedger(db);
   const boardRefreshGate = new BoardRefreshGate({ initialGeneration: 500 });
+  const ownerEventInbox = new OwnerEventInbox(db, () => 9_000);
+  const ownerEventBoardRefreshLedger = new OwnerEventBoardRefreshLedger(db, ledger, () => 9_000);
+  const boardRepairNudge: { current: (() => void) | null } = { current: null };
+  const duringRun: { current: (() => void) | null } = { current: null };
   toolExecutor.setSessionsDb(db);
   toolExecutor.setTaskLedger(ledger);
   const apiServer = createApiServer({
@@ -211,6 +217,7 @@ async function registerOwnerFullRuntime(effect: 'report' | 'no-update' | 'failed
             .execute('report_publish', {} as never, context as never)
             .catch(() => undefined);
         }
+        duringRun.current?.();
         return { response: effect === 'none' ? 'DONE in prose only' : 'DONE' };
       },
     },
@@ -218,6 +225,15 @@ async function registerOwnerFullRuntime(effect: 'report' | 'no-update' | 'failed
     runOptionsFor: (workOrder) => ({ workorderAttemptId: workOrder.id }),
     noticeOwner: () => undefined,
     opsAlarm: { configured: false, send: async () => undefined },
+    onEvent: (event) => {
+      if (
+        event.type === 'complete' &&
+        event.workKind === 'board' &&
+        ownerEventBoardRefreshLedger.consumePostTerminalFollowup(event.workOrderId)
+      ) {
+        boardRepairNudge.current?.();
+      }
+    },
   });
 
   const routeHandle = await registerApiRoutes({
@@ -238,10 +254,13 @@ async function registerOwnerFullRuntime(effect: 'report' | 'no-update' | 'failed
     sessionsDb: db,
     workOrderConsumer: consumer,
     boardRefreshGate,
+    ownerEventBoardRefreshLedger,
   });
+  boardRepairNudge.current = routeHandle.requestBoardRepair;
   const ownerRequest = buildOwnerWorkOrderRequestHandler({
     taskLedger: ledger,
     boardRefreshGate,
+    ownerEventBoardRefreshLedger,
     now: () => 9_000,
   });
   return {
@@ -251,6 +270,18 @@ async function registerOwnerFullRuntime(effect: 'report' | 'no-update' | 'failed
     db,
     eventBus,
     ledger,
+    ownerEventBoardRefreshLedger,
+    enqueueOwnerBatch: (eventId: string) => {
+      const batchId = ownerEventInbox.enqueue({
+        channelKey: 'kagemusha:feedback',
+        eventIds: [eventId],
+        lines: [`line:${eventId}`],
+        activations: [],
+      });
+      if (batchId === null) throw new Error(`owner-event batch deduplicated: ${eventId}`);
+      return batchId;
+    },
+    duringRun,
     ownerRequest,
     routeHandle,
   };
@@ -490,6 +521,106 @@ describe('TG-04 Task 7: registered reconcile callback private lifecycle isolatio
         expect(runtime.boardRefreshGate.needsFullRepair()).toBe(false);
         await vi.advanceTimersByTimeAsync(10_000 + 30 * 60 * 1000);
         expect(runtime.ledger.claimNextWorkOrder()).toBeNull();
+      } finally {
+        runtime.routeHandle.stop();
+        runtime.db.close();
+      }
+    }
+  );
+
+  it('TG-06 schedules one non-force repair after a verified run when a later intent arrived in-flight', async () => {
+    const runtime = await registerOwnerFullRuntime('report');
+    try {
+      const firstBatchId = runtime.enqueueOwnerBatch('evt-owner-first');
+      expect(
+        runtime.ownerRequest('board', {
+          kind: 'owner_event',
+          batchId: firstBatchId,
+          eventIds: ['evt-owner-first'],
+        })
+      ).toEqual({ accepted: true });
+      const first = runtime.ownerEventBoardRefreshLedger.findAcceptance(firstBatchId);
+      if (!first) throw new Error('first owner-event Board acceptance expected');
+
+      let lateBatchId = 0;
+      runtime.duringRun.current = () => {
+        lateBatchId = runtime.enqueueOwnerBatch('evt-owner-late');
+        expect(
+          runtime.ownerRequest('board', {
+            kind: 'owner_event',
+            batchId: lateBatchId,
+            eventIds: ['evt-owner-late'],
+          })
+        ).toEqual({ accepted: true });
+        expect(runtime.ownerEventBoardRefreshLedger.findAcceptance(lateBatchId)?.workOrderId).toBe(
+          first.workOrderId
+        );
+      };
+
+      await runtime.consumer.tick();
+
+      expect(runtime.ownerEventBoardRefreshLedger.findAcceptance(firstBatchId)?.appliedAt).toBe(
+        9_000
+      );
+      expect(
+        runtime.ownerEventBoardRefreshLedger.findAcceptance(lateBatchId)?.appliedAt
+      ).toBeNull();
+      const followup = runtime.ledger.claimNextWorkOrder();
+      expect(followup).toMatchObject({
+        idempotencyKey: 'board:full:repair',
+        payload: {
+          mode: 'full',
+          force: false,
+          repairGeneration: 502,
+          noUpdateScope: 'full:502',
+        },
+      });
+      expect(followup?.id).not.toBe(first.workOrderId);
+      expect(runtime.ownerEventBoardRefreshLedger.findAcceptance(lateBatchId)?.workOrderId).toBe(
+        followup?.id
+      );
+      expect(runtime.ledger.claimNextWorkOrder()).toBeNull();
+    } finally {
+      runtime.routeHandle.stop();
+      runtime.db.close();
+    }
+  });
+
+  it.each(['none', 'failed'] as const)(
+    'TG-06 %s full completion does not hot-loop a later accepted intent without verification',
+    async (effect) => {
+      const runtime = await registerOwnerFullRuntime(effect);
+      try {
+        const firstBatchId = runtime.enqueueOwnerBatch(`evt-${effect}-first`);
+        expect(
+          runtime.ownerRequest('board', {
+            kind: 'owner_event',
+            batchId: firstBatchId,
+            eventIds: [`evt-${effect}-first`],
+          })
+        ).toEqual({ accepted: true });
+
+        let lateBatchId = 0;
+        runtime.duringRun.current = () => {
+          lateBatchId = runtime.enqueueOwnerBatch(`evt-${effect}-late`);
+          expect(
+            runtime.ownerRequest('board', {
+              kind: 'owner_event',
+              batchId: lateBatchId,
+              eventIds: [`evt-${effect}-late`],
+            })
+          ).toEqual({ accepted: true });
+        };
+
+        await runtime.consumer.tick();
+
+        expect(
+          runtime.ownerEventBoardRefreshLedger.findAcceptance(firstBatchId)?.appliedAt
+        ).toBeNull();
+        expect(
+          runtime.ownerEventBoardRefreshLedger.findAcceptance(lateBatchId)?.appliedAt
+        ).toBeNull();
+        expect(runtime.ledger.countPendingWorkOrders()).toBe(0);
       } finally {
         runtime.routeHandle.stop();
         runtime.db.close();

--- a/packages/standalone/tests/cli/runtime/api-routes-init-reconcile.test.ts
+++ b/packages/standalone/tests/cli/runtime/api-routes-init-reconcile.test.ts
@@ -21,7 +21,10 @@ import type { ReportStore } from '../../../src/api/report-handler.js';
 import { WorkOrderConsumer } from '../../../src/operator/workorder-consumer.js';
 import { OwnerEventInbox } from '../../../src/operator/owner-event-inbox.js';
 import { OwnerEventBoardRefreshLedger } from '../../../src/operator/owner-event-board-refresh.js';
-import { buildOwnerWorkOrderRequestHandler } from '../../../src/cli/commands/start.js';
+import {
+  buildOwnerEventBoardRefreshRuntime,
+  buildOwnerWorkOrderRequestHandler,
+} from '../../../src/cli/commands/start.js';
 import { CronScheduler } from '../../../src/scheduler/cron-scheduler.js';
 import Database from '../../../src/sqlite.js';
 import type { AgentLoop } from '../../../src/agent/index.js';
@@ -99,6 +102,7 @@ async function registerReconcileRuntime(input: {
   connectorConfigLoadResult: ConnectorConfigLoadResult;
   ledger?: TaskLedger;
   boardRefreshGate?: BoardRefreshGate | null;
+  ownerEventBoardRefreshLedger?: OwnerEventBoardRefreshLedger;
   eventBus?: AgentEventBus;
   rawConnectorScope?: readonly string[];
   getAdapter?: () => { prepare: (sql: string) => { all: (...args: unknown[]) => unknown[] } };
@@ -107,7 +111,11 @@ async function registerReconcileRuntime(input: {
   boardRefreshGate: BoardRefreshGate | null;
   eventBus: AgentEventBus;
   ledger: TaskLedger;
-  routeHandle: { stop: () => void };
+  routeHandle: {
+    readonly boardReconcileEnabled: boolean;
+    requestBoardRepair: () => void;
+    stop: () => void;
+  };
 }> {
   const policy = resolvePrivateConnectorPolicy(input.connectorConfigLoadResult);
   const eventBus = input.eventBus ?? new AgentEventBus();
@@ -117,11 +125,7 @@ async function registerReconcileRuntime(input: {
   });
   const ledger = input.ledger ?? new TaskLedger(input.db);
   const boardRefreshGate =
-    input.boardRefreshGate !== undefined
-      ? input.boardRefreshGate
-      : process.env.MAMA_BOARD_RECONCILE === '1'
-        ? new BoardRefreshGate()
-        : null;
+    input.boardRefreshGate !== undefined ? input.boardRefreshGate : new BoardRefreshGate();
   toolExecutor.setTaskLedger(ledger);
   const apiServer = createApiServer({
     scheduler: new CronScheduler(),
@@ -145,6 +149,9 @@ async function registerReconcileRuntime(input: {
     privateConnectorPolicy: policy,
     rawConnectorScope: input.rawConnectorScope ?? input.connectorConfigLoadResult.enabledNames,
     boardRefreshGate,
+    ...(input.ownerEventBoardRefreshLedger
+      ? { ownerEventBoardRefreshLedger: input.ownerEventBoardRefreshLedger }
+      : {}),
     getAdapter: input.getAdapter ?? (() => input.db),
   });
 
@@ -343,6 +350,66 @@ describe('TG-04 Task 7: registered reconcile callback private lifecycle isolatio
       await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
       expect(ledger.claimNextWorkOrder()).toBeNull();
     } finally {
+      db.close();
+    }
+  });
+
+  it('TG-06 flag-off boot reattaches persisted intents to one non-force repair', async () => {
+    const db = new Database(':memory:');
+    const previousTestReconcile = process.env.MAMA_BOARD_RECONCILE;
+    process.env.MAMA_BOARD_RECONCILE = '0';
+    try {
+      createBoardInputTables(db);
+      const taskLedger = new TaskLedger(db, { now: () => 1_000, timeZone: 'UTC' });
+      const inbox = new OwnerEventInbox(db, () => 1_000);
+      const firstRuntime = buildOwnerEventBoardRefreshRuntime(db, taskLedger, () => 20);
+      const batchId = inbox.enqueue({
+        channelKey: 'kagemusha:feedback',
+        eventIds: ['evt-boot-repair'],
+        lines: ['line:evt-boot-repair'],
+        activations: [],
+      });
+      if (batchId === null) throw new Error('test batch unexpectedly deduplicated');
+      firstRuntime.boardRefreshGate.markChannelDirty('host:test-owner-event');
+      const accepted = firstRuntime.ownerEventBoardRefreshLedger.accept({
+        batchId,
+        eventIds: ['evt-boot-repair'],
+        repair: firstRuntime.boardRefreshGate.captureFullRepair(),
+      });
+      const abandoned = taskLedger.claimNextWorkOrder();
+      if (!abandoned) throw new Error('abandoned Board workorder expected');
+      taskLedger.failWorkOrder(abandoned.id, 'simulated daemon cutover');
+
+      const restarted = buildOwnerEventBoardRefreshRuntime(db, taskLedger, () => 10);
+      const { ledger, routeHandle } = await registerReconcileRuntime({
+        db,
+        connectorConfigLoadResult: enabledConnectorConfig,
+        ledger: taskLedger,
+        boardRefreshGate: restarted.boardRefreshGate,
+        ownerEventBoardRefreshLedger: restarted.ownerEventBoardRefreshLedger,
+      });
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      const repair = ledger.claimNextWorkOrder();
+      expect(repair).toMatchObject({
+        idempotencyKey: 'board:full:repair',
+        priority: 'high',
+        payload: {
+          mode: 'full',
+          force: false,
+          repairGeneration: 22,
+          noUpdateScope: 'full:22',
+        },
+      });
+      expect(repair?.id).not.toBe(accepted.workOrderId);
+      expect(restarted.ownerEventBoardRefreshLedger.findAcceptance(batchId)?.workOrderId).toBe(
+        repair?.id
+      );
+      expect(routeHandle.boardReconcileEnabled).toBe(false);
+      routeHandle.stop();
+    } finally {
+      if (previousTestReconcile === undefined) delete process.env.MAMA_BOARD_RECONCILE;
+      else process.env.MAMA_BOARD_RECONCILE = previousTestReconcile;
       db.close();
     }
   });
@@ -568,6 +635,7 @@ describe('TG-04 Task 7: registered reconcile callback private lifecycle isolatio
       const followup = runtime.ledger.claimNextWorkOrder();
       expect(followup).toMatchObject({
         idempotencyKey: 'board:full:repair',
+        priority: 'high',
         payload: {
           mode: 'full',
           force: false,
@@ -759,13 +827,13 @@ describe('TG-04 Task 7: registered reconcile callback private lifecycle isolatio
     }
   });
 
-  it('TG-06 forced agent refresh keeps the disabled legacy payload', async () => {
+  it('TG-06 flag off keeps the host gate on for forced full refreshes', async () => {
     const db = new Database(':memory:');
     const previousTestReconcile = process.env.MAMA_BOARD_RECONCILE;
     process.env.MAMA_BOARD_RECONCILE = '0';
     try {
       createBoardInputTables(db);
-      const { apiServer, ledger } = await registerReconcileRuntime({
+      const { apiServer, ledger, routeHandle } = await registerReconcileRuntime({
         db,
         connectorConfigLoadResult: enabledConnectorConfig,
       });
@@ -776,9 +844,13 @@ describe('TG-04 Task 7: registered reconcile callback private lifecycle isolatio
         attempts: 1,
         mode: 'full',
         force: true,
+        repairGeneration: expect.any(Number),
+        noUpdateScope: expect.stringMatching(/^full:\d+$/),
         // A forced full run is still a real rebuild, so it records a baseline.
         deltaWatermark: expect.any(String),
       });
+      expect(routeHandle.boardReconcileEnabled).toBe(false);
+      routeHandle.stop();
     } finally {
       if (previousTestReconcile === undefined) delete process.env.MAMA_BOARD_RECONCILE;
       else process.env.MAMA_BOARD_RECONCILE = previousTestReconcile;

--- a/packages/standalone/tests/cli/start-board-refresh-gate.test.ts
+++ b/packages/standalone/tests/cli/start-board-refresh-gate.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { buildOwnerWorkOrderRequestHandler } from '../../src/cli/commands/start.js';
+import {
+  buildOwnerEventBoardRefreshRuntime,
+  buildOwnerWorkOrderRequestHandler,
+} from '../../src/cli/commands/start.js';
 import { BoardRefreshGate } from '../../src/operator/board-refresh-gate.js';
 import { OwnerEventBoardRefreshLedger } from '../../src/operator/owner-event-board-refresh.js';
 import { OwnerEventInbox } from '../../src/operator/owner-event-inbox.js';
@@ -45,6 +48,48 @@ describe('TG-03/TG-04/TG-06 owner Board workorder coordination', () => {
       enqueueBatch,
     };
   }
+
+  it('seeds a restarted gate above every pending durable intent generation', () => {
+    const db = new Database(':memory:');
+    const taskLedger = new TaskLedger(db, { now: () => 1_000, timeZone: 'UTC' });
+    const inbox = new OwnerEventInbox(db, () => 1_000);
+    const firstRuntime = buildOwnerEventBoardRefreshRuntime(db, taskLedger, () => 100);
+    const batchId = inbox.enqueue({
+      channelKey: 'chatwork:feedback',
+      eventIds: ['evt-restart'],
+      lines: ['line:evt-restart'],
+      activations: [],
+    });
+    if (batchId === null) throw new Error('test batch unexpectedly deduplicated');
+    firstRuntime.ownerEventBoardRefreshLedger.accept({
+      batchId,
+      eventIds: ['evt-restart'],
+      repair: { repairGeneration: 150, noUpdateScope: 'full:150' },
+    });
+
+    const restarted = buildOwnerEventBoardRefreshRuntime(db, taskLedger, () => 50);
+
+    expect(restarted.boardRefreshGate.captureFullRepair()).toEqual({
+      repairGeneration: 151,
+      noUpdateScope: 'full:151',
+    });
+    expect(restarted.boardRefreshGate.needsFullRepair()).toBe(true);
+    db.close();
+  });
+
+  it('uses wall time unchanged when no pending Board intent exists', () => {
+    const db = new Database(':memory:');
+    const taskLedger = new TaskLedger(db, { now: () => 1_000, timeZone: 'UTC' });
+    new OwnerEventInbox(db, () => 1_000);
+
+    const runtime = buildOwnerEventBoardRefreshRuntime(db, taskLedger, () => 700);
+
+    expect(runtime.boardRefreshGate.captureFullRepair()).toEqual({
+      repairGeneration: 700,
+      noUpdateScope: 'full:700',
+    });
+    db.close();
+  });
 
   it.each(['wiki', 'memory-curation'] as const)(
     'preserves permanent owner-event %s handoff identity after terminal completion',

--- a/packages/standalone/tests/cli/start-board-refresh-gate.test.ts
+++ b/packages/standalone/tests/cli/start-board-refresh-gate.test.ts
@@ -219,6 +219,32 @@ describe('TG-03/TG-04/TG-06 owner Board workorder coordination', () => {
     db.close();
   });
 
+  it('fails closed when the Board worker is explicitly disabled despite an always-on gate', () => {
+    const ctx = createHarness(350);
+    const handler = buildOwnerWorkOrderRequestHandler({
+      taskLedger: ctx.taskLedger,
+      boardRefreshGate: ctx.boardRefreshGate,
+      ownerEventBoardRefreshLedger: ctx.ownerEventBoardRefreshLedger,
+      boardWorkOrderEnabled: false,
+      now: () => 1_000,
+      log: vi.fn(),
+      logError: vi.fn(),
+    });
+    const eventId = 'evt-disabled-board';
+    const batchId = ctx.enqueueBatch(eventId);
+
+    expect(
+      handler('board', {
+        kind: 'owner_event',
+        batchId,
+        eventIds: [eventId],
+      })
+    ).toEqual({ accepted: false, reason: 'enqueue-failed' });
+    expect(ctx.taskLedger.countPendingWorkOrders()).toBe(0);
+    expect(ctx.ownerEventBoardRefreshLedger.findAcceptance(batchId)).toBeNull();
+    ctx.db.close();
+  });
+
   it('leaves synthetic dirt when a manual Board enqueue fails', () => {
     const ctx = createHarness(400);
     ctx.db.close();

--- a/packages/standalone/tests/cli/start-board-refresh-gate.test.ts
+++ b/packages/standalone/tests/cli/start-board-refresh-gate.test.ts
@@ -219,32 +219,6 @@ describe('TG-03/TG-04/TG-06 owner Board workorder coordination', () => {
     db.close();
   });
 
-  it('fails closed when the Board worker is explicitly disabled despite an always-on gate', () => {
-    const ctx = createHarness(350);
-    const handler = buildOwnerWorkOrderRequestHandler({
-      taskLedger: ctx.taskLedger,
-      boardRefreshGate: ctx.boardRefreshGate,
-      ownerEventBoardRefreshLedger: ctx.ownerEventBoardRefreshLedger,
-      boardWorkOrderEnabled: false,
-      now: () => 1_000,
-      log: vi.fn(),
-      logError: vi.fn(),
-    });
-    const eventId = 'evt-disabled-board';
-    const batchId = ctx.enqueueBatch(eventId);
-
-    expect(
-      handler('board', {
-        kind: 'owner_event',
-        batchId,
-        eventIds: [eventId],
-      })
-    ).toEqual({ accepted: false, reason: 'enqueue-failed' });
-    expect(ctx.taskLedger.countPendingWorkOrders()).toBe(0);
-    expect(ctx.ownerEventBoardRefreshLedger.findAcceptance(batchId)).toBeNull();
-    ctx.db.close();
-  });
-
   it('leaves synthetic dirt when a manual Board enqueue fails', () => {
     const ctx = createHarness(400);
     ctx.db.close();

--- a/packages/standalone/tests/cli/start-board-refresh-gate.test.ts
+++ b/packages/standalone/tests/cli/start-board-refresh-gate.test.ts
@@ -1,120 +1,191 @@
 import { describe, expect, it, vi } from 'vitest';
-import Database from '../../src/sqlite.js';
-import { BoardRefreshGate } from '../../src/operator/board-refresh-gate.js';
-import { TaskLedger } from '../../src/operator/task-ledger.js';
+
 import { buildOwnerWorkOrderRequestHandler } from '../../src/cli/commands/start.js';
+import { BoardRefreshGate } from '../../src/operator/board-refresh-gate.js';
+import { OwnerEventBoardRefreshLedger } from '../../src/operator/owner-event-board-refresh.js';
+import { OwnerEventInbox } from '../../src/operator/owner-event-inbox.js';
+import { TaskLedger } from '../../src/operator/task-ledger.js';
+import Database from '../../src/sqlite.js';
 
-describe('TG-06 owner board workorder repair generation', () => {
-  it.each(['board', 'wiki', 'memory-curation'] as const)(
-    'dedupes a receipted owner-event %s handoff even after the first workorder is terminal',
-    (kind) => {
-      const db = new Database(':memory:');
-      const ledger = new TaskLedger(db);
-      let now = 1_000;
-      const handler = buildOwnerWorkOrderRequestHandler({
-        taskLedger: ledger,
-        boardRefreshGate: null,
-        now: () => now,
-        log: vi.fn(),
-        logError: vi.fn(),
-      });
-
-      expect(handler(kind, ['evt-owner-1'])).toEqual({ accepted: true });
-      const first = ledger.claimNextWorkOrder();
-      if (!first) throw new Error('owner-event workorder expected');
-      expect(first.idempotencyKey).toMatch(new RegExp(`^owner-event:${kind}:`));
-      ledger.completeWorkOrder(first.id);
-
-      now = 9_000;
-      expect(handler(kind, ['evt-owner-1'])).toEqual({ accepted: true });
-      expect(ledger.claimNextWorkOrder()).toBeNull();
-      expect(
-        (
-          db.prepare(`SELECT COUNT(*) AS n FROM operator_tasks WHERE kind = 'system'`).get() as {
-            n: number;
-          }
-        ).n
-      ).toBe(1);
-      db.close();
-    }
-  );
-
-  it('marks eventless and event-backed owner full requests dirty before enqueue and carries exact scopes', () => {
+describe('TG-03/TG-04/TG-06 owner Board workorder coordination', () => {
+  function createHarness(initialGeneration = 100) {
     const db = new Database(':memory:');
-    const ledger = new TaskLedger(db);
-    const gate = new BoardRefreshGate({ initialGeneration: 100 });
+    const taskLedger = new TaskLedger(db, { now: () => 1_000, timeZone: 'UTC' });
+    const inbox = new OwnerEventInbox(db, () => 1_000);
+    const ownerEventBoardRefreshLedger = new OwnerEventBoardRefreshLedger(
+      db,
+      taskLedger,
+      () => 1_000
+    );
+    const boardRefreshGate = new BoardRefreshGate({ initialGeneration });
     const handler = buildOwnerWorkOrderRequestHandler({
-      taskLedger: ledger,
-      boardRefreshGate: gate,
+      taskLedger,
+      boardRefreshGate,
+      ownerEventBoardRefreshLedger,
       now: () => 1_000,
       log: vi.fn(),
       logError: vi.fn(),
     });
+    const enqueueBatch = (eventId: string): number => {
+      const batchId = inbox.enqueue({
+        channelKey: 'chatwork:feedback',
+        eventIds: [eventId],
+        lines: [`line:${eventId}`],
+        activations: [],
+      });
+      if (batchId === null) throw new Error('test batch unexpectedly deduplicated');
+      return batchId;
+    };
+    return {
+      db,
+      taskLedger,
+      ownerEventBoardRefreshLedger,
+      boardRefreshGate,
+      handler,
+      enqueueBatch,
+    };
+  }
 
-    expect(handler('board')).toEqual({ accepted: true });
-    const eventless = ledger.claimNextWorkOrder();
-    expect(eventless?.payload).toEqual({
+  it.each(['wiki', 'memory-curation'] as const)(
+    'preserves permanent owner-event %s handoff identity after terminal completion',
+    (kind) => {
+      const ctx = createHarness();
+      const origin = {
+        kind: 'owner_event' as const,
+        batchId: ctx.enqueueBatch('evt-owner-1'),
+        eventIds: ['evt-owner-1'],
+      };
+
+      expect(ctx.handler(kind, origin)).toEqual({ accepted: true });
+      const first = ctx.taskLedger.claimNextWorkOrder();
+      if (!first) throw new Error('owner-event workorder expected');
+      expect(first.idempotencyKey).toMatch(new RegExp(`^owner-event:${kind}:`));
+      ctx.taskLedger.completeWorkOrder(first.id);
+
+      expect(ctx.handler(kind, origin)).toEqual({ accepted: true });
+      expect(ctx.taskLedger.claimNextWorkOrder()).toBeNull();
+      expect(
+        (
+          ctx.db
+            .prepare(`SELECT COUNT(*) AS n FROM operator_tasks WHERE kind = 'system'`)
+            .get() as {
+            n: number;
+          }
+        ).n
+      ).toBe(1);
+      ctx.db.close();
+    }
+  );
+
+  it('keeps a direct owner manual Board request forced and uniquely keyed', () => {
+    const ctx = createHarness(100);
+
+    expect(ctx.handler('board', { kind: 'owner_manual' })).toEqual({ accepted: true });
+    expect(ctx.taskLedger.claimNextWorkOrder()?.payload).toEqual({
       attempts: 1,
       mode: 'full',
       force: true,
       repairGeneration: 101,
       noUpdateScope: 'full:101',
     });
-    if (!eventless) throw new Error('eventless owner board workorder expected');
-    ledger.completeWorkOrder(eventless.id);
-
-    expect(handler('board', ['evt-host-1'])).toEqual({ accepted: true });
-    expect(ledger.claimNextWorkOrder()?.payload).toEqual({
-      attempts: 1,
-      mode: 'full',
-      force: true,
-      eventIds: ['evt-host-1'],
-      repairGeneration: 102,
-      noUpdateScope: 'full:102',
-    });
-    db.close();
+    ctx.db.close();
   });
 
-  it('leaves synthetic dirt when owner board enqueue fails', () => {
-    const db = new Database(':memory:');
-    const ledger = new TaskLedger(db);
-    const gate = new BoardRefreshGate({ initialGeneration: 200 });
-    const logError = vi.fn();
-    const handler = buildOwnerWorkOrderRequestHandler({
-      taskLedger: ledger,
-      boardRefreshGate: gate,
-      now: () => 2_000,
-      log: vi.fn(),
-      logError,
+  it('coalesces owner-event Board requests into one shared non-force workorder', () => {
+    const ctx = createHarness(200);
+    const origins = Array.from({ length: 20 }, (_, index) => {
+      const eventId = `evt-${index + 1}`;
+      return {
+        kind: 'owner_event' as const,
+        batchId: ctx.enqueueBatch(eventId),
+        eventIds: [eventId],
+      };
     });
-    db.close();
 
-    expect(handler('board')).toEqual({ accepted: false, reason: 'enqueue-failed' });
-    expect(gate.captureFullRepair()).toEqual({
+    for (const origin of origins) {
+      expect(ctx.handler('board', origin)).toEqual({ accepted: true });
+    }
+
+    expect(ctx.taskLedger.countPendingWorkOrders()).toBe(1);
+    const workOrder = ctx.taskLedger.claimNextWorkOrder();
+    expect(workOrder?.idempotencyKey).toBe('board:full:repair');
+    expect(workOrder?.payload).toEqual({
+      attempts: 1,
+      mode: 'full',
+      force: false,
       repairGeneration: 201,
       noUpdateScope: 'full:201',
     });
-    expect(gate.needsFullRepair()).toBe(true);
-    expect(logError).toHaveBeenCalledOnce();
+    expect(
+      new Set(
+        origins.map(
+          (origin) => ctx.ownerEventBoardRefreshLedger.findAcceptance(origin.batchId)?.workOrderId
+        )
+      ).size
+    ).toBe(1);
+    expect(ctx.ownerEventBoardRefreshLedger.maxPendingGeneration()).toBe(220);
+    ctx.db.close();
   });
 
-  it('preserves legacy owner board payloads when reconcile is disabled', () => {
+  it('returns the same durable acceptance when one owner-event batch retries', () => {
+    const ctx = createHarness(300);
+    const origin = {
+      kind: 'owner_event' as const,
+      batchId: ctx.enqueueBatch('evt-retry'),
+      eventIds: ['evt-retry'],
+    };
+
+    expect(ctx.handler('board', origin)).toEqual({ accepted: true });
+    const first = ctx.ownerEventBoardRefreshLedger.findAcceptance(origin.batchId);
+    expect(ctx.handler('board', origin)).toEqual({ accepted: true });
+
+    expect(ctx.ownerEventBoardRefreshLedger.findAcceptance(origin.batchId)).toEqual(first);
+    expect(ctx.taskLedger.countPendingWorkOrders()).toBe(1);
+    ctx.db.close();
+  });
+
+  it('fails closed instead of restoring the forced owner-event path when coordination is absent', () => {
     const db = new Database(':memory:');
-    const ledger = new TaskLedger(db);
+    const taskLedger = new TaskLedger(db);
+    const inbox = new OwnerEventInbox(db);
+    const batchId = inbox.enqueue({
+      channelKey: 'chatwork:feedback',
+      eventIds: ['evt-missing'],
+      lines: ['line'],
+      activations: [],
+    });
+    if (batchId === null) throw new Error('test batch unexpectedly deduplicated');
     const handler = buildOwnerWorkOrderRequestHandler({
-      taskLedger: ledger,
+      taskLedger,
       boardRefreshGate: null,
-      now: () => 3_000,
+      ownerEventBoardRefreshLedger: undefined,
       log: vi.fn(),
       logError: vi.fn(),
     });
 
-    expect(handler('board')).toEqual({ accepted: true });
-    expect(ledger.claimNextWorkOrder()?.payload).toEqual({
-      attempts: 1,
-      mode: 'full',
-      force: true,
-    });
+    expect(
+      handler('board', {
+        kind: 'owner_event',
+        batchId,
+        eventIds: ['evt-missing'],
+      })
+    ).toEqual({ accepted: false, reason: 'enqueue-failed' });
+    expect(taskLedger.countPendingWorkOrders()).toBe(0);
     db.close();
+  });
+
+  it('leaves synthetic dirt when a manual Board enqueue fails', () => {
+    const ctx = createHarness(400);
+    ctx.db.close();
+
+    expect(ctx.handler('board', { kind: 'owner_manual' })).toEqual({
+      accepted: false,
+      reason: 'enqueue-failed',
+    });
+    expect(ctx.boardRefreshGate.captureFullRepair()).toEqual({
+      repairGeneration: 401,
+      noUpdateScope: 'full:401',
+    });
+    expect(ctx.boardRefreshGate.needsFullRepair()).toBe(true);
   });
 });

--- a/packages/standalone/tests/operator/owner-event-board-refresh.test.ts
+++ b/packages/standalone/tests/operator/owner-event-board-refresh.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  OwnerEventBoardRefreshLedger,
+  resolveInitialBoardRepairGeneration,
+} from '../../src/operator/owner-event-board-refresh.js';
+import { OwnerEventInbox } from '../../src/operator/owner-event-inbox.js';
+import { boardRepairKey } from '../../src/operator/workorder-publishers.js';
+import { TaskLedger } from '../../src/operator/task-ledger.js';
+import Database from '../../src/sqlite.js';
+
+describe('TG-06 owner-event Board refresh intents', () => {
+  let db: Database;
+  let inbox: OwnerEventInbox;
+  let tasks: TaskLedger;
+  let ledger: OwnerEventBoardRefreshLedger;
+  let now: number;
+
+  beforeEach(() => {
+    now = 1_000;
+    db = new Database(':memory:');
+    tasks = new TaskLedger(db, { now: () => now, timeZone: 'UTC' });
+    inbox = new OwnerEventInbox(db, () => now);
+    ledger = new OwnerEventBoardRefreshLedger(db, tasks, () => now);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function enqueueBatch(eventIds: string[]): number {
+    const id = inbox.enqueue({
+      channelKey: 'chatwork:feedback',
+      eventIds,
+      lines: eventIds.map((eventId) => `line:${eventId}`),
+      activations: [],
+    });
+    if (id === null) throw new Error('test batch unexpectedly deduplicated');
+    return id;
+  }
+
+  it('atomically binds one exact batch to one shared non-force Board workorder', () => {
+    const batchId = enqueueBatch(['evt-b', 'evt-a']);
+
+    const accepted = ledger.accept({
+      batchId,
+      eventIds: ['evt-b', 'evt-a'],
+      repair: { repairGeneration: 11, noUpdateScope: 'full:11' },
+    });
+
+    expect(accepted).toEqual({
+      batchId,
+      batchKey: 'owner-event:board:02b6fa63682561df',
+      repairGeneration: 11,
+      workOrderId: accepted.workOrderId,
+      appliedAt: null,
+    });
+    expect(accepted.workOrderId).toBeGreaterThan(0);
+    expect(tasks.countPendingWorkOrders()).toBe(1);
+    expect(tasks.findWorkOrderByOccurrence('board', boardRepairKey())).toMatchObject({
+      id: accepted.workOrderId,
+      payload: {
+        mode: 'full',
+        force: false,
+        repairGeneration: 11,
+        noUpdateScope: 'full:11',
+        attempts: 1,
+      },
+    });
+  });
+
+  it('returns the same acceptance for one batch without enqueueing again', () => {
+    const batchId = enqueueBatch(['evt-1']);
+    const input = {
+      batchId,
+      eventIds: ['evt-1'],
+      repair: { repairGeneration: 12, noUpdateScope: 'full:12' },
+    } as const;
+
+    const first = ledger.accept(input);
+    const second = ledger.accept(input);
+
+    expect(second).toEqual(first);
+    expect(tasks.countPendingWorkOrders()).toBe(1);
+  });
+
+  it('refuses reuse of one inbox batch with different event identity', () => {
+    const batchId = enqueueBatch(['evt-1']);
+    ledger.accept({
+      batchId,
+      eventIds: ['evt-1'],
+      repair: { repairGeneration: 12, noUpdateScope: 'full:12' },
+    });
+
+    expect(() =>
+      ledger.accept({
+        batchId,
+        eventIds: ['evt-2'],
+        repair: { repairGeneration: 13, noUpdateScope: 'full:13' },
+      })
+    ).toThrow(/conflicts with its stored event identity/);
+  });
+
+  it('coalesces twenty distinct batches onto one open workorder', () => {
+    const accepted = Array.from({ length: 20 }, (_, index) => {
+      const eventId = `evt-${index + 1}`;
+      return ledger.accept({
+        batchId: enqueueBatch([eventId]),
+        eventIds: [eventId],
+        repair: {
+          repairGeneration: 20 + index,
+          noUpdateScope: `full:${20 + index}`,
+        },
+      });
+    });
+
+    expect(new Set(accepted.map((row) => row.workOrderId)).size).toBe(1);
+    expect(tasks.countPendingWorkOrders()).toBe(1);
+    expect(ledger.maxPendingGeneration()).toBe(39);
+  });
+
+  it('rolls back the newly enqueued workorder when intent persistence fails', () => {
+    const batchId = enqueueBatch(['evt-rollback']);
+    db.exec(`
+      CREATE TRIGGER fail_owner_event_board_intent
+      BEFORE INSERT ON owner_event_board_refresh_intents
+      BEGIN
+        SELECT RAISE(ABORT, 'forced intent failure');
+      END;
+    `);
+
+    expect(() =>
+      ledger.accept({
+        batchId,
+        eventIds: ['evt-rollback'],
+        repair: { repairGeneration: 30, noUpdateScope: 'full:30' },
+      })
+    ).toThrow(/forced intent failure/);
+    expect(tasks.countPendingWorkOrders()).toBe(0);
+    expect(ledger.findAcceptance(batchId)).toBeNull();
+  });
+
+  it('applies only captured generations and emits one post-terminal follow-up signal', () => {
+    const accepted = Array.from({ length: 10 }, (_, index) => {
+      const eventId = `evt-${index + 1}`;
+      return ledger.accept({
+        batchId: enqueueBatch([eventId]),
+        eventIds: [eventId],
+        repair: {
+          repairGeneration: 20 + index,
+          noUpdateScope: `full:${20 + index}`,
+        },
+      });
+    });
+    const workOrderId = accepted[0].workOrderId;
+
+    expect(ledger.markVerified(workOrderId, 25)).toEqual({
+      applied: 6,
+      followupPending: true,
+    });
+    expect(ledger.findAcceptance(accepted[0].batchId)?.appliedAt).toBe(now);
+    expect(ledger.findAcceptance(accepted[9].batchId)?.appliedAt).toBeNull();
+    expect(ledger.consumePostTerminalFollowup(workOrderId)).toBe(true);
+    expect(ledger.consumePostTerminalFollowup(workOrderId)).toBe(false);
+    expect(ledger.maxPendingGeneration()).toBe(29);
+  });
+
+  it('reattaches only pending intents to a replacement workorder', () => {
+    const firstBatch = enqueueBatch(['evt-first']);
+    const secondBatch = enqueueBatch(['evt-second']);
+    const first = ledger.accept({
+      batchId: firstBatch,
+      eventIds: ['evt-first'],
+      repair: { repairGeneration: 20, noUpdateScope: 'full:20' },
+    });
+    ledger.accept({
+      batchId: secondBatch,
+      eventIds: ['evt-second'],
+      repair: { repairGeneration: 21, noUpdateScope: 'full:21' },
+    });
+    ledger.markVerified(first.workOrderId, 20);
+    expect(tasks.claimNextWorkOrder()?.id).toBe(first.workOrderId);
+    tasks.completeWorkOrder(first.workOrderId);
+    const replacement = tasks.enqueueWorkOrder({
+      workKind: 'board',
+      idempotencyKey: boardRepairKey(),
+      input: {
+        mode: 'full',
+        force: false,
+        repairGeneration: 21,
+        noUpdateScope: 'full:21',
+      },
+    });
+
+    expect(ledger.attachPendingToWorkOrder(replacement.id)).toBe(1);
+    expect(ledger.findAcceptance(firstBatch)?.workOrderId).toBe(first.workOrderId);
+    expect(ledger.findAcceptance(secondBatch)?.workOrderId).toBe(replacement.id);
+  });
+
+  it('deletes an intent with its retained owner-event inbox row', () => {
+    const batchId = enqueueBatch(['evt-delete']);
+    ledger.accept({
+      batchId,
+      eventIds: ['evt-delete'],
+      repair: { repairGeneration: 40, noUpdateScope: 'full:40' },
+    });
+
+    db.prepare('DELETE FROM owner_event_inbox WHERE id = ?').run(batchId);
+
+    expect(ledger.findAcceptance(batchId)).toBeNull();
+  });
+
+  it('chooses a boot generation above both wall time and pending intent generations', () => {
+    expect(resolveInitialBoardRepairGeneration(100, null)).toBe(100);
+    expect(resolveInitialBoardRepairGeneration(100, 150)).toBe(151);
+    expect(resolveInitialBoardRepairGeneration(200, 150)).toBe(200);
+    expect(() => resolveInitialBoardRepairGeneration(-1, null)).toThrow(/non-negative/);
+    expect(() => resolveInitialBoardRepairGeneration(100, Number.MAX_SAFE_INTEGER)).toThrow(
+      /generation exhausted/
+    );
+  });
+});

--- a/packages/standalone/tests/operator/workorder-hooks.test.ts
+++ b/packages/standalone/tests/operator/workorder-hooks.test.ts
@@ -99,9 +99,16 @@ describe('Story S2-T3: extracted workorder hooks', () => {
 
     it('clears all captured dirt only after a host-verified full effect', () => {
       const cleared: number[] = [];
+      const applied: Array<[number, number]> = [];
       const gate = {
         completeVerifiedReconcile: () => undefined,
         completeVerifiedFull: (generation: number) => cleared.push(generation),
+      };
+      const intents = {
+        markVerified: (workOrderId: number, generation: number) => {
+          applied.push([workOrderId, generation]);
+          return { applied: 1, followupPending: false };
+        },
       };
       const workOrder = {
         id: 13,
@@ -109,10 +116,54 @@ describe('Story S2-T3: extracted workorder hooks', () => {
         payload: { attempts: 1, mode: 'full', repairGeneration: 88, noUpdateScope: 'full:88' },
       } as unknown as WorkOrderRecord;
 
-      applyBoardRefreshVerdict(workOrder, false, { disposition: 'complete' }, gate);
+      applyBoardRefreshVerdict(workOrder, false, { disposition: 'complete' }, gate, intents);
       expect(cleared).toEqual([]);
-      applyBoardRefreshVerdict(workOrder, true, { disposition: 'complete' }, gate);
+      expect(applied).toEqual([]);
+      applyBoardRefreshVerdict(
+        workOrder,
+        true,
+        { disposition: 'fail', reason: 'receipt incomplete' },
+        gate,
+        intents
+      );
+      expect(cleared).toEqual([]);
+      expect(applied).toEqual([]);
+
+      applyBoardRefreshVerdict(workOrder, true, { disposition: 'complete' }, gate, intents);
       expect(cleared).toEqual([88]);
+      expect(applied).toEqual([[13, 88]]);
+    });
+
+    it('does not apply full-repair intents from a reconcile verdict', () => {
+      const applied: Array<[number, number]> = [];
+      const workOrder = {
+        id: 14,
+        workKind: 'board',
+        payload: {
+          attempts: 1,
+          mode: 'reconcile',
+          channelKey: 'telegram:owner',
+          repairGeneration: 89,
+        },
+      } as unknown as WorkOrderRecord;
+
+      applyBoardRefreshVerdict(
+        workOrder,
+        true,
+        { disposition: 'complete' },
+        {
+          completeVerifiedReconcile: () => undefined,
+          completeVerifiedFull: () => undefined,
+        },
+        {
+          markVerified: (workOrderId, generation) => {
+            applied.push([workOrderId, generation]);
+            return { applied: 1, followupPending: false };
+          },
+        }
+      );
+
+      expect(applied).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## Summary

**Performance**
- Persist each exact owner-event Board delegation as a durable intent while coalescing bursts onto one open, non-force full repair.
- Apply only host-verified captured generations and schedule at most one post-terminal repair for later arrivals.

**Safety and recovery**
- Derive owner-event batch authority from trusted execution state, never model input.
- Commit workorder acceptance and exact-batch intent atomically in SQLite, recover acceptance before model replay, and reattach unapplied intents after restart.
- Keep direct owner refreshes forced, keep the full repair gate active when delta reconcile is off, and keep the Stage-2 publisher/verifier independent of optional legacy `dashboard-agent` persona configuration.
- Preserve TG-03/TG-04 agent freedom, TG-05 owner-event run boundaries, and TG-06 receipt-first completion.

This is PR-A of two. The package remains `0.38.0`; PR-B will land before one shared release bump and runtime cutover.

## Test Coverage

All 30 new or changed paths are covered, including burst coalescing, exact retry, forged authority, transaction rollback, verified generation application, in-flight follow-up, crash recovery, flag-off behavior, and Stage-2 runtime independence from optional legacy persona configuration.

Focused gate: 8 files, 198 tests. Coverage gate: PASS (30/30 paths, 100%).

## Pre-Landing Review

One TG-04/TG-06 correctness issue was found and fixed: optional legacy `dashboard-agent` persona configuration incorrectly gated the independent Stage-2 Board publisher/verifier. The runtime is now decoupled and pinned by a boot-wiring regression test. Final diff review: CLEAN, 0 unresolved P0-P3.

## Documentation

- `README.md`: current `0.38.0` package state, verified 6,205 passing-test total, and update date.
- `docs/index.md`: current package version and update date.
- Runtime-overhead design, executable PR-A plan, and Kagemusha TG-03/TG-04/TG-05/TG-06 evidence: synchronized with the final implementation.
- `CHANGELOG.md`: intentionally unchanged because PR-A and PR-B share one later release bump.

## Design Review

No frontend files changed; design review skipped.

## Eval Results

No prompt-related files changed; evals skipped.

## Scope Drift

Scope Check: CLEAN. Delivered PR-A only: owner-event Board coalescing, durable acceptance/recovery, verified follow-up, tests, and evidence. PR-B, release, and live canary remain intentionally separate.

## Plan Completion

Plan: `docs/development/runtime-overhead-board-coalescing-plan.md`

- Tasks 1-5 and the diff-scoped review gate: 30/30 steps DONE.
- PR-B Temporal work, release cutover, and 24-hour canary are outside this PR by design.

## Verification Results

- Focused PR-A gate: 8 files, 198 tests passed.
- Standalone: 382 files, 5,166 tests passed; 4 files / 7 tests skipped.
- Root typecheck: 3/3 Turbo tasks passed.
- Root build: 2/2 Turbo tasks passed.
- Root tests: 7/7 Turbo tasks passed; 6,205 total passing tests.
- Changed-file Prettier and `git diff --check`: passed.
- Browser/Telegram UI verification intentionally not used. Live behavior waits for the shared release and a real owner event.

## TODOS

No existing TODO item is completed by PR-A; no new TODO was added because PR-B and canary remain in the approved Slice A plan.

## Test plan

- [x] Exact owner-event batch authority cannot be forged by tool input.
- [x] Twenty Board delegations produce twenty durable intents and one open non-force repair.
- [x] Only verified full effects apply captured generations.
- [x] Later in-flight generations schedule one post-terminal follow-up.
- [x] Restart recovery reattaches pending intents without replaying the owner model.
- [x] Reconcile flag-off keeps the full repair gate active.
- [x] Stage-2 Board publisher/verifier remains independent of optional legacy persona configuration.
- [x] Full package and root suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Coalesced multiple owner-event Board refreshes into shared repair work while preserving each event’s receipt.
  * Added durable recovery across restarts, verified-generation application, and follow-up repairs after completion.
  * Added trusted origin validation for owner-event work-order requests.
  * Board repair and reconciliation controls are now independently configurable.

* **Bug Fixes**
  * Prevented duplicate or unauthorized Board repairs.
  * Ensured accepted events are acknowledged after restart and only applied after verified completion.

* **Documentation**
  * Updated Board repair behavior, operational checklists, and runtime-overhead design documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
