### PR TITLE
fix(standalone): persist exact Telegram delivery receipts

### DIFF
--- a/docs/development/kagemusha-telegram-parity.md
+++ b/docs/development/kagemusha-telegram-parity.md
@@ -171,7 +171,33 @@ promotes one delayed owner-event repair on the normal schedule` pins reuse and p
 its intents` pins verified-generation application before an obsolete delayed row can be claimed.
 - **Verification:** the four focused files pass 95 tests. The complete standalone suite passes 383
   files and 5,194 tests, with four files and seven tests skipped; typecheck and production build
-  pass. This is branch code/test evidence only, not merged, released, or live-canary evidence.
+  pass.
+- **Status:** CODE GREEN, merged as PR #234. Patch release and live-canary evidence remain pending.
+
+### Owner-event Telegram exact-receipt remediation evidence: 2026-08-26
+
+- **TG-01/TG-06 exact visible payload:** `OwnerEventEffectLedger` retains one versioned canonical
+  text, caption/path, or sticker intent before transmission. An exact confirmed retry returns the
+  stored receipt without transport; changed target, requested variant, delivery ID, body, path, or
+  emotion fails closed. Legacy rows remain authoritative no-replay evidence without inferred
+  payloads.
+- **TG-01 existing delivery authority:** `TelegramGateway` exposes one narrow read of its existing
+  outbound ledger. A delivered receipt includes the existing payload identity, actual transport
+  variant, and delivered timestamp. Long text still uses the established chunk progression. A
+  missing, pending, or malformed local proof cannot become effect confirmation.
+- **TG-03/TG-04 production wiring:** `initGateways` now forwards Telegram idempotency keys,
+  active-turn methods, and the receipt read instead of reducing the real gateway to four
+  mock-shaped methods. This preserves same-chat active-turn delivery and makes the owner-event
+  receipt path work in the launchd runtime, not only executor tests.
+- **TG-03/TG-06 fallback and failure:** definite photo rejection keeps the existing document
+  fallback and confirms the actual `file` ledger receipt. Ambiguous photo or transport outcomes do
+  not fall back or replay. A returned send without an exact delivered ledger row marks the effect
+  unknown and leaves later attempts reconcile-only.
+- **Verification:** the four focused files pass 203 tests. The complete standalone suite passes
+  383 files and 5,206 tests, with four files and seven tests skipped; standalone typecheck and
+  production build pass. Root lint, changed-file format, and `git diff --check` pass. PR review,
+  merge, release, and live canary remain pending.
+- **Status:** BRANCH CODE GREEN; no operational claim.
 
 ### Sender-boundary completion evidence: 2026-08-13
 

