### PR TITLE
chore(release): bump mama-core 2.4.0 and mama-os 0.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## mama-core [2.4.0] - 2026-09-08
+
+### Added
+
+- `getRawHistory` returns a connector-scoped, chronological, cursor-paged change history for one
+  entity, under the same connector/scope visibility as raw search. `connector_event_index` gains a
+  `source_entity_id` column (migration 067, additive and backfilled) to make revisions queryable
+  by entity.
+
+## mama-os [0.51.0] - 2026-09-08
+
+### Added
+
+- Raw change-history read path: `GET /api/agent/raw/:rawId/revisions` exposes an entity's stored
+  revisions beside search/detail/window, with the same worker-envelope visibility.
+
+### Changed
+
+- `RawStore.save` distinguishes real change from re-delivery/re-observation: a re-listed immutable
+  version and an `observedAt`-only re-poll no longer create new revisions, while a genuine
+  A→B→A is preserved and last-seen is still advanced.
+
+### Fixed
+
+- `schedule_upcoming` contains a bad all-day calendar row to that row instead of aborting the whole
+  read and clearing the schedule DB.
+- The calendar connector shell-escapes the `gws --params` argument so an upstream value cannot
+  inject a command. Recovered report logging reports the actual digest/full mode.
+
 ## mama-os [0.50.0] - 2026-09-07
 
 ### Changed

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -256,10 +256,10 @@ pnpm clean
 
 Each package has independent versioning:
 
-- **mama-core:** 2.3.0 (stable API)
+- **mama-core:** 2.4.0 (stable API)
 - **mama-server:** 1.15.0 (follows MAMA version)
 - **claude-code-plugin:** 1.11.0 (follows MAMA version)
-- **mama-os:** 0.50.0 (standalone agent)
+- **mama-os:** 0.51.0 (standalone agent)
 
 ## Distribution Strategy
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -11,9 +11,9 @@ MAMA is a pnpm workspace-based monorepo with four release targets (plus the inte
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.50.0  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.51.0  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.15.0  |
-| MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 2.3.0   |
+| MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 2.4.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.11.0  |
 
 ---
@@ -61,9 +61,9 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.50.0          |
+| `packages/standalone/package.json`                       | `version` | 0.51.0          |
 | `packages/mcp-server/package.json`                       | `version` | 1.15.0          |
-| `packages/mama-core/package.json`                        | `version` | 2.3.0           |
+| `packages/mama-core/package.json`                        | `version` | 2.4.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.11.0          |
 | `packages/claude-code-plugin/.claude-plugin/plugin.json` | `version` | 1.11.0          |
 

--- a/packages/mama-core/package.json
+++ b/packages/mama-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-core",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "MAMA Core - Shared modules for Memory-Augmented MCP Assistant",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "MAMA OS - The local work agent behind your messenger.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Prepare release versions on main so release.yml can publish with bump_versions=false (inline bumps are disabled on protected main).

- mama-core 2.3.0 -> 2.4.0
- mama-os 0.50.0 -> 0.51.0
- CHANGELOG + doc version references synced

Releases the raw change-history read path merged in #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added chronological, cursor-based raw change history for individual entities.
  - Added an API endpoint for retrieving raw item revisions.

- **Bug Fixes**
  - Prevented duplicate revisions when items are re-listed unchanged or only their observation time changes.
  - Preserved genuine changes while continuing to update last-seen information.
  - Isolated invalid all-day calendar entries so they no longer disrupt the full schedule.
  - Improved calendar query handling and recovered-report mode logging.

- **Documentation**
  - Updated package versions to MAMA Core 2.4.0 and MAMA OS 0.51.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->