### PR TITLE
chore: prepare mama-os v0.39.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## mama-os [0.39.1] - 2026-08-26
+
+### Fixed
+
+- **Owner-event Board repairs now wait long enough to coalesce real traffic.** The first accepted
+  intent pins one existing workorder deadline, later pending intents widen that same row, and the
+  normal schedule promotes it without creating another queue or model path. Ready lower-priority
+  work is no longer blocked by a future high-priority row, and restart-seeded generations only
+  widen so boot dirt cannot trigger an extra repair.
+- **Owner-event Telegram effects retain their exact visible payload and delivered receipt.** Text,
+  captions, resolved paths, and sticker emotion are reserved before transmission. Exact confirmed
+  retries replay the stored receipt with zero transport calls; changed or unknown retries remain
+  fail-closed. The existing Telegram delivery ledger supplies the payload identity, actual
+  image-to-file fallback variant, and delivery time.
+- **The production Telegram adapter preserves delivery capabilities.** Idempotency keys,
+  active-turn methods, and receipt reads now reach the real gateway instead of being dropped by the
+  boot adapter. Confirmed transient-file sends remain successful after the local source ages out,
+  but only when the surviving path proves the same canonical file.
+
 ## mama-os [0.39.0] - 2026-08-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ running, and skips quietly when it is not:
 
 | Package                                       | What it is                                                                                                     | You run it?          |
 | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------------- |
-| [mama-os](packages/standalone/) 0.39.0        | The always-on server: connectors, trigger loop, reports, task board, web UI. 92k lines. "MAMA" means this.     | `mama start`         |
+| [mama-os](packages/standalone/) 0.39.1        | The always-on server: connectors, trigger loop, reports, task board, web UI. 92k lines. "MAMA" means this.     | `mama start`         |
 | [mama-core](packages/mama-core/) 2.2.0        | The library underneath: memory, provenance, graph, embeddings. Everything imports it; it imports nothing here. | No binary            |
 | [mama-server](packages/mcp-server/) 1.15.0    | A deliberately thin MCP adapter over the core — 3.7k lines, no logic of its own.                               | As an MCP server     |
 | [plugin](packages/claude-code-plugin/) 1.11.0 | Claude Code hooks + slash commands. No background process.                                                     | Installed, not run   |

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -259,7 +259,7 @@ Each package has independent versioning:
 - **mama-core:** 2.2.0 (stable API)
 - **mama-server:** 1.15.0 (follows MAMA version)
 - **claude-code-plugin:** 1.11.0 (follows MAMA version)
-- **mama-os:** 0.39.0 (standalone agent)
+- **mama-os:** 0.39.1 (standalone agent)
 
 ## Distribution Strategy
 

