### PR TITLE
feat(onboarding): agent contract module + self-teaching status (round branch 1/N)

### DIFF
--- a/packages/standalone/src/cli/commands/status.ts
+++ b/packages/standalone/src/cli/commands/status.ts
@@ -28,8 +28,47 @@ export function formatVersionStatus(cliVersion: string, runtimeVersion: string |
 /**
  * Execute status command
  */
-export async function statusCommand(): Promise<void> {
+export async function statusCommand(options: { json?: boolean } = {}): Promise<void> {
+  // Onboarding contract: observe, migrate legacy markers, and either surface
+  // the missing items (with per-item next actions) or record completion.
+  const { collectAssessDeps, writeCompletionMarker, migrateLegacyInstall } = await import(
+    '../../onboarding/assess-live.js'
+  );
+  const { assessOnboarding, renderContractStatus } = await import(
+    '../../onboarding/agent-contract.js'
+  );
+  const { getMAMAHome } = await import('../config/config-manager.js');
+  const mamaHome = getMAMAHome();
+  migrateLegacyInstall(mamaHome);
+  const deps = await collectAssessDeps();
+  const onboarding = assessOnboarding(deps);
+  if (options.json) {
+    const runningForJson = await isDaemonRunning();
+    console.log(
+      JSON.stringify(
+        {
+          onboarding,
+          daemon: runningForJson
+            ? { running: true, pid: runningForJson.pid, startedAt: runningForJson.startedAt }
+            : { running: false },
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+  if (onboarding.complete) {
+    await writeCompletionMarker(mamaHome);
+  }
+
   console.log('\n📊 MAMA Standalone Status\n');
+  if (!onboarding.complete) {
+    console.log(renderContractStatus(onboarding));
+    console.log('');
+  } else {
+    console.log('Onboarding: complete');
+  }
 
   // Check if running
   const runningInfo = await isDaemonRunning();

--- a/packages/standalone/src/cli/commands/status.ts
+++ b/packages/standalone/src/cli/commands/status.ts
@@ -31,43 +31,46 @@ export function formatVersionStatus(cliVersion: string, runtimeVersion: string |
 export async function statusCommand(options: { json?: boolean } = {}): Promise<void> {
   // Onboarding contract: observe, migrate legacy markers, and either surface
   // the missing items (with per-item next actions) or record completion.
-  const { collectAssessDeps, writeCompletionMarker, migrateLegacyInstall } = await import(
-    '../../onboarding/assess-live.js'
-  );
-  const { assessOnboarding, renderContractStatus } = await import(
-    '../../onboarding/agent-contract.js'
-  );
+  const { collectAssessDeps, writeCompletionMarker, migrateLegacyInstall } =
+    await import('../../onboarding/assess-live.js');
+  const { assessOnboarding, renderContractStatus } =
+    await import('../../onboarding/agent-contract.js');
   const { getMAMAHome } = await import('../config/config-manager.js');
   const mamaHome = getMAMAHome();
-  migrateLegacyInstall(mamaHome);
-  const deps = await collectAssessDeps();
-  const onboarding = assessOnboarding(deps);
+  let onboarding: ReturnType<typeof assessOnboarding> | null = null;
+  let onboardingError: string | undefined;
+  try {
+    await migrateLegacyInstall(mamaHome);
+    onboarding = assessOnboarding(await collectAssessDeps());
+  } catch (error) {
+    onboardingError = error instanceof Error ? error.message : String(error);
+  }
   if (options.json) {
     const runningForJson = await isDaemonRunning();
-    console.log(
+    process.stdout.write(
       JSON.stringify(
         {
           onboarding,
+          ...(onboardingError ? { onboardingError } : {}),
           daemon: runningForJson
             ? { running: true, pid: runningForJson.pid, startedAt: runningForJson.startedAt }
             : { running: false },
         },
         null,
         2
-      )
+      ) + '\n'
     );
     return;
   }
-  if (onboarding.complete) {
+  if (onboardingError) {
+    process.stdout.write(`Onboarding: unavailable\n  ${onboardingError}\n\n`);
+  } else if (onboarding?.complete) {
     await writeCompletionMarker(mamaHome);
   }
 
   console.log('\n📊 MAMA Standalone Status\n');
-  if (!onboarding.complete) {
-    console.log(renderContractStatus(onboarding));
-    console.log('');
-  } else {
-    console.log('Onboarding: complete');
+  if (onboarding) {
+    process.stdout.write(`${renderContractStatus(onboarding)}\n\n`);
   }
 
   // Check if running

--- a/packages/standalone/src/cli/config/types.ts
+++ b/packages/standalone/src/cli/config/types.ts
@@ -719,8 +719,6 @@ export interface MAMAConfig {
   logging: LoggingConfig;
   /** Role-based permission settings (optional) */
   roles?: RolesConfig;
-  /** Owner facts the operator personalizes reports with (onboarding contract item) */
-  owner?: { name?: string; language?: string; timezone?: string };
   /** @deprecated Always uses Claude CLI now (ToS compliance) */
   use_claude_cli?: boolean;
   /** Discord gateway settings (optional) */

--- a/packages/standalone/src/cli/config/types.ts
+++ b/packages/standalone/src/cli/config/types.ts
@@ -719,6 +719,8 @@ export interface MAMAConfig {
   logging: LoggingConfig;
   /** Role-based permission settings (optional) */
   roles?: RolesConfig;
+  /** Owner facts the operator personalizes reports with (onboarding contract item) */
+  owner?: { name?: string; language?: string; timezone?: string };
   /** @deprecated Always uses Claude CLI now (ToS compliance) */
   use_claude_cli?: boolean;
   /** Discord gateway settings (optional) */

--- a/packages/standalone/src/cli/index.ts
+++ b/packages/standalone/src/cli/index.ts
@@ -79,8 +79,9 @@ program
 program
   .command('status')
   .description('Check MAMA agent status')
-  .action(async () => {
-    await statusCommand();
+  .option('--json', 'Machine-readable status with onboarding contract')
+  .action(async (options: { json?: boolean }) => {
+    await statusCommand(options);
   });
 
 program

--- a/packages/standalone/src/onboarding/agent-contract.ts
+++ b/packages/standalone/src/onboarding/agent-contract.ts
@@ -1,0 +1,149 @@
+/**
+ * The onboarding contract - the single source of onboarding truth.
+ *
+ * `mama --help` renders the static half (what the journey is), `mama status`
+ * renders the dynamic half (where this install stands and the exact next
+ * action per missing item). Everything else - plugin skill, README, the agent
+ * driving a conversation - is a thin pointer to these two renders. Guidance
+ * strings live ONLY here; duplicating them elsewhere reintroduces the drift
+ * this module exists to kill.
+ *
+ * Pure evaluation: no I/O. Observation lives in assess-live.ts; this module
+ * owns judgment and wording. The journey endpoint is deliberately not
+ * "setup complete" but the first evidenced report arriving.
+ */
+
+export type OnboardingItemId =
+  | 'config'
+  | 'gateway'
+  | 'trust_anchor'
+  | 'owner_facts'
+  | 'sources'
+  | 'first_report';
+
+export interface OnboardingItemState {
+  id: OnboardingItemId;
+  done: boolean;
+  guidance: string;
+}
+
+export interface OnboardingState {
+  complete: boolean;
+  missing: OnboardingItemId[];
+  items: OnboardingItemState[];
+}
+
+export interface AssessDeps {
+  mamaHome: string;
+  configExists: boolean;
+  daemonRunning: boolean;
+  telegramToken: boolean;
+  allowedChats: boolean;
+  ownerFacts: boolean;
+  enabledConnectors: number;
+  firstReportAt: string | null;
+}
+
+/** Journey order is fixed: `missing` reports in this order, always. */
+export const ONBOARDING_ITEMS: readonly OnboardingItemId[] = [
+  'config',
+  'gateway',
+  'trust_anchor',
+  'owner_facts',
+  'sources',
+  'first_report',
+] as const;
+
+/**
+ * Telegram allows exactly one polling consumer, so gateway/anchor work must
+ * happen with the daemon stopped. The contract owns this ordering knowledge -
+ * the commands themselves carry no pre-guards.
+ */
+const STOP_DAEMON_FIRST = 'Stop the daemon first: mama stop (Telegram allows one polling consumer)';
+
+function guidanceFor(id: OnboardingItemId, deps: AssessDeps): string {
+  switch (id) {
+    case 'config':
+      return 'Run: mama init (checks backend auth and writes ~/.mama/config.yaml)';
+    case 'gateway': {
+      const line = 'Run: mama gateway telegram set-token <bot-token> (create one via @BotFather)';
+      return deps.daemonRunning ? `${STOP_DAEMON_FIRST}\n${line}` : line;
+    }
+    case 'trust_anchor': {
+      const line = deps.telegramToken
+        ? 'Human step: send any message to the bot, then run: mama gateway telegram detect-owner'
+        : 'Set the gateway token first (see the gateway item), then: mama gateway telegram detect-owner';
+      return deps.daemonRunning ? `${STOP_DAEMON_FIRST}\n${line}` : line;
+    }
+    case 'owner_facts':
+      return 'Run: mama owner --name <name> --language <lang> --timezone <tz>';
+    case 'sources':
+      return 'Run: mama connector add <name> (mama connector list shows what exists)';
+    case 'first_report':
+      return 'Run: mama start, then: mama report now - the journey ends when the first report arrives';
+  }
+}
+
+function isDone(id: OnboardingItemId, deps: AssessDeps): boolean {
+  switch (id) {
+    case 'config':
+      // mama init already gates backend availability + auth fail-loud, so an
+      // existing config implies auth passed at init time; later auth rot fails
+      // loudly at start/run - the real boundary (review decision #3).
+      return deps.configExists;
+    case 'gateway':
+      return deps.telegramToken;
+    case 'trust_anchor':
+      return deps.allowedChats;
+    case 'owner_facts':
+      return deps.ownerFacts;
+    case 'sources':
+      return deps.enabledConnectors >= 1;
+    case 'first_report':
+      return deps.firstReportAt !== null;
+  }
+}
+
+export function assessOnboarding(deps: AssessDeps): OnboardingState {
+  const items: OnboardingItemState[] = ONBOARDING_ITEMS.map((id) => ({
+    id,
+    done: isDone(id, deps),
+    guidance: guidanceFor(id, deps),
+  }));
+  const missing = items.filter((i) => !i.done).map((i) => i.id);
+  return { complete: missing.length === 0, missing, items };
+}
+
+/** Static contract block for `mama --help` and the README pointer. */
+export function renderContractIntro(): string {
+  return [
+    'MAMA is an always-on agent server: it reads your work channels and',
+    'delivers evidenced reports. The setup journey ends when the FIRST REPORT',
+    'arrives - not when installation finishes.',
+    '',
+    'New install? Run: mama status - it shows exactly what is missing and the',
+    'next command for each item. Machine-readable: mama status --json',
+  ].join('\n');
+}
+
+/** Dynamic contract block for `mama status` when onboarding is incomplete. */
+export function renderContractStatus(state: OnboardingState): string {
+  if (state.complete) {
+    return 'Onboarding: complete';
+  }
+  const lines: string[] = ['Onboarding: incomplete', ''];
+  for (const item of state.items) {
+    const mark = item.done ? '[x]' : '[ ]';
+    lines.push(`${mark} ${item.id}`);
+    if (!item.done) {
+      for (const g of item.guidance.split('\n')) {
+        lines.push(`      ${g}`);
+      }
+    }
+  }
+  const next = state.items.find((i) => !i.done);
+  if (next) {
+    lines.push('', `Next: ${next.guidance.split('\n').pop() ?? ''}`);
+  }
+  return lines.join('\n');
+}

--- a/packages/standalone/src/onboarding/agent-contract.ts
+++ b/packages/standalone/src/onboarding/agent-contract.ts
@@ -17,7 +17,7 @@ export type OnboardingItemId =
   | 'config'
   | 'gateway'
   | 'trust_anchor'
-  | 'owner_facts'
+  | 'daemon'
   | 'sources'
   | 'first_report';
 
@@ -34,12 +34,10 @@ export interface OnboardingState {
 }
 
 export interface AssessDeps {
-  mamaHome: string;
-  configExists: boolean;
+  configLoadable: boolean;
   daemonRunning: boolean;
-  telegramToken: boolean;
+  telegramConfigured: boolean;
   allowedChats: boolean;
-  ownerFacts: boolean;
   enabledConnectors: number;
   firstReportAt: string | null;
 }
@@ -49,7 +47,7 @@ export const ONBOARDING_ITEMS: readonly OnboardingItemId[] = [
   'config',
   'gateway',
   'trust_anchor',
-  'owner_facts',
+  'daemon',
   'sources',
   'first_report',
 ] as const;
@@ -66,21 +64,22 @@ function guidanceFor(id: OnboardingItemId, deps: AssessDeps): string {
     case 'config':
       return 'Run: mama init (checks backend auth and writes ~/.mama/config.yaml)';
     case 'gateway': {
-      const line = 'Run: mama gateway telegram set-token <bot-token> (create one via @BotFather)';
+      const line =
+        'Run: mama gateway telegram --token-stdin (create the bot token with @BotFather first)';
       return deps.daemonRunning ? `${STOP_DAEMON_FIRST}\n${line}` : line;
     }
     case 'trust_anchor': {
-      const line = deps.telegramToken
+      const line = deps.telegramConfigured
         ? 'Human step: send any message to the bot, then run: mama gateway telegram detect-owner'
-        : 'Set the gateway token first (see the gateway item), then: mama gateway telegram detect-owner';
+        : 'Human step: configure the gateway first, send any message to the bot, then run: mama gateway telegram detect-owner';
       return deps.daemonRunning ? `${STOP_DAEMON_FIRST}\n${line}` : line;
     }
-    case 'owner_facts':
-      return 'Run: mama owner --name <name> --language <lang> --timezone <tz>';
+    case 'daemon':
+      return 'Start the daemon: mama start';
     case 'sources':
       return 'Run: mama connector add <name> (mama connector list shows what exists)';
     case 'first_report':
-      return 'Run: mama start, then: mama report now - the journey ends when the first report arrives';
+      return 'Run: mama report now - the journey ends when the first report arrives';
   }
 }
 
@@ -88,15 +87,15 @@ function isDone(id: OnboardingItemId, deps: AssessDeps): boolean {
   switch (id) {
     case 'config':
       // mama init already gates backend availability + auth fail-loud, so an
-      // existing config implies auth passed at init time; later auth rot fails
+      // loadable config implies auth passed at init time; later auth rot fails
       // loudly at start/run - the real boundary (review decision #3).
-      return deps.configExists;
+      return deps.configLoadable;
     case 'gateway':
-      return deps.telegramToken;
+      return deps.telegramConfigured;
     case 'trust_anchor':
       return deps.allowedChats;
-    case 'owner_facts':
-      return deps.ownerFacts;
+    case 'daemon':
+      return deps.daemonRunning;
     case 'sources':
       return deps.enabledConnectors >= 1;
     case 'first_report':
@@ -131,19 +130,30 @@ export function renderContractStatus(state: OnboardingState): string {
   if (state.complete) {
     return 'Onboarding: complete';
   }
-  const lines: string[] = ['Onboarding: incomplete', ''];
-  for (const item of state.items) {
-    const mark = item.done ? '[x]' : '[ ]';
-    lines.push(`${mark} ${item.id}`);
-    if (!item.done) {
-      for (const g of item.guidance.split('\n')) {
-        lines.push(`      ${g}`);
+  const missing = state.items.filter((item) => !item.done);
+  const agentActions = missing.filter((item) => item.id !== 'trust_anchor');
+  const humanActions = missing.filter((item) => item.id === 'trust_anchor');
+  const lines: string[] = ['Onboarding: incomplete'];
+
+  const appendActions = (heading: string, items: OnboardingItemState[]): void => {
+    if (items.length === 0) {
+      return;
+    }
+    lines.push('', heading);
+    for (const item of items) {
+      lines.push(`[ ] ${item.id}`);
+      for (const guidance of item.guidance.split('\n')) {
+        lines.push(`      ${guidance}`);
       }
     }
-  }
-  const next = state.items.find((i) => !i.done);
-  if (next) {
-    lines.push('', `Next: ${next.guidance.split('\n').pop() ?? ''}`);
+  };
+
+  appendActions('Agent can do now:', agentActions);
+  appendActions('Human required:', humanActions);
+
+  const nextAgentAction = agentActions[0];
+  if (nextAgentAction) {
+    lines.push('', `Next: ${nextAgentAction.guidance.split('\n').pop() ?? ''}`);
   }
   return lines.join('\n');
 }

--- a/packages/standalone/src/onboarding/assess-live.ts
+++ b/packages/standalone/src/onboarding/assess-live.ts
@@ -1,108 +1,158 @@
 /**
  * Live observation for the onboarding contract.
  *
- * This module only OBSERVES - config file, marker files, the pid file, the
- * connectors registry. Judgment and wording live in agent-contract.ts. The
- * completion marker is a cache of an observed state, never an authority:
- * status recomputes from observation every time and the marker exists so a
- * completed install can say so without re-deriving history.
+ * This module observes the current installation. Judgment and wording remain
+ * in agent-contract.ts. Completion markers cache observed history; they never
+ * gate runtime behavior.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import yaml from 'js-yaml';
-import { getMAMAHome } from '../cli/config/config-manager.js';
+import { getConfigPath, getMAMAHome, loadConfig } from '../cli/config/config-manager.js';
 import { isDaemonRunning } from '../cli/utils/pid-manager.js';
+import { loadConnectorConfig } from '../connectors/config-loader.js';
 import type { AssessDeps } from './agent-contract.js';
 
-interface RawConfigShape {
-  telegram?: { token?: string; allowed_chats?: string[] };
-  owner?: { name?: string; language?: string; timezone?: string };
+interface CompletionMarker {
+  completed_at?: string;
 }
 
-interface RawConnectorsShape {
-  connectors?: Record<string, { enabled?: boolean } | undefined>;
+interface FirstReportMarker {
+  at?: string;
 }
 
-function readYamlConfig(home: string): RawConfigShape | null {
-  const p = join(home, 'config.yaml');
-  if (!existsSync(p)) return null;
+function parseJsonFile<T>(path: string): T {
   try {
-    return (yaml.load(readFileSync(p, 'utf-8')) as RawConfigShape) ?? null;
-  } catch {
-    // A corrupt config is observed as absent; init/start fail loudly on it at
-    // the real boundary - status must not crash while reporting.
+    return JSON.parse(readFileSync(path, 'utf8')) as T;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse onboarding state file ${path}: ${message}`);
+  }
+}
+
+function parseJsonObjectFile(path: string): Record<string, unknown> {
+  const value = parseJsonFile<unknown>(path);
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Invalid onboarding state file ${path}: expected a JSON object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function countEnabledConnectors(mamaHome: string): number {
+  const path = join(mamaHome, 'connectors.json');
+  const result = loadConnectorConfig(path);
+  if (!result.ok) {
+    throw new Error(
+      `Failed to load onboarding connector state ${result.error.path}: ${result.error.message}`
+    );
+  }
+  return result.enabledNames.length;
+}
+
+function readFirstReportAt(mamaHome: string): string | null {
+  const path = join(mamaHome, 'state', 'first-report.json');
+  if (!existsSync(path)) {
     return null;
   }
-}
-
-function countEnabledConnectors(home: string): number {
-  const p = join(home, 'connectors.json');
-  if (!existsSync(p)) return 0;
-  try {
-    const raw = JSON.parse(readFileSync(p, 'utf-8')) as RawConnectorsShape;
-    const entries = raw.connectors ?? (raw as Record<string, { enabled?: boolean }>);
-    return Object.values(entries).filter(
-      (c) => c && typeof c === 'object' && c.enabled === true
-    ).length;
-  } catch {
-    return 0;
+  const raw = parseJsonObjectFile(path) as FirstReportMarker;
+  if (typeof raw.at !== 'string' || raw.at.length === 0) {
+    throw new Error(`Invalid onboarding state file ${path}: expected a non-empty string "at"`);
   }
+  return raw.at;
 }
 
-function readFirstReportAt(home: string): string | null {
-  const p = join(home, 'state', 'first-report.json');
-  if (!existsSync(p)) return null;
-  try {
-    const raw = JSON.parse(readFileSync(p, 'utf-8')) as { at?: string };
-    return typeof raw.at === 'string' ? raw.at : null;
-  } catch {
-    return null;
+export async function collectAssessDeps(): Promise<AssessDeps> {
+  const mamaHome = getMAMAHome();
+  const configPath = getConfigPath();
+  let config: Awaited<ReturnType<typeof loadConfig>> | null = null;
+
+  if (existsSync(configPath)) {
+    try {
+      config = await loadConfig();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to load onboarding config ${configPath}: ${message}`);
+    }
   }
-}
 
-export async function collectAssessDeps(mamaHome?: string): Promise<AssessDeps> {
-  const home = mamaHome ?? getMAMAHome();
-  const config = readYamlConfig(home);
-  const running = mamaHome === undefined ? await isDaemonRunning() : null;
+  const running = await isDaemonRunning();
   return {
-    mamaHome: home,
-    configExists: config !== null || existsSync(join(home, 'config.yaml')),
-    daemonRunning: running !== null && running !== undefined && Boolean(running),
-    telegramToken: Boolean(config?.telegram?.token?.trim()),
-    allowedChats: Array.isArray(config?.telegram?.allowed_chats)
-      ? config.telegram.allowed_chats.length > 0
-      : false,
-    ownerFacts: Boolean(config?.owner?.name?.trim()),
-    enabledConnectors: countEnabledConnectors(home),
-    firstReportAt: readFirstReportAt(home),
+    configLoadable: config !== null,
+    daemonRunning: Boolean(running),
+    telegramConfigured:
+      config?.telegram?.enabled === true && Boolean(config.telegram.token?.trim()),
+    allowedChats:
+      Array.isArray(config?.telegram?.allowed_chats) && config.telegram.allowed_chats.length > 0,
+    enabledConnectors: countEnabledConnectors(mamaHome),
+    firstReportAt: readFirstReportAt(mamaHome),
   };
 }
 
 /** Idempotent: the first completed_at is preserved forever. */
 export async function writeCompletionMarker(mamaHome: string): Promise<void> {
-  const p = join(mamaHome, 'setup-complete.json');
-  if (existsSync(p)) return;
+  const path = join(mamaHome, 'setup-complete.json');
+  if (existsSync(path)) {
+    return;
+  }
   mkdirSync(mamaHome, { recursive: true });
-  writeFileSync(p, JSON.stringify({ completed_at: new Date().toISOString() }, null, 2));
+  writeFileSync(path, JSON.stringify({ completed_at: new Date().toISOString() }, null, 2));
 }
 
 /**
- * A legacy install (persona files present + telegram configured) predates the
- * marker; backfill it so status never tells a working install to onboard.
+ * Backfill observed completion evidence for an existing working installation.
+ * The markers describe history only; assessment still recomputes live state.
  */
-export function migrateLegacyInstall(mamaHome: string): boolean {
-  const markerPath = join(mamaHome, 'setup-complete.json');
-  if (existsSync(markerPath)) return false;
+export async function migrateLegacyInstall(mamaHome: string): Promise<boolean> {
+  const completionPath = join(mamaHome, 'setup-complete.json');
+  const reportPath = join(mamaHome, 'state', 'first-report.json');
+  if (existsSync(completionPath) && existsSync(reportPath)) {
+    return false;
+  }
+
   const hasPersonas =
     existsSync(join(mamaHome, 'SOUL.md')) && existsSync(join(mamaHome, 'USER.md'));
-  if (!hasPersonas) return false;
-  const config = readYamlConfig(mamaHome);
+  if (!hasPersonas || !existsSync(getConfigPath())) {
+    return false;
+  }
+
+  let config: Awaited<ReturnType<typeof loadConfig>>;
+  try {
+    config = await loadConfig();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to load onboarding config ${getConfigPath()}: ${message}`);
+  }
   const telegramConfigured =
-    Boolean(config?.telegram?.token?.trim()) &&
-    Array.isArray(config?.telegram?.allowed_chats) &&
-    (config?.telegram?.allowed_chats?.length ?? 0) > 0;
-  if (!telegramConfigured) return false;
-  writeFileSync(markerPath, JSON.stringify({ completed_at: new Date().toISOString() }, null, 2));
-  return true;
+    config.telegram?.enabled === true &&
+    Boolean(config.telegram.token?.trim()) &&
+    Array.isArray(config.telegram.allowed_chats) &&
+    config.telegram.allowed_chats.length > 0;
+  if (!telegramConfigured) {
+    return false;
+  }
+
+  let completedAt = new Date().toISOString();
+  let changed = false;
+
+  if (existsSync(completionPath)) {
+    const marker = parseJsonObjectFile(completionPath) as CompletionMarker;
+    if (typeof marker.completed_at !== 'string' || marker.completed_at.length === 0) {
+      throw new Error(
+        `Invalid onboarding state file ${completionPath}: expected a non-empty string "completed_at"`
+      );
+    }
+    completedAt = marker.completed_at;
+  } else {
+    mkdirSync(mamaHome, { recursive: true });
+    writeFileSync(completionPath, JSON.stringify({ completed_at: completedAt }, null, 2));
+    changed = true;
+  }
+
+  if (!existsSync(reportPath)) {
+    mkdirSync(join(mamaHome, 'state'), { recursive: true });
+    writeFileSync(reportPath, JSON.stringify({ at: completedAt }, null, 2));
+    changed = true;
+  }
+
+  return changed;
 }

--- a/packages/standalone/src/onboarding/assess-live.ts
+++ b/packages/standalone/src/onboarding/assess-live.ts
@@ -1,0 +1,108 @@
+/**
+ * Live observation for the onboarding contract.
+ *
+ * This module only OBSERVES - config file, marker files, the pid file, the
+ * connectors registry. Judgment and wording live in agent-contract.ts. The
+ * completion marker is a cache of an observed state, never an authority:
+ * status recomputes from observation every time and the marker exists so a
+ * completed install can say so without re-deriving history.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import yaml from 'js-yaml';
+import { getMAMAHome } from '../cli/config/config-manager.js';
+import { isDaemonRunning } from '../cli/utils/pid-manager.js';
+import type { AssessDeps } from './agent-contract.js';
+
+interface RawConfigShape {
+  telegram?: { token?: string; allowed_chats?: string[] };
+  owner?: { name?: string; language?: string; timezone?: string };
+}
+
+interface RawConnectorsShape {
+  connectors?: Record<string, { enabled?: boolean } | undefined>;
+}
+
+function readYamlConfig(home: string): RawConfigShape | null {
+  const p = join(home, 'config.yaml');
+  if (!existsSync(p)) return null;
+  try {
+    return (yaml.load(readFileSync(p, 'utf-8')) as RawConfigShape) ?? null;
+  } catch {
+    // A corrupt config is observed as absent; init/start fail loudly on it at
+    // the real boundary - status must not crash while reporting.
+    return null;
+  }
+}
+
+function countEnabledConnectors(home: string): number {
+  const p = join(home, 'connectors.json');
+  if (!existsSync(p)) return 0;
+  try {
+    const raw = JSON.parse(readFileSync(p, 'utf-8')) as RawConnectorsShape;
+    const entries = raw.connectors ?? (raw as Record<string, { enabled?: boolean }>);
+    return Object.values(entries).filter(
+      (c) => c && typeof c === 'object' && c.enabled === true
+    ).length;
+  } catch {
+    return 0;
+  }
+}
+
+function readFirstReportAt(home: string): string | null {
+  const p = join(home, 'state', 'first-report.json');
+  if (!existsSync(p)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(p, 'utf-8')) as { at?: string };
+    return typeof raw.at === 'string' ? raw.at : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function collectAssessDeps(mamaHome?: string): Promise<AssessDeps> {
+  const home = mamaHome ?? getMAMAHome();
+  const config = readYamlConfig(home);
+  const running = mamaHome === undefined ? await isDaemonRunning() : null;
+  return {
+    mamaHome: home,
+    configExists: config !== null || existsSync(join(home, 'config.yaml')),
+    daemonRunning: running !== null && running !== undefined && Boolean(running),
+    telegramToken: Boolean(config?.telegram?.token?.trim()),
+    allowedChats: Array.isArray(config?.telegram?.allowed_chats)
+      ? config.telegram.allowed_chats.length > 0
+      : false,
+    ownerFacts: Boolean(config?.owner?.name?.trim()),
+    enabledConnectors: countEnabledConnectors(home),
+    firstReportAt: readFirstReportAt(home),
+  };
+}
+
+/** Idempotent: the first completed_at is preserved forever. */
+export async function writeCompletionMarker(mamaHome: string): Promise<void> {
+  const p = join(mamaHome, 'setup-complete.json');
+  if (existsSync(p)) return;
+  mkdirSync(mamaHome, { recursive: true });
+  writeFileSync(p, JSON.stringify({ completed_at: new Date().toISOString() }, null, 2));
+}
+
+/**
+ * A legacy install (persona files present + telegram configured) predates the
+ * marker; backfill it so status never tells a working install to onboard.
+ */
+export function migrateLegacyInstall(mamaHome: string): boolean {
+  const markerPath = join(mamaHome, 'setup-complete.json');
+  if (existsSync(markerPath)) return false;
+  const hasPersonas =
+    existsSync(join(mamaHome, 'SOUL.md')) && existsSync(join(mamaHome, 'USER.md'));
+  if (!hasPersonas) return false;
+  const config = readYamlConfig(mamaHome);
+  const telegramConfigured =
+    Boolean(config?.telegram?.token?.trim()) &&
+    Array.isArray(config?.telegram?.allowed_chats) &&
+    (config?.telegram?.allowed_chats?.length ?? 0) > 0;
+  if (!telegramConfigured) return false;
+  writeFileSync(markerPath, JSON.stringify({ completed_at: new Date().toISOString() }, null, 2));
+  return true;
+}

--- a/packages/standalone/tests/onboarding/agent-contract.test.ts
+++ b/packages/standalone/tests/onboarding/agent-contract.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   assessOnboarding,
   renderContractStatus,
@@ -6,61 +6,108 @@ import {
 } from '../../src/onboarding/agent-contract.js';
 
 const base: AssessDeps = {
-  mamaHome: '/tmp/x',
-  configExists: true,
-  daemonRunning: false,
-  telegramToken: true,
+  configLoadable: true,
+  daemonRunning: true,
+  telegramConfigured: true,
   allowedChats: true,
-  ownerFacts: true,
   enabledConnectors: 1,
   firstReportAt: '2026-08-28T00:00:00Z',
 };
 
-describe('assessOnboarding', () => {
-  it('reports complete only when every item is done', () => {
-    expect(assessOnboarding(base).complete).toBe(true);
-    expect(assessOnboarding(base).missing).toEqual([]);
-  });
-
-  it('never completes without trust anchor even if everything else is done', () => {
-    const s = assessOnboarding({ ...base, allowedChats: false });
-    expect(s.complete).toBe(false);
-    expect(s.missing).toContain('trust_anchor');
-  });
-
-  it('missing preserves journey order: config first, first_report last', () => {
-    const s = assessOnboarding({
-      ...base,
-      configExists: false,
-      firstReportAt: null,
+describe('Story ONB-1: self-teaching onboarding contract', () => {
+  describe('AC #1: completion follows the six observed journey items', () => {
+    it('reports complete only when every item is done', () => {
+      expect(assessOnboarding(base).complete).toBe(true);
+      expect(assessOnboarding(base).missing).toEqual([]);
     });
-    expect(s.missing[0]).toBe('config');
-    expect(s.missing[s.missing.length - 1]).toBe('first_report');
-  });
 
-  it('every missing item carries actionable guidance with a command', () => {
-    const s = assessOnboarding({
-      ...base,
-      telegramToken: false,
-      allowedChats: false,
-      enabledConnectors: 0,
-      firstReportAt: null,
+    it('requires the daemon before the first report can complete the journey', () => {
+      const state = assessOnboarding({ ...base, daemonRunning: false });
+
+      expect(state.complete).toBe(false);
+      expect(state.missing).toEqual(['daemon']);
+      expect(state.items.map((item) => item.id)).toEqual([
+        'config',
+        'gateway',
+        'trust_anchor',
+        'daemon',
+        'sources',
+        'first_report',
+      ]);
     });
-    for (const item of s.items.filter((i) => !i.done)) {
-      expect(item.guidance).toMatch(/mama /);
-    }
+
+    it('never completes without a trust anchor even if everything else is done', () => {
+      const state = assessOnboarding({ ...base, allowedChats: false });
+
+      expect(state.complete).toBe(false);
+      expect(state.missing).toContain('trust_anchor');
+    });
+
+    it('missing preserves journey order: config first, first_report last', () => {
+      const state = assessOnboarding({
+        ...base,
+        configLoadable: false,
+        firstReportAt: null,
+      });
+
+      expect(state.missing[0]).toBe('config');
+      expect(state.missing[state.missing.length - 1]).toBe('first_report');
+    });
   });
 
-  it('gateway guidance says stop the daemon first when it is running', () => {
-    const s = assessOnboarding({ ...base, daemonRunning: true, telegramToken: false, allowedChats: false });
-    const gateway = s.items.find((i) => i.id === 'gateway');
-    expect(gateway?.guidance).toContain('mama stop');
+  describe('AC #2: guidance is executable without leaking secrets through argv', () => {
+    it('every missing item carries actionable guidance with a command', () => {
+      const state = assessOnboarding({
+        ...base,
+        telegramConfigured: false,
+        allowedChats: false,
+        daemonRunning: false,
+        enabledConnectors: 0,
+        firstReportAt: null,
+      });
+
+      for (const item of state.items.filter((candidate) => !candidate.done)) {
+        expect(item.guidance).toMatch(/mama /);
+      }
+    });
+
+    it('uses stdin for the Telegram token and never places a token placeholder on argv', () => {
+      const state = assessOnboarding({ ...base, telegramConfigured: false });
+      const gateway = state.items.find((item) => item.id === 'gateway');
+
+      expect(gateway?.guidance).toContain('--token-stdin');
+      expect(gateway?.guidance).not.toMatch(/<.*token.*>/i);
+    });
+
+    it('says to stop the daemon before changing the Telegram gateway or anchor', () => {
+      const state = assessOnboarding({
+        ...base,
+        telegramConfigured: false,
+        allowedChats: false,
+      });
+
+      expect(state.items.find((item) => item.id === 'gateway')?.guidance).toContain('mama stop');
+      expect(state.items.find((item) => item.id === 'trust_anchor')?.guidance).toContain(
+        'mama stop'
+      );
+    });
   });
 
-  it('renderContractStatus prints next action for the first missing item', () => {
-    const s = assessOnboarding({ ...base, firstReportAt: null });
-    const text = renderContractStatus(s);
-    expect(text).toContain('first_report');
-    expect(text).toContain('mama report now');
+  describe('AC #3: rendering separates agent actions from human-required actions', () => {
+    it('shows every missing action and identifies the human-required trust anchor', () => {
+      const state = assessOnboarding({
+        ...base,
+        allowedChats: false,
+        enabledConnectors: 0,
+        firstReportAt: null,
+      });
+      const text = renderContractStatus(state);
+
+      expect(text).toContain('Agent can do now:');
+      expect(text).toContain('Human required:');
+      expect(text).toContain('trust_anchor');
+      expect(text).toContain('sources');
+      expect(text).toContain('first_report');
+    });
   });
 });

--- a/packages/standalone/tests/onboarding/agent-contract.test.ts
+++ b/packages/standalone/tests/onboarding/agent-contract.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  assessOnboarding,
+  renderContractStatus,
+  type AssessDeps,
+} from '../../src/onboarding/agent-contract.js';
+
+const base: AssessDeps = {
+  mamaHome: '/tmp/x',
+  configExists: true,
+  daemonRunning: false,
+  telegramToken: true,
+  allowedChats: true,
+  ownerFacts: true,
+  enabledConnectors: 1,
+  firstReportAt: '2026-08-28T00:00:00Z',
+};
+
+describe('assessOnboarding', () => {
+  it('reports complete only when every item is done', () => {
+    expect(assessOnboarding(base).complete).toBe(true);
+    expect(assessOnboarding(base).missing).toEqual([]);
+  });
+
+  it('never completes without trust anchor even if everything else is done', () => {
+    const s = assessOnboarding({ ...base, allowedChats: false });
+    expect(s.complete).toBe(false);
+    expect(s.missing).toContain('trust_anchor');
+  });
+
+  it('missing preserves journey order: config first, first_report last', () => {
+    const s = assessOnboarding({
+      ...base,
+      configExists: false,
+      firstReportAt: null,
+    });
+    expect(s.missing[0]).toBe('config');
+    expect(s.missing[s.missing.length - 1]).toBe('first_report');
+  });
+
+  it('every missing item carries actionable guidance with a command', () => {
+    const s = assessOnboarding({
+      ...base,
+      telegramToken: false,
+      allowedChats: false,
+      enabledConnectors: 0,
+      firstReportAt: null,
+    });
+    for (const item of s.items.filter((i) => !i.done)) {
+      expect(item.guidance).toMatch(/mama /);
+    }
+  });
+
+  it('gateway guidance says stop the daemon first when it is running', () => {
+    const s = assessOnboarding({ ...base, daemonRunning: true, telegramToken: false, allowedChats: false });
+    const gateway = s.items.find((i) => i.id === 'gateway');
+    expect(gateway?.guidance).toContain('mama stop');
+  });
+
+  it('renderContractStatus prints next action for the first missing item', () => {
+    const s = assessOnboarding({ ...base, firstReportAt: null });
+    const text = renderContractStatus(s);
+    expect(text).toContain('first_report');
+    expect(text).toContain('mama report now');
+  });
+});

--- a/packages/standalone/tests/onboarding/assess-live.test.ts
+++ b/packages/standalone/tests/onboarding/assess-live.test.ts
@@ -1,100 +1,198 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, writeFileSync, mkdirSync, existsSync, rmSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import yaml from 'js-yaml';
+import { join } from 'node:path';
 import {
   collectAssessDeps,
-  writeCompletionMarker,
   migrateLegacyInstall,
+  writeCompletionMarker,
 } from '../../src/onboarding/assess-live.js';
+import { saveConfig } from '../../src/cli/config/config-manager.js';
+import { DEFAULT_CONFIG, type MAMAConfig } from '../../src/cli/config/types.js';
 
 let home: string;
-beforeEach(() => {
-  home = mkdtempSync(join(tmpdir(), 'mama-onb-'));
-});
-afterEach(() => rmSync(home, { recursive: true, force: true }));
+let mamaHome: string;
+let originalHome: string | undefined;
 
-function writeConfig(home: string, config: unknown): void {
-  writeFileSync(join(home, 'config.yaml'), yaml.dump(config));
+beforeEach(() => {
+  originalHome = process.env.HOME;
+  home = mkdtempSync(join(tmpdir(), 'mama-onb-home-'));
+  mamaHome = join(home, '.mama');
+  process.env.HOME = home;
+});
+
+afterEach(() => {
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+  rmSync(home, { recursive: true, force: true });
+});
+
+async function writeConfig(overrides: Partial<MAMAConfig> = {}): Promise<void> {
+  const config = structuredClone(DEFAULT_CONFIG);
+  await saveConfig({ ...config, ...overrides });
 }
 
-describe('collectAssessDeps', () => {
-  it('fresh home reports everything missing', async () => {
-    const deps = await collectAssessDeps(home);
-    expect(deps.configExists).toBe(false);
-    expect(deps.telegramToken).toBe(false);
-    expect(deps.allowedChats).toBe(false);
-    expect(deps.ownerFacts).toBe(false);
-    expect(deps.enabledConnectors).toBe(0);
-    expect(deps.firstReportAt).toBeNull();
-  });
+function connectorConfig(enabled: boolean): Record<string, unknown> {
+  return {
+    enabled,
+    pollIntervalMinutes: 5,
+    channels: {},
+    auth: { type: 'none' },
+  };
+}
 
-  it('reads telegram token, allowed_chats and owner facts from config.yaml', async () => {
-    writeConfig(home, {
-      telegram: { enabled: true, token: 't', allowed_chats: ['1001'] },
-      owner: { name: 'Owner', language: 'ko', timezone: 'Asia/Seoul' },
+describe('Story ONB-2: live onboarding assessment', () => {
+  describe('AC #1: configuration and gateway readiness come from loadable live state', () => {
+    it('reports a fresh HOME as missing without accepting an alternate path authority', async () => {
+      const deps = await collectAssessDeps();
+
+      expect(deps.configLoadable).toBe(false);
+      expect(deps.telegramConfigured).toBe(false);
+      expect(deps.allowedChats).toBe(false);
+      expect(deps.enabledConnectors).toBe(0);
+      expect(deps.firstReportAt).toBeNull();
     });
-    const deps = await collectAssessDeps(home);
-    expect(deps.configExists).toBe(true);
-    expect(deps.telegramToken).toBe(true);
-    expect(deps.allowedChats).toBe(true);
-    expect(deps.ownerFacts).toBe(true);
+
+    it('requires Telegram to be enabled and have a token', async () => {
+      await writeConfig({ telegram: { enabled: false, token: 't', allowed_chats: ['1001'] } });
+
+      expect((await collectAssessDeps()).telegramConfigured).toBe(false);
+
+      await writeConfig({ telegram: { enabled: true, token: 't', allowed_chats: ['1001'] } });
+      const deps = await collectAssessDeps();
+
+      expect(deps.configLoadable).toBe(true);
+      expect(deps.telegramConfigured).toBe(true);
+      expect(deps.allowedChats).toBe(true);
+    });
+
+    it('does not treat an empty allowed_chats list as a trust anchor', async () => {
+      await writeConfig({ telegram: { enabled: true, token: 't', allowed_chats: [] } });
+
+      expect((await collectAssessDeps()).allowedChats).toBe(false);
+    });
+
+    it('throws an explicit config path when config.yaml is malformed', async () => {
+      mkdirSync(mamaHome, { recursive: true });
+      const configPath = join(mamaHome, 'config.yaml');
+      writeFileSync(configPath, 'version: [');
+
+      await expect(collectAssessDeps()).rejects.toThrow(configPath);
+    });
   });
 
-  it('empty allowed_chats is NOT an anchor', async () => {
-    writeConfig(home, { telegram: { enabled: true, token: 't', allowed_chats: [] } });
-    const deps = await collectAssessDeps(home);
-    expect(deps.allowedChats).toBe(false);
+  describe('AC #2: connector and first-report state fail loudly when malformed', () => {
+    it('counts only enabled connectors', async () => {
+      mkdirSync(mamaHome, { recursive: true });
+      writeFileSync(
+        join(mamaHome, 'connectors.json'),
+        JSON.stringify({ slack: connectorConfig(true), gmail: connectorConfig(false) })
+      );
+
+      expect((await collectAssessDeps()).enabledConnectors).toBe(1);
+    });
+
+    it('throws an explicit connectors path when connectors.json is malformed', async () => {
+      mkdirSync(mamaHome, { recursive: true });
+      const connectorsPath = join(mamaHome, 'connectors.json');
+      writeFileSync(connectorsPath, '{');
+
+      await expect(collectAssessDeps()).rejects.toThrow(connectorsPath);
+    });
+
+    it('throws an explicit connectors path when connectors.json has an invalid shape', async () => {
+      mkdirSync(mamaHome, { recursive: true });
+      const connectorsPath = join(mamaHome, 'connectors.json');
+      writeFileSync(connectorsPath, 'null');
+
+      await expect(collectAssessDeps()).rejects.toThrow(connectorsPath);
+    });
+
+    it('reads the first confirmed report timestamp', async () => {
+      mkdirSync(join(mamaHome, 'state'), { recursive: true });
+      writeFileSync(
+        join(mamaHome, 'state', 'first-report.json'),
+        JSON.stringify({ at: '2026-08-28T01:00:00Z' })
+      );
+
+      expect((await collectAssessDeps()).firstReportAt).toBe('2026-08-28T01:00:00Z');
+    });
+
+    it('throws an explicit first-report path when first-report.json is malformed', async () => {
+      mkdirSync(join(mamaHome, 'state'), { recursive: true });
+      const reportPath = join(mamaHome, 'state', 'first-report.json');
+      writeFileSync(reportPath, '{');
+
+      await expect(collectAssessDeps()).rejects.toThrow(reportPath);
+    });
+
+    it('throws an explicit first-report path when first-report.json has an invalid shape', async () => {
+      mkdirSync(join(mamaHome, 'state'), { recursive: true });
+      const reportPath = join(mamaHome, 'state', 'first-report.json');
+      writeFileSync(reportPath, 'null');
+
+      await expect(collectAssessDeps()).rejects.toThrow(reportPath);
+    });
   });
 
-  it('counts only enabled connectors', async () => {
-    writeFileSync(
-      join(home, 'connectors.json'),
-      JSON.stringify({ connectors: { slack: { enabled: true }, gmail: { enabled: false } } })
-    );
-    const deps = await collectAssessDeps(home);
-    expect(deps.enabledConnectors).toBe(1);
-  });
+  describe('AC #3: completion and legacy migration markers are consistent and idempotent', () => {
+    it('preserves the first completion timestamp', async () => {
+      await writeCompletionMarker(mamaHome);
+      const first = JSON.parse(readFileSync(join(mamaHome, 'setup-complete.json'), 'utf-8'));
+      await writeCompletionMarker(mamaHome);
+      const second = JSON.parse(readFileSync(join(mamaHome, 'setup-complete.json'), 'utf-8'));
 
-  it('first_report reads state/first-report.json', async () => {
-    mkdirSync(join(home, 'state'), { recursive: true });
-    writeFileSync(
-      join(home, 'state', 'first-report.json'),
-      JSON.stringify({ at: '2026-08-28T01:00:00Z' })
-    );
-    const deps = await collectAssessDeps(home);
-    expect(deps.firstReportAt).toBe('2026-08-28T01:00:00Z');
-  });
-});
+      expect(second.completed_at).toBe(first.completed_at);
+    });
 
-describe('writeCompletionMarker', () => {
-  it('is idempotent and preserves first completed_at', async () => {
-    await writeCompletionMarker(home);
-    const first = JSON.parse(readFileSync(join(home, 'setup-complete.json'), 'utf-8'));
-    await writeCompletionMarker(home);
-    const second = JSON.parse(readFileSync(join(home, 'setup-complete.json'), 'utf-8'));
-    expect(second.completed_at).toBe(first.completed_at);
-  });
-});
+    it('backfills both completion and first-report evidence for a working legacy install', async () => {
+      mkdirSync(mamaHome, { recursive: true });
+      writeFileSync(join(mamaHome, 'SOUL.md'), '# soul');
+      writeFileSync(join(mamaHome, 'USER.md'), '# user');
+      await writeConfig({ telegram: { enabled: true, token: 't', allowed_chats: ['1'] } });
 
-describe('migrateLegacyInstall', () => {
-  it('backfills marker when persona files + telegram config exist', () => {
-    writeFileSync(join(home, 'SOUL.md'), '# soul');
-    writeFileSync(join(home, 'USER.md'), '# user');
-    writeConfig(home, { telegram: { enabled: true, token: 't', allowed_chats: ['1'] } });
-    expect(migrateLegacyInstall(home)).toBe(true);
-    expect(existsSync(join(home, 'setup-complete.json'))).toBe(true);
-  });
+      expect(await migrateLegacyInstall(mamaHome)).toBe(true);
+      expect(existsSync(join(mamaHome, 'setup-complete.json'))).toBe(true);
+      expect(existsSync(join(mamaHome, 'state', 'first-report.json'))).toBe(true);
+      expect((await collectAssessDeps()).firstReportAt).not.toBeNull();
+    });
 
-  it('does not backfill on fresh home', () => {
-    expect(migrateLegacyInstall(home)).toBe(false);
-  });
+    it('does not re-read legacy eligibility after both migration markers exist', async () => {
+      mkdirSync(mamaHome, { recursive: true });
+      writeFileSync(join(mamaHome, 'SOUL.md'), '# soul');
+      writeFileSync(join(mamaHome, 'USER.md'), '# user');
+      await writeConfig({ telegram: { enabled: true, token: 't', allowed_chats: ['1'] } });
+      expect(await migrateLegacyInstall(mamaHome)).toBe(true);
 
-  it('does not backfill on partial legacy (personas only, no telegram config)', () => {
-    writeFileSync(join(home, 'SOUL.md'), '# soul');
-    writeFileSync(join(home, 'USER.md'), '# user');
-    expect(migrateLegacyInstall(home)).toBe(false);
-    expect(existsSync(join(home, 'setup-complete.json'))).toBe(false);
+      writeFileSync(join(mamaHome, 'config.yaml'), 'version: [');
+
+      expect(await migrateLegacyInstall(mamaHome)).toBe(false);
+    });
+
+    it('does not backfill a fresh or partial legacy install', async () => {
+      expect(await migrateLegacyInstall(mamaHome)).toBe(false);
+
+      mkdirSync(mamaHome, { recursive: true });
+      writeFileSync(join(mamaHome, 'SOUL.md'), '# soul');
+      writeFileSync(join(mamaHome, 'USER.md'), '# user');
+
+      expect(await migrateLegacyInstall(mamaHome)).toBe(false);
+      expect(existsSync(join(mamaHome, 'setup-complete.json'))).toBe(false);
+      expect(existsSync(join(mamaHome, 'state', 'first-report.json'))).toBe(false);
+    });
+
+    it('throws an explicit completion path when an existing legacy marker is invalid', async () => {
+      mkdirSync(mamaHome, { recursive: true });
+      writeFileSync(join(mamaHome, 'SOUL.md'), '# soul');
+      writeFileSync(join(mamaHome, 'USER.md'), '# user');
+      await writeConfig({ telegram: { enabled: true, token: 't', allowed_chats: ['1'] } });
+      const completionPath = join(mamaHome, 'setup-complete.json');
+      writeFileSync(completionPath, 'null');
+
+      await expect(migrateLegacyInstall(mamaHome)).rejects.toThrow(completionPath);
+    });
   });
 });

--- a/packages/standalone/tests/onboarding/assess-live.test.ts
+++ b/packages/standalone/tests/onboarding/assess-live.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, existsSync, rmSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import yaml from 'js-yaml';
+import {
+  collectAssessDeps,
+  writeCompletionMarker,
+  migrateLegacyInstall,
+} from '../../src/onboarding/assess-live.js';
+
+let home: string;
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'mama-onb-'));
+});
+afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+function writeConfig(home: string, config: unknown): void {
+  writeFileSync(join(home, 'config.yaml'), yaml.dump(config));
+}
+
+describe('collectAssessDeps', () => {
+  it('fresh home reports everything missing', async () => {
+    const deps = await collectAssessDeps(home);
+    expect(deps.configExists).toBe(false);
+    expect(deps.telegramToken).toBe(false);
+    expect(deps.allowedChats).toBe(false);
+    expect(deps.ownerFacts).toBe(false);
+    expect(deps.enabledConnectors).toBe(0);
+    expect(deps.firstReportAt).toBeNull();
+  });
+
+  it('reads telegram token, allowed_chats and owner facts from config.yaml', async () => {
+    writeConfig(home, {
+      telegram: { enabled: true, token: 't', allowed_chats: ['1001'] },
+      owner: { name: 'Owner', language: 'ko', timezone: 'Asia/Seoul' },
+    });
+    const deps = await collectAssessDeps(home);
+    expect(deps.configExists).toBe(true);
+    expect(deps.telegramToken).toBe(true);
+    expect(deps.allowedChats).toBe(true);
+    expect(deps.ownerFacts).toBe(true);
+  });
+
+  it('empty allowed_chats is NOT an anchor', async () => {
+    writeConfig(home, { telegram: { enabled: true, token: 't', allowed_chats: [] } });
+    const deps = await collectAssessDeps(home);
+    expect(deps.allowedChats).toBe(false);
+  });
+
+  it('counts only enabled connectors', async () => {
+    writeFileSync(
+      join(home, 'connectors.json'),
+      JSON.stringify({ connectors: { slack: { enabled: true }, gmail: { enabled: false } } })
+    );
+    const deps = await collectAssessDeps(home);
+    expect(deps.enabledConnectors).toBe(1);
+  });
+
+  it('first_report reads state/first-report.json', async () => {
+    mkdirSync(join(home, 'state'), { recursive: true });
+    writeFileSync(
+      join(home, 'state', 'first-report.json'),
+      JSON.stringify({ at: '2026-08-28T01:00:00Z' })
+    );
+    const deps = await collectAssessDeps(home);
+    expect(deps.firstReportAt).toBe('2026-08-28T01:00:00Z');
+  });
+});
+
+describe('writeCompletionMarker', () => {
+  it('is idempotent and preserves first completed_at', async () => {
+    await writeCompletionMarker(home);
+    const first = JSON.parse(readFileSync(join(home, 'setup-complete.json'), 'utf-8'));
+    await writeCompletionMarker(home);
+    const second = JSON.parse(readFileSync(join(home, 'setup-complete.json'), 'utf-8'));
+    expect(second.completed_at).toBe(first.completed_at);
+  });
+});
+
+describe('migrateLegacyInstall', () => {
+  it('backfills marker when persona files + telegram config exist', () => {
+    writeFileSync(join(home, 'SOUL.md'), '# soul');
+    writeFileSync(join(home, 'USER.md'), '# user');
+    writeConfig(home, { telegram: { enabled: true, token: 't', allowed_chats: ['1'] } });
+    expect(migrateLegacyInstall(home)).toBe(true);
+    expect(existsSync(join(home, 'setup-complete.json'))).toBe(true);
+  });
+
+  it('does not backfill on fresh home', () => {
+    expect(migrateLegacyInstall(home)).toBe(false);
+  });
+
+  it('does not backfill on partial legacy (personas only, no telegram config)', () => {
+    writeFileSync(join(home, 'SOUL.md'), '# soul');
+    writeFileSync(join(home, 'USER.md'), '# user');
+    expect(migrateLegacyInstall(home)).toBe(false);
+    expect(existsSync(join(home, 'setup-complete.json'))).toBe(false);
+  });
+});

--- a/packages/standalone/tests/onboarding/status-onboarding.test.ts
+++ b/packages/standalone/tests/onboarding/status-onboarding.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { statusCommand } from '../../src/cli/commands/status.js';
+
+let home: string;
+let originalHome: string | undefined;
+
+beforeEach(() => {
+  originalHome = process.env.HOME;
+  home = mkdtempSync(join(tmpdir(), 'mama-status-home-'));
+  process.env.HOME = home;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe('Story ONB-2: machine-readable onboarding status', () => {
+  describe('AC #4: JSON output remains parseable and reports observation failures', () => {
+    it('writes only JSON to stdout for a fresh HOME', async () => {
+      let output = '';
+      vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+        output += String(chunk);
+        return true;
+      });
+      vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+      await statusCommand({ json: true });
+
+      const payload = JSON.parse(output) as {
+        onboarding: { complete: boolean; missing: string[] };
+        daemon: { running: boolean };
+      };
+      expect(payload.onboarding.complete).toBe(false);
+      expect(payload.onboarding.missing[0]).toBe('config');
+      expect(payload.daemon.running).toBe(false);
+    });
+
+    it('keeps JSON status available while surfacing a malformed state-file path', async () => {
+      const mamaHome = join(home, '.mama');
+      mkdirSync(mamaHome, { recursive: true });
+      const configPath = join(mamaHome, 'config.yaml');
+      writeFileSync(configPath, 'version: [');
+      let output = '';
+      vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+        output += String(chunk);
+        return true;
+      });
+      vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+      await statusCommand({ json: true });
+
+      const payload = JSON.parse(output) as {
+        onboarding: null;
+        onboardingError: string;
+        daemon: { running: boolean };
+      };
+      expect(payload.onboarding).toBeNull();
+      expect(payload.onboardingError).toContain(configPath);
+      expect(payload.daemon.running).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## What

First branch of the onboarding round, covering Tasks 1–2 of the reviewed 2026-08-28 onboarding plan. This is the contract and live-status foundation that later branches consume. It is not an independent production release.

- **agent-contract.ts** is the single source of onboarding judgment and wording. The six observed items are config → gateway → trust_anchor → daemon → sources → first_report.
- **assess-live.ts** reads one HOME-scoped configuration authority, reuses the strict runtime connector loader, checks Telegram enabled plus token, and reports malformed state files with their paths.
- **mama status** renders all missing agent actions and human-required actions. --json writes machine-readable onboarding and daemon state only; observation failures remain valid JSON through onboardingError.
- Legacy working installs backfill setup-complete.json and state/first-report.json together. Once both exist, migration exits before rereading config. Markers remain historical caches and never gate runtime behavior.
- Telegram token guidance uses stdin and never places the token on argv.

## Invariants

- No trust anchor means onboarding cannot be complete.
- A config file counts only when the production config loader accepts it.
- Telegram gateway readiness requires enabled plus token.
- Daemon running is an explicit journey item before first_report.
- owner_facts is intentionally absent because no runtime consumer exists.
- Status recomputes live state; completion markers are not authority.
- Filesystem tests replace HOME and never touch the real installation.

## Verification

- Standalone full suite: 5,330 passed, 7 skipped.
- Onboarding plus status regression suite: 34 passed.
- Standalone typecheck: passed.
- Repository lint: passed.
- Standalone build and UI bundle: passed.
- Prettier and git diff check: passed.
- Early contract walkthrough: fresh → configured → anchored → running → complete.

## Next branches

Help and entry rendering, Telegram setter and detect-owner, anchor boot enforcement, report-now plus confirmed first-report marker, scripted onboarding and web-wizard deletion, thin plugin and README pointers, the four approved ride-alongs, then the final live verification round.

The overall journey ends only when the first evidenced report arrives.