### PR TITLE
release: mama-os 0.39.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## mama-os [0.39.2] - 2026-08-27
+
+### Changed
+
+- **Product documentation now defines one front for delegated work.** The architecture and v1 plan
+  align around one visible Work Agent reached through existing messengers. Today's shipped product
+  remains owner-only; human-team grants, shared Cases, and migration of named compatibility
+  surfaces remain explicit v1 work rather than a v0.39.2 capability claim.
+- **Board and report runs carry bounded working context.** Ranked active-task projections stop at
+  the requested page, overlapping review rows are deduplicated by task ID, and oversized owner
+  report history is dropped as one structured layer before it can displace current tool policy.
+  Owner-event runs start from the exact connector delta and no longer poll accepted workorders.
+
+### Fixed
+
+- **Scheduled memory promotion no longer repeats a completed slot after restart.** Versioned keys
+  include the normalized configured interval and slot, preserve compatibility with released
+  six-hour keys, keep failed slots retryable, and reject invalid sub-millisecond intervals.
+- **Runtime brief upgrades preserve owner-authored instructions.** Only exact fingerprints of
+  generated legacy Board contracts and pipelines are replaced. Owner-edited sections remain
+  intact, including final sections at EOF, with the current bounded pipeline appended cleanly.
+
 ## mama-os [0.39.1] - 2026-08-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ running, and skips quietly when it is not:
 
 | Package                                       | What it is                                                                                                     | You run it?          |
 | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------------- |
-| [mama-os](packages/standalone/) 0.39.1        | The always-on server: connectors, trigger loop, reports, task board, and web UI. "MAMA" means this.            | `mama start`         |
+| [mama-os](packages/standalone/) 0.39.2        | The always-on server: connectors, trigger loop, reports, task board, and web UI. "MAMA" means this.            | `mama start`         |
 | [mama-core](packages/mama-core/) 2.2.0        | The library underneath: memory, provenance, graph, embeddings. Everything imports it; it imports nothing here. | No binary            |
 | [mama-server](packages/mcp-server/) 1.15.0    | A deliberately thin MCP adapter over the core with no independent product logic.                               | As an MCP server     |
 | [plugin](packages/claude-code-plugin/) 1.11.0 | Claude Code hooks + slash commands. No background process.                                                     | Installed, not run   |

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -259,7 +259,7 @@ Each package has independent versioning:
 - **mama-core:** 2.2.0 (stable API)
 - **mama-server:** 1.15.0 (follows MAMA version)
 - **claude-code-plugin:** 1.11.0 (follows MAMA version)
-- **mama-os:** 0.39.1 (standalone agent)
+- **mama-os:** 0.39.2 (standalone agent)
 
 ## Distribution Strategy
 

--- a/docs/development/kagemusha-telegram-parity.md
+++ b/docs/development/kagemusha-telegram-parity.md
@@ -830,6 +830,12 @@ change unless they are release-blocking security or data-loss issues.
   history before bounded truncation. The replacement regression proves prompt-structure markers
   are neutralized while public conversation continuity remains available.
 
+- 2026-08-27: PR #238 aligned TG-05/TG-06 runtime context with the one-front Work Agent boundary.
+  Owner-report history is a structured removable layer, owner-event runs stay exact-delta-first,
+  accepted workorders are not status-polled, and generated legacy Board pipelines are projected
+  only by known fingerprints. Scheduled promotion keys now remain restart-idempotent across
+  configured intervals without adding a queue, worker, timer, or schema.
+
 - 2026-08-13: Closed the sender-boundary round-2 review: fail-closed public child-runtime
   containment (TG-04), principal-before-queue Telegram lane isolation (TG-01), and lane-scoped or
   zero-persistence history behavior (TG-05). The external Slack file-share fixture now exercises

--- a/docs/development/runtime-overhead-canary-remediation-design.md
+++ b/docs/development/runtime-overhead-canary-remediation-design.md
@@ -1,6 +1,6 @@
 # MAMA Runtime Overhead Canary Remediation
 
-> **Status:** PR #234/#235 merged, v0.39.1 released/cut over, 24-hour live canary active
+> **Status:** PR #238 merged, v0.39.2 release candidate, new 24-hour live canary pending
 >
 > **Date:** 2026-08-26
 >

--- a/docs/development/runtime-overhead-reduction-design.md
+++ b/docs/development/runtime-overhead-reduction-design.md
@@ -784,6 +784,8 @@ v0.39.0 운영 canary가 드러낸 두 결손을 기존 경계 안에서 교정�
 v0.39.1 canary의 후속 조사에서 안전 검증 자체가 아니라 반복 모델 입력과 예약 key 경계에 남은
 오버헤드를 확인했고, PR #238에서 기존 메커니즘 안에서 닫았다.
 
+**MAMA decision record:** `decision_runtime_model_work_boundaries_1787771678852_9ebc641d`
+
 - Board와 report는 active top-12와 review top-5만 읽고 task ID로 중복을 제거한다. 전체 ledger paging은
   요청 결과가 실제로 요구할 때만 사용한다.
 - owner-report history는 문자열 marker가 아니라 구조화된 prompt layer다. 예산을 넘으면 현재 Code-Act

--- a/docs/development/runtime-overhead-reduction-design.md
+++ b/docs/development/runtime-overhead-reduction-design.md
@@ -1,7 +1,6 @@
 # MAMA Runtime Overhead Reduction — 검증을 보존하고 모델 낭비를 제거하는 설계
 
-> **상태:** Eng review CLEAR, PR #234/#235 MERGED, v0.39.1 RELEASED/CUTOVER,
-> 실제 owner-event·Temporal 24시간 canary 진행 중
+> **상태:** PR #238 MERGED, v0.39.2 release candidate, 새 owner-event·Temporal 24시간 canary 대기
 >
 > **작성일:** 2026-08-26
 >
