### PR TITLE
fix(connectors): Chatwork force=1, Calendar bounded window, Kagemusha declared sources (0.53.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## mama-os [0.53.2] - 2026-09-10
+
+Three connector fixes measured on the live install: Chatwork polling that a second reader on
+the same token had starved, a Calendar listing window that ran without bound, and a Kagemusha
+bridge that read every mirrored platform regardless of what was declared.
+
+### Fixed
+
+- **Chatwork polls with `force=1`.** `force=0` returns only what the SERVER has not yet handed to
+  the token, and that read cursor is shared by every reader of the token. With another poller on
+  the same token at a 30 s cadence, this 5-minute poller saw about one message a day while the
+  rooms carried about thirty. The connector now asks for the latest window regardless of read
+  state and decides new-ness itself, with the `since` timestamp and the per-room last seen
+  message id it already kept.
+- **Calendar listing is bounded to now + 90 days, 250 events per page.** `singleEvents:true`
+  without `timeMax` expanded recurring events to the end of their recurrence; since the paging
+  cap landed on 2026-09-07 every poll exceeded it, threw, saved nothing, and left the cursor
+  stuck for three days while the health surfaces stayed green. Events further out enter the
+  window as time passes.
+
+### Changed
+
+- **The Kagemusha bridge reads only the platforms its configured channel keys declare.**
+  `kakao:<room>` admits kakao, `line:<room>` admits LINE, and task cards flow only when a
+  `kagemusha-tasks:<room>` key exists. The Kagemusha DB mirrors slack, chatwork and telegram as
+  well, which produced the same Slack channel twice (native and mirrored) and duplicate MAMA
+  tasks from mirrored cards. An empty channel map keeps the previous behaviour of reading
+  everything.
+
 ## mama-os [0.53.1] - 2026-09-10
 
 ### Fixed

--- a/docs/development/intent-checks.md
+++ b/docs/development/intent-checks.md
@@ -584,3 +584,9 @@
 - 의도 판정: 코드 수준에서 **부합**. 라이브 판정은 설치 후 첫 poll 사이클과 이후 24시간 수치로 다시 기록한다.
 - 하위 작업 상태 / 최상위 목표 상태 / 다음: 코드 완료·미커밋. 최상위 목표 미완료. 다음: 전체 스위트 → 커밋/PR → 로컬
   개밥먹기 설치(0.53.2-local) → 첫 poll 증거 → 공개 릴리즈 여부 오너 확인.
+- 라이브 증거(0.53.2-local.1, 19:01 설치, connectors.json kagemusha 채널을 kakao/line/airbnb/schedule/telegram 그룹으로 선언·
+  kagemusha-tasks 6개 제거): 첫 pollAll에서 `[connector:calendar] polled 68 items (since: 2026-09-07T10:31:56Z)` — 3일 만의
+  첫 성공, 커서 10:01Z로 전진, raw 2851→2919, 다음 사이클 65건 정상. kagemusha 신규 인덱스 행은 kakao만(slack/chatwork/카드 0).
+  Chatwork는 두 사이클 0건이나 카게무샤 DB 기준 오늘 사람 메시지 3건(14·15·18시)뿐이라 방이 조용한 것과 일치, force=1 효과는
+  새 메시지 도착 후 판정. CodeRabbit CLI 0건, CI 전 job 통과. 미결: force=1이 공유 토큰의 서버 포인터를 전진시키면 카게무샤
+  (force=0)가 약 10% 놓칠 수 있음 — 공식 문서 미명시, 오너 결정(카게무샤 force=1 전환 또는 별도 토큰).

--- a/docs/development/intent-checks.md
+++ b/docs/development/intent-checks.md
@@ -541,3 +541,46 @@
 - 0.53.0 (mama-os) released 15:50 via the Release action after PR #288; live replaced with npm 0.53.0 at 15:52. Release evidence: board#4818/#4820 and curation#4819 delegated on Claude Sonnet 5 under local.22/.23.
 - Under npm 0.53.0 a forced board (#4822) overlapped the boot board (#4821) on the one owner session. The adapter superseded the lease #4822's child held, so the child's `report_publish` (15:54:43) was traced under #4821's run (`mr_92eec3a3…`); #4821 verified, #4822 stayed `delegated` with `full_unverified` although the slots were published. The same path would run an unattended child under a chat turn's grant. Fix: the next turn waits for the live child (bound = DELEGATED_ATTEMPT_TIMEOUT_MS, logged when passed). Not yet observed live at the time of writing.
 
+
+## 2026-09-10 18:41 — 설치 환경 정리: 카게무샤 .env 의존 제거 (코드 변경 없음)
+
+- 작업 / 인텐트 버전 / 연결 시나리오: INTENT v6 §데이터와 접근, §판단의 자유와 운영 품질. 오너 지적 "소스가 아니라 설치 환경의 문제".
+- 실측(변경 전): `~/.mama/auth.env`가 `set -a; source ~/project/mama-suite/apps/kagemusha/.env`로 카게무샤 env 전체를 데몬에 주입.
+  connectors.json tokenName이 KAGEMUSHA_SLACK_USER_TOKEN / KAGEMUSHA_CHATWORK_TOKEN, `MAMA_TRELLO_TOKEN`도
+  `${KAGEMUSHA_TRELLO_KEY}:${KAGEMUSHA_TRELLO_TOKEN}` 참조. `envFile`/`apiKeyName`은 코드가 읽지 않는 죽은 필드.
+  `mama connector status`는 CLI 셸에 그 env가 없어 "token not found"를 표시(데몬 실상과 무관).
+  데이터도 이번 주 chatwork 네이티브 1건 vs 카게무샤 DB 경유 86건, slack 42 vs 120(카드 74 포함).
+- 변경: auth.env에서 카게무샤 .env source 제거, MAMA_SLACK_TOKEN / MAMA_CHATWORK_TOKEN / MAMA_TRELLO_KEY /
+  MAMA_TRELLO_USER_TOKEN을 MAMA 이름으로 정의(값은 셸 변수로만 복사, 미출력). connectors.json tokenName을 그 이름으로
+  교체하고 envFile·apiKeyName 삭제. 백업 `~/.mama/backups/env-cleanup-20260910-1839/`.
+- 사고: 첫 재시작(18:40:11)에서 `MAMA_TRELLO_TOKEN`의 `${KAGEMUSHA_TRELLO_KEY}` 참조가 start.sh `set -u`에 걸려
+  auth.env source 실패 → launchd 26회 재시도 실패, 약 71초 다운. 참조를 MAMA 변수로 바꾸고 `bash -u -c 'source …'`로
+  검증 후 18:41:22 재시작 성공. 교훈: auth.env/start.sh 편집 후 재시작 전 반드시 `set -u` source 검증.
+- 검증: 데몬 env에 KAGEMUSHA_* 0개·MAMA_* 토큰 4개, `[connector] 6 connectors active`, 첫 pollAll에서
+  chatwork/slack/kagemusha/drive/trello 오류 없음(캘린더 page cap은 기존 결함), Telegram 연결, health 98, runtime 0.53.1.
+- 남은 실패·미확인 / 기준 축소: 토큰 값 자체는 여전히 카게무샤와 같은 계정의 토큰(파일 결합만 끊음). Chatwork는
+  `force=0` 서버 읽음 커서를 카게무샤와 공유해 네이티브 수집 굶음 지속 → 소스 수정 또는 별도 계정 필요.
+  `canonicalChannelKey`가 null이면 항목을 통과시키므로 kagemusha-tasks 채널 삭제로는 카드 수집을 못 막음 → 소스 수정 필요.
+  캘린더 page cap(timeMax 부재), CLI status 표면, 오너 텔레그램 그룹의 hub 유입은 미해결.
+- 의도 판정: **부분 부합** — 설치 환경의 외부 의존을 제거해 재시작 안정성·설정 진실성을 회복. 데이터 출처의 카게무샤 의존은
+  아직 그대로이며 v1 목표 진전은 아니다.
+- 하위 작업 상태 / 최상위 목표 상태 / 다음: 환경 정리 완료. 최상위 목표 미완료. 다음은 소스 3건(kagemusha 카드 필터,
+  chatwork 조회 방식, calendar timeMax)과 점검 기록 두 갈래 병합 PR.
+
+## 2026-09-10 19:0x — 커넥터 3건 소스 수정 (Chatwork force=1, Calendar 창 닫기, Kagemusha 선언 필터)
+
+- 작업 / 인텐트 버전 / 연결 시나리오: INTENT v6 §데이터와 접근(수집 범위·누락 구분), §현시점의 이해. 오너 지시 "전체 수정하자".
+  카게무샤 코드와 메커니즘만 대조했고 개인 데이터는 옮기지 않았다.
+- 기대한 사용자 행동 변화: Chatwork 원문이 카게무샤 없이 MAMA 자체 수집으로 들어온다. 캘린더 수집이 3일 만에 재개되고
+  이후 poll마다 죽지 않는다. 카게무샤 카드가 MAMA 태스크로 복제되지 않고, 같은 Slack 채널이 두 번 들어오지 않는다.
+- 실제 결과와 증거: TDD. RED 6개(force=1 URL, timeMax=now+90d, maxResults=250, 플랫폼 필터, 카드 미방출, pollBulk 동일 규칙)를
+  먼저 실패 확인 후 최소 구현으로 GREEN. 가드 3개(force=1 재조회 시 중복 미방출, 카드 선언 시 방출, 빈 설정=기존 계약)는
+  변경 전에도 통과함을 명시한다. 대상 3파일 77/77, connectors 스위트 32파일 537/537, eslint 0, tsc 0, prettier 적용.
+  전체 standalone 스위트는 백그라운드 실행 결과를 커밋 전 확인한다. 라이브 설치·관측은 아직 전이다.
+- 남은 실패·미확인 / 기준 축소: 토큰 값은 여전히 카게무샤와 같은 계정. force=1은 방당 최근 100건 창이라 5분 사이 100건을
+  넘는 방은 놓친다(기존 제약). 캘린더는 90일 밖 일정의 변경을 창에 들어올 때까지 못 본다. 카게무샤 필터는 설정으로만
+  작동하므로 설치 시 connectors.json에서 kagemusha-tasks 6개를 빼고 airbnb/schedule/telegram 그룹을 명시해야 한다.
+  오너 텔레그램 그룹 유입(결함 1)과 산출물 앵커(결함 2)는 이 PR 범위 밖이다.
+- 의도 판정: 코드 수준에서 **부합**. 라이브 판정은 설치 후 첫 poll 사이클과 이후 24시간 수치로 다시 기록한다.
+- 하위 작업 상태 / 최상위 목표 상태 / 다음: 코드 완료·미커밋. 최상위 목표 미완료. 다음: 전체 스위트 → 커밋/PR → 로컬
+  개밥먹기 설치(0.53.2-local) → 첫 poll 증거 → 공개 릴리즈 여부 오너 확인.

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jungjaehoon/mama-os",
-  "version": "0.53.1",
+  "version": "0.53.2",
   "description": "MAMA OS - The local work agent behind your messenger.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/standalone/src/connectors/calendar/index.ts
+++ b/packages/standalone/src/connectors/calendar/index.ts
@@ -44,6 +44,15 @@ interface CalendarEventList {
 }
 
 const MAX_EVENT_LIST_PAGES = 20;
+/**
+ * `singleEvents:true` expands recurring events into instances, and without an upper
+ * bound the expansion runs to the end of the recurrence — thousands of rows for an
+ * ordinary personal calendar. Measured live 2026-09-07..10: every poll hit the page
+ * cap, threw, saved nothing and left the cursor stuck for three days. The window is
+ * therefore closed at now + 90 days; events further out enter it as time passes.
+ */
+const EVENT_LIST_HORIZON_MS = 90 * 24 * 60 * 60 * 1000;
+const EVENT_LIST_PAGE_SIZE = 250;
 
 export class CalendarConnector implements IConnector {
   readonly name = 'calendar';
@@ -113,6 +122,7 @@ export class CalendarConnector implements IConnector {
 
     try {
       const timeMin = since.toISOString();
+      const timeMax = new Date(Date.now() + EVENT_LIST_HORIZON_MS).toISOString();
       const observedAt = new Date().toISOString();
       let pageToken: string | undefined;
       const visitedPageTokens = new Set<string>();
@@ -120,10 +130,11 @@ export class CalendarConnector implements IConnector {
         const params = JSON.stringify({
           calendarId: 'primary',
           timeMin,
+          timeMax,
           singleEvents: true,
           showDeleted: true,
           orderBy: 'startTime',
-          maxResults: 50,
+          maxResults: EVENT_LIST_PAGE_SIZE,
           ...(pageToken ? { pageToken } : {}),
         });
         // Escape single quotes so an upstream-controlled value inside the JSON (e.g. a pageToken)

--- a/packages/standalone/src/connectors/chatwork/index.ts
+++ b/packages/standalone/src/connectors/chatwork/index.ts
@@ -36,10 +36,13 @@ export class ChatworkConnector implements IConnector {
 
   /**
    * Per-room last seen message ID for incremental polling.
-   * NOTE: The Chatwork API has no cursor-based pagination. The `force=0` mode
-   * returns messages since the server-tracked read cursor (up to 100 per call).
-   * We additionally track the last seen message_id client-side so we can skip
-   * already-processed messages on the first poll after restart.
+   * NOTE: The Chatwork API has no cursor-based pagination. `force=0` returns only
+   * messages the SERVER has not yet handed to this token — a read cursor shared by
+   * every reader of the token. Measured live 2026-09-10: a second poller on the same
+   * token (30 s cadence vs our 5 min) consumed the cursor first and this connector
+   * saw ~1 message/day while the rooms carried ~30/day. So we ask for `force=1`
+   * (the latest 100 regardless of read state) and dedupe client-side with the
+   * `since` timestamp plus this per-room last seen message_id.
    * Limitation: if a room receives >100 messages between polls, the oldest
    * messages in that batch will be missed — this is a Chatwork API constraint.
    */
@@ -105,13 +108,11 @@ export class ChatworkConnector implements IConnector {
       if (channelCfg.role === 'ignore') continue;
 
       try {
-        // Use force=0 to rely on the server-side read cursor rather than
-        // force-fetching all messages. This avoids clobbering the server cursor
-        // and correctly returns only new messages since the last acknowledged read.
-        // Limitation: up to 100 messages per call — busy rooms may drop messages
-        // between polls if the interval is too long relative to message volume.
+        // force=1: the latest 100 messages independent of the server-side read cursor,
+        // which any other reader of this token would otherwise consume first. New-ness
+        // is decided below by `since` and the per-room last seen message_id.
         const lastMsgId = this.lastMessageIds.get(roomId);
-        const res = await fetch(`${this.baseUrl}/rooms/${roomId}/messages?force=0`, {
+        const res = await fetch(`${this.baseUrl}/rooms/${roomId}/messages?force=1`, {
           headers: { 'X-ChatWorkToken': this.token },
         });
 

--- a/packages/standalone/src/connectors/kagemusha/index.ts
+++ b/packages/standalone/src/connectors/kagemusha/index.ts
@@ -47,13 +47,29 @@ export class KagemushaConnector implements IConnector {
 
   private db: SQLiteDatabase | null = null;
   private dbPath: string;
+  /**
+   * Platforms this connector may read, derived from the configured channel keys
+   * (`kakao:<room>` → `kakao`, `kagemusha-tasks:<room>` → `kagemusha-tasks`). The
+   * Kagemusha DB mirrors every platform it bridges (kakao, line, slack, chatwork,
+   * telegram, …) plus its own task cards; the owner's declaration (2026-07-30) is
+   * that MAMA reads the kakao/LINE conversations from it, not the rest. An empty
+   * channel map keeps the legacy contract: everything is read.
+   */
+  private readonly declaredSources: Set<string> | null;
   private lastPollTime: Date | null = null;
   private lastPollCount = 0;
   private lastError: string | undefined = undefined;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  constructor(_config: ConnectorConfig, dbPath?: string) {
+  constructor(config: ConnectorConfig, dbPath?: string) {
     this.dbPath = dbPath ?? join(homedir(), '.kagemusha', 'kagemusha.db');
+    const keys = Object.keys(config.channels ?? {});
+    this.declaredSources =
+      keys.length === 0 ? null : new Set(keys.map((key) => key.split(':')[0] ?? key));
+  }
+
+  private reads(source: string): boolean {
+    return this.declaredSources === null || this.declaredSources.has(source);
   }
 
   async init(): Promise<void> {
@@ -112,6 +128,7 @@ export class KagemushaConnector implements IConnector {
         .all(sinceMs) as ChannelMessage[];
 
       for (const row of rows) {
+        if (!this.reads(row.channel)) continue;
         items.push({
           source: row.channel,
           sourceId: `${row.channel_id}:${row.id}`,
@@ -134,12 +151,14 @@ export class KagemushaConnector implements IConnector {
       this.lastError = err instanceof Error ? err.message : String(err);
     }
 
-    // 2. Tasks (new) — include updated tasks since last poll
+    // 2. Tasks — only when a `kagemusha-tasks:*` channel is declared
     try {
       const sinceMs = since.getTime();
-      const tasks = this.db
-        .prepare(`SELECT * FROM tasks WHERE updated_at > ? ORDER BY updated_at ASC LIMIT 500`)
-        .all(sinceMs) as KagemushaTask[];
+      const tasks = this.reads('kagemusha-tasks')
+        ? (this.db
+            .prepare(`SELECT * FROM tasks WHERE updated_at > ? ORDER BY updated_at ASC LIMIT 500`)
+            .all(sinceMs) as KagemushaTask[])
+        : [];
 
       for (const task of tasks) {
         const deadline = task.deadline
@@ -196,22 +215,24 @@ export class KagemushaConnector implements IConnector {
 
       if (rows.length === 0) break;
 
-      const items: NormalizedItem[] = rows.map((row) => ({
-        source: row.channel,
-        sourceId: `${row.channel_id}:${row.id}`,
-        channel: row.channel_id,
-        author: row.user_id,
-        content: row.content,
-        timestamp: new Date(Number(row.created_at)),
-        type: 'message' as const,
-        metadata: {
-          channel: row.channel,
-          channelId: row.channel_id,
-          rawConnector: 'kagemusha',
-          userId: row.user_id,
-          role: row.role,
-        },
-      }));
+      const items: NormalizedItem[] = rows
+        .filter((row) => this.reads(row.channel))
+        .map((row) => ({
+          source: row.channel,
+          sourceId: `${row.channel_id}:${row.id}`,
+          channel: row.channel_id,
+          author: row.user_id,
+          content: row.content,
+          timestamp: new Date(Number(row.created_at)),
+          type: 'message' as const,
+          metadata: {
+            channel: row.channel,
+            channelId: row.channel_id,
+            rawConnector: 'kagemusha',
+            userId: row.user_id,
+            role: row.role,
+          },
+        }));
 
       yield items;
       offset += batchSize;
@@ -219,11 +240,11 @@ export class KagemushaConnector implements IConnector {
       if (rows.length < batchSize) break;
     }
 
-    // Also yield all tasks
+    // Also yield all tasks — only when a `kagemusha-tasks:*` channel is declared
     try {
-      const tasks = this.db
-        .prepare(`SELECT * FROM tasks ORDER BY updated_at ASC`)
-        .all() as KagemushaTask[];
+      const tasks = this.reads('kagemusha-tasks')
+        ? (this.db.prepare(`SELECT * FROM tasks ORDER BY updated_at ASC`).all() as KagemushaTask[])
+        : [];
 
       if (tasks.length > 0) {
         yield tasks.map((task) => {

--- a/packages/standalone/tests/connectors/calendar.test.ts
+++ b/packages/standalone/tests/connectors/calendar.test.ts
@@ -432,4 +432,45 @@ describe('CalendarConnector', () => {
       await expect(connector.dispose()).resolves.toBeUndefined();
     });
   });
+
+  describe('poll — bounded listing window', () => {
+    function listParams(): Record<string, unknown> {
+      const listCall = mockExecSync.mock.calls.find((c: unknown[]) =>
+        String(c[0]).includes('calendar events list')
+      );
+      const cmd = String(listCall?.[0]);
+      const marker = "--params '";
+      const start = cmd.indexOf(marker) + marker.length;
+      const end = cmd.lastIndexOf("'");
+      return JSON.parse(cmd.slice(start, end).replace(/'\\''/g, "'")) as Record<string, unknown>;
+    }
+
+    it('caps the window with timeMax = now + 90 days so recurring events cannot expand without bound', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-01-15T00:00:00.000Z'));
+      try {
+        mockExecSync
+          .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+          .mockReturnValueOnce(makeEventListJson([]) as unknown as ReturnType<typeof execSync>);
+        const connector = new CalendarConnector(makeConfig());
+        await connector.init();
+        await connector.poll(new Date('2024-01-10T00:00:00.000Z'));
+        const params = listParams();
+        expect(params.timeMin).toBe('2024-01-10T00:00:00.000Z');
+        expect(params.timeMax).toBe('2024-04-14T00:00:00.000Z');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('lists 250 events per page so a 90-day window stays far below the page cap', async () => {
+      mockExecSync
+        .mockReturnValueOnce('' as unknown as ReturnType<typeof execSync>)
+        .mockReturnValueOnce(makeEventListJson([]) as unknown as ReturnType<typeof execSync>);
+      const connector = new CalendarConnector(makeConfig());
+      await connector.init();
+      await connector.poll(new Date('2024-01-10T00:00:00.000Z'));
+      expect(listParams().maxResults).toBe(250);
+    });
+  });
 });

--- a/packages/standalone/tests/connectors/chatwork.test.ts
+++ b/packages/standalone/tests/connectors/chatwork.test.ts
@@ -320,4 +320,38 @@ describe('ChatworkConnector', () => {
       expect(await connector.authenticate()).toBe(false);
     });
   });
+
+  describe('poll — shared-token safety', () => {
+    it('requests force=1 so another reader on the same token cannot consume messages first', async () => {
+      const mockFetch = vi
+        .fn()
+        .mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue([]) });
+      vi.stubGlobal('fetch', mockFetch);
+      const connector = new ChatworkConnector(
+        makeConfig({ channels: { '12345': { role: 'hub', name: 'project' } } })
+      );
+      await connector.init();
+      await connector.poll(new Date(0));
+      expect(String(mockFetch.mock.calls[0]?.[0])).toContain('/rooms/12345/messages?force=1');
+    });
+
+    it('does not re-emit messages on the next poll even though force=1 returns the same window again', async () => {
+      const batch = [
+        makeChatworkMessage({ message_id: '1001', send_time: 1704067201 }),
+        makeChatworkMessage({ message_id: '1002', send_time: 1704067202 }),
+      ];
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue(batch) })
+      );
+      const connector = new ChatworkConnector(
+        makeConfig({ channels: { '12345': { role: 'hub', name: 'project' } } })
+      );
+      await connector.init();
+      const first = await connector.poll(new Date(0));
+      const second = await connector.poll(new Date(0));
+      expect(first).toHaveLength(2);
+      expect(second).toHaveLength(0);
+    });
+  });
 });

--- a/packages/standalone/tests/connectors/kagemusha.test.ts
+++ b/packages/standalone/tests/connectors/kagemusha.test.ts
@@ -273,4 +273,114 @@ describe('KagemushaConnector', () => {
       expect(await connector.authenticate()).toBe(false);
     });
   });
+
+  describe('poll — configured channels declare what is read', () => {
+    function createTasksTable(db: Database): void {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS tasks (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          title TEXT NOT NULL,
+          status TEXT NOT NULL,
+          priority TEXT NOT NULL,
+          deadline INTEGER,
+          source_room TEXT,
+          auto_created INTEGER NOT NULL DEFAULT 0,
+          confirmed INTEGER NOT NULL DEFAULT 0,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        )
+      `);
+    }
+    function insertMessage(
+      db: Database,
+      channel: string,
+      channelId: string,
+      content: string
+    ): void {
+      db.prepare(
+        `INSERT INTO channel_messages (channel, channel_id, user_id, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)`
+      ).run(channel, channelId, 'user-a', 'user', content, 1705309200000);
+    }
+    function insertTask(db: Database, sourceRoom: string): void {
+      db.prepare(
+        `INSERT INTO tasks (title, status, priority, deadline, source_room, auto_created, confirmed, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 0, 0, ?, ?)`
+      ).run('card', 'pending', 'normal', null, sourceRoom, 1705309200000, 1705309200000);
+    }
+    const since = new Date('2024-01-01T00:00:00.000Z');
+
+    it('emits only platforms present in the configured channel keys', async () => {
+      const db = createTestDb(tempDbPath);
+      insertMessage(db, 'kakao', 'kakao:room-a', 'from kakao');
+      insertMessage(db, 'slack', 'slack:C1', 'from the slack mirror');
+      db.close();
+      const connector = new KagemushaConnector(
+        makeConfig({ channels: { 'kakao:room-a': { role: 'hub' } } }),
+        tempDbPath
+      );
+      await connector.init();
+      const items = await connector.poll(since);
+      expect(items.map((i) => i.source)).toEqual(['kakao']);
+      await connector.dispose();
+    });
+
+    it('does not emit task cards unless a kagemusha-tasks channel is configured', async () => {
+      const db = createTestDb(tempDbPath);
+      createTasksTable(db);
+      insertTask(db, 'kakao:room-a');
+      db.close();
+      const connector = new KagemushaConnector(
+        makeConfig({ channels: { 'kakao:room-a': { role: 'hub' } } }),
+        tempDbPath
+      );
+      await connector.init();
+      const items = await connector.poll(since);
+      expect(items.filter((i) => i.type === 'kanban_card')).toHaveLength(0);
+      await connector.dispose();
+    });
+
+    it('emits task cards when a kagemusha-tasks channel is configured', async () => {
+      const db = createTestDb(tempDbPath);
+      createTasksTable(db);
+      insertTask(db, 'kakao:room-a');
+      db.close();
+      const connector = new KagemushaConnector(
+        makeConfig({ channels: { 'kagemusha-tasks:kakao:room-a': { role: 'truth' } } }),
+        tempDbPath
+      );
+      await connector.init();
+      const items = await connector.poll(since);
+      expect(items.filter((i) => i.type === 'kanban_card')).toHaveLength(1);
+      await connector.dispose();
+    });
+
+    it('keeps emitting every platform when no channels are configured (legacy contract)', async () => {
+      const db = createTestDb(tempDbPath);
+      insertMessage(db, 'kakao', 'kakao:room-a', 'from kakao');
+      insertMessage(db, 'slack', 'slack:C1', 'from the slack mirror');
+      db.close();
+      const connector = new KagemushaConnector(makeConfig({ channels: {} }), tempDbPath);
+      await connector.init();
+      const items = await connector.poll(since);
+      expect(items).toHaveLength(2);
+      await connector.dispose();
+    });
+
+    it('pollBulk honours the same declaration', async () => {
+      const db = createTestDb(tempDbPath);
+      insertMessage(db, 'kakao', 'kakao:room-a', 'from kakao');
+      insertMessage(db, 'chatwork', 'chatwork:1', 'from the chatwork mirror');
+      db.close();
+      const connector = new KagemushaConnector(
+        makeConfig({ channels: { 'kakao:room-a': { role: 'hub' } } }),
+        tempDbPath
+      );
+      await connector.init();
+      const sources: string[] = [];
+      for await (const batch of connector.pollBulk(since)) {
+        sources.push(...batch.map((i) => i.source));
+      }
+      expect(sources).toEqual(['kakao']);
+      await connector.dispose();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Three connector fixes, each measured on the live install today (2026-09-10):

- **Chatwork polls with `force=1`.** `force=0` hands out only what the server has not yet given to the token, a read cursor shared by every reader of that token. A second poller on the same token (30 s cadence) consumed it first and this connector saw ~1 message/day against ~30/day in the rooms. New-ness is decided client-side with the `since` timestamp and the per-room last seen message id that already existed.
- **Calendar listing is bounded to now + 90 days, 250/page.** `singleEvents:true` without `timeMax` expanded recurring events without bound; since paging landed on 09-07 every poll hit the 20-page cap, threw, saved nothing, and left the cursor stuck for three days while `/api/connectors/status` and `mama status` stayed green.
- **The Kagemusha bridge reads only what its configured channel keys declare.** `kakao:*` admits kakao, `line:*` admits LINE, `kagemusha-tasks:*` admits task cards. Mirrored slack/chatwork produced the same channel twice, and mirrored cards produced duplicate MAMA tasks (e.g. two open tasks for one asset id). An empty channel map keeps the legacy read-everything contract.

Version bump to 0.53.2 and CHANGELOG entry included, per docs/development/release-process.md.

## Test plan

- [x] RED first: 6 new tests failed for the intended reasons (force=1 URL, timeMax, maxResults, platform filter, cards not emitted, pollBulk parity)
- [x] GREEN: targeted files 77/77, `tests/connectors` 32 files 537/537
- [x] eslint 0, `tsc --noEmit` 0, prettier applied
- [ ] Full standalone suite (running)
- [ ] Local dogfood install: first poll cycle shows native Chatwork items and a Calendar poll without the page-cap error, before any public release

## Out of scope

Owner-authored messages in the bridged Telegram group are still processed as connector deltas, and tasks still lack a canonical artifact key. Both need design, not a connector patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Chatwork message polling to reduce missed messages and prevent duplicate deliveries.
  - Limited Calendar recurring-event searches to a 90-day window and increased page size to 250 events.
  - Kagemusha now reads only platforms and task channels declared in its configuration.
  - Preserved the existing behavior of reading all supported sources when no Kagemusha channels are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->