--- a/docs/development/runtime-overhead-canary-remediation-design.md
+++ b/docs/development/runtime-overhead-canary-remediation-design.md
@@ -270,6 +270,7 @@ After the awaited Telegram gateway call succeeds, confirm with versioned result 
 interface OwnerEventTelegramReceiptV1 {
   version: 1;
   deliveryId: string;
+  variant: 'text' | 'file' | 'image' | 'sticker';
   payloadIdentity: string;
   state: 'delivered';
   confirmedAt: number;
@@ -323,6 +324,7 @@ the generic ready-row claim predicate. Do not duplicate the twenty-minute rule i
 | `operator/owner-event-effects.ts`                   | Versioned intent/result types and pure exact-intent comparison       |
 | `agent/gateway-tool-executor.ts`                    | Normalize once, reserve, send, read existing ledger receipt, confirm |
 | `gateways/telegram.ts`                              | One narrow read method for an existing outbound delivery row         |
+| `cli/runtime/gateway-init.ts`                       | Preserve delivery ID, active-turn methods, and receipt read          |
 | Existing owner-effect, executor, and Telegram tests | RED exact payload, retry, fallback, legacy, missing-receipt cases    |
 
 Keep normalization and version parsing out of the already-large gateway executor. The executor
@@ -374,6 +376,7 @@ CODE PATH COVERAGE
     |-- [RED ***] transport ambiguity -> unknown, zero automatic resend
     |-- [RED ***] missing ledger receipt after send -> unknown, no false confirm
     |-- [RED ***] image rejection -> file fallback + actual variant receipt
+    |-- [RED ***] production adapter -> forwards delivery ID + active-turn + receipt read
     `-- [RED ***] legacy confirmed/unknown -> no replay, no inferred payload
 
 USER FLOW COVERAGE
@@ -391,7 +394,7 @@ USER FLOW COVERAGE
 [+] [->EVAL] Temporal parity
     `-- [LIVE] real host-bound receipt or one-run deterministic breaker
 
-PLANNED UNIT/INTEGRATION COVERAGE: 22/22 paths (100%)
+PLANNED UNIT/INTEGRATION COVERAGE: 23/23 paths (100%)
 LIVE-ONLY EVIDENCE: 3 canary assertions
 ```
 
@@ -432,6 +435,8 @@ LIVE-ONLY EVIDENCE: 3 canary assertions
 11. Logs and public telemetry contain only identity-free counts/hashes, never the retained body.
 12. Internal metadata is absent from the persisted canary payload in a real post-release event; unit
     tests pin only the structural inspection surface, not model quality.
+13. The production gateway adapter forwards every Telegram delivery identity, active-turn method,
+    and receipt read instead of reducing the real gateway to an unreceipted mock-shaped surface.
 
 ## 11. Production failure modes
 
@@ -530,7 +535,7 @@ Telegram UI, browser, and Computer Use remain forbidden.
   empty delayed work, and missing post-send receipt now have explicit state transitions.
 - Code Quality Review: 2 issues found, 2 resolved. Existing modules own the behavior; the gateway
   executor keeps orchestration only.
-- Test Review: coverage diagram produced, 22/22 planned code paths covered, 7 missing regression
+- Test Review: coverage diagram produced, 23/23 planned code paths covered, 8 missing regression
   cases added to the RED plan.
 - Performance Review: 2 issues found, 2 resolved. No new timer, poller, file I/O, hash path, or
   unmeasured index remains.

--- a/docs/development/runtime-overhead-telegram-receipt-plan.md
+++ b/docs/development/runtime-overhead-telegram-receipt-plan.md
@@ -1,0 +1,346 @@
+# Runtime overhead remediation PR-B: Telegram exact receipt implementation plan
+
+> Status: reviewed implementation plan for `codex/v0-39-telegram-receipt`.
+>
+> Scope: TG-01/TG-03/TG-04/TG-06 owner-event Telegram delivery only. This PR does not add a
+> ledger, schema, service, worker, timer, queue, file snapshot, or second payload hash.
+
+## Goal
+
+Make a real owner-event Telegram send locally inspectable from the exact validated payload through
+the already-existing Telegram delivery ledger, without changing Telegram's delivery semantics or
+adding model work.
+
+The production path must preserve the idempotency key instead of dropping it at gateway wiring.
+That is required for the receipt contract to work outside tests.
+
+## What already exists
+
+- `OwnerEventEffectLedger` already reserves one host-issued effect before transmission, blocks
+  replay after an unknown outcome, confirms completed effects, and deletes them with inbox
+  retention.
+- `TelegramGateway` already derives one delivery-ledger key from `{transport variant, deliveryId}`,
+  binds the target and payload identity, tracks every text chunk, and marks `delivered` only after
+  the final Telegram call returns.
+- `GatewayToolExecutor` already validates owner-event authority, derives a stable delivery ID,
+  resolves private-workspace files, distinguishes definite photo rejection from ambiguous failure,
+  and owns image-to-file fallback.
+- `initGateways` already creates one adapter shared by the tool executor and agent loop, but that
+  adapter currently drops the optional idempotency key and the active-turn methods.
+
+These existing boundaries are sufficient. PR-B connects them; it does not build parallel ones.
+
+## Selected data flow
+
+```text
+telegram_send input
+  |
+  +-- normalize once
+  |     text: exact Unicode body, non-blank
+  |     file/image: existing regular-file + private-workspace resolution
+  |     sticker: normalized emotion
+  |
+  +-- persist exact V1 owner-event intent before send
+  |     {chatId, requestedVariant, body/caption, resolved path/emotion, deliveryId}
+  |
+  +-- existing TelegramGateway
+  |     adapter forwards deliveryId and active-turn method
+  |     existing TelegramMessageLedger binds target + payloadIdentity
+  |     image definite rejection may deliver through existing file fallback
+  |
+  +-- read the existing delivered row by {deliveryId, actualVariant}
+        |
+        +-- valid delivered row -> confirm V1 effect receipt
+        +-- missing/malformed row -> mark effect unknown, never resend automatically
+```
+
+## State contract
+
+```text
+no effect row
+  -> begin(exact V1 intent) -> transmitting -> send
+                                      |          |
+                                      |          +-- delivered ledger receipt -> confirmed
+                                      |          `-- error/missing receipt -> unknown
+                                      |
+same exact V1 retry ------------------+
+  transmitting/unknown -> reconcile-only
+  confirmed            -> return stored receipt, zero transport calls
+
+changed V1 retry -> fail closed, zero transport calls
+legacy row       -> preserve current no-replay authority; infer no body or receipt
+```
+
+## Implementation tasks
+
+### Task 1: Pin canonical intent and compatibility behavior with RED tests
+
+Files:
+
+- Modify `packages/standalone/tests/operator/owner-event-effects.test.ts`
+- Modify `packages/standalone/src/operator/owner-event-effects.ts`
+
+RED cases:
+
+1. Exact Unicode text, delivery ID, and null fields persist in a versioned intent.
+2. Blank text and missing payload fail before a reservation can be written.
+3. A resolved file/image path and exact caption persist without copying or hashing file bytes.
+4. Sticker emotion is normalized once.
+5. A changed versioned target, variant, body, path, emotion, or delivery ID is rejected.
+6. An exact versioned retry remains reconcile-only or replays its confirmed receipt.
+7. Legacy confirmed and unknown rows remain authoritative no-replay rows and gain no inferred data.
+8. Inbox deletion still removes the retained payload and receipt.
+
+Implementation:
+
+- Add `OwnerEventTelegramIntentV1`, `OwnerEventTelegramReceiptV1`, and pure canonical construction,
+  parsing, and exact-comparison helpers beside `OwnerEventEffectLedger`.
+- Move the existing private-workspace file resolver into that module and reuse the same regular-file,
+  realpath, and containment boundary.
+- Compare only recognized versioned Telegram intents. Legacy rows retain their current compatibility
+  behavior; Drive effect semantics remain unchanged.
+
+Gate:
+
+```bash
+pnpm --dir packages/standalone vitest run tests/operator/owner-event-effects.test.ts
+```
+
+### Task 2: Expose one narrow read on the existing Telegram gateway with RED tests
+
+Files:
+
+- Modify `packages/standalone/tests/gateways/telegram.test.ts`
+- Modify `packages/standalone/src/gateways/telegram.ts`
+
+RED cases:
+
+1. A delivered long text returns one receipt with the existing payload identity and delivered time.
+2. A missing, processing, or payload-identity-free row returns no receipt.
+3. Reusing one owner-event delivery ID with changed text reaches the existing binding mismatch
+   instead of silently succeeding.
+4. File, image, and sticker reads use the actual transport-variant ledger key.
+
+Implementation:
+
+- Add one read-only `readOutboundDeliveryReceipt(deliveryId, variant)` method to
+  `TelegramGateway`.
+- Return only `{deliveryId, variant, state, payloadIdentity, confirmedAt}` from an existing
+  delivered row.
+- Remove the owner-event delivered shortcut that precedes `claim`; let the existing binding check
+  reject changed payloads. Exact retries remain idempotent through the existing claim result.
+
+Gate:
+
+```bash
+pnpm --dir packages/standalone vitest run tests/gateways/telegram.test.ts
+```
+
+### Task 3: Preserve the real production adapter capabilities with a RED wiring test
+
+Files:
+
+- Modify `packages/standalone/tests/cli/runtime/gateway-init-owner-identity.test.ts`
+- Modify `packages/standalone/src/cli/runtime/gateway-init.ts`
+
+RED cases:
+
+1. The adapter forwards text/file/image/sticker idempotency keys unchanged.
+2. The adapter exposes the real active-turn methods, avoiding same-chat queue re-entry.
+3. The adapter forwards the narrow existing-ledger receipt read.
+
+Implementation:
+
+- Preserve every optional argument and method already provided by `TelegramGateway`.
+- Keep one adapter object shared by the existing executor and agent loop. Add no new wrapper class.
+
+Gate:
+
+```bash
+pnpm --dir packages/standalone vitest run tests/cli/runtime/gateway-init-owner-identity.test.ts
+```
+
+### Task 4: Orchestrate reserve, send, receipt, confirm/unknown with RED tests
+
+Files:
+
+- Modify `packages/standalone/tests/agent/gateway-tool-executor.test.ts`
+- Modify `packages/standalone/src/agent/gateway-tool-executor.ts`
+
+RED cases:
+
+1. Exact Unicode text is reserved before transport and confirmed with the matching ledger identity.
+2. Long multi-chunk text stores one exact intent and one delivered receipt.
+3. A confirmed exact retry returns success with zero transport calls.
+4. A rephrased retry fails with zero transport calls.
+5. A target or requested-variant change fails with zero transport calls.
+6. A transport error marks unknown and a later exact retry remains reconcile-only.
+7. A returned send with no valid ledger receipt marks unknown and does not false-confirm.
+8. A definite image rejection followed by file success confirms the actual `file` variant receipt.
+9. An ambiguous image error does not fall back or confirm.
+10. Legacy confirmed/unknown rows remain no-replay and unobservable.
+11. Direct non-owner-event Telegram sends retain their current behavior.
+
+Implementation:
+
+- Canonicalize before reservation, including the existing path boundary and empty-input rejection.
+- Add the requested transport variant to the exact intent and track the actual delivered variant
+  only for the receipt.
+- After the awaited send, require `readOutboundDeliveryReceipt`; validate the delivery ID,
+  actual variant, delivered state, payload identity, and timestamp before confirming.
+- Missing method or receipt is an unknown effect. The result cannot be upgraded from the returned
+  network promise alone.
+- Keep the existing failure classification and image fallback. Add the small inline state diagram
+  from this plan at the orchestration boundary.
+
+Gate:
+
+```bash
+pnpm --dir packages/standalone vitest run \
+  tests/operator/owner-event-effects.test.ts \
+  tests/gateways/telegram.test.ts \
+  tests/cli/runtime/gateway-init-owner-identity.test.ts \
+  tests/agent/gateway-tool-executor.test.ts
+```
+
+### Task 5: Update parity evidence and run regression gates
+
+Files:
+
+- Modify `docs/development/runtime-overhead-canary-remediation-design.md`
+- Modify `docs/development/kagemusha-telegram-parity.md`
+
+Documentation:
+
+- Add `variant` to the V1 delivered receipt because image-to-file fallback must record the actual
+  ledger key.
+- Record TG-01/TG-03/TG-04/TG-06 code/test evidence only. Do not claim merge, release, or canary.
+- Record that the production adapter now preserves delivery identity and active-turn delivery.
+
+Regression gates:
+
+```bash
+pnpm --dir packages/standalone typecheck
+pnpm --dir packages/standalone build
+pnpm --dir packages/standalone test
+pnpm exec prettier --check \
+  packages/standalone/src/operator/owner-event-effects.ts \
+  packages/standalone/src/agent/gateway-tool-executor.ts \
+  packages/standalone/src/gateways/telegram.ts \
+  packages/standalone/src/cli/runtime/gateway-init.ts \
+  packages/standalone/tests/operator/owner-event-effects.test.ts \
+  packages/standalone/tests/agent/gateway-tool-executor.test.ts \
+  packages/standalone/tests/gateways/telegram.test.ts \
+  packages/standalone/tests/cli/runtime/gateway-init-owner-identity.test.ts \
+  docs/development/runtime-overhead-canary-remediation-design.md \
+  docs/development/runtime-overhead-telegram-receipt-plan.md \
+  docs/development/kagemusha-telegram-parity.md
+git diff --check
+```
+
+## Code-path coverage
+
+```text
+[+] canonical intent
+    |-- text / file / image / sticker
+    |-- blank or missing input
+    |-- exact retry / changed retry / legacy row
+    `-- inbox-retention cleanup
+
+[+] existing Telegram ledger
+    |-- text chunks complete -> delivered receipt
+    |-- file / image / sticker transport keys
+    |-- processing / missing / malformed receipt
+    `-- exact binding match / changed binding rejection
+
+[+] executor
+    |-- reserve -> send -> receipt -> confirm
+    |-- transport failure -> unknown
+    |-- returned send + missing receipt -> unknown
+    |-- image rejection -> actual file receipt
+    `-- confirmed / unknown / legacy retry no-replay
+
+[+] production wiring
+    |-- idempotency key forwarded
+    |-- active-turn method forwarded
+    `-- receipt read forwarded
+```
+
+Planned unit/integration coverage: 27/27 branches. One real post-release owner-event delivery remains
+live-only evidence.
+
+## Failure modes
+
+| Failure                                    | Existing/new handling                       | Test | User/operator outcome             |
+| ------------------------------------------ | ------------------------------------------- | ---- | --------------------------------- |
+| Changed body on retry                      | Exact versioned intent mismatch             | Yes  | Tool fails, no second send        |
+| Adapter drops delivery ID                  | Adapter forwarding regression               | Yes  | Prevented before release          |
+| Telegram accepts but ledger cannot be read | Mark effect unknown                         | Yes  | No false success or resend        |
+| Definite photo rejection                   | Existing file fallback, actual file receipt | Yes  | One delivered document            |
+| Ambiguous photo outcome                    | Existing no-fallback rule, unknown effect   | Yes  | No second transport               |
+| Legacy confirmed row                       | Existing success/no-replay authority        | Yes  | Payload remains unobservable      |
+| Legacy unknown row                         | Existing reconcile-only authority           | Yes  | Existing paging/retry path        |
+| Inbox retention deletes batch              | Existing trigger deletes effect             | Yes  | Body and receipt age out together |
+
+Critical silent gaps after planned tests: 0.
+
+## NOT in scope
+
+- New SQLite columns or migrations. Existing `intent_json` and `result_json` are sufficient.
+- A second delivery ledger, receipt service, worker, queue, timer, or file-snapshot store.
+- File-byte hashing or copied outbound files. Existing resolved path plus caption remains identity.
+- Telegram provider-side exactly-once guarantees. The existing local at-least-once chunk semantics
+  remain unchanged.
+- Inferring payloads or receipts for legacy effects.
+- Model prompt/tool-definition changes or synthetic Telegram traffic.
+- Version bump, install, restart, and canary. Those happen after this PR merges in the shared patch
+  release gate.
+
+## Execution strategy
+
+Sequential implementation, no parallelization opportunity. The four steps share the same Telegram
+effect contract and must land in dependency order: canonical intent, ledger read, production wiring,
+then orchestration. This avoids two competing definitions of delivery identity.
+
+## Review decisions to lock
+
+1. Reuse the existing Telegram message ledger and its SHA-256 payload identity. No new hash path.
+2. Keep exact outbound text in bounded owner-effect JSON, never logs or public telemetry.
+3. Treat a missing local delivered receipt as unknown even when the send promise returned.
+4. Preserve legacy no-replay authority without inventing observability.
+5. Fix the lossy production adapter because receipt code that works only in mocks is not a product.
+
+## Engineering review closure
+
+- Step 0, scope challenge: accepted. The diff reuses the existing effect JSON and Telegram ledger;
+  no new infrastructure is justified. Although documentation plus tests bring the touched-file
+  count above eight, the product code remains four existing modules and zero new classes/services.
+- Architecture review: two issues found and incorporated. The production adapter must forward the
+  delivery ID/active-turn methods, and the receipt must name the actual transport variant after
+  image fallback.
+- Code-quality review: clear. Canonical construction/comparison stays beside the effect ledger;
+  the already-large executor only orchestrates boundaries.
+- Test review: 27/27 planned branches, no uncovered code path after the additions above. No prompt
+  or model behavior changes, so no eval suite is required.
+- Performance review: clear. The new hot-path work is one bounded JSON-field comparison and one
+  in-memory lookup in the existing Telegram ledger. No extra model call, SQLite query loop, file
+  read, or network call is added.
+- Failure-mode review: zero critical silent gaps.
+- TODOS.md: no new deferred item. The remaining release/canary/v1.0 work already belongs to the
+  active goal rather than repository debt.
+- Outside voice: skipped. Repository policy forbids recursive Codex, and this small sequential
+  backend patch has no user-requested subagent review.
+- Lake score: 5/5 review decisions choose the complete existing-boundary path without adding
+  parallel machinery.
+
+## GSTACK REVIEW REPORT
+
+| Review        | Trigger               | Why                        | Runs | Status         | Findings                                             |
+| ------------- | --------------------- | -------------------------- | ---: | -------------- | ---------------------------------------------------- |
+| CEO Review    | `/plan-ceo-review`    | Scope and strategy         |    0 | skipped        | Backend remediation scope already approved           |
+| Codex Review  | `/codex review`       | Independent second opinion |    0 | prohibited     | Nested Codex is forbidden by repository policy       |
+| Eng Review    | `/plan-eng-review`    | Architecture and tests     |    1 | clear          | 2 issues incorporated, 0 unresolved, 0 critical gaps |
+| Design Review | `/plan-design-review` | UI/UX gaps                 |    0 | not applicable | No frontend change                                   |
+| DX Review     | `/plan-devex-review`  | Developer experience gaps  |    0 | not applicable | No public API or onboarding change                   |
+
+**VERDICT:** ENG CLEARED. Ready for test-first implementation.

--- a/docs/development/runtime-overhead-telegram-receipt-plan.md
+++ b/docs/development/runtime-overhead-telegram-receipt-plan.md
@@ -103,7 +103,7 @@ Implementation:
 Gate:
 
 ```bash
-pnpm --dir packages/standalone vitest run tests/operator/owner-event-effects.test.ts
+pnpm --dir packages/standalone exec vitest run tests/operator/owner-event-effects.test.ts
 ```
 
 ### Task 2: Expose one narrow read on the existing Telegram gateway with RED tests
@@ -133,7 +133,7 @@ Implementation:
 Gate:
 
 ```bash
-pnpm --dir packages/standalone vitest run tests/gateways/telegram.test.ts
+pnpm --dir packages/standalone exec vitest run tests/gateways/telegram.test.ts
 ```
 
 ### Task 3: Preserve the real production adapter capabilities with a RED wiring test
@@ -157,7 +157,7 @@ Implementation:
 Gate:
 
 ```bash
-pnpm --dir packages/standalone vitest run tests/cli/runtime/gateway-init-owner-identity.test.ts
+pnpm --dir packages/standalone exec vitest run tests/cli/runtime/gateway-init-owner-identity.test.ts
 ```
 
 ### Task 4: Orchestrate reserve, send, receipt, confirm/unknown with RED tests
@@ -196,7 +196,7 @@ Implementation:
 Gate:
 
 ```bash
-pnpm --dir packages/standalone vitest run \
+pnpm --dir packages/standalone exec vitest run \
   tests/operator/owner-event-effects.test.ts \
   tests/gateways/telegram.test.ts \
   tests/cli/runtime/gateway-init-owner-identity.test.ts \
@@ -220,9 +220,9 @@ Documentation:
 Regression gates:
 
 ```bash
-pnpm --dir packages/standalone typecheck
-pnpm --dir packages/standalone build
-pnpm --dir packages/standalone test
+pnpm --dir packages/standalone run typecheck
+pnpm --dir packages/standalone run build
+pnpm --dir packages/standalone run test
 pnpm exec prettier --check \
   packages/standalone/src/operator/owner-event-effects.ts \
   packages/standalone/src/agent/gateway-tool-executor.ts \

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -11,18 +11,10 @@
  * - Path-based tools (Read, Write) also check path permissions
  */
 
-import {
-  readFileSync,
-  existsSync,
-  writeFileSync,
-  mkdirSync,
-  copyFileSync,
-  lstatSync,
-  realpathSync,
-} from 'fs';
+import { readFileSync, existsSync, writeFileSync, mkdirSync, copyFileSync, realpathSync } from 'fs';
 import { AsyncLocalStorage } from 'async_hooks';
 import { createHash, randomUUID } from 'crypto';
-import { join, dirname, resolve, relative, isAbsolute, basename, extname, sep } from 'path';
+import { join, dirname, resolve, relative, isAbsolute, basename, extname } from 'path';
 import { homedir } from 'os';
 import { execSync, spawn, execFile } from 'child_process';
 import { promisify } from 'util';
@@ -118,7 +110,15 @@ import {
   type PrivateConnectorPolicy,
 } from '../connectors/private-connector-policy.js';
 import { getMemberCandidateStore } from '../gateways/member-candidate-store.js';
+import type { TelegramOutboundDeliveryReceipt } from '../gateways/telegram.js';
 import type { ReportPublishResult } from '../api/report-handler.js';
+import {
+  buildOwnerEventTelegramIntent,
+  isOwnerEventTelegramIntentV1,
+  resolvePrivateWorkspaceFile,
+  type OwnerEventTelegramIntentV1,
+  type OwnerEventTelegramVariant,
+} from '../operator/owner-event-effects.js';
 
 const DEFAULT_PRIVATE_CONNECTOR_POLICY = resolvePrivateConnectorPolicy({
   ok: true,
@@ -583,6 +583,10 @@ export interface TelegramGatewayInterface {
     emotion: string,
     idempotencyKey?: string
   ): Promise<boolean>;
+  readOutboundDeliveryReceipt?(
+    deliveryId: string,
+    variant: OwnerEventTelegramVariant
+  ): TelegramOutboundDeliveryReceipt | null;
 }
 
 /**
@@ -610,18 +614,19 @@ function isDefinitiveTelegramPhotoRejection(error: unknown): boolean {
   return TELEGRAM_DEFINITIVE_PHOTO_REJECTIONS.some((code) => message.includes(code));
 }
 
-function resolvePrivateWorkspaceFile(filePath: string): string {
-  const root = resolve(process.env.MAMA_WORKSPACE || join(homedir(), '.mama', 'workspace'));
-  const stats = lstatSync(filePath);
-  if (stats.isSymbolicLink() || !stats.isFile()) {
-    throw new Error('Outbound file must be a regular file, not a symlink');
-  }
-  const realPath = realpathSync(filePath);
-  const realRoot = realpathSync(root);
-  if (realPath !== realRoot && !realPath.startsWith(`${realRoot}${sep}`)) {
-    throw new Error(`Outbound file must stay under the private MAMA workspace: ${realRoot}`);
-  }
-  return realPath;
+function isExactTelegramDeliveryReceipt(
+  value: TelegramOutboundDeliveryReceipt | null | undefined,
+  deliveryId: string,
+  variant: OwnerEventTelegramVariant
+): value is TelegramOutboundDeliveryReceipt {
+  return (
+    value?.deliveryId === deliveryId &&
+    value.variant === variant &&
+    value.state === 'delivered' &&
+    /^[a-f0-9]{64}$/.test(value.payloadIdentity) &&
+    Number.isFinite(value.confirmedAt) &&
+    value.confirmedAt >= 0
+  );
 }
 
 export class GatewayToolExecutor {
@@ -3832,47 +3837,65 @@ export class GatewayToolExecutor {
 
     const sourceMessageRef = this.getExecutionState().sourceMessageRef;
     const ownerEvent = sourceMessageRef?.startsWith('owner-event:') === true;
-    const deliveryVariant = sticker_emotion
-      ? 'sticker'
-      : file_path
-        ? TELEGRAM_PHOTO_EXTENSIONS.has(extname(file_path).toLowerCase())
-          ? 'image'
-          : 'file'
-        : 'text';
     let ownerEffect: { batchId: number; actionKey: string } | null = null;
     let ownerLedger: import('../operator/owner-event-effects.js').OwnerEventEffectLedger | null =
       null;
+    let ownerIntent: OwnerEventTelegramIntentV1 | null = null;
+    let idempotencyKey: string | undefined;
+    // TG-06 owner-event delivery state:
+    // reserve exact intent -> send -> delivered ledger receipt -> confirm
+    //                      `-> error/missing receipt -> unknown -> reconcile-only
     try {
       if (ownerEvent) {
         ownerEffect = this.requireOwnerEventEffect(delivery_key, 'telegram_send');
         ownerLedger = this.requireOwnerEventEffectLedger();
+        idempotencyKey = `${sourceMessageRef}:telegram:${delivery_key}`;
+        const existing = ownerLedger.inspect(
+          ownerEffect.batchId,
+          ownerEffect.actionKey,
+          'telegram_send'
+        );
+        if (existing && !isOwnerEventTelegramIntentV1(existing.intent)) {
+          return existing.state === 'confirmed'
+            ? { success: true }
+            : {
+                success: false,
+                error:
+                  'owner-event Telegram legacy effect is reconcile-only; automatic replay is disabled',
+              };
+        }
+        const trustedExisting =
+          existing && isOwnerEventTelegramIntentV1(existing.intent) ? existing.intent : undefined;
+        ownerIntent = buildOwnerEventTelegramIntent(
+          {
+            chatId: chat_id,
+            deliveryId: idempotencyKey,
+            message,
+            filePath: file_path,
+            stickerEmotion: sticker_emotion,
+          },
+          trustedExisting
+        );
         const reservation = ownerLedger.begin(
           ownerEffect.batchId,
           ownerEffect.actionKey,
           'telegram_send',
-          { chatId: chat_id, variant: deliveryVariant }
+          ownerIntent
         );
         if (reservation.state === 'confirmed') return { success: true };
-        if (reservation.intent.chatId !== chat_id) {
+        if (reservation.state === 'reconcile') {
           return {
             success: false,
-            error: 'owner-event Telegram target differs from the host-reserved destination',
-          };
-        }
-        if (reservation.intent.variant !== deliveryVariant) {
-          return {
-            success: false,
-            error: 'owner-event Telegram retry must use the originally reserved delivery variant',
+            error: 'owner-event Telegram effect is reconcile-only; automatic replay is disabled',
           };
         }
       }
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
-    const idempotencyKey = sourceMessageRef
-      ? ownerEvent
-        ? `${sourceMessageRef}:telegram:${delivery_key}`
-        : createHash('sha256')
+    if (!ownerEvent) {
+      idempotencyKey = sourceMessageRef
+        ? createHash('sha256')
             .update(
               JSON.stringify([
                 sourceMessageRef,
@@ -3883,68 +3906,104 @@ export class GatewayToolExecutor {
               ])
             )
             .digest('hex')
-      : undefined;
+        : undefined;
+    }
 
+    let deliveredVariant: OwnerEventTelegramVariant | null = ownerIntent?.variant ?? null;
     try {
-      if (sticker_emotion) {
-        await (this.telegramGateway.sendStickerFromActiveTurn?.(
-          chat_id,
-          sticker_emotion,
-          idempotencyKey
-        ) ?? this.telegramGateway.sendSticker(chat_id, sticker_emotion, idempotencyKey));
-      } else if (file_path) {
-        const safePath = resolvePrivateWorkspaceFile(file_path);
-        if (TELEGRAM_PHOTO_EXTENSIONS.has(extname(safePath).toLowerCase())) {
+      if (ownerIntent?.variant === 'sticker' || sticker_emotion) {
+        const emotion = ownerIntent?.stickerEmotion ?? sticker_emotion;
+        if (!emotion) throw new Error('Telegram sticker emotion is missing after normalization');
+        await (this.telegramGateway.sendStickerFromActiveTurn?.(chat_id, emotion, idempotencyKey) ??
+          this.telegramGateway.sendSticker(chat_id, emotion, idempotencyKey));
+        deliveredVariant = 'sticker';
+      } else if (ownerIntent?.filePath || file_path) {
+        const safePath = ownerIntent?.filePath ?? resolvePrivateWorkspaceFile(file_path!);
+        const caption = ownerIntent?.message ?? message;
+        const sendAsImage = ownerIntent
+          ? ownerIntent.variant === 'image'
+          : TELEGRAM_PHOTO_EXTENSIONS.has(extname(safePath).toLowerCase());
+        if (sendAsImage) {
           try {
             if (idempotencyKey) {
               await (this.telegramGateway.sendImageFromActiveTurn?.(
                 chat_id,
                 safePath,
-                message,
+                caption ?? undefined,
                 idempotencyKey
-              ) ?? this.telegramGateway.sendImage(chat_id, safePath, message, idempotencyKey));
+              ) ??
+                this.telegramGateway.sendImage(
+                  chat_id,
+                  safePath,
+                  caption ?? undefined,
+                  idempotencyKey
+                ));
             } else {
-              await (this.telegramGateway.sendImageFromActiveTurn?.(chat_id, safePath, message) ??
-                this.telegramGateway.sendImage(chat_id, safePath, message));
+              await (this.telegramGateway.sendImageFromActiveTurn?.(
+                chat_id,
+                safePath,
+                caption ?? undefined
+              ) ?? this.telegramGateway.sendImage(chat_id, safePath, caption ?? undefined));
             }
+            deliveredVariant = 'image';
           } catch (error) {
             if (!isDefinitiveTelegramPhotoRejection(error)) throw error;
             if (idempotencyKey) {
               await (this.telegramGateway.sendFileFromActiveTurn?.(
                 chat_id,
                 safePath,
-                message,
+                caption ?? undefined,
                 idempotencyKey
-              ) ?? this.telegramGateway.sendFile(chat_id, safePath, message, idempotencyKey));
+              ) ??
+                this.telegramGateway.sendFile(
+                  chat_id,
+                  safePath,
+                  caption ?? undefined,
+                  idempotencyKey
+                ));
             } else {
-              await (this.telegramGateway.sendFileFromActiveTurn?.(chat_id, safePath, message) ??
-                this.telegramGateway.sendFile(chat_id, safePath, message));
+              await (this.telegramGateway.sendFileFromActiveTurn?.(
+                chat_id,
+                safePath,
+                caption ?? undefined
+              ) ?? this.telegramGateway.sendFile(chat_id, safePath, caption ?? undefined));
             }
+            deliveredVariant = 'file';
           }
         } else {
           if (idempotencyKey) {
             await (this.telegramGateway.sendFileFromActiveTurn?.(
               chat_id,
               safePath,
-              message,
+              caption ?? undefined,
               idempotencyKey
-            ) ?? this.telegramGateway.sendFile(chat_id, safePath, message, idempotencyKey));
+            ) ??
+              this.telegramGateway.sendFile(
+                chat_id,
+                safePath,
+                caption ?? undefined,
+                idempotencyKey
+              ));
           } else {
-            await (this.telegramGateway.sendFileFromActiveTurn?.(chat_id, safePath, message) ??
-              this.telegramGateway.sendFile(chat_id, safePath, message));
+            await (this.telegramGateway.sendFileFromActiveTurn?.(
+              chat_id,
+              safePath,
+              caption ?? undefined
+            ) ?? this.telegramGateway.sendFile(chat_id, safePath, caption ?? undefined));
           }
+          deliveredVariant = 'file';
         }
-      } else if (message) {
+      } else if (ownerIntent?.message || message) {
+        const text = ownerIntent?.message ?? message;
+        if (!text) throw new Error('Telegram text message is missing after normalization');
         if (idempotencyKey) {
-          await (this.telegramGateway.sendMessageFromActiveTurn?.(
-            chat_id,
-            message,
-            idempotencyKey
-          ) ?? this.telegramGateway.sendMessage(chat_id, message, idempotencyKey));
+          await (this.telegramGateway.sendMessageFromActiveTurn?.(chat_id, text, idempotencyKey) ??
+            this.telegramGateway.sendMessage(chat_id, text, idempotencyKey));
         } else {
-          await (this.telegramGateway.sendMessageFromActiveTurn?.(chat_id, message) ??
-            this.telegramGateway.sendMessage(chat_id, message));
+          await (this.telegramGateway.sendMessageFromActiveTurn?.(chat_id, text) ??
+            this.telegramGateway.sendMessage(chat_id, text));
         }
+        deliveredVariant = 'text';
       } else {
         return {
           success: false,
@@ -3953,7 +4012,21 @@ export class GatewayToolExecutor {
       }
 
       if (ownerEffect && ownerLedger) {
-        ownerLedger.confirm(ownerEffect.batchId, ownerEffect.actionKey, 'telegram_send', null);
+        const receipt =
+          idempotencyKey && deliveredVariant
+            ? this.telegramGateway.readOutboundDeliveryReceipt?.(idempotencyKey, deliveredVariant)
+            : null;
+        if (
+          !idempotencyKey ||
+          !deliveredVariant ||
+          !isExactTelegramDeliveryReceipt(receipt, idempotencyKey, deliveredVariant)
+        ) {
+          throw new Error('Owner-event Telegram send is missing its exact local delivery receipt');
+        }
+        ownerLedger.confirm(ownerEffect.batchId, ownerEffect.actionKey, 'telegram_send', {
+          version: 1,
+          ...receipt,
+        });
       }
       return { success: true };
     } catch (err) {

--- a/packages/standalone/src/cli/runtime/gateway-init.ts
+++ b/packages/standalone/src/cli/runtime/gateway-init.ts
@@ -206,14 +206,41 @@ export async function initGateways(
 
       // Wire tool executor
       const telegramGatewayInterface = {
-        sendMessage: async (chatId: string, message: string) =>
-          telegramGateway!.sendMessage(chatId, message),
-        sendFile: async (chatId: string, filePath: string, caption?: string) =>
-          telegramGateway!.sendFile(chatId, filePath, caption),
-        sendImage: async (chatId: string, imagePath: string, caption?: string) =>
-          telegramGateway!.sendImage(chatId, imagePath, caption),
-        sendSticker: async (chatId: string | number, emotion: string) =>
-          telegramGateway!.sendSticker(chatId, emotion),
+        sendMessage: async (chatId: string, message: string, deliveryId?: string) =>
+          telegramGateway!.sendMessage(chatId, message, deliveryId),
+        sendFile: async (chatId: string, filePath: string, caption?: string, deliveryId?: string) =>
+          telegramGateway!.sendFile(chatId, filePath, caption, deliveryId),
+        sendImage: async (
+          chatId: string,
+          imagePath: string,
+          caption?: string,
+          deliveryId?: string
+        ) => telegramGateway!.sendImage(chatId, imagePath, caption, deliveryId),
+        sendSticker: async (chatId: string | number, emotion: string, deliveryId?: string) =>
+          telegramGateway!.sendSticker(chatId, emotion, deliveryId),
+        sendMessageFromActiveTurn: async (chatId: string, message: string, deliveryId?: string) =>
+          telegramGateway!.sendMessageFromActiveTurn(chatId, message, deliveryId),
+        sendFileFromActiveTurn: async (
+          chatId: string,
+          filePath: string,
+          caption?: string,
+          deliveryId?: string
+        ) => telegramGateway!.sendFileFromActiveTurn(chatId, filePath, caption, deliveryId),
+        sendImageFromActiveTurn: async (
+          chatId: string,
+          imagePath: string,
+          caption?: string,
+          deliveryId?: string
+        ) => telegramGateway!.sendImageFromActiveTurn(chatId, imagePath, caption, deliveryId),
+        sendStickerFromActiveTurn: async (
+          chatId: string | number,
+          emotion: string,
+          deliveryId?: string
+        ) => telegramGateway!.sendStickerFromActiveTurn(chatId, emotion, deliveryId),
+        readOutboundDeliveryReceipt: (
+          deliveryId: string,
+          variant: 'text' | 'file' | 'image' | 'sticker'
+        ) => telegramGateway!.readOutboundDeliveryReceipt(deliveryId, variant),
       };
       toolExecutor.setTelegramGateway(telegramGatewayInterface);
       agentLoop.setTelegramGateway(telegramGatewayInterface);

--- a/packages/standalone/src/gateways/telegram.ts
+++ b/packages/standalone/src/gateways/telegram.ts
@@ -186,6 +186,16 @@ export interface TelegramGatewayOptions {
   ) => { principalId: string; kind: 'owner' | 'member'; status: string } | null;
 }
 
+export type TelegramOutboundVariant = 'text' | 'file' | 'image' | 'sticker';
+
+export interface TelegramOutboundDeliveryReceipt {
+  deliveryId: string;
+  variant: TelegramOutboundVariant;
+  state: 'delivered';
+  payloadIdentity: string;
+  confirmedAt: number;
+}
+
 /**
  * Telegram Gateway class
  */
@@ -896,8 +906,6 @@ export class TelegramGateway extends BaseGateway {
       deliveryTarget: `telegram:${chatId}`,
       payloadIdentity: createHash('sha256').update(text).digest('hex'),
     };
-    const prior = this.messageLedger.get(ledgerKey);
-    if (idempotencyKey.startsWith('owner-event:') && prior?.state === 'delivered') return;
     const { entry: existing } = this.messageLedger.claim(ledgerKey, binding);
     if (existing?.state === 'delivered') return;
 
@@ -1027,8 +1035,6 @@ export class TelegramGateway extends BaseGateway {
       return;
     }
     const ledgerKey = this.outboundLedgerKey(idempotencyKey, kind);
-    const prior = this.messageLedger.get(ledgerKey);
-    if (idempotencyKey.startsWith('owner-event:') && prior?.state === 'delivered') return;
     const { entry: existing } = this.messageLedger.claim(ledgerKey, {
       deliveryTarget: `telegram:${chatId}`,
       payloadIdentity: createHash('sha256').update(payload).digest('hex'),
@@ -1109,6 +1115,28 @@ export class TelegramGateway extends BaseGateway {
   private outboundLedgerKey(idempotencyKey: string, kind: string): string {
     const digest = createHash('sha256').update(`${kind}\0${idempotencyKey}`).digest('hex');
     return `outbound:${digest}`;
+  }
+
+  /** Read the existing durable proof for one exact outbound delivery occurrence. */
+  readOutboundDeliveryReceipt(
+    deliveryId: string,
+    variant: TelegramOutboundVariant
+  ): TelegramOutboundDeliveryReceipt | null {
+    const entry = this.messageLedger.get(this.outboundLedgerKey(deliveryId, variant));
+    if (
+      entry?.state !== 'delivered' ||
+      typeof entry.payloadIdentity !== 'string' ||
+      !/^[a-f0-9]{64}$/.test(entry.payloadIdentity)
+    ) {
+      return null;
+    }
+    return {
+      deliveryId,
+      variant,
+      state: 'delivered',
+      payloadIdentity: entry.payloadIdentity,
+      confirmedAt: entry.updatedAt,
+    };
   }
 
   async sendSticker(

--- a/packages/standalone/src/operator/owner-event-effects.ts
+++ b/packages/standalone/src/operator/owner-event-effects.ts
@@ -1,13 +1,150 @@
+import { lstatSync, realpathSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { extname, join, resolve, sep } from 'node:path';
+
 import type { OwnerEventEffectAuthority } from '../agent/types.js';
 import type { SQLiteDatabase } from '../sqlite.js';
 import type { OwnerEventBatch } from './owner-event-inbox.js';
 
 export type OwnerEventEffectKind = 'telegram_send' | 'drive_upload';
 
+export type OwnerEventTelegramVariant = 'text' | 'file' | 'image' | 'sticker';
+
+export interface OwnerEventTelegramIntentV1 extends Record<string, unknown> {
+  version: 1;
+  chatId: string;
+  variant: OwnerEventTelegramVariant;
+  deliveryId: string;
+  message: string | null;
+  filePath: string | null;
+  stickerEmotion: string | null;
+}
+
+export interface OwnerEventTelegramReceiptV1 extends Record<string, unknown> {
+  version: 1;
+  deliveryId: string;
+  variant: OwnerEventTelegramVariant;
+  state: 'delivered';
+  payloadIdentity: string;
+  confirmedAt: number;
+}
+
+export interface OwnerEventTelegramIntentInput {
+  chatId: string;
+  deliveryId: string;
+  message?: string;
+  filePath?: string;
+  stickerEmotion?: string;
+}
+
+const TELEGRAM_PHOTO_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif']);
+
+export function resolvePrivateWorkspaceFile(filePath: string): string {
+  const root = resolve(process.env.MAMA_WORKSPACE || join(homedir(), '.mama', 'workspace'));
+  const stats = lstatSync(filePath);
+  if (stats.isSymbolicLink() || !stats.isFile()) {
+    throw new Error('Outbound file must be a regular file, not a symlink');
+  }
+  const realPath = realpathSync(filePath);
+  const realRoot = realpathSync(root);
+  if (realPath !== realRoot && !realPath.startsWith(`${realRoot}${sep}`)) {
+    throw new Error(`Outbound file must stay under the private MAMA workspace: ${realRoot}`);
+  }
+  return realPath;
+}
+
+/** Canonicalize exactly the payload Telegram will receive, before reserving the effect. */
+export function buildOwnerEventTelegramIntent(
+  input: OwnerEventTelegramIntentInput,
+  trustedExisting?: OwnerEventTelegramIntentV1
+): OwnerEventTelegramIntentV1 {
+  if (!input.chatId) throw new Error('chat_id is required');
+  if (!input.deliveryId) throw new Error('owner-event Telegram delivery ID is required');
+
+  const stickerEmotion = input.stickerEmotion?.trim().toLowerCase();
+  if (stickerEmotion) {
+    return {
+      version: 1,
+      chatId: input.chatId,
+      variant: 'sticker',
+      deliveryId: input.deliveryId,
+      message: null,
+      filePath: null,
+      stickerEmotion,
+    };
+  }
+
+  if (input.filePath) {
+    const filePath =
+      input.filePath === trustedExisting?.filePath
+        ? trustedExisting.filePath
+        : resolvePrivateWorkspaceFile(input.filePath);
+    return {
+      version: 1,
+      chatId: input.chatId,
+      variant: TELEGRAM_PHOTO_EXTENSIONS.has(extname(filePath).toLowerCase()) ? 'image' : 'file',
+      deliveryId: input.deliveryId,
+      message: input.message ?? null,
+      filePath,
+      stickerEmotion: null,
+    };
+  }
+
+  if (input.message !== undefined) {
+    if (!input.message.trim()) throw new Error('Telegram text message must not be blank');
+    return {
+      version: 1,
+      chatId: input.chatId,
+      variant: 'text',
+      deliveryId: input.deliveryId,
+      message: input.message,
+      filePath: null,
+      stickerEmotion: null,
+    };
+  }
+
+  throw new Error('Either message, file_path, or sticker_emotion is required');
+}
+
+export function isOwnerEventTelegramIntentV1(
+  value: Record<string, unknown>
+): value is OwnerEventTelegramIntentV1 {
+  return (
+    value.version === 1 &&
+    typeof value.chatId === 'string' &&
+    (value.variant === 'text' ||
+      value.variant === 'file' ||
+      value.variant === 'image' ||
+      value.variant === 'sticker') &&
+    typeof value.deliveryId === 'string' &&
+    (typeof value.message === 'string' || value.message === null) &&
+    (typeof value.filePath === 'string' || value.filePath === null) &&
+    (typeof value.stickerEmotion === 'string' || value.stickerEmotion === null)
+  );
+}
+
+export function ownerEventTelegramIntentsEqual(
+  left: OwnerEventTelegramIntentV1,
+  right: OwnerEventTelegramIntentV1
+): boolean {
+  return (
+    left.chatId === right.chatId &&
+    left.variant === right.variant &&
+    left.deliveryId === right.deliveryId &&
+    left.message === right.message &&
+    left.filePath === right.filePath &&
+    left.stickerEmotion === right.stickerEmotion
+  );
+}
+
 export type OwnerEventEffectBeginResult =
   | { state: 'execute'; intent: Record<string, unknown> }
   | { state: 'reconcile'; intent: Record<string, unknown> }
-  | { state: 'confirmed'; result: Record<string, unknown> | null };
+  | {
+      state: 'confirmed';
+      intent: Record<string, unknown>;
+      result: Record<string, unknown> | null;
+    };
 
 interface StoredEffectRow {
   effect_kind: string;
@@ -93,14 +230,24 @@ export class OwnerEventEffectLedger {
       if (row.effect_kind !== effectKind) {
         throw new Error(`Owner-event action ${actionKey} is already bound to ${row.effect_kind}`);
       }
+      const storedIntent = JSON.parse(row.intent_json) as Record<string, unknown>;
+      if (
+        effectKind === 'telegram_send' &&
+        isOwnerEventTelegramIntentV1(storedIntent) &&
+        (!isOwnerEventTelegramIntentV1(intent) ||
+          !ownerEventTelegramIntentsEqual(storedIntent, intent))
+      ) {
+        throw new Error('Owner-event Telegram intent mismatch for the host-issued delivery key');
+      }
       if (row.status !== 'confirmed') {
         return {
           state: 'reconcile',
-          intent: JSON.parse(row.intent_json) as Record<string, unknown>,
+          intent: storedIntent,
         } as const;
       }
       return {
         state: 'confirmed',
+        intent: storedIntent,
         result: row.result_json ? (JSON.parse(row.result_json) as Record<string, unknown>) : null,
       } as const;
     });
@@ -130,6 +277,7 @@ export class OwnerEventEffectLedger {
     }
     return {
       state: 'confirmed',
+      intent: JSON.parse(row.intent_json) as Record<string, unknown>,
       result: row.result_json ? (JSON.parse(row.result_json) as Record<string, unknown>) : null,
     };
   }

--- a/packages/standalone/src/operator/owner-event-effects.ts
+++ b/packages/standalone/src/operator/owner-event-effects.ts
@@ -1,6 +1,6 @@
 import { lstatSync, realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { extname, join, resolve, sep } from 'node:path';
+import { basename, dirname, extname, join, resolve, sep } from 'node:path';
 
 import type { OwnerEventEffectAuthority } from '../agent/types.js';
 import type { SQLiteDatabase } from '../sqlite.js';
@@ -53,6 +53,28 @@ export function resolvePrivateWorkspaceFile(filePath: string): string {
   return realPath;
 }
 
+function resolveReservedTelegramFilePath(requested: string, trusted?: string): string {
+  if (!trusted) return resolvePrivateWorkspaceFile(requested);
+  if (requested === trusted || resolve(requested) === trusted) return trusted;
+  try {
+    return resolvePrivateWorkspaceFile(requested);
+  } catch (error) {
+    // Transient media may be deleted after delivery. Reuse the already-proven path only when the
+    // surviving parent realpath proves that this is the same canonical filename.
+    try {
+      const requestedPath = resolve(requested);
+      const canonicalMissingPath = join(
+        realpathSync(dirname(requestedPath)),
+        basename(requestedPath)
+      );
+      if (canonicalMissingPath === trusted) return trusted;
+    } catch {
+      // Preserve the original validation error when equivalence cannot be proven.
+    }
+    throw error;
+  }
+}
+
 /** Canonicalize exactly the payload Telegram will receive, before reserving the effect. */
 export function buildOwnerEventTelegramIntent(
   input: OwnerEventTelegramIntentInput,
@@ -75,10 +97,10 @@ export function buildOwnerEventTelegramIntent(
   }
 
   if (input.filePath) {
-    const filePath =
-      input.filePath === trustedExisting?.filePath
-        ? trustedExisting.filePath
-        : resolvePrivateWorkspaceFile(input.filePath);
+    const filePath = resolveReservedTelegramFilePath(
+      input.filePath,
+      trustedExisting?.filePath ?? undefined
+    );
     return {
       version: 1,
       chatId: input.chatId,

--- a/packages/standalone/tests/agent/gateway-tool-executor.test.ts
+++ b/packages/standalone/tests/agent/gateway-tool-executor.test.ts
@@ -1684,7 +1684,7 @@ describe('STORY-V019 - GatewayToolExecutor', () => {
           };
           const input = {
             chat_id: '7777',
-            file_path: realpathSync(outputPath),
+            file_path: outputPath,
             message: ' exact caption ',
             delivery_key: 'telegram-delivery',
           };

--- a/packages/standalone/tests/agent/gateway-tool-executor.test.ts
+++ b/packages/standalone/tests/agent/gateway-tool-executor.test.ts
@@ -1229,14 +1229,23 @@ describe('STORY-V019 - GatewayToolExecutor', () => {
     });
 
     describe('Telegram output parity', () => {
-      it('dedupes owner-event Telegram actions by stable semantic key across retry reordering', async () => {
+      it('TG-01/TG-06 confirms exact owner-event text from the existing delivery receipt', async () => {
         const keys: Array<string | undefined> = [];
         const api = createMockApi();
         api.beginModelRun = vi.fn().mockResolvedValue(modelRunForAttempt(0));
         api.commitModelRun = vi.fn().mockResolvedValue(modelRunForAttempt(0, 'completed'));
         api.failModelRun = vi.fn().mockResolvedValue(modelRunForAttempt(0, 'failed'));
         const executor = new GatewayToolExecutor({ mamaApi: api });
-        executor.setOwnerEventEffectLedger(new OwnerEventEffectLedger(new Database(':memory:')));
+        const db = new Database(':memory:');
+        executor.setOwnerEventEffectLedger(new OwnerEventEffectLedger(db, () => 1_000));
+        const receipt = {
+          deliveryId: 'owner-event:41:telegram:telegram-delivery',
+          variant: 'text' as const,
+          state: 'delivered' as const,
+          payloadIdentity: 'a'.repeat(64),
+          confirmedAt: 900,
+        };
+        const readOutboundDeliveryReceipt = vi.fn().mockReturnValue(receipt);
         executor.setTelegramGateway({
           sendMessage: vi.fn(async (_chatId, _message, idempotencyKey) => {
             keys.push(idempotencyKey);
@@ -1244,6 +1253,7 @@ describe('STORY-V019 - GatewayToolExecutor', () => {
           sendFile: vi.fn(),
           sendImage: vi.fn(),
           sendSticker: vi.fn(),
+          readOutboundDeliveryReceipt,
         });
         executor.setAgentContext({
           ...createViewerContext(),
@@ -1269,30 +1279,57 @@ describe('STORY-V019 - GatewayToolExecutor', () => {
         };
         const retryRun = { ...firstRun, modelRunId: 'mr-owner-event-retry' };
 
-        await executor.execute(
-          'telegram_send',
-          { chat_id: '7777', message: 'first translation', delivery_key: 'telegram-delivery' },
-          firstRun
-        );
-        await executor.execute(
-          'telegram_send',
-          {
-            chat_id: '7777',
-            message: 'duplicate notice in the same batch',
-            delivery_key: 'telegram-delivery',
-          },
-          firstRun
-        );
-        await executor.execute(
-          'telegram_send',
-          {
-            chat_id: '7777',
-            message: 'rephrased translation on retry',
-            delivery_key: 'telegram-delivery',
-          },
-          retryRun
-        );
+        await expect(
+          executor.execute(
+            'telegram_send',
+            { chat_id: '7777', message: 'first translation', delivery_key: 'telegram-delivery' },
+            firstRun
+          )
+        ).resolves.toEqual({ success: true });
+        await expect(
+          executor.execute(
+            'telegram_send',
+            { chat_id: '7777', message: 'first translation', delivery_key: 'telegram-delivery' },
+            retryRun
+          )
+        ).resolves.toEqual({ success: true });
+        await expect(
+          executor.execute(
+            'telegram_send',
+            {
+              chat_id: '7777',
+              message: 'rephrased translation on retry',
+              delivery_key: 'telegram-delivery',
+            },
+            retryRun
+          )
+        ).resolves.toMatchObject({
+          success: false,
+          error: expect.stringContaining('intent mismatch'),
+        });
+
         expect(keys).toEqual(['owner-event:41:telegram:telegram-delivery']);
+        expect(readOutboundDeliveryReceipt).toHaveBeenCalledWith(
+          'owner-event:41:telegram:telegram-delivery',
+          'text'
+        );
+        const row = db
+          .prepare(
+            `SELECT status, intent_json, result_json FROM owner_event_effects
+              WHERE batch_id = 41 AND action_key = 'telegram-delivery'`
+          )
+          .get() as { status: string; intent_json: string; result_json: string };
+        expect(row.status).toBe('confirmed');
+        expect(JSON.parse(row.intent_json)).toEqual({
+          version: 1,
+          chatId: '7777',
+          variant: 'text',
+          deliveryId: 'owner-event:41:telegram:telegram-delivery',
+          message: 'first translation',
+          filePath: null,
+          stickerEmotion: null,
+        });
+        expect(JSON.parse(row.result_json)).toEqual({ version: 1, ...receipt });
       });
 
       it('rejects a syntactically valid owner-event key that the host did not issue', async () => {
@@ -1389,16 +1426,16 @@ describe('STORY-V019 - GatewayToolExecutor', () => {
         expect(sendMessage).not.toHaveBeenCalled();
       });
 
-      it('does not change Telegram transport variant after an ambiguous owner-event send', async () => {
+      it('TG-06 keeps an ambiguous owner-event send reconcile-only without another transport', async () => {
         const executor = new GatewayToolExecutor({ mamaApi: createMockApi() });
         executor.setOwnerEventEffectLedger(new OwnerEventEffectLedger(new Database(':memory:')));
         const sendMessage = vi.fn().mockRejectedValue(new Error('unknown transport outcome'));
-        const sendFile = vi.fn();
         executor.setTelegramGateway({
           sendMessage,
-          sendFile,
+          sendFile: vi.fn(),
           sendImage: vi.fn(),
           sendSticker: vi.fn(),
+          readOutboundDeliveryReceipt: vi.fn(),
         });
         executor.setAgentContext({
           ...createViewerContext(),
@@ -1434,7 +1471,7 @@ describe('STORY-V019 - GatewayToolExecutor', () => {
           'telegram_send',
           {
             chat_id: '7777',
-            file_path: '/private/workspace/retry.png',
+            message: 'first',
             delivery_key: 'telegram-delivery',
           },
           { ...run, modelRunId: 'mr-owner-event-telegram-variant-retry' }
@@ -1442,10 +1479,258 @@ describe('STORY-V019 - GatewayToolExecutor', () => {
 
         expect(retry).toMatchObject({
           success: false,
-          error: expect.stringContaining('originally reserved delivery variant'),
+          error: expect.stringContaining('reconcile'),
         });
         expect(sendMessage).toHaveBeenCalledTimes(1);
-        expect(sendFile).not.toHaveBeenCalled();
+
+        const changed = await executor.execute(
+          'telegram_send',
+          {
+            chat_id: '7777',
+            message: 'changed after unknown outcome',
+            delivery_key: 'telegram-delivery',
+          },
+          { ...run, modelRunId: 'mr-owner-event-telegram-changed-retry' }
+        );
+        expect(changed).toMatchObject({
+          success: false,
+          error: expect.stringContaining('intent mismatch'),
+        });
+        expect(sendMessage).toHaveBeenCalledTimes(1);
+      });
+
+      it('TG-06 marks a returned send unknown when the durable delivery receipt is missing', async () => {
+        const db = new Database(':memory:');
+        const ledger = new OwnerEventEffectLedger(db, () => 1_000);
+        const executor = new GatewayToolExecutor({ mamaApi: createMockApi() });
+        executor.setOwnerEventEffectLedger(ledger);
+        const sendMessage = vi.fn().mockResolvedValue(undefined);
+        executor.setTelegramGateway({
+          sendMessage,
+          sendFile: vi.fn(),
+          sendImage: vi.fn(),
+          sendSticker: vi.fn(),
+          readOutboundDeliveryReceipt: vi.fn().mockReturnValue(null),
+        });
+        executor.setAgentContext({
+          ...createViewerContext(),
+          source: 'owner-event',
+          platform: 'cli',
+          roleName: 'owner_console',
+          role: { ...DEFAULT_ROLES.definitions.owner_console, allowedTools: ['telegram_send'] },
+        });
+        const run = {
+          agentId: 'owner_console',
+          source: 'owner-event',
+          channelId: 'chatwork:C1',
+          sourceMessageRef: 'owner-event:46',
+          modelRunId: 'mr-owner-event-missing-receipt',
+          executionSurface: 'direct' as const,
+          ownerEventEffects: {
+            batchId: 46,
+            effectKeys: {
+              telegram_send: 'telegram-delivery',
+              drive_upload: 'drive-upload',
+            },
+          },
+        };
+        const input = {
+          chat_id: '7777',
+          message: 'receipt required',
+          delivery_key: 'telegram-delivery',
+        };
+
+        await expect(executor.execute('telegram_send', input, run)).resolves.toMatchObject({
+          success: false,
+          error: expect.stringContaining('delivery receipt'),
+        });
+        await expect(
+          executor.execute('telegram_send', input, {
+            ...run,
+            modelRunId: 'mr-owner-event-missing-receipt-retry',
+          })
+        ).resolves.toMatchObject({
+          success: false,
+          error: expect.stringContaining('reconcile'),
+        });
+        expect(sendMessage).toHaveBeenCalledTimes(1);
+        expect(ledger.confirmedKinds(46)).toEqual([]);
+        expect(ledger.inspect(46, 'telegram-delivery', 'telegram_send')).toMatchObject({
+          state: 'reconcile',
+          intent: { version: 1, message: 'receipt required' },
+        });
+      });
+
+      it('TG-06 keeps legacy confirmed and unknown Telegram effects no-replay', async () => {
+        const ledger = new OwnerEventEffectLedger(new Database(':memory:'), () => 1_000);
+        ledger.begin(47, 'telegram-delivery', 'telegram_send', {
+          chatId: '7777',
+          variant: 'text',
+        });
+        ledger.confirm(47, 'telegram-delivery', 'telegram_send', null);
+        ledger.begin(48, 'telegram-delivery', 'telegram_send', {
+          chatId: '7777',
+          variant: 'text',
+        });
+        ledger.markUnknown(48, 'telegram-delivery', 'telegram_send', 'legacy ambiguity');
+        const executor = new GatewayToolExecutor({ mamaApi: createMockApi() });
+        executor.setOwnerEventEffectLedger(ledger);
+        const sendMessage = vi.fn();
+        executor.setTelegramGateway({
+          sendMessage,
+          sendFile: vi.fn(),
+          sendImage: vi.fn(),
+          sendSticker: vi.fn(),
+          readOutboundDeliveryReceipt: vi.fn(),
+        });
+        executor.setAgentContext({
+          ...createViewerContext(),
+          source: 'owner-event',
+          platform: 'cli',
+          roleName: 'owner_console',
+          role: { ...DEFAULT_ROLES.definitions.owner_console, allowedTools: ['telegram_send'] },
+        });
+        const execution = (batchId: number) => ({
+          agentId: 'owner_console',
+          source: 'owner-event',
+          channelId: 'chatwork:C1',
+          sourceMessageRef: `owner-event:${batchId}`,
+          modelRunId: `mr-owner-event-legacy-${batchId}`,
+          executionSurface: 'direct' as const,
+          ownerEventEffects: {
+            batchId,
+            effectKeys: {
+              telegram_send: 'telegram-delivery',
+              drive_upload: 'drive-upload',
+            },
+          },
+        });
+
+        await expect(
+          executor.execute(
+            'telegram_send',
+            { chat_id: '7777', message: 'unobservable', delivery_key: 'telegram-delivery' },
+            execution(47)
+          )
+        ).resolves.toEqual({ success: true });
+        await expect(
+          executor.execute(
+            'telegram_send',
+            {
+              chat_id: '7777',
+              file_path: '/already-removed/legacy-output.png',
+              delivery_key: 'telegram-delivery',
+            },
+            execution(48)
+          )
+        ).resolves.toMatchObject({
+          success: false,
+          error: expect.stringContaining('reconcile'),
+        });
+        expect(sendMessage).not.toHaveBeenCalled();
+      });
+
+      it('TG-03/TG-06 confirms the actual file receipt after definite photo rejection', async () => {
+        const workspace = await mkdtemp(join(tmpdir(), 'mama-owner-event-photo-fallback-'));
+        const outputPath = join(workspace, 'translated.png');
+        await writeFile(outputPath, 'image-result');
+        const previousWorkspace = process.env.MAMA_WORKSPACE;
+        process.env.MAMA_WORKSPACE = workspace;
+        try {
+          const db = new Database(':memory:');
+          const executor = new GatewayToolExecutor({ mamaApi: createMockApi() });
+          executor.setOwnerEventEffectLedger(new OwnerEventEffectLedger(db, () => 1_000));
+          const sendImage = vi.fn().mockRejectedValue(new Error('PHOTO_INVALID_DIMENSIONS'));
+          const sendFile = vi.fn().mockResolvedValue(undefined);
+          const readOutboundDeliveryReceipt = vi.fn((_deliveryId: string, variant: string) =>
+            variant === 'file'
+              ? {
+                  deliveryId: 'owner-event:49:telegram:telegram-delivery',
+                  variant: 'file',
+                  state: 'delivered',
+                  payloadIdentity: 'c'.repeat(64),
+                  confirmedAt: 950,
+                }
+              : null
+          );
+          executor.setTelegramGateway({
+            sendMessage: vi.fn(),
+            sendFile,
+            sendImage,
+            sendSticker: vi.fn(),
+            readOutboundDeliveryReceipt,
+          });
+          executor.setAgentContext({
+            ...createViewerContext(),
+            source: 'owner-event',
+            platform: 'cli',
+            roleName: 'owner_console',
+            role: { ...DEFAULT_ROLES.definitions.owner_console, allowedTools: ['telegram_send'] },
+          });
+          const run = {
+            agentId: 'owner_console',
+            source: 'owner-event',
+            channelId: 'chatwork:C1',
+            sourceMessageRef: 'owner-event:49',
+            modelRunId: 'mr-owner-event-photo-fallback',
+            executionSurface: 'direct' as const,
+            ownerEventEffects: {
+              batchId: 49,
+              effectKeys: {
+                telegram_send: 'telegram-delivery',
+                drive_upload: 'drive-upload',
+              },
+            },
+          };
+          const input = {
+            chat_id: '7777',
+            file_path: realpathSync(outputPath),
+            message: ' exact caption ',
+            delivery_key: 'telegram-delivery',
+          };
+
+          await expect(executor.execute('telegram_send', input, run)).resolves.toEqual({
+            success: true,
+          });
+
+          const row = db
+            .prepare(
+              `SELECT intent_json, result_json FROM owner_event_effects
+                WHERE batch_id = 49 AND action_key = 'telegram-delivery'`
+            )
+            .get() as { intent_json: string; result_json: string };
+          expect(JSON.parse(row.intent_json)).toMatchObject({
+            version: 1,
+            variant: 'image',
+            filePath: realpathSync(outputPath),
+            message: ' exact caption ',
+          });
+          expect(JSON.parse(row.result_json)).toMatchObject({
+            version: 1,
+            variant: 'file',
+            state: 'delivered',
+            payloadIdentity: 'c'.repeat(64),
+          });
+          expect(sendImage).toHaveBeenCalledTimes(1);
+          expect(sendFile).toHaveBeenCalledTimes(1);
+          expect(readOutboundDeliveryReceipt).toHaveBeenCalledWith(
+            'owner-event:49:telegram:telegram-delivery',
+            'file'
+          );
+          await rm(outputPath);
+          await expect(
+            executor.execute('telegram_send', input, {
+              ...run,
+              modelRunId: 'mr-owner-event-photo-confirmed-retry',
+            })
+          ).resolves.toEqual({ success: true });
+          expect(sendImage).toHaveBeenCalledTimes(1);
+          expect(sendFile).toHaveBeenCalledTimes(1);
+        } finally {
+          if (previousWorkspace === undefined) delete process.env.MAMA_WORKSPACE;
+          else process.env.MAMA_WORKSPACE = previousWorkspace;
+          await rm(workspace, { recursive: true, force: true });
+        }
       });
 
       it('reconciles an ambiguous owner-event Drive upload from the host reservation without another create', async () => {

--- a/packages/standalone/tests/cli/runtime/gateway-init-owner-identity.test.ts
+++ b/packages/standalone/tests/cli/runtime/gateway-init-owner-identity.test.ts
@@ -7,6 +7,21 @@ const gatewayMocks = vi.hoisted(() => ({
   slackOptions: vi.fn(),
   telegramOptions: vi.fn(),
   setTelegramTrust: vi.fn(),
+  telegramSendMessage: vi.fn().mockResolvedValue(undefined),
+  telegramSendFile: vi.fn().mockResolvedValue(undefined),
+  telegramSendImage: vi.fn().mockResolvedValue(undefined),
+  telegramSendSticker: vi.fn().mockResolvedValue(true),
+  telegramSendMessageFromActiveTurn: vi.fn().mockResolvedValue(undefined),
+  telegramSendFileFromActiveTurn: vi.fn().mockResolvedValue(undefined),
+  telegramSendImageFromActiveTurn: vi.fn().mockResolvedValue(undefined),
+  telegramSendStickerFromActiveTurn: vi.fn().mockResolvedValue(true),
+  telegramReadReceipt: vi.fn().mockReturnValue({
+    deliveryId: 'delivery-1',
+    variant: 'text',
+    state: 'delivered',
+    payloadIdentity: 'a'.repeat(64),
+    confirmedAt: 1_000,
+  }),
 }));
 
 vi.mock('../../../src/gateways/index.js', () => {
@@ -45,6 +60,42 @@ vi.mock('../../../src/gateways/index.js', () => {
       constructor(options: unknown) {
         super(options);
         gatewayMocks.telegramOptions(options);
+      }
+
+      override async sendMessage(...args: unknown[]): Promise<void> {
+        await gatewayMocks.telegramSendMessage(...args);
+      }
+
+      override async sendFile(...args: unknown[]): Promise<void> {
+        await gatewayMocks.telegramSendFile(...args);
+      }
+
+      override async sendImage(...args: unknown[]): Promise<void> {
+        await gatewayMocks.telegramSendImage(...args);
+      }
+
+      override async sendSticker(...args: unknown[]): Promise<void> {
+        await gatewayMocks.telegramSendSticker(...args);
+      }
+
+      async sendMessageFromActiveTurn(...args: unknown[]): Promise<void> {
+        await gatewayMocks.telegramSendMessageFromActiveTurn(...args);
+      }
+
+      async sendFileFromActiveTurn(...args: unknown[]): Promise<void> {
+        await gatewayMocks.telegramSendFileFromActiveTurn(...args);
+      }
+
+      async sendImageFromActiveTurn(...args: unknown[]): Promise<void> {
+        await gatewayMocks.telegramSendImageFromActiveTurn(...args);
+      }
+
+      async sendStickerFromActiveTurn(...args: unknown[]): Promise<boolean> {
+        return gatewayMocks.telegramSendStickerFromActiveTurn(...args) as Promise<boolean>;
+      }
+
+      readOutboundDeliveryReceipt(...args: unknown[]): unknown {
+        return gatewayMocks.telegramReadReceipt(...args);
       }
     },
     MessageRouter: class {},
@@ -124,5 +175,69 @@ describe('Gateway owner identity initialization', () => {
         }),
       })
     );
+  });
+
+  it('TG-01/TG-06 preserves Telegram delivery identity and active-turn capabilities', async () => {
+    const config = {
+      telegram: {
+        enabled: true,
+        token: 'telegram-token-synthetic',
+        allowed_chats: ['telegram-chat-1'],
+      },
+    } as unknown as MAMAConfig;
+    const toolExecutor = { setTelegramGateway: vi.fn() };
+    const agentLoop = { setTelegramGateway: vi.fn() };
+
+    await initGateways(
+      config,
+      {} as never,
+      toolExecutor as never,
+      agentLoop as never,
+      'codex',
+      {} as never
+    );
+
+    const adapter = toolExecutor.setTelegramGateway.mock.calls[0]?.[0] as {
+      sendMessage(chatId: string, text: string, deliveryId?: string): Promise<void>;
+      sendFile(chatId: string, path: string, caption?: string, deliveryId?: string): Promise<void>;
+      sendImage(chatId: string, path: string, caption?: string, deliveryId?: string): Promise<void>;
+      sendSticker(chatId: string, emotion: string, deliveryId?: string): Promise<boolean>;
+      sendMessageFromActiveTurn(chatId: string, text: string, deliveryId?: string): Promise<void>;
+      readOutboundDeliveryReceipt(deliveryId: string, variant: string): unknown;
+    };
+    expect(agentLoop.setTelegramGateway).toHaveBeenCalledWith(adapter);
+
+    await adapter.sendMessage('7777', 'body', 'delivery-text');
+    await adapter.sendFile('7777', '/private/file', 'caption', 'delivery-file');
+    await adapter.sendImage('7777', '/private/image', 'caption', 'delivery-image');
+    await adapter.sendSticker('7777', 'happy', 'delivery-sticker');
+    await adapter.sendMessageFromActiveTurn('7777', 'active body', 'delivery-active');
+    const receipt = adapter.readOutboundDeliveryReceipt('delivery-1', 'text');
+
+    expect(gatewayMocks.telegramSendMessage).toHaveBeenCalledWith('7777', 'body', 'delivery-text');
+    expect(gatewayMocks.telegramSendFile).toHaveBeenCalledWith(
+      '7777',
+      '/private/file',
+      'caption',
+      'delivery-file'
+    );
+    expect(gatewayMocks.telegramSendImage).toHaveBeenCalledWith(
+      '7777',
+      '/private/image',
+      'caption',
+      'delivery-image'
+    );
+    expect(gatewayMocks.telegramSendSticker).toHaveBeenCalledWith(
+      '7777',
+      'happy',
+      'delivery-sticker'
+    );
+    expect(gatewayMocks.telegramSendMessageFromActiveTurn).toHaveBeenCalledWith(
+      '7777',
+      'active body',
+      'delivery-active'
+    );
+    expect(gatewayMocks.telegramReadReceipt).toHaveBeenCalledWith('delivery-1', 'text');
+    expect(receipt).toMatchObject({ state: 'delivered', variant: 'text' });
   });
 });

--- a/packages/standalone/tests/gateways/telegram.test.ts
+++ b/packages/standalone/tests/gateways/telegram.test.ts
@@ -349,7 +349,7 @@ describe('TelegramGateway - message splitting', () => {
     await gateway.stop();
   });
 
-  it('treats a delivered owner-event occurrence as complete even if retry wording changes', async () => {
+  it('TG-06 rejects changed text for an already-delivered owner-event occurrence', async () => {
     mockApi.sendMessage.mockReset().mockResolvedValue({ message_id: 1 });
     const ledgerPath = join(
       await makeMediaRoot(join(tmpdir(), 'mama-telegram-owner-event-ledger-')),
@@ -365,9 +365,90 @@ describe('TelegramGateway - message splitting', () => {
     await gateway.sendMessage('7777', 'first translation', 'owner-event:41:message:0');
     await expect(
       gateway.sendMessage('7777', 'wording changed on retry', 'owner-event:41:message:0')
-    ).resolves.toBeUndefined();
+    ).rejects.toThrow(/delivery.*binding.*mismatch/i);
 
     expect(mockApi.sendMessage.mock.calls.map((call) => call[1])).toEqual(['first translation']);
+    await gateway.stop();
+  });
+
+  it('TG-01/TG-06 reads one exact delivered receipt after long multi-chunk text', async () => {
+    mockApi.sendMessage.mockReset().mockResolvedValue({ message_id: 1 });
+    const gateway = new TelegramGateway({
+      token: 'test-bot-token',
+      turnProcessor: mockMessageRouter,
+      messageLedgerPath: join(
+        await makeMediaRoot(join(tmpdir(), 'mama-telegram-receipt-text-')),
+        'ledger.json'
+      ),
+    });
+    await gateway.start();
+    const deliveryId = 'owner-event:41:telegram:telegram-delivery';
+    const text = `${'a'.repeat(4_096)}🌕${'b'.repeat(300)}`;
+
+    expect(gateway.readOutboundDeliveryReceipt(deliveryId, 'text')).toBeNull();
+    await gateway.sendMessage('7777', text, deliveryId);
+
+    expect(gateway.readOutboundDeliveryReceipt(deliveryId, 'text')).toMatchObject({
+      deliveryId,
+      variant: 'text',
+      state: 'delivered',
+      payloadIdentity: expect.stringMatching(/^[a-f0-9]{64}$/),
+      confirmedAt: expect.any(Number),
+    });
+    expect(mockApi.sendMessage).toHaveBeenCalledTimes(2);
+    await gateway.stop();
+  });
+
+  it('TG-06 reads receipts only from the actual delivered transport variant', async () => {
+    mockApi.sendMessage.mockReset().mockResolvedValue({ message_id: 1 });
+    mockApi.sendDocument.mockReset().mockResolvedValue({ message_id: 2 });
+    mockApi.sendPhoto.mockReset().mockResolvedValue({ message_id: 3 });
+    mockApi.getStickerSet.mockReset().mockResolvedValue({ stickers: [] });
+    const gateway = new TelegramGateway({
+      token: 'test-bot-token',
+      turnProcessor: mockMessageRouter,
+      messageLedgerPath: join(
+        await makeMediaRoot(join(tmpdir(), 'mama-telegram-receipt-variants-')),
+        'ledger.json'
+      ),
+    });
+    await gateway.start();
+
+    await gateway.sendFile('7777', '/private/file.bin', 'caption', 'delivery-file');
+    await gateway.sendImage('7777', '/private/image.png', 'caption', 'delivery-image');
+    await gateway.sendSticker('7777', 'happy', 'delivery-sticker');
+
+    expect(gateway.readOutboundDeliveryReceipt('delivery-file', 'file')).toMatchObject({
+      variant: 'file',
+      state: 'delivered',
+    });
+    expect(gateway.readOutboundDeliveryReceipt('delivery-file', 'image')).toBeNull();
+    expect(gateway.readOutboundDeliveryReceipt('delivery-image', 'image')).toMatchObject({
+      variant: 'image',
+      state: 'delivered',
+    });
+    expect(gateway.readOutboundDeliveryReceipt('delivery-sticker', 'sticker')).toMatchObject({
+      variant: 'sticker',
+      state: 'delivered',
+    });
+    await gateway.stop();
+  });
+
+  it('TG-06 does not expose a receipt while delivery remains retryable', async () => {
+    mockApi.sendMessage.mockReset().mockRejectedValueOnce(new Error('ambiguous timeout'));
+    const gateway = new TelegramGateway({
+      token: 'test-bot-token',
+      turnProcessor: mockMessageRouter,
+      messageLedgerPath: join(
+        await makeMediaRoot(join(tmpdir(), 'mama-telegram-receipt-pending-')),
+        'ledger.json'
+      ),
+    });
+    await gateway.start();
+
+    await expect(gateway.sendMessage('7777', 'pending', 'delivery-pending')).rejects.toThrow();
+    mockApi.sendMessage.mockResolvedValue({ message_id: 1 });
+    expect(gateway.readOutboundDeliveryReceipt('delivery-pending', 'text')).toBeNull();
     await gateway.stop();
   });
 });

--- a/packages/standalone/tests/operator/owner-event-effects.test.ts
+++ b/packages/standalone/tests/operator/owner-event-effects.test.ts
@@ -1,6 +1,11 @@
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 import Database from '../../src/sqlite.js';
 import {
+  buildOwnerEventTelegramIntent,
   buildOwnerEventEffectAuthority,
   OwnerEventEffectLedger,
 } from '../../src/operator/owner-event-effects.js';
@@ -67,6 +72,7 @@ describe('TG-03/TG-04/TG-06 host-issued owner-event effects', () => {
     });
     expect(ledger.begin(41, 'drive-upload', 'drive_upload')).toEqual({
       state: 'confirmed',
+      intent: { folderId: 'folder-original' },
       result: { fileId: 'uploaded-1', name: 'translated.png' },
     });
     expect(ledger.confirmedKinds(41)).toEqual(['drive_upload']);
@@ -88,5 +94,167 @@ describe('TG-03/TG-04/TG-06 host-issued owner-event effects', () => {
       state: 'reconcile',
       intent: {},
     });
+  });
+
+  it('TG-06 builds one exact versioned Telegram intent before transmission', () => {
+    expect(
+      buildOwnerEventTelegramIntent({
+        chatId: '7777',
+        message: '  Hello 🌕\nsecond line  ',
+        deliveryId: 'owner-event:41:telegram:telegram-delivery',
+      })
+    ).toEqual({
+      version: 1,
+      chatId: '7777',
+      variant: 'text',
+      deliveryId: 'owner-event:41:telegram:telegram-delivery',
+      message: '  Hello 🌕\nsecond line  ',
+      filePath: null,
+      stickerEmotion: null,
+    });
+
+    expect(() =>
+      buildOwnerEventTelegramIntent({
+        chatId: '7777',
+        message: '   ',
+        deliveryId: 'owner-event:41:telegram:telegram-delivery',
+      })
+    ).toThrow(/message.*blank/i);
+    expect(() =>
+      buildOwnerEventTelegramIntent({
+        chatId: '7777',
+        deliveryId: 'owner-event:41:telegram:telegram-delivery',
+      })
+    ).toThrow(/message.*file_path.*sticker_emotion/i);
+  });
+
+  it('TG-03/TG-06 resolves file intent once and normalizes sticker emotion', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'mama-owner-effect-intent-'));
+    const imagePath = join(workspace, 'translated.png');
+    writeFileSync(imagePath, 'synthetic-image');
+    const previousWorkspace = process.env.MAMA_WORKSPACE;
+    process.env.MAMA_WORKSPACE = workspace;
+    try {
+      expect(
+        buildOwnerEventTelegramIntent({
+          chatId: '7777',
+          message: ' exact caption ',
+          filePath: imagePath,
+          deliveryId: 'owner-event:41:telegram:telegram-delivery',
+        })
+      ).toEqual({
+        version: 1,
+        chatId: '7777',
+        variant: 'image',
+        deliveryId: 'owner-event:41:telegram:telegram-delivery',
+        message: ' exact caption ',
+        filePath: realpathSync(imagePath),
+        stickerEmotion: null,
+      });
+      expect(
+        buildOwnerEventTelegramIntent({
+          chatId: '7777',
+          stickerEmotion: '  HAPPY ',
+          deliveryId: 'owner-event:41:telegram:telegram-delivery',
+        })
+      ).toEqual({
+        version: 1,
+        chatId: '7777',
+        variant: 'sticker',
+        deliveryId: 'owner-event:41:telegram:telegram-delivery',
+        message: null,
+        filePath: null,
+        stickerEmotion: 'happy',
+      });
+    } finally {
+      if (previousWorkspace === undefined) delete process.env.MAMA_WORKSPACE;
+      else process.env.MAMA_WORKSPACE = previousWorkspace;
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it('TG-06 rejects changed versioned Telegram intent but replays an exact receipt', () => {
+    const ledger = new OwnerEventEffectLedger(new Database(':memory:'), () => 1_000);
+    const intent = buildOwnerEventTelegramIntent({
+      chatId: '7777',
+      message: 'first translation',
+      deliveryId: 'owner-event:41:telegram:telegram-delivery',
+    });
+    expect(ledger.begin(41, 'telegram-delivery', 'telegram_send', intent)).toEqual({
+      state: 'execute',
+      intent,
+    });
+    expect(ledger.begin(41, 'telegram-delivery', 'telegram_send', intent)).toEqual({
+      state: 'reconcile',
+      intent,
+    });
+    expect(() =>
+      ledger.begin(41, 'telegram-delivery', 'telegram_send', {
+        ...intent,
+        message: 'rephrased retry',
+      })
+    ).toThrow(/intent.*mismatch/i);
+
+    const receipt = {
+      version: 1,
+      deliveryId: intent.deliveryId,
+      variant: 'text',
+      state: 'delivered',
+      payloadIdentity: 'a'.repeat(64),
+      confirmedAt: 1_000,
+    } as const;
+    ledger.confirm(41, 'telegram-delivery', 'telegram_send', receipt);
+    expect(ledger.begin(41, 'telegram-delivery', 'telegram_send', intent)).toEqual({
+      state: 'confirmed',
+      intent,
+      result: receipt,
+    });
+  });
+
+  it('TG-06 preserves legacy no-replay rows without inferring payloads', () => {
+    const ledger = new OwnerEventEffectLedger(new Database(':memory:'), () => 1_000);
+    expect(
+      ledger.begin(41, 'telegram-delivery', 'telegram_send', {
+        chatId: '7777',
+        variant: 'text',
+      })
+    ).toMatchObject({ state: 'execute' });
+    ledger.confirm(41, 'telegram-delivery', 'telegram_send', null);
+
+    const versioned = buildOwnerEventTelegramIntent({
+      chatId: '7777',
+      message: 'new text must not be inferred as old text',
+      deliveryId: 'owner-event:41:telegram:telegram-delivery',
+    });
+    expect(ledger.begin(41, 'telegram-delivery', 'telegram_send', versioned)).toEqual({
+      state: 'confirmed',
+      intent: { chatId: '7777', variant: 'text' },
+      result: null,
+    });
+  });
+
+  it('TG-06 deletes retained Telegram intent and receipt with its inbox batch', () => {
+    const db = new Database(':memory:');
+    db.exec('CREATE TABLE owner_event_inbox (id INTEGER PRIMARY KEY)');
+    db.prepare('INSERT INTO owner_event_inbox (id) VALUES (?)').run(41);
+    const ledger = new OwnerEventEffectLedger(db, () => 1_000);
+    const intent = buildOwnerEventTelegramIntent({
+      chatId: '7777',
+      message: 'bounded body',
+      deliveryId: 'owner-event:41:telegram:telegram-delivery',
+    });
+    ledger.begin(41, 'telegram-delivery', 'telegram_send', intent);
+    ledger.confirm(41, 'telegram-delivery', 'telegram_send', {
+      version: 1,
+      deliveryId: intent.deliveryId,
+      variant: 'text',
+      state: 'delivered',
+      payloadIdentity: 'b'.repeat(64),
+      confirmedAt: 1_000,
+    });
+
+    db.prepare('DELETE FROM owner_event_inbox WHERE id = ?').run(41);
+
+    expect(ledger.inspect(41, 'telegram-delivery', 'telegram_send')).toBeNull();
   });
 });

--- a/packages/standalone/tests/operator/owner-event-effects.test.ts
+++ b/packages/standalone/tests/operator/owner-event-effects.test.ts
@@ -135,14 +135,14 @@ describe('TG-03/TG-04/TG-06 host-issued owner-event effects', () => {
     const previousWorkspace = process.env.MAMA_WORKSPACE;
     process.env.MAMA_WORKSPACE = workspace;
     try {
-      expect(
-        buildOwnerEventTelegramIntent({
-          chatId: '7777',
-          message: ' exact caption ',
-          filePath: imagePath,
-          deliveryId: 'owner-event:41:telegram:telegram-delivery',
-        })
-      ).toEqual({
+      const fileInput = {
+        chatId: '7777',
+        message: ' exact caption ',
+        filePath: imagePath,
+        deliveryId: 'owner-event:41:telegram:telegram-delivery',
+      };
+      const fileIntent = buildOwnerEventTelegramIntent(fileInput);
+      expect(fileIntent).toEqual({
         version: 1,
         chatId: '7777',
         variant: 'image',
@@ -151,6 +151,14 @@ describe('TG-03/TG-04/TG-06 host-issued owner-event effects', () => {
         filePath: realpathSync(imagePath),
         stickerEmotion: null,
       });
+      rmSync(imagePath);
+      expect(buildOwnerEventTelegramIntent(fileInput, fileIntent)).toEqual(fileIntent);
+      expect(() =>
+        buildOwnerEventTelegramIntent(
+          { ...fileInput, filePath: join(workspace, 'different.png') },
+          fileIntent
+        )
+      ).toThrow(/ENOENT/);
       expect(
         buildOwnerEventTelegramIntent({
           chatId: '7777',


### PR DESCRIPTION
## Summary

- Persist the exact validated owner-event Telegram payload in the existing effect JSON before transmission.
- Reuse the existing Telegram message ledger as the delivered receipt authority, including actual image-to-file fallback variant.
- Reject changed retries, keep unknown/legacy effects no-replay, and never false-confirm a missing receipt.
- Fix the production gateway adapter so delivery IDs, active-turn methods, and receipt reads reach the real launchd runtime.
- Add no schema, migration, service, worker, timer, queue, file snapshot, or second hash path.

## Verification

- Focused gate: 4 files, 203 tests passed.
- Full standalone: 383 files, 5,206 tests passed; 4 files and 7 tests skipped.
- Standalone typecheck: PASS.
- Production build: PASS.
- Root lint: PASS.
- Changed-file Prettier and git diff check: PASS.

## Review

- Plan engineering review: clear.
- Pre-landing review: clear after fixing confirmed-file retry when the local source file has aged out.
- TG-01/TG-03/TG-04/TG-06 evidence updated.

## Release boundary

Version and CHANGELOG are intentionally deferred. After this PR merges, PR-A and PR-B will ship together as one patch release, one global install, and one launchd cutover.

## Test plan

- [x] Exact text/file/image/sticker intent before send
- [x] Exact confirmed retry, changed retry rejection, and legacy no-replay
- [x] Missing receipt and transport ambiguity remain unknown/reconcile-only
- [x] Long text uses one delivered identity
- [x] Definite photo rejection confirms actual file receipt
- [x] Production adapter forwards delivery and active-turn capabilities

Generated with OpenAI Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added durable Telegram delivery receipts for text, files, images, and stickers.
  - Added reliable retry handling that preserves the original message and prevents duplicate sends.
  - Added support for confirming delivery through exact receipt matching, including image-to-file fallback.

- **Bug Fixes**
  - Improved handling of uncertain or interrupted deliveries through safe reconciliation.
  - Prevented retries from changing message content or delivery format after an ambiguous outcome.

- **Documentation**
  - Updated remediation plans, verification status, coverage targets, and operational guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->