@@ -779,3 +778,20 @@ v0.39.0 운영 canary가 드러낸 두 결손을 기존 경계 안에서 교정�
   기록된 cutover 부작용으로 보존하되 같은 실패가 후속 작업에서 반복되면 새 회귀로 판정한다.
 - v0.39.1 cutover 이후 canary 기준 시각을 새로 잡았다. 이전 v0.39.0 창은 실패 원인 증거로 보존하지만
   새 24시간 판정에 합산하지 않는다. `mama-v0-39-1-canary` heartbeat가 실제 이벤트만 매시간 읽는다.
+
+## 28. v0.39.2 모델 작업 경계 후속
+
+v0.39.1 canary의 후속 조사에서 안전 검증 자체가 아니라 반복 모델 입력과 예약 key 경계에 남은
+오버헤드를 확인했고, PR #238에서 기존 메커니즘 안에서 닫았다.
+
+- Board와 report는 active top-12와 review top-5만 읽고 task ID로 중복을 제거한다. 전체 ledger paging은
+  요청 결과가 실제로 요구할 때만 사용한다.
+- owner-report history는 문자열 marker가 아니라 구조화된 prompt layer다. 예산을 넘으면 현재 Code-Act
+  정책을 자르기 전에 history 전체를 한 번 버린다.
+- owner-event는 exact connector delta에서 시작하고 accepted workorder를 다시 status-poll하지 않는다.
+- scheduled memory promotion key는 version, 정수 millisecond interval, slot을 함께 보존한다. released
+  six-hour key와 호환되며 failed/cancelled slot은 계속 retry 가능하다.
+- generated legacy Board brief만 exact fingerprint로 runtime projection하고 owner 편집본과 disk bytes는
+  보존한다.
+- v0.39.2 cutover 이후 실제 owner-event, Temporal, Telegram 왕복과 24시간 비용 회귀를 새 기준으로
+  측정한다. synthetic event나 workorder는 만들지 않는다.

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -11,7 +11,7 @@ MAMA is a pnpm workspace-based monorepo with four release targets (plus the inte
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.39.1  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.39.2  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.15.0  |
 | MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 2.2.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.11.0  |
@@ -61,7 +61,7 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.39.1          |
+| `packages/standalone/package.json`                       | `version` | 0.39.2          |
 | `packages/mcp-server/package.json`                       | `version` | 1.15.0          |
 | `packages/mama-core/package.json`                        | `version` | 2.2.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.11.0          |

--- a/docs/index.md
+++ b/docs/index.md
@@ -165,9 +165,9 @@ _Contributing, testing, and development guidelines_
 
 ---
 
-**Status:** MAMA OS v0.39.1 — Claude CLI, Codex app-server, and Cline Hub are equivalent supported
+**Status:** MAMA OS v0.39.2 — Claude CLI, Codex app-server, and Cline Hub are equivalent supported
 backends with backend-owned durable context, role-scoped Code-Act projection, bounded recovery,
 and explicit non-replayable mutation outcomes. MAMA itself owns connector-event work as
 stateless fresh runs per batch on durable per-channel lane keys; configured private connectors
 remain installation-local and are never promoted into generic catalogs or prompts.
-**Last Updated:** 2026-08-26
+**Last Updated:** 2026-08-27

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -992,7 +992,7 @@
           <a href="#local">Local</a>
           <a href="#install">Install</a>
         </div>
-        <span class="nav-cta">v0.39.1</span>
+        <span class="nav-cta">v0.39.2</span>
         <button
           class="nav-toggle"
           type="button"
@@ -1361,7 +1361,7 @@ human principal + Case + files → MAMA → verified artifact
         <div class="footer-brand">
           <img src="assets/mama-icon.svg" alt="" />
           <span>MAMA OS</span>
-          <span class="footer-version">v0.39.1</span>
+          <span class="footer-version">v0.39.2</span>
         </div>
         <div class="footer-links">
           <a href="https://github.com/jungjaehoon-lifegamez/MAMA">GitHub</a>

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.39.1",
-  "description": "MAMA OS - Local AI Runtime. Your scattered knowledge, organized by AI agents that never sleep.",
+  "version": "0.39.2",
+  "description": "MAMA OS - The local work agent behind your messenger.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {


### PR DESCRIPTION
## Release

- bump `@jungjaehoon/mama-os` from 0.39.1 to 0.39.2
- add the authoritative 0.39.2 CHANGELOG entry for one-front product alignment and runtime model-overhead fixes
- synchronize README, package/deployment references, docs status, parity evidence, and website version surfaces
- keep historical v0.39.1 cutover evidence intact and mark the new 24-hour canary as pending

## Review

- release metadata security/scope review: CLEAR
- documentation/product scope review found 3 overstatement/staleness issues; all fixed
- final documentation re-review: CLEAR
- no runtime source, auth, permission, workflow, lockfile, or publish configuration changes

## Verification

- `pnpm typecheck`: 3/3 successful
- `pnpm lint`: passed
- `pnpm build`: 2/2 successful
- `pnpm test`: 7/7 successful; standalone 5,224 passed, 7 skipped
- `node scripts/sync-versions.js --check`: passed
- Prettier and `git diff --check`: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Scheduled memory promotion no longer repeats completed slots after a restart, while failed slots remain eligible for retry.
  - Runtime brief updates now preserve owner-authored instructions and edited content.
  - Board and report runs use bounded context, avoid duplicate review items, and reduce unnecessary status checks.

- **Documentation**
  - Updated product, deployment, architecture, and website documentation for version 0.39.2.
  - Clarified current delegated-work boundaries and deferred capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->