--- a/docs/development/kagemusha-telegram-parity.md
+++ b/docs/development/kagemusha-telegram-parity.md
@@ -195,9 +195,9 @@ its intents` pins verified-generation application before an obsolete delayed row
   unknown and leaves later attempts reconcile-only.
 - **Verification:** the four focused files pass 203 tests. The complete standalone suite passes
   383 files and 5,206 tests, with four files and seven tests skipped; standalone typecheck and
-  production build pass. Root lint, changed-file format, and `git diff --check` pass. PR review,
-  merge, release, and live canary remain pending.
-- **Status:** BRANCH CODE GREEN; no operational claim.
+  production build pass. Root lint, changed-file format, and `git diff --check` pass. Release and
+  live canary remain pending.
+- **Status:** CODE GREEN, merged as PR #235. v0.39.1 release and live canary remain pending.
 
 ### Sender-boundary completion evidence: 2026-08-13
 
@@ -776,6 +776,7 @@ change unless they are release-blocking security or data-loss issues.
       complete standalone suite (383 files / 5,188 tests; four files / seven tests skipped), root
       typecheck, build, lint, and all seven root Turbo test tasks. PR #231 is merged.
 - [x] Release, install, and rebuild/restart v0.39.0 as one healthy launchd-owned daemon.
+- [ ] Release, install, and rebuild/restart v0.39.1 as one healthy launchd-owned daemon.
 - [x] Observe a real owner-event burst preserve exact durable intent, non-force workorders,
       verified-generation application, receipt-first ACK, and durable retry on a missing receipt.
 - [ ] Complete a real owner-event and Temporal turn, then compare visible delivery plus 24-hour

--- a/docs/development/runtime-overhead-reduction-design.md
+++ b/docs/development/runtime-overhead-reduction-design.md
@@ -1,7 +1,7 @@
 # MAMA Runtime Overhead Reduction — 검증을 보존하고 모델 낭비를 제거하는 설계
 
-> **상태:** Eng review CLEAR, PR-A/PR-B MERGED, v0.39.0 RELEASED/CUTOVER,
-> 실제 owner-event·Temporal canary 진행 중
+> **상태:** Eng review CLEAR, PR #234/#235 MERGED, v0.39.1 RELEASE PREP,
+> 기존 v0.39.0 canary 실패 후 교정 릴리즈 대기
 >
 > **작성일:** 2026-08-26
 >
@@ -758,3 +758,17 @@ WorkOrder retry 정책은 코드와 테스트, diff review, PR #231 merge까지 
   event, workorder는 만들지 않는다.
 - 따라서 24시간 무회귀 창이 지나더라도 실제 Temporal receipt, owner-event 비용 목표, Telegram payload
   증거가 모두 확보되지 않으면 완료로 판정하지 않는다. canary 자동화를 유지한다.
+
+## 27. v0.39.1 교정 릴리즈 준비
+
+v0.39.0 운영 canary가 드러낸 두 결손을 기존 경계 안에서 교정했다.
+
+- PR #234는 새 queue나 timer 없이 기존 `operator_tasks.due_at`을 claim-not-before 경계로 사용해
+  owner-event Board intent를 한 pending repair로 모은다. 첫 deadline은 고정하고 generation은 넓히기만
+  하며, scheduled tick은 같은 row를 승격한다.
+- PR #235는 새 ledger나 schema 없이 기존 `owner_event_effects` JSON에 exact Telegram payload를 남기고,
+  기존 Telegram message ledger의 delivered row를 effect confirmation authority로 연결한다. 운영 gateway
+  adapter가 delivery ID와 active-turn method를 버리던 결손도 같은 PR에서 닫았다.
+- 두 PR은 각각 main에 merge됐고 `@jungjaehoon/mama-os` 0.39.1 패치 릴리즈로 한 번만 설치·재시작한다.
+- v0.39.1 cutover 이후 canary 기준 시각을 새로 잡는다. 이전 v0.39.0 창은 실패 원인 증거로 보존하지만
+  새 24시간 판정에 합산하지 않는다.

--- a/docs/development/runtime-overhead-telegram-receipt-plan.md
+++ b/docs/development/runtime-overhead-telegram-receipt-plan.md
@@ -1,6 +1,6 @@
 # Runtime overhead remediation PR-B: Telegram exact receipt implementation plan
 
-> Status: reviewed implementation plan for `codex/v0-39-telegram-receipt`.
+> Status: implemented and merged as PR #235; v0.39.1 release/cutover pending.
 >
 > Scope: TG-01/TG-03/TG-04/TG-06 owner-event Telegram delivery only. This PR does not add a
 > ledger, schema, service, worker, timer, queue, file snapshot, or second payload hash.

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -11,7 +11,7 @@ MAMA is a pnpm workspace-based monorepo with four release targets (plus the inte
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.39.0  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.39.1  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.15.0  |
 | MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 2.2.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.11.0  |
@@ -61,7 +61,7 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.39.0          |
+| `packages/standalone/package.json`                       | `version` | 0.39.1          |
 | `packages/mcp-server/package.json`                       | `version` | 1.15.0          |
 | `packages/mama-core/package.json`                        | `version` | 2.2.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.11.0          |

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,7 +157,7 @@ _Contributing, testing, and development guidelines_
 
 ---
 
-**Status:** MAMA OS v0.39.0 — Claude CLI, Codex app-server, and Cline Hub are equivalent supported
+**Status:** MAMA OS v0.39.1 — Claude CLI, Codex app-server, and Cline Hub are equivalent supported
 backends with backend-owned durable context, role-scoped Code-Act projection, bounded recovery,
 and explicit non-replayable mutation outcomes. MAMA itself owns connector-event work as
 stateless fresh runs per batch on durable per-channel lane keys; configured private connectors

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "description": "MAMA OS - Local AI Runtime. Your scattered knowledge, organized by AI agents that never sleep.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Release

Prepare `@jungjaehoon/mama-os` 0.39.1 as the single patch release for:

- PR #234: durable Board claim window on the existing workorder row.
- PR #235: exact owner-event Telegram payload and existing-ledger delivery receipt.

## Metadata

- Bump only `packages/standalone/package.json` from 0.39.0 to 0.39.1.
- Add exact 0.39.1 CHANGELOG notes.
- Sync README, package structure, deployment guide, docs index, parity evidence, and remediation status.
- No source-code change in this release-prep PR.

## Verification

- `pnpm sync-versions --check`: PASS.
- Root `pnpm test`: 7/7 Turbo tasks passed.
- Root `pnpm build`: 2/2 Turbo tasks passed.
- Standalone: 383 files, 5,206 tests passed; 4 files and 7 tests skipped.
- Commit hook typecheck/build/test: PASS.
- Prettier and `git diff --check`: PASS.

## Publish plan

After merge, run `release.yml` on `main` with:

- `release_type=patch`
- `packages=mama-os`
- `dry_run=false`
- `bump_versions=false`

Then verify tag `v0.39.1`, GitHub release, npm package, global install, and one launchd cutover.

Generated with OpenAI Codex.