### PR TITLE
docs: 0.44.0 install evidence; fix the operating brief path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,7 +359,7 @@ The MAMA OS daemon runs an OPERATOR identity alongside chat:
   occurrence-keyed workorders into the TaskLedger (`operator_tasks`,
   kind='system' rows, host-managed); a single unconditional consumer claims
   serially and runs briefed workerRuns. Since v0.41.0 (One MAMA) every scheduled turn runs as
-  the ONE `owner_console` principal with the ONE operating brief (`~/.mama/operator/console-brief.md`)
+  the ONE `owner_console` principal with the ONE operating brief (`~/.mama/briefs/brief-owner-console.md`)
   plus a host-authored turn-kind section (`buildTurnKindSection`, workorder-consumer.ts); the
   per-kind briefs and the `workorder-*` roles are gone. The grant is projected by the host from
   data in start.ts: owner console + `TURN_KIND_REQUIRED_TOOLS` − `ADMINISTRATION_TOOLS` −

--- a/docs/development/kagemusha-telegram-parity.md
+++ b/docs/development/kagemusha-telegram-parity.md
@@ -1002,6 +1002,26 @@ Installed acceptance (to be recorded after cutover):
 - [ ] Phase 0 gate: if acceptance 1 fails after one working day, the diagnosis is wrong and the
       lane collapse (already merged behind the same release) is re-argued before Phase 2.
 
+## 0.44.0: 2026-09-04 (installed 09:56Z)
+
+PR #254 (squash e099373a), tag v0.44.0, publish.yml published mama-os 0.44.0 (`^2.3.0`,
+mama-core unchanged). The owner chat turn holds the gateway `Bash`/`Write`; every unattended
+turn blocks both by name. Review record: Opus found the budget-stopped turn counted zero
+tokens and the day guard blocked failed rows (859f6fe8); CodeRabbit found neither
+`agent.prompt()` call passed the budget, so the in-turn enforcement shipped in fd0184e3 was
+dead in the loop (1503871c, source-pinned).
+
+- [x] Self-check re-enqueue: before the install the old process created a self-check order every
+      two minutes (36 done + 2 failed on 2026-09-04); after the 09:56:26Z boot, zero new orders
+      in the next eight minutes, and none through the 10:04Z restart.
+- [x] Run budget: `run_token_budget: 0` removed from `config.yaml`, daemon restarted 10:04:24Z on
+      the 3,000,000 default. The first board run (order 4472) completed, counting 1,520,382
+      tokens in its single codex turn; no budget stop was logged after the boot (the five in
+      the log predate it). The same turn was cut at 400,000 on 0.43.0.
+- [ ] A budget stop that is a real receipt on a run that deserved it (none has occurred yet).
+- Note: the operating brief lives at `~/.mama/briefs/brief-owner-console.md`; the earlier
+  `operator/console-brief.md` path in CLAUDE.md was wrong and is corrected.
+
 ## One MAMA Phase 3: 2026-09-04 (release 0.43.0 / mama-core 2.3.0, installed)
 
 PR #253 (squash 3494ac50), tag v0.43.0, publish.yml published mama-core 2.3.0 then mama-os


### PR DESCRIPTION
Doc-only. Records the 0.44.0 install evidence (self-check dedupe holds live; first board run under the 3,000,000 default completed at 1.52M counted tokens with no budget stop) and fixes the operating brief path in CLAUDE.md (`~/.mama/briefs/brief-owner-console.md`, which is what the code reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Stage 2 workorder pipeline documentation with the correct operating brief path.
  * Added parity contract notes for version 0.44.0, including release details, acceptance evidence, token-budget behavior, and gateway access controls.
  * Documented fixes addressing self-check re-enqueue behavior, failed-row handling, and in-turn budget enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->