### PR TITLE
chore: release mama-os v0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
+## mama-os [0.39.0] - 2026-08-26
+
+### Added
+
+- **Owner-event Board delegations now coalesce without losing exact receipts.** Every connector
+  batch persists one durable intent, while bursts share one open non-force full repair. Acceptance
+  is atomic with workorder enqueue, survives restart, and can ACK the exact batch before a replayed
+  model run. Only a verified all-slot publish or exact no-update receipt applies a generation;
+  later generations schedule one post-terminal repair instead of one model run per event.
+- **Temporal workers stop repeated deterministic tool-contract failures.** A run-local breaker
+  fingerprints only trusted failed `{tool, code}` audit entries from a closed allowlist. The third
+  equal consecutive denial, or ninth outer Code-Act attempt, ends as non-retryable
+  `TOOL_CONTRACT_REPEAT`. Claude, Codex, and Cline preserve that terminal code, and another
+  Temporal model run is suppressed only after exact typed-code validation and durable receipt
+  arbitration.
+
+### Changed
+
+- **Temporal context compilation is host-bound by default.** ToolRegistry and the Code-Act
+  HostBridge share one `context_compile` contract. The Temporal brief removes `scopes`,
+  `connectors`, and raw seeds from model-selected authority; the host applies current generation
+  grants and the active task seed. Explicit narrowing still uses the existing authorization checks,
+  and widening remains fail-closed.
+- **Board repair no longer depends on the optional legacy dashboard persona.** The independent
+  Stage-2 publisher and verifier remain active regardless of `dashboard-agent` persona settings.
+  Direct owner refreshes stay forced, while owner-event repairs stay non-force and replay-safe.
+
 ## mama-os [0.38.0] - 2026-08-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node Version](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org)
 [![LongMemEval 100Q](https://img.shields.io/badge/LongMemEval%20100Q-93%25-blue)](packages/memorybench/)
-[![Tests](https://img.shields.io/badge/tests-6205%20passing-success)](https://github.com/jungjaehoon-lifegamez/MAMA)
+[![Tests](https://img.shields.io/badge/tests-6227%20passing-success)](https://github.com/jungjaehoon-lifegamez/MAMA)
 
 > Right now, you read every channel yourself so nothing slips past you.
 > MAMA reads them instead, and sends you the few things that need you.
@@ -133,7 +133,7 @@ running, and skips quietly when it is not:
 
 | Package                                       | What it is                                                                                                     | You run it?          |
 | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------------- |
-| [mama-os](packages/standalone/) 0.38.0        | The always-on server: connectors, trigger loop, reports, task board, web UI. 92k lines. "MAMA" means this.     | `mama start`         |
+| [mama-os](packages/standalone/) 0.39.0        | The always-on server: connectors, trigger loop, reports, task board, web UI. 92k lines. "MAMA" means this.     | `mama start`         |
 | [mama-core](packages/mama-core/) 2.2.0        | The library underneath: memory, provenance, graph, embeddings. Everything imports it; it imports nothing here. | No binary            |
 | [mama-server](packages/mcp-server/) 1.15.0    | A deliberately thin MCP adapter over the core — 3.7k lines, no logic of its own.                               | As an MCP server     |
 | [plugin](packages/claude-code-plugin/) 1.11.0 | Claude Code hooks + slash commands. No background process.                                                     | Installed, not run   |
@@ -196,7 +196,7 @@ Each "Next" item comes from a measurement, or from a competitor doing it better:
 ```bash
 git clone https://github.com/jungjaehoon-lifegamez/MAMA.git
 cd MAMA && pnpm install && pnpm build
-pnpm test     # 6,205 passing tests across five packages
+pnpm test     # 6,227 passing tests across five packages
 ```
 
 Guidelines in [CLAUDE.md](CLAUDE.md). _Last updated: 2026-08-26_

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -259,7 +259,7 @@ Each package has independent versioning:
 - **mama-core:** 2.2.0 (stable API)
 - **mama-server:** 1.15.0 (follows MAMA version)
 - **claude-code-plugin:** 1.11.0 (follows MAMA version)
-- **mama-os:** 0.38.0 (standalone agent)
+- **mama-os:** 0.39.0 (standalone agent)
 
 ## Distribution Strategy
 

--- a/docs/development/kagemusha-telegram-parity.md
+++ b/docs/development/kagemusha-telegram-parity.md
@@ -130,7 +130,7 @@ scenario IDs from this document.
   suite passed 383 files and 5,188 tests, with four files and seven tests skipped. Root typecheck
   passed 3/3 tasks, build passed 2/2 tasks, and all seven Turbo test tasks passed. Changed-file
   Prettier and `git diff --check` passed.
-- **Status:** CODE GREEN; diff review, PR-B merge, the shared release, and a real Temporal canary
+- **Status:** CODE GREEN and merged as PR #231; the shared release and a real Temporal canary
   remain pending.
 
 ### Sender-boundary completion evidence: 2026-08-13
@@ -706,7 +706,10 @@ change unless they are release-blocking security or data-loss issues.
 - [x] The 2026-08-26 owner-event Board coalescing gate passed eight focused files / 198 tests, the
       complete standalone suite (382 files / 5,166 tests; four files / seven tests skipped), root
       typecheck and build, and all seven root Turbo test tasks. This does not claim live behavior.
-- [ ] Merge both Slice A PRs, rebuild/restart the next release, complete a real owner-event turn,
+- [x] The 2026-08-26 Temporal contract-repeat gate passed nine focused files / 368 tests, the
+      complete standalone suite (383 files / 5,188 tests; four files / seven tests skipped), root
+      typecheck, build, lint, and all seven root Turbo test tasks. PR #231 is merged.
+- [ ] Rebuild/restart v0.39.0, complete a real owner-event and Temporal turn,
       and compare visible delivery plus 24-hour model-work cost against the saved baseline.
 
 ## Change log
@@ -714,7 +717,12 @@ change unless they are release-blocking security or data-loss issues.
 - 2026-08-26: Recorded TG-03/TG-04/TG-05/TG-06 code evidence for durable exact-batch Board
   acceptance, many-to-one non-force coalescing, verified-generation application, post-terminal
   follow-up, crash recovery, and flag semantics. The focused, standalone, and root gates passed.
-  PR-A review/merge, PR-B, release cutover, and a real owner-event canary remain pending.
+  PR #230 and PR #231 are merged. The v0.39.0 release cutover and real canaries remain pending.
+
+- 2026-08-26: Recorded TG-03/TG-04/TG-05/TG-06 code evidence for host-bound Temporal context,
+  run-local deterministic failure fingerprints, the eight-call ceiling, mutation precedence,
+  Claude/Codex/Cline terminal propagation, and exact retry suppression. Focused, standalone, root,
+  lint, format, and diff gates passed; PR #231 is merged.
 
 - 2026-08-19: Recorded the uncommitted operator stabilization patch for TG-03/TG-04/TG-05/TG-06:
   named-object Code-Act declarations with wrapped/legacy report compatibility, actual

--- a/docs/development/runtime-overhead-reduction-design.md
+++ b/docs/development/runtime-overhead-reduction-design.md
@@ -1,6 +1,6 @@
 # MAMA Runtime Overhead Reduction — 검증을 보존하고 모델 낭비를 제거하는 설계
 
-> **상태:** Eng review CLEAR, PR-A MERGED, PR-B CODE GREEN / diff review 대기
+> **상태:** Eng review CLEAR, PR-A/PR-B MERGED, v0.39.0 release 준비
 >
 > **작성일:** 2026-08-26
 >
@@ -707,7 +707,7 @@ Slice B와 C는 본 문서에 이미 이유·범위·승인 게이트가 있어 
 ## 25. PR-B implementation evidence
 
 2026-08-26 기준 PR-B의 context contract, Temporal circuit breaker, backend terminal 전달,
-WorkOrder retry 정책은 코드와 테스트가 완료됐고 diff review를 기다린다.
+WorkOrder retry 정책은 코드와 테스트, diff review, PR #231 merge까지 완료됐다.
 
 - canonical ToolRegistry와 Code-Act HostBridge는 하나의 host-bound `context_compile` 설명을
   사용한다. Temporal brief는 `scopes`, `connectors`, `seed_refs`를 모델 선택 영역에서 제거하고
@@ -730,4 +730,5 @@ WorkOrder retry 정책은 코드와 테스트가 완료됐고 diff review를 기
 - Standalone: 383 files, 5,188 tests passed; 4 files / 7 tests skipped.
 - Root: typecheck 3/3, build 2/2, test 7/7 Turbo tasks passed.
 - 변경 파일 Prettier와 `git diff --check`가 통과했다.
-- diff review, PR-B merge, 단일 shared release, 실제 Temporal/owner-event canary는 아직 수행하지 않았다.
+- diff review와 PR-B merge는 완료됐다. 단일 shared release와 실제 Temporal/owner-event canary는 아직
+  수행하지 않았다.

--- a/docs/development/runtime-overhead-temporal-breaker-plan.md
+++ b/docs/development/runtime-overhead-temporal-breaker-plan.md
@@ -1,6 +1,6 @@
 # Runtime overhead PR-B: Temporal contract and circuit breaker plan
 
-> **Status:** code and verification green, diff review in progress
+> **Status:** reviewed and merged as PR #231, shared release pending
 >
 > **Date:** 2026-08-26
 >
@@ -111,5 +111,5 @@ GREEN:
 - [x] Root typecheck, build, and tests pass.
 - [x] Changed-file Prettier and `git diff --check` pass.
 - [x] Update the design and Kagemusha TG-03/TG-04/TG-05/TG-06 evidence.
-- [ ] Run diff review, clear all findings, open PR-B, clear CI and review comments,
+- [x] Run diff review, clear all findings, open PR-B, clear CI and review comments,
       then merge before the single shared release.

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -11,7 +11,7 @@ MAMA is a pnpm workspace-based monorepo with four release targets (plus the inte
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.38.0  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.39.0  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.15.0  |
 | MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 2.2.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.11.0  |
@@ -61,7 +61,7 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.38.0          |
+| `packages/standalone/package.json`                       | `version` | 0.39.0          |
 | `packages/mcp-server/package.json`                       | `version` | 1.15.0          |
 | `packages/mama-core/package.json`                        | `version` | 2.2.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.11.0          |

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,7 +157,7 @@ _Contributing, testing, and development guidelines_
 
 ---
 
-**Status:** MAMA OS v0.38.0 — Claude CLI, Codex app-server, and Cline Hub are equivalent supported
+**Status:** MAMA OS v0.39.0 — Claude CLI, Codex app-server, and Cline Hub are equivalent supported
 backends with backend-owned durable context, role-scoped Code-Act projection, bounded recovery,
 and explicit non-replayable mutation outcomes. MAMA itself owns connector-event work as
 stateless fresh runs per batch on durable per-channel lane keys; configured private connectors

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "MAMA OS - Local AI Runtime. Your scattered knowledge, organized by AI agents that never sleep.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Prepare the single shared MAMA OS release for merged PR-A #230 and PR-B #231.

- Bump only `@jungjaehoon/mama-os` from `0.38.0` to `0.39.0`.
- Add release notes for durable owner-event Board coalescing and the Temporal deterministic contract breaker.
- Synchronize README, package architecture, deployment guide, docs index, implementation status, and TG-03/TG-04/TG-05/TG-06 parity evidence.
- Update the verified passing-test total to 6,227.

After merge, `release.yml` will run on `main` with `packages=mama-os`, `bump_versions=false`, and `dry_run=false`.

## Pre-Landing Review

Release diff review at `8833abe8`: CLEAN, 0 unresolved P0-P3. `v0.39.0` is absent from both git tags and npm; current npm latest is `0.38.0`.

## Verification Results

- Version/document synchronization: passed.
- Package/runtime version tests: 4/4 passed.
- Root build: 2/2 Turbo tasks passed.
- Root typecheck: 3/3 Turbo tasks passed.
- Standalone: 383 files, 5,188 tests passed; 4 files / 7 tests skipped.
- Changed-file Prettier and `git diff --check`: passed.
- Both implementation merge commits passed full main CI before this release PR.

## Documentation

- `CHANGELOG.md`: adds the complete v0.39.0 product notes.
- `README.md`, `docs/index.md`, architecture and deployment guides: version-synchronized.
- Runtime-overhead design and parity checklist: both implementation PRs marked merged; live release/canary remains pending.

## Test plan

- [x] `0.39.0` tag is available.
- [x] `@jungjaehoon/mama-os@0.39.0` is not yet published.
- [x] `pnpm sync-versions --check` passes.
- [x] Package version endpoints/tests report 0.39.0.
- [x] Build, typecheck, standalone, format, and diff gates pass.
- [ ] Merge this PR.
- [ ] Dispatch and verify the release workflow.
- [ ] Install the published package and restart one launchd instance.
- [ ] Verify runtime version/backend/model and wait for real canary events.
