### PR TITLE
fix(standalone): prepare policy for default owner turns (0.49.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## mama-os [0.49.3] - 2026-09-07
+
+### Fixed
+
+- Default owner turns now include native-subagent guidance even without a per-call system prompt
+  or Code-Act mode. A background-first Claude owner session receives the same standing policy
+  as an interactive owner turn; compatible sessions still avoid historical replay.
+
 ## mama-os [0.49.2] - 2026-09-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,7 +318,7 @@ Once saved:
 - Important function signature changes
 - Architecture pattern decisions
 
-## Owner Runtime & Owner Console (v0.49.2)
+## Owner Runtime & Owner Console (v0.49.3)
 
 - Authenticated owner conversations, reports, events, cron, heartbeat, and maintenance all enter
   `owner:runtime`. Channel and work kind select source/authority metadata, not a separate model.

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -259,7 +259,7 @@ Each package has independent versioning:
 - **mama-core:** 2.3.0 (stable API)
 - **mama-server:** 1.15.0 (follows MAMA version)
 - **claude-code-plugin:** 1.11.0 (follows MAMA version)
-- **mama-os:** 0.49.2 (standalone agent)
+- **mama-os:** 0.49.3 (standalone agent)
 
 ## Distribution Strategy
 
@@ -411,4 +411,4 @@ Existing decisions remain valid across all package updates. SQLite schema change
 
 ---
 
-**Last Updated:** 2026-08-03
+**Last Updated:** 2026-09-07

--- a/docs/development/kagemusha-telegram-parity.md
+++ b/docs/development/kagemusha-telegram-parity.md
@@ -1516,3 +1516,13 @@ scope bindings, and the day's `[learning]` audit lines).
   expired leases that are still draining pinned executions.
 - 2026-07-22: Created after partial, file-by-file parity work repeatedly missed end-to-end
   boundaries. Reference source was re-read from `mama-suite` commit `ea982c1`.
+
+## 0.49.3 owner default-path correction: 2026-09-07
+
+- TG-04/TG-05: a background-first owner turn without a custom system prompt or Code-Act now
+  prepares the standing owner policy. This closes the default Claude path omitted by 0.49.2.
+  Non-owner defaults and compatible Cline continuation retain their prior behavior.
+- Public 0.49.2 installed Trello reads succeeded; the first tool-free continuity probe committed
+  on the canonical owner thread. A compatible 0.49.2 restart returned the
+  withheld value from the same thread, with zero tools and zero new recovery blocks. Final public
+  0.49.3 publication/install remains a distinct gate, recorded in the final release audit.

--- a/docs/development/one-mama-owner-runtime.md
+++ b/docs/development/one-mama-owner-runtime.md
@@ -193,3 +193,21 @@ subagent used a full-history fork; 0.49.2 adds stable guidance to prefer bounded
 no history fork when sufficient. This guidance is part of the owner policy fingerprint so each
 backend adopts the genuine policy change once. A subsequent compatible restart must not replay
 history. Public 0.49.2 installation remains the final runtime gate.
+
+## Final default-path correction: 0.49.3
+
+A post-merge review found one remaining TG-04/TG-05 default-path omission: Claude with Code-Act
+turned off could start from a background stimulus without the standing native-subagent policy.
+The default owner branch now prepares the policy even without a caller-supplied prompt. Non-owner
+defaults and compatible Cline continuation keep their existing behavior. This does not introduce
+another session, historical context read, model call, or tool-count limit.
+
+Public 0.49.2 installation and an authenticated live Trello overview succeeded (ten boards).
+The first restart-continuity probe committed without tools and acknowledged a random value in
+owner thread `01a077a2-2a8d-72c0-9123-8aa1fca066bd`. After a compatible 0.49.2 restart, a second probe returned that value exactly without receiving
+it again, using tools, or adding a recovery block; the backend thread was unchanged. Final public
+0.49.3 release/install remains pending, distinct from this observed continuity result.
+
+Post-publication installation and runtime receipts are recorded in the
+[0.49.3 release audit](https://github.com/jungjaehoon-lifegamez/MAMA/releases/tag/v0.49.3), so the
+release gate is closed by observed evidence after publication rather than another version bump.

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -11,7 +11,7 @@ MAMA is a pnpm workspace-based monorepo with four release targets (plus the inte
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.49.2  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.49.3  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.15.0  |
 | MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 2.3.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.11.0  |
@@ -61,7 +61,7 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.49.2          |
+| `packages/standalone/package.json`                       | `version` | 0.49.3          |
 | `packages/mcp-server/package.json`                       | `version` | 1.15.0          |
 | `packages/mama-core/package.json`                        | `version` | 2.3.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.11.0          |
@@ -412,4 +412,4 @@ pnpm vitest run tests/hooks/pretooluse-hook.test.js
 
 ---
 
-_Last Updated: 2026-07-31_
+_Last Updated: 2026-09-07_

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.49.2",
+  "version": "0.49.3",
   "description": "MAMA OS - The local work agent behind your messenger.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/standalone/src/agent/agent-loop.ts
+++ b/packages/standalone/src/agent/agent-loop.ts
@@ -1690,6 +1690,7 @@ export class AgentLoop {
         // complete policy lazily through freshSessionSystemPrompt below.
         perCallSystemPrompt = options?.systemPrompt ?? this.defaultSystemPrompt;
       } else if (
+        ownerRuntime ||
         options?.systemPrompt ||
         options?.gatewayToolsPrompt !== undefined ||
         (this.isGatewayMode && this.useCodeAct)

--- a/packages/standalone/tests/agent/agent-loop.test.ts
+++ b/packages/standalone/tests/agent/agent-loop.test.ts
@@ -32,7 +32,10 @@ import type {
 } from '../../src/agent/types.js';
 import { makeSignedEnvelope } from '../envelope/fixtures.js';
 import { createPersonaReportAsk } from '../../src/operator/report-run.js';
-import { OWNER_RUNTIME_SESSION_KEY } from '../../src/operator/owner-runtime.js';
+import {
+  OWNER_RUNTIME_SESSION_KEY,
+  OWNER_SUBAGENT_INSTRUCTIONS,
+} from '../../src/operator/owner-runtime.js';
 import { buildMemoryAuditAckFromAgentResult } from '../../src/memory/memory-agent-ack.js';
 import { TypeDefinitionGenerator } from '../../src/agent/code-act/type-definition-generator.js';
 import { projectCodeActToolPolicy } from '../../src/agent/code-act/tool-policy.js';
@@ -3887,6 +3890,51 @@ Skills provide additional tools.
       expect(fingerprints[0]).toBe(fingerprints[1]);
       expect(fingerprints[0]).not.toContain('telegram-channel-policy');
       expect(fingerprints[0]).not.toContain('operator-report-policy');
+    });
+
+    it('TG-05 prepares the default Claude policy for the first background owner stimulus', async () => {
+      const ownerContext = {
+        ...createChatBotContext(),
+        roleName: 'owner_console',
+        role: DEFAULT_ROLES.definitions.owner_console,
+      };
+      const agentLoop = new AgentLoop(
+        createMockOAuthManager(),
+        { backend: 'claude', systemPrompt: 'default owner policy', useCodeAct: false },
+        {},
+        { mamaApi: createMockApi() }
+      );
+
+      await agentLoop.run('background owner event', {
+        sessionKey: OWNER_RUNTIME_SESSION_KEY,
+        source: 'operator',
+        channelId: 'owner-event',
+        agentContext: ownerContext,
+        sessionPolicyRole: DEFAULT_ROLES.definitions.owner_console,
+      });
+
+      const delivered = persistentPromptMock.mock.calls[0]?.[2]?.systemPrompt;
+      expect(delivered).toContain('default owner policy');
+      expect(delivered).toContain(OWNER_SUBAGENT_INSTRUCTIONS);
+    });
+
+    it('TG-05 leaves a default initial non-owner Claude policy unchanged', async () => {
+      const agentLoop = new AgentLoop(
+        createMockOAuthManager(),
+        { backend: 'claude', systemPrompt: 'default member policy', useCodeAct: false },
+        {},
+        { mamaApi: createMockApi() }
+      );
+
+      await agentLoop.run('background member event', {
+        source: 'operator',
+        channelId: 'member-event',
+        agentContext: createChatBotContext(),
+      });
+
+      const delivered = persistentPromptMock.mock.calls[0]?.[2]?.systemPrompt;
+      expect(delivered).toContain('default member policy');
+      expect(delivered).not.toContain(OWNER_SUBAGENT_INSTRUCTIONS);
     });
 
     it.each(['claude', 'codex', 'cline'] as const)(

--- a/packages/standalone/tests/agent/codex-app-server-process.test.ts
+++ b/packages/standalone/tests/agent/codex-app-server-process.test.ts
@@ -1838,6 +1838,8 @@ describe('Story: Codex app-server process', () => {
     await runner.stop();
   });
 
+  // Story TG-05: preserve an active durable Codex turn.
+  // AC: streamed progress refreshes the idle deadline beyond the original timeout.
   it('treats streamed progress as activity and refreshes the turn idle timeout', async () => {
     const item = fixture('progress-delayed');
     const runner = new CodexAppServerProcess({ ...item.options, requestTimeout: 2_000 });


### PR DESCRIPTION
A background-first Claude owner turn with Code-Act disabled could bypass system-prompt preparation and omit the standing native-subagent policy. Prepare the policy for every owner default path while preserving compatible Cline continuation and non-owner defaults (TG-04/TG-05).

The regression failed before the fix and passed afterward; independent review found no remaining blocker. Includes the 0.49.3 version/changelog and the final One MAMA audit evidence accumulated after 0.49.2.

Validation: focused AgentLoop 120/120; root build and lint passed. Full root tests passed (7/7 tasks; 5,519 standalone tests, seven existing skips). An installed 0.49.2 restart kept the same owner thread and recalled a withheld value without tools, historical replay, or re-supplying the value. Final public 0.49.3 installation remains a separate runtime check.
