### PR TITLE
docs: 0.45.0 budget default + live board-render evidence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,8 +349,9 @@ The MAMA OS daemon runs an OPERATOR identity alongside chat:
   `observability/operational-issues.ts`, redacted, aggregated by signature) and rides in every
   packet as `operationalIssues`; a daily `self-check` turn triages them with `repair_request`
   (bundle under `~/.mama/repairs/`, OUTSIDE the workspace so it cannot be sent out) and
-  `issue_close`; `agent.run_token_budget` (default 400000, includes cache tokens) stops a run
-  with a `run_budget_stop` receipt. The agent never edits or restarts its own daemon.
+  `issue_close`; `agent.run_token_budget` (default 0 = off since 0.45.0; codex counts
+  input+output, Anthropic also adds cache) stops a run with a `run_budget_stop` receipt when
+  set. The agent never edits or restarts its own daemon.
 - **workerRun** (src/operator/worker-run.ts): briefed FRESH lane run - host-code
   callers only, never from inside an active lane run (deadlock seal).
 - **Stage 2 workorder pipeline** (the ONLY system run path since v0.28.0; the

--- a/docs/development/kagemusha-telegram-parity.md
+++ b/docs/development/kagemusha-telegram-parity.md
@@ -1002,6 +1002,28 @@ Installed acceptance (to be recorded after cutover):
 - [ ] Phase 0 gate: if acceptance 1 fails after one working day, the diagnosis is wrong and the
       lane collapse (already merged behind the same release) is re-argued before Phase 2.
 
+## 0.45.0: 2026-09-04 (installed, board render verified live)
+
+PR #256 (squash 9b4cb079), tag v0.45.0, published mama-os 0.45.0 (mama-core unchanged). Three
+defects the owner surfaced on Telegram within the first hour of 0.44.0.
+
+- [x] Board line breaks. The pre-fix board publish (19:53Z) carried the briefing,
+      action_required and decisions slots as PLAIN TEXT (no `report-card`, no `<div>`), while
+      the host-rendered pipeline slot was already an HTML `<table>` — the exact split the owner
+      saw. After 0.45.0, board run 4483 (20:32 local) published all three judgment slots as HTML
+      using the class vocabulary (`report-summary`, `report-card`, `report-section-title`,
+      `card-badge`). Root cause: One MAMA 0.41.0 replaced the per-kind board brief, which carried
+      that vocabulary, with a host turn section that did not; restored to `buildTurnKindSection`.
+- [x] Run budget off. Codex reports input inclusive of cache; the loop added cache reads again,
+      so the 3,000,000 default stopped a 2.8M wiki turn (logged as 5.5M), a board turn and the
+      owner chat turn within fifteen minutes of the 0.44.0 install. Counting is backend-aware and
+      the default is 0. With it off, wiki orders 4482/4483 completed and zero budget stops were
+      logged after the default-0 boot. The 4.28M "pathology" was itself doubled; no run the budget
+      would legitimately have caught has ever been observed.
+- [x] Chat shell inline interpreters. `python -c` / `node -e` / `bash -c` are what the owner
+      chat shell exists for and were on the Bash guard's block list; removed, with
+      setuid/chown/pipe-to-shell/nc/`/dev/tcp`/mkfifo kept. The owner's first shell request hit it.
+
 ## 0.44.0: 2026-09-04 (installed 09:56Z)
 
 PR #254 (squash e099373a), tag v0.44.0, publish.yml published mama-os 0.44.0 (`^2.3.0`,

--- a/docs/development/kagemusha-telegram-parity.md
+++ b/docs/development/kagemusha-telegram-parity.md
@@ -1007,6 +1007,9 @@ Installed acceptance (to be recorded after cutover):
 PR #256 (squash 9b4cb079), tag v0.45.0, published mama-os 0.45.0 (mama-core unchanged). Three
 defects the owner surfaced on Telegram within the first hour of 0.44.0.
 
+Scenarios: TG-06 (report and board-pipeline capabilities — board rendering, budget on scheduled
+turns), TG-04 (the owner gets the full proven toolset — the chat shell).
+
 - [x] Board line breaks. The pre-fix board publish (19:53Z) carried the briefing,
       action_required and decisions slots as PLAIN TEXT (no `report-card`, no `<div>`), while
       the host-rendered pipeline slot was already an HTML `<table>` — the exact split the owner


### PR DESCRIPTION
Doc-only follow-up to 0.45.0.

- CLAUDE.md isolation table: the run budget default is 0 (off) since 0.45.0, and codex counts input+output (input is cache-inclusive), not the old 400000/cache-inclusive line.
- Parity doc: records the 0.45.0 install and the live board-render evidence. Board run 4483 published the three judgment slots as HTML with the class vocabulary; the pre-fix 19:53 publish had them as plain text. Budget-off and shell-guard outcomes recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Board judgment slots now display using the intended formatting instead of plain text.
  * Run-budget accounting now reflects backend-specific token reporting, preventing Codex input from being counted twice.
  * Budget-stop notifications now appear only when a run budget is configured.

* **Documentation**
  * Updated runtime budget documentation with the current default, token-counting behavior, and notification conditions.
  * Added release evidence covering the verified fixes and security guard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->