### PR TITLE
docs: installed owner report evidence for 0.40.0 and the Board-lane evidence blocker

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -2,6 +2,23 @@
 
 ## Deferred until cognitive foundation repair is proven
 
+### Let the Board lane read bounded evidence for lifecycle candidates
+
+**What:** The forced Board workorder on 0.40.0 (#4380) called `context_compile` once for the
+lifecycle candidate set with exact task/source refs and the envelope scope audit rejected it
+(`[envelope] scope mismatch`, parent `code_act`), so the run retained every task. The same
+rejection is logged daily since 2026-08-25. Carry the run's host context (principal, channel
+scope) into Code-Act scoped reads so the Board lane can compile candidate evidence, then re-run
+the installed lifecycle gate: at least one real stale row reclassified with a receipt.
+
+**Why:** The offline copied-DB gate reclassified two stale rows through the ledger primitive, but
+the installed lane cannot reach the same evidence. This is the S3 "principal follows run" defect,
+not a report-path regression; the report path passed its installed gate.
+
+**Effort:** M
+**Priority:** P1
+**Depends on:** Nothing; blocks the installed lifecycle gate and the Case roadmap
+
 ### Fail the full-report request, not the tick, when the packet runtime is missing
 
 **What:** In `operator-trigger-loop.ts`, `preparePendingRequest` throws when `reportAsk.full`,

--- a/docs/development/kagemusha-telegram-parity.md
+++ b/docs/development/kagemusha-telegram-parity.md
@@ -62,6 +62,33 @@ scenario IDs from this document.
   Standalone typecheck, changed-file ESLint/Prettier, and `git diff --check` passed. This is code
   evidence only; a real owner report remains pending.
 
+### Cognitive foundation Task 4 installed evidence: 2026-09-03
+
+- **Cutover:** PR #247 squash-merged as 500a7b45; release run 33712987915 published mama-core
+  2.2.3 then mama-os 0.40.0 (dependency `^2.2.3`) and tagged v0.40.0. Pre-cutover `VACUUM INTO`
+  backups of the memory, sessions and operator databases plus the decision watermark (1,914
+  rows) were taken; the global install moved 0.39.5 -> 0.40.0 and the launchd daemon respawned
+  on the new dist with CLI and runtime both at 0.40.0, the owner-report leg and the scheduled
+  full-report leg enabled, health 98.
+- **TG-03/TG-04/TG-05/TG-06 real scheduled report (13:00 local):** the host compiled one
+  `mama.owner-report-context/v1` packet (sources: changes complete; claims, tasks, trello
+  partial) whose SHA-256 appears in the compile log and again as the model run's
+  `sourceMessageRef`; exactly one committed `operator-report` model run with zero tool traces;
+  one delivered receipt row (attempt 1) in the Telegram report context store; the delivered text
+  carries no event/run/chat ids, tool syntax, Code-Act markers or trailer. Codex rollout usage:
+  41,687 input + 18,044 output tokens (59,731 total) in one turn, against 273K-759K for the
+  self-gather runs of the previous day.
+- **On-demand report (`mama report now`):** a second real report on the same installed runtime: packet SHA `5d3be5b1…` in the compile log and the model run `sourceMessageRef`, one committed `operator-report` run with zero tool traces, delivered receipt seq 476 (attempt 1, `on_demand_full`), pending store cleared afterwards, zero internal ids or tool syntax in the text; rollout usage 42,582 input + 17,878 output tokens (60,460 total) in one turn, 325 s.
+- **Installed lifecycle gate: not demonstrated.** The forced Board workorder (#4380) completed and
+  republished the board, but its single `context_compile` call for the lifecycle candidate set
+  was rejected by the envelope scope audit (`[envelope] scope mismatch`, parent `code_act`) and
+  the run retained every task. The same audit rejection is logged daily since 2026-08-25 (342
+  on that day alone), so it predates this release; it is the S3 "principal follows run" defect
+  in how Code-Act carries host context into scoped reads. Until it is fixed, the Board lane can
+  correlate but cannot read bounded message evidence for candidates, so real stale rows are only
+  reclassified through the offline copied-DB gate. This is recorded as an open blocker, not a
+  pass.
+
 ### Cognitive foundation Task 4 offline quality gate: 2026-09-02
 
 - **Corpus:** copied operational databases (memory + operator ledger, snapshot 09:53Z), one


### PR DESCRIPTION
Records the two real reports on the installed 0.40.0 runtime (scheduled 13:00 and on-demand) with packet SHA, one model run, zero tool traces, delivery receipts, leak scan and rollout usage, and tracks the Board-lane context_compile envelope scope rejection as a P1 follow-up. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added evidence for the v0.40.0 Telegram parity cutover, including scheduled and on-demand reports, delivery receipts, and token usage.
  * Documented that the installed lifecycle gate remains unverified because Board workorders cannot access bounded candidate evidence.
  * Added a deferred-work item to address lifecycle candidate evidence access and enable stale-row reclassification in the installed runtime.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->