### PR TITLE
v0.51.1 chore: prepare mama-os release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## mama-os [0.51.1] - 2026-09-08
+
+### Fixed
+
+- Board refresh can resume after a confirmed atomic task creation without weakening the replay block for shell/native or unsettled effects.
+- Telegram owner replies and reports render supported HTML as native text entities, including streamed and multipart answers. Styling rejection preserves the text, and legacy pending deliveries retain their original chunk boundaries after upgrades.
+- The formatting guide is part of the shared owner session policy instead of repeated report prompts.
+
+Existing installations with historical plain-text-only owner instructions should update those local instructions to permit the Telegram HTML subset. The owner-confirmed local report rendered five bold headings; its roughly 166-second response is a single observation, not a percentile guarantee.
+
 ## mama-core [2.4.0] - 2026-09-08
 
 ### Added

--- a/docs/architecture/package-structure.md
+++ b/docs/architecture/package-structure.md
@@ -259,7 +259,7 @@ Each package has independent versioning:
 - **mama-core:** 2.4.0 (stable API)
 - **mama-server:** 1.15.0 (follows MAMA version)
 - **claude-code-plugin:** 1.11.0 (follows MAMA version)
-- **mama-os:** 0.51.0 (standalone agent)
+- **mama-os:** 0.51.1 (standalone agent)
 
 ## Distribution Strategy
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -11,7 +11,7 @@ MAMA is a pnpm workspace-based monorepo with four release targets (plus the inte
 
 | Package            | Location                       | Deployment Target  | npm Name                   | Version |
 | ------------------ | ------------------------------ | ------------------ | -------------------------- | ------- |
-| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.51.0  |
+| MAMA OS            | `packages/standalone/`         | npm registry       | `@jungjaehoon/mama-os`     | 0.51.1  |
 | MCP Server         | `packages/mcp-server/`         | npm registry       | `@jungjaehoon/mama-server` | 1.15.0  |
 | MAMA Core          | `packages/mama-core/`          | npm registry       | `@jungjaehoon/mama-core`   | 2.4.0   |
 | Claude Code Plugin | `packages/claude-code-plugin/` | Claude Marketplace | `mama`                     | 1.11.0  |
@@ -61,7 +61,7 @@ Synchronize versions across these files before deployment:
 
 | File                                                     | Field     | Current Version |
 | -------------------------------------------------------- | --------- | --------------- |
-| `packages/standalone/package.json`                       | `version` | 0.51.0          |
+| `packages/standalone/package.json`                       | `version` | 0.51.1          |
 | `packages/mcp-server/package.json`                       | `version` | 1.15.0          |
 | `packages/mama-core/package.json`                        | `version` | 2.4.0           |
 | `packages/claude-code-plugin/package.json`               | `version` | 1.11.0          |

--- a/packages/standalone/CHANGELOG.md
+++ b/packages/standalone/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.51.1] - 2026-09-08
+
+### Fixed
+
+- Board refresh can resume after a confirmed atomic task creation without weakening the replay block for shell/native or unsettled effects.
+- Telegram owner replies and reports render supported HTML as native text entities, including streamed and multipart answers. Styling rejection preserves the text, and legacy pending deliveries retain their original chunk boundaries after upgrades.
+- The formatting guide is part of the shared owner session policy instead of repeated report prompts.
+
+Existing installations with historical plain-text-only owner instructions should update those local instructions to permit the Telegram HTML subset. The owner-confirmed local report rendered five bold headings; its roughly 166-second response is a single observation, not a percentile guarantee.
+
 ## [0.32.2] - 2026-08-02
 
 Cline is now a first-class persisted backend with role-scoped native tools and the shared Code-Act

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "description": "MAMA OS - The local work agent behind your messenger.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Prepare mama-os 0.51.1 for the board-refresh and Telegram formatting fixes merged in #274. This PR changes only package metadata and release documentation; mama-core stays at 2.4.0.

Version-related tests passed (3 files, 27 tests), documentation synchronization passed, and all changed files passed formatting and diff checks. Functional validation and the owner-confirmed bold-title report are recorded in #274.

After merge, release only mama-os through release.yml with bump_versions=false, then install and verify the published package. Existing calendar incompleteness and percentile latency validation remain open.
