### PR TITLE
feat: add core judgment command foundation

### DIFF
--- a/docs/development/intent-checks.md
+++ b/docs/development/intent-checks.md
@@ -777,3 +777,16 @@
   파일·전달 흐름은 아직 완료되지 않았다.
 - 하위 작업 상태 / 최상위 목표 상태 / 다음 작업의 연결 이유: PR3B source 후보 구현.
   **최상위 목표 미완료.** 다음 PR은 같은 현재 원장을 지식·업무 writer와 연결한다.
+
+## 2026-09-13 — PR3B CodeRabbit closure와 병합
+
+- 결과: PR #301의 100파일 diff에 대해 immutable observation/correction 경계, pending projection
+  drain·enqueue invariant, owner-event quarantine, Slack principal startup, replay 오류 분류를
+  명시적으로 닫고, 불필요한 null-ref fallback·unused context merge·bulk docstring 확장은 적용하지 않았다.
+- 근거: CodeRabbit 19개 스레드에 각각 수정 근거 또는 타당한 반론을 답변하고 모두 resolve했다. 코어
+  38개와 standalone 233개 집중 테스트, pre-commit 전체 workspace 검증, GitHub PR CI 7개가 통과했다.
+  관리자 계정 squash merge 후 main CI와 Pages도 통과했다.
+- 판정: INTENT v6의 원문·관측 시각·교정·재시작 가능한 Case 경로에 **부분 부합**한다. 설치된
+  서비스, 실제 모델 판단, 실제 Telegram 전달, 장기 raw 평가와 실제 파일 업무는 아직 검증하지 않았다.
+- 다음 단계: PR4에서 현재 원장의 지식 저장·조회와 업무 약속 writer 전환 후보를 main 기준으로
+  failure-first 인벤토리하고, 100파일 이하의 실제 소비자 범위를 확정한다.

--- a/packages/mama-core/db/migrations/075-agent-judgments.sql
+++ b/packages/mama-core/db/migrations/075-agent-judgments.sql
@@ -1,0 +1,58 @@
+-- Core-owned judgment and commitment command bindings.
+-- Existing decisions, registry, observations, edges, and effect receipts remain authoritative.
+
+ALTER TABLE decisions ADD COLUMN record_kind TEXT NOT NULL DEFAULT 'judgment'
+  CHECK (record_kind IN ('judgment', 'commitment'));
+ALTER TABLE decisions ADD COLUMN payload_json TEXT NOT NULL DEFAULT '{}'
+  CHECK (json_valid(payload_json));
+ALTER TABLE decisions ADD COLUMN applies_from INTEGER;
+ALTER TABLE decisions ADD COLUMN applies_until INTEGER;
+
+CREATE TABLE IF NOT EXISTS command_bindings (
+  command_id TEXT PRIMARY KEY,
+  principal_id TEXT NOT NULL CHECK (length(trim(principal_id)) > 0),
+  action TEXT NOT NULL CHECK (length(trim(action)) > 0),
+  payload_hash TEXT NOT NULL CHECK (length(trim(payload_hash)) > 0),
+  receipt_kind TEXT NOT NULL CHECK (receipt_kind IN ('judgment', 'observation', 'identity', 'effect')),
+  receipt_key TEXT NOT NULL CHECK (length(trim(receipt_key)) > 0),
+  created_at INTEGER NOT NULL CHECK (created_at >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS judgment_commands (
+  command_id TEXT PRIMARY KEY REFERENCES command_bindings(command_id) ON DELETE RESTRICT,
+  record_id TEXT NOT NULL REFERENCES decisions(id) ON DELETE RESTRICT,
+  committed_watermark INTEGER NOT NULL CHECK (committed_watermark >= 0),
+  receipt_json TEXT NOT NULL CHECK (json_valid(receipt_json)),
+  created_at INTEGER NOT NULL CHECK (created_at >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS commitments (
+  task_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  commitment_id TEXT NOT NULL UNIQUE,
+  current_revision INTEGER NOT NULL CHECK (current_revision >= 1),
+  head_record_id TEXT NOT NULL REFERENCES decisions(id) ON DELETE RESTRICT,
+  withdrawn INTEGER NOT NULL DEFAULT 0 CHECK (withdrawn IN (0, 1)),
+  created_at INTEGER NOT NULL CHECK (created_at >= 0),
+  updated_at INTEGER NOT NULL CHECK (updated_at >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS commitment_assignments (
+  commitment_id TEXT NOT NULL REFERENCES commitments(commitment_id) ON DELETE RESTRICT,
+  revision INTEGER NOT NULL CHECK (revision >= 1),
+  record_id TEXT NOT NULL REFERENCES decisions(id) ON DELETE RESTRICT,
+  operation TEXT NOT NULL CHECK (operation IN ('create', 'revise', 'withdraw')),
+  set_json TEXT NOT NULL CHECK (json_valid(set_json)),
+  clear_json TEXT NOT NULL CHECK (json_valid(clear_json)),
+  applies_from INTEGER,
+  applies_until INTEGER,
+  created_at INTEGER NOT NULL CHECK (created_at >= 0),
+  PRIMARY KEY (commitment_id, revision),
+  UNIQUE (commitment_id, record_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_judgment_commands_record ON judgment_commands(record_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_commitments_head ON commitments(head_record_id);
+CREATE INDEX IF NOT EXISTS idx_commitment_assignments_record ON commitment_assignments(record_id);
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES (75, 'Core-owned agent judgment and commitment commands');

--- a/packages/mama-core/db/migrations/076-scoped-checkpoint-bindings.sql
+++ b/packages/mama-core/db/migrations/076-scoped-checkpoint-bindings.sql
@@ -1,0 +1,15 @@
+-- Checkpoints are readable only when their explicit scope is bound. Legacy rows remain unscoped.
+
+CREATE TABLE IF NOT EXISTS checkpoint_scope_bindings (
+  checkpoint_id INTEGER NOT NULL REFERENCES checkpoints(id) ON DELETE CASCADE,
+  scope_id TEXT NOT NULL REFERENCES memory_scopes(id) ON DELETE RESTRICT,
+  is_primary INTEGER NOT NULL DEFAULT 0 CHECK (is_primary IN (0, 1)),
+  created_at INTEGER NOT NULL CHECK (created_at >= 0),
+  PRIMARY KEY (checkpoint_id, scope_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_checkpoint_scope_bindings_scope
+  ON checkpoint_scope_bindings(scope_id, checkpoint_id DESC);
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES (76, 'Scoped checkpoint bindings');

--- a/packages/mama-core/package.json
+++ b/packages/mama-core/package.json
@@ -51,7 +51,8 @@
     "./registry/store": "./dist/registry/store.js",
     "./registry/record-identity": "./dist/registry/record-identity.js",
     "./registry/corrections": "./dist/registry/corrections.js",
-    "./operations/owner-action-effects": "./dist/operations/owner-action-effects.js"
+    "./operations/owner-action-effects": "./dist/operations/owner-action-effects.js",
+    "./knowledge": "./dist/knowledge/index.js"
   },
   "scripts": {
     "build": "node scripts/clean-dist.mjs && tsc",

--- a/packages/mama-core/src/index.ts
+++ b/packages/mama-core/src/index.ts
@@ -114,6 +114,14 @@ export {
   getChannelSummary,
 } from './memory/api.js';
 export { buildExtractionPrompt, parseExtractionResponse } from './memory/extraction-prompt.js';
+export {
+  createKnowledge,
+  appendJudgment,
+  JudgmentError,
+  type Knowledge,
+  type KnowledgeOptions,
+  type JudgmentAccess,
+} from './knowledge/index.js';
 export { queryRelevantTruth } from './memory/truth-store.js';
 export { createAuditFinding, listOpenAuditFindings } from './memory/finding-store.js';
 export {

--- a/packages/mama-core/src/knowledge/index.ts
+++ b/packages/mama-core/src/knowledge/index.ts
@@ -1,0 +1,38 @@
+import type { DatabaseAdapter } from '../db-manager.js';
+import {
+  createJudgmentWriter,
+  type JudgmentAccess,
+  type JudgmentKnowledgeOptions,
+} from './judgments.js';
+import type { JudgmentCommand, JudgmentReceipt } from '../memory/judgment-types.js';
+
+export type { JudgmentAccess } from './judgments.js';
+
+export type {
+  IdentityCorrection,
+  IdentityCorrectionReceipt,
+  JudgmentCommand,
+  JudgmentReceipt,
+  JsonValue,
+  OwnerWorkPatch,
+  RecordLink,
+  WorkGraphPage,
+  WorkGraphQuery,
+  WorkReference,
+} from '../memory/judgment-types.js';
+export { JudgmentError, appendJudgment } from './judgments.js';
+
+export interface KnowledgeOptions extends JudgmentKnowledgeOptions {
+  adapter: DatabaseAdapter;
+}
+
+export interface Knowledge {
+  appendJudgment(command: JudgmentCommand, access: JudgmentAccess): Promise<JudgmentReceipt>;
+}
+
+export function createKnowledge(options: KnowledgeOptions): Knowledge {
+  const writer = createJudgmentWriter(options);
+  return {
+    appendJudgment: writer.appendJudgment,
+  };
+}

--- a/packages/mama-core/src/knowledge/judgments.ts
+++ b/packages/mama-core/src/knowledge/judgments.ts
@@ -295,7 +295,8 @@ async function appendJudgmentOnAdapter(
   }
   validateBounds(command);
   const allowedScopeIds = scopeIds(access, command);
-  const hash = commandHash(command);
+  const effectiveCommand = command.scopes ? command : { ...command, scopes: [...access.scopes] };
+  const hash = commandHash(effectiveCommand);
   const replay = assertReplay(adapter, command, access, hash);
   if (replay) {
     validateLinks(adapter, command.links ?? [], allowedScopeIds);

--- a/packages/mama-core/src/knowledge/judgments.ts
+++ b/packages/mama-core/src/knowledge/judgments.ts
@@ -1,0 +1,498 @@
+import crypto from 'node:crypto';
+
+import { getAdapter, initDB, insertPreparedDecision } from '../db-manager.js';
+import type { DatabaseAdapter } from '../db-manager.js';
+import { canonicalizeJSON } from '../canonicalize.js';
+import { insertMemoryEventInTransaction } from '../memory/event-store.js';
+import type {
+  JudgmentCommand,
+  JudgmentReceipt,
+  OwnerWorkPatch,
+  RecordLink,
+  WorkReference,
+  WorkAssignment,
+} from '../memory/judgment-types.js';
+import type { MemoryScopeRef } from '../memory/types.js';
+
+export interface JudgmentAccess {
+  principalId: string;
+  agentId: string;
+  scopes: readonly MemoryScopeRef[];
+}
+
+export interface JudgmentKnowledgeOptions {
+  adapter: DatabaseAdapter;
+  embedder?: {
+    embed(text: string, role: 'query' | 'passage'): Promise<Float32Array>;
+  };
+}
+
+export class JudgmentError extends Error {
+  constructor(
+    readonly code: string,
+    message: string
+  ) {
+    super(message);
+    this.name = 'JudgmentError';
+  }
+}
+
+function commandHash(command: JudgmentCommand): string {
+  return crypto.createHash('sha256').update(canonicalizeJSON(command)).digest('hex');
+}
+
+function recordIdForCommand(command: JudgmentCommand): string {
+  return `judgment_${crypto.createHash('sha256').update(command.commandId).digest('hex').slice(0, 24)}`;
+}
+
+function commitmentIdForCommand(command: JudgmentCommand): string {
+  return `commitment_${crypto
+    .createHash('sha256')
+    .update(command.commandId)
+    .digest('hex')
+    .slice(0, 24)}`;
+}
+
+function requireText(value: string, field: string): void {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new JudgmentError('INVALID_COMMAND', `${field} must be nonblank`);
+  }
+}
+
+function scopeIds(access: JudgmentAccess, command: JudgmentCommand): string[] {
+  const scopes = command.scopes ?? access.scopes;
+  if (scopes.length === 0) {
+    throw new JudgmentError('INVALID_SCOPE', 'At least one judgment scope is required');
+  }
+  const admitted = new Set(access.scopes.map((scope) => `${scope.kind}\0${scope.id}`));
+  const seen = new Set<string>();
+  return scopes.map((scope) => {
+    if (!['global', 'user', 'channel', 'project'].includes(scope.kind)) {
+      throw new JudgmentError('INVALID_SCOPE', 'scope kind is invalid');
+    }
+    requireText(scope.kind, 'scope kind');
+    requireText(scope.id, 'scope id');
+    const key = `${scope.kind}\0${scope.id}`;
+    if (seen.has(key)) {
+      throw new JudgmentError('INVALID_SCOPE', 'Judgment scopes must be unique');
+    }
+    seen.add(key);
+    if (!admitted.has(key)) {
+      throw new JudgmentError('SCOPE_DENIED', 'Judgment scope is outside the admitted access');
+    }
+    return `scope_${scope.kind}_${Buffer.from(scope.id).toString('base64url')}`;
+  });
+}
+
+function validateBounds(command: JudgmentCommand): void {
+  for (const [name, value] of [
+    ['appliesFrom', command.appliesFrom],
+    ['appliesUntil', command.appliesUntil],
+  ] as const) {
+    if (value !== undefined && (!Number.isFinite(value) || value < 0)) {
+      throw new JudgmentError('INVALID_TIME', `${name} must be a finite nonnegative epoch`);
+    }
+  }
+  if (
+    command.appliesFrom !== undefined &&
+    command.appliesUntil !== undefined &&
+    command.appliesFrom > command.appliesUntil
+  ) {
+    throw new JudgmentError('INVALID_TIME', 'appliesFrom cannot be after appliesUntil');
+  }
+}
+
+function referenceExists(
+  adapter: Pick<DatabaseAdapter, 'prepare'>,
+  reference: WorkReference,
+  allowedScopeIds: readonly string[]
+): boolean {
+  if (reference.kind === 'memory') {
+    if (allowedScopeIds.length === 0) return false;
+    const placeholders = allowedScopeIds.map(() => '?').join(', ');
+    return (
+      adapter
+        .prepare(
+          `SELECT 1 FROM decisions d
+           JOIN memory_scope_bindings b ON b.memory_id = d.id
+           WHERE d.id = ? AND b.scope_id IN (${placeholders}) LIMIT 1`
+        )
+        .get(reference.id, ...allowedScopeIds) !== undefined
+    );
+  }
+  if (reference.kind === 'registry') {
+    const node =
+      adapter.prepare('SELECT 1 FROM registry_nodes WHERE id = ?').get(reference.id) !== undefined;
+    if (!node) return false;
+    const bindings = adapter
+      .prepare('SELECT scope_kind, scope_id FROM registry_scope_bindings WHERE node_id = ?')
+      .all(reference.id) as Array<{ scope_kind: string; scope_id: string }>;
+    return (
+      bindings.length === 0 ||
+      bindings.some((binding) =>
+        allowedScopeIds.includes(
+          `scope_${binding.scope_kind}_${Buffer.from(binding.scope_id).toString('base64url')}`
+        )
+      )
+    );
+  }
+  if (reference.kind === 'observation') {
+    return (
+      adapter
+        .prepare('SELECT 1 FROM observation_versions WHERE observation_id = ?')
+        .get(reference.id) !== undefined
+    );
+  }
+  if (reference.kind === 'edge') {
+    return (
+      adapter.prepare('SELECT 1 FROM twin_edges WHERE edge_id = ?').get(reference.id) !== undefined
+    );
+  }
+  return true;
+}
+
+function validateLinks(
+  adapter: Pick<DatabaseAdapter, 'prepare'>,
+  links: readonly RecordLink[],
+  allowedScopeIds: readonly string[]
+): void {
+  const keys = new Set<string>();
+  for (const link of links) {
+    requireText(link.relation, 'link relation');
+    requireText(link.target.id, 'link target id');
+    const attrs = link.attrs ?? {};
+    const key = canonicalizeJSON({
+      relation: link.relation,
+      target: link.target,
+      role: attrs.role ?? null,
+      slot: attrs.slot ?? null,
+    });
+    if (keys.has(key)) {
+      throw new JudgmentError(
+        'DUPLICATE_LINK',
+        'A judgment cannot repeat the same relation target slot'
+      );
+    }
+    keys.add(key);
+    if (!referenceExists(adapter, link.target, allowedScopeIds)) {
+      throw new JudgmentError('REFERENCE_NOT_FOUND', 'A judgment reference is unavailable');
+    }
+  }
+}
+
+function parseReceipt(value: string): JudgmentReceipt {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch (error) {
+    throw new Error('judgment_commands.receipt_json is malformed', { cause: error });
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('judgment_commands.receipt_json must contain an object');
+  }
+  return parsed as JudgmentReceipt;
+}
+
+function assertReplay(
+  adapter: Pick<DatabaseAdapter, 'prepare'>,
+  command: JudgmentCommand,
+  access: JudgmentAccess,
+  hash: string
+): JudgmentReceipt | null {
+  const binding = adapter
+    .prepare(
+      'SELECT principal_id, action, payload_hash, receipt_key FROM command_bindings WHERE command_id = ?'
+    )
+    .get(command.commandId) as
+    | { principal_id: string; action: string; payload_hash: string; receipt_key: string }
+    | undefined;
+  if (!binding) return null;
+  if (
+    binding.principal_id !== access.principalId ||
+    binding.action !== 'judgment.append' ||
+    binding.payload_hash !== hash
+  ) {
+    throw new JudgmentError(
+      'COMMAND_CONFLICT',
+      'The command id is already bound to another request'
+    );
+  }
+  const row = adapter
+    .prepare('SELECT receipt_json FROM judgment_commands WHERE command_id = ?')
+    .get(command.commandId) as { receipt_json: string } | undefined;
+  if (!row) {
+    throw new Error('Command binding has no judgment receipt');
+  }
+  return parseReceipt(row.receipt_json);
+}
+
+function edgeId(commandId: string, index: number, relation: string, target: WorkReference): string {
+  return `edge_${crypto
+    .createHash('sha256')
+    .update(canonicalizeJSON({ commandId, index, relation, target }))
+    .digest('hex')
+    .slice(0, 24)}`;
+}
+
+function insertLink(
+  adapter: Pick<DatabaseAdapter, 'prepare'>,
+  command: JudgmentCommand,
+  recordId: string,
+  link: RecordLink,
+  index: number,
+  access: JudgmentAccess,
+  now: number
+): string {
+  const id = edgeId(command.commandId, index, link.relation, link.target);
+  const attrs = link.attrs ?? {};
+  const contentHash = crypto
+    .createHash('sha256')
+    .update(canonicalizeJSON({ id, recordId, link }))
+    .digest();
+  adapter
+    .prepare(
+      `INSERT INTO twin_edges (
+         edge_id, edge_type, subject_kind, subject_id, object_kind, object_id,
+         relation_attrs_json, confidence, source, agent_id, evidence_refs_json,
+         content_hash, created_at
+       ) VALUES (?, ?, 'memory', ?, ?, ?, ?, 1.0, 'agent', ?, ?, ?, ?)`
+    )
+    .run(
+      id,
+      link.relation,
+      recordId,
+      link.target.kind,
+      link.target.id,
+      canonicalizeJSON(attrs),
+      access.agentId,
+      command.replaces?.length ? canonicalizeJSON(command.replaces) : null,
+      contentHash,
+      now
+    );
+  return id;
+}
+
+function workPatch(value: WorkAssignment | undefined): OwnerWorkPatch {
+  return value?.set ?? {};
+}
+
+async function appendJudgmentOnAdapter(
+  adapter: DatabaseAdapter,
+  command: JudgmentCommand,
+  access: JudgmentAccess,
+  embedder?: JudgmentKnowledgeOptions['embedder']
+): Promise<JudgmentReceipt> {
+  requireText(command.commandId, 'commandId');
+  requireText(command.topic, 'topic');
+  requireText(command.summary, 'summary');
+  requireText(access.principalId, 'principalId');
+  requireText(access.agentId, 'agentId');
+  if (command.recordKind !== 'judgment' && command.recordKind !== 'commitment') {
+    throw new JudgmentError('INVALID_COMMAND', 'recordKind is invalid');
+  }
+  if ((command.recordKind === 'commitment') !== (command.work !== undefined)) {
+    throw new JudgmentError('INVALID_COMMAND', 'Commitment records require a work assignment');
+  }
+  validateBounds(command);
+  const allowedScopeIds = scopeIds(access, command);
+  const hash = commandHash(command);
+  const replay = assertReplay(adapter, command, access, hash);
+  if (replay) {
+    validateLinks(adapter, command.links ?? [], allowedScopeIds);
+    for (const replacement of command.replaces ?? []) {
+      if (!referenceExists(adapter, { kind: 'memory', id: replacement.id }, allowedScopeIds)) {
+        throw new JudgmentError('REFERENCE_NOT_FOUND', 'A replacement target is unavailable');
+      }
+    }
+    return replay;
+  }
+  validateLinks(adapter, command.links ?? [], allowedScopeIds);
+
+  const recordId = recordIdForCommand(command);
+  const now = Date.now();
+  const embedding = embedder
+    ? await embedder.embed(`${command.topic}\n${command.summary}`, 'passage')
+    : null;
+  const edgeIds: string[] = [];
+  let workReceipt: JudgmentReceipt['work'];
+  adapter.transaction(() => {
+    const decisionRowId = insertPreparedDecision(
+      adapter,
+      {
+        id: recordId,
+        topic: command.topic,
+        decision: command.summary,
+        reasoning: command.reasoning ?? null,
+        created_at: now,
+        updated_at: now,
+        agent_id: access.agentId,
+      },
+      embedding
+    );
+    if (!Number.isSafeInteger(decisionRowId) || decisionRowId <= 0) {
+      throw new Error('Judgment decision row was not inserted');
+    }
+    adapter
+      .prepare(
+        `UPDATE decisions SET record_kind = ?, payload_json = ?, applies_from = ?, applies_until = ?
+         WHERE id = ?`
+      )
+      .run(
+        command.recordKind,
+        canonicalizeJSON(command.payload ?? {}),
+        command.appliesFrom ?? null,
+        command.appliesUntil ?? null,
+        recordId
+      );
+    for (const [index, scopeId] of allowedScopeIds.entries()) {
+      const scope = (command.scopes ?? access.scopes)[index]!;
+      adapter
+        .prepare('INSERT OR IGNORE INTO memory_scopes (id, kind, external_id) VALUES (?, ?, ?)')
+        .run(scopeId, scope.kind, scope.id);
+      adapter
+        .prepare(
+          'INSERT INTO memory_scope_bindings (memory_id, scope_id, is_primary) VALUES (?, ?, ?)'
+        )
+        .run(recordId, scopeId, index === 0 ? 1 : 0);
+    }
+    for (const [index, link] of (command.links ?? []).entries()) {
+      edgeIds.push(insertLink(adapter, command, recordId, link, index, access, now));
+    }
+    for (const replacement of command.replaces ?? []) {
+      if (!referenceExists(adapter, { kind: 'memory', id: replacement.id }, allowedScopeIds)) {
+        throw new JudgmentError('REFERENCE_NOT_FOUND', 'A replacement target is unavailable');
+      }
+      adapter
+        .prepare(
+          "UPDATE decisions SET superseded_by = ?, status = 'superseded', updated_at = ? WHERE id = ?"
+        )
+        .run(recordId, now, replacement.id);
+      edgeIds.push(
+        insertLink(
+          adapter,
+          { ...command, links: [] },
+          recordId,
+          { relation: 'supersedes', target: { kind: 'memory', id: replacement.id } },
+          edgeIds.length,
+          access,
+          now
+        )
+      );
+    }
+    if (command.recordKind === 'commitment' && command.work) {
+      const work = command.work;
+      if (work.operation === 'create') {
+        const commitmentId = commitmentIdForCommand(command);
+        adapter
+          .prepare(
+            `INSERT INTO commitments
+             (commitment_id, current_revision, head_record_id, withdrawn, created_at, updated_at)
+             VALUES (?, 1, ?, 0, ?, ?)`
+          )
+          .run(commitmentId, recordId, now, now);
+        adapter
+          .prepare(
+            `INSERT INTO commitment_assignments
+             (commitment_id, revision, record_id, operation, set_json, clear_json, created_at)
+             VALUES (?, 1, ?, 'create', ?, '[]', ?)`
+          )
+          .run(commitmentId, recordId, canonicalizeJSON(workPatch(work)), now);
+        workReceipt = { commitmentId, revision: 1 };
+      } else {
+        const current = adapter
+          .prepare('SELECT current_revision FROM commitments WHERE commitment_id = ?')
+          .get(work.commitmentId) as { current_revision: number } | undefined;
+        if (!current) {
+          throw new JudgmentError('REFERENCE_NOT_FOUND', 'Commitment is unavailable');
+        }
+        if (current.current_revision !== work.expectedRevision) {
+          throw new JudgmentError('STALE_REVISION', 'Commitment revision is stale');
+        }
+        const revision = current.current_revision + 1;
+        adapter
+          .prepare(
+            `INSERT INTO commitment_assignments
+             (commitment_id, revision, record_id, operation, set_json, clear_json, created_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?)`
+          )
+          .run(
+            work.commitmentId,
+            revision,
+            recordId,
+            work.operation,
+            canonicalizeJSON(workPatch(work)),
+            canonicalizeJSON(work.clear ?? []),
+            now
+          );
+        if (work.operation === 'withdraw') {
+          adapter.prepare("UPDATE decisions SET status = 'withdrawn' WHERE id = ?").run(recordId);
+        }
+        adapter
+          .prepare(
+            'UPDATE commitments SET current_revision = ?, head_record_id = ?, withdrawn = ?, updated_at = ? WHERE commitment_id = ?'
+          )
+          .run(revision, recordId, work.operation === 'withdraw' ? 1 : 0, now, work.commitmentId);
+        workReceipt = { commitmentId: work.commitmentId, revision };
+      }
+    }
+    insertMemoryEventInTransaction(adapter, {
+      event_type: 'save',
+      actor: `actor:${access.principalId}`,
+      memory_id: recordId,
+      topic: command.topic,
+      scope_refs: command.scopes ?? [...access.scopes],
+      reason: 'agent judgment command',
+      created_at: now,
+    });
+    const receipt: JudgmentReceipt = {
+      status: 'committed',
+      recordId,
+      commandId: command.commandId,
+      edgeIds,
+      watermark: now,
+      ...(workReceipt ? { work: workReceipt } : {}),
+      diagnostics: [],
+    };
+    adapter
+      .prepare(
+        `INSERT INTO command_bindings
+         (command_id, principal_id, action, payload_hash, receipt_kind, receipt_key, created_at)
+         VALUES (?, ?, 'judgment.append', ?, ?, ?, ?)`
+      )
+      .run(command.commandId, access.principalId, hash, 'judgment', recordId, now);
+    adapter
+      .prepare(
+        `INSERT INTO judgment_commands (command_id, record_id, committed_watermark, receipt_json, created_at)
+         VALUES (?, ?, ?, ?, ?)`
+      )
+      .run(command.commandId, recordId, receipt.watermark, canonicalizeJSON(receipt), now);
+  });
+  return {
+    status: 'committed',
+    recordId,
+    commandId: command.commandId,
+    edgeIds,
+    watermark: now,
+    ...(workReceipt ? { work: workReceipt } : {}),
+    diagnostics: [],
+  };
+}
+
+export async function appendJudgment(
+  command: JudgmentCommand,
+  access: JudgmentAccess,
+  options?: Partial<JudgmentKnowledgeOptions>
+): Promise<JudgmentReceipt> {
+  if (options?.adapter) {
+    return appendJudgmentOnAdapter(options.adapter, command, access, options.embedder);
+  }
+  await initDB();
+  return appendJudgmentOnAdapter(getAdapter(), command, access, options?.embedder);
+}
+
+export function createJudgmentWriter(options: JudgmentKnowledgeOptions) {
+  return {
+    appendJudgment: (command: JudgmentCommand, access: JudgmentAccess) =>
+      appendJudgmentOnAdapter(options.adapter, command, access, options.embedder),
+  };
+}

--- a/packages/mama-core/src/memory/judgment-types.ts
+++ b/packages/mama-core/src/memory/judgment-types.ts
@@ -1,0 +1,187 @@
+import type { MemoryScopeRef } from './types.js';
+import type { TwinRef } from '../edges/types.js';
+
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export type WorkReference = TwinRef | { kind: 'registry' | 'observation'; id: string };
+export type WorkRef = WorkReference;
+
+export interface RecordLink {
+  relation:
+    | 'supersedes'
+    | 'mentions'
+    | 'derived_from'
+    | 'builds_on'
+    | 'debates'
+    | 'synthesizes'
+    | 'blocks'
+    | 'next_action_for'
+    | 'case_member';
+  target: WorkReference;
+  attrs?: { role?: string; slot?: string; [key: string]: JsonValue | undefined };
+}
+
+export interface OwnerWorkPatch {
+  title?: string | null;
+  description?: string | null;
+  status?: string | null;
+  priority?: string | null;
+  dueAt?: string | null;
+  deadline?: string | null;
+  completionCriteria?: string | null;
+  assigneeText?: string | null;
+  latestEvent?: string | null;
+  resolutionKind?: string | null;
+  confirmed?: boolean | null;
+  roles?: Array<{ person: { kind: 'registry'; id: string }; role: string }> | null;
+  data?: Record<string, JsonValue> | null;
+}
+
+export type WorkAssignment = {
+  set?: OwnerWorkPatch;
+  clear?: Array<keyof OwnerWorkPatch>;
+} & (
+  | { operation: 'create'; creationKey: string }
+  | { operation: 'revise' | 'withdraw'; commitmentId: string; expectedRevision: number }
+);
+
+export interface JudgmentCommand {
+  commandId: string;
+  topic: string;
+  summary: string;
+  reasoning?: string;
+  recordKind: 'judgment' | 'commitment';
+  payload?: Record<string, JsonValue>;
+  appliesFrom?: number;
+  appliesUntil?: number;
+  links?: RecordLink[];
+  replaces?: Array<{ id: string; reason: string }>;
+  work?: WorkAssignment;
+  scopes?: MemoryScopeRef[];
+}
+
+export interface JudgmentReceipt {
+  status: 'committed';
+  recordId: string;
+  commandId: string;
+  edgeIds: string[];
+  watermark: number;
+  work?: { commitmentId: string; revision: number };
+  diagnostics: Array<{ stage: string; code: string; message: string }>;
+}
+
+export type IdentityCorrection = {
+  commandId: string;
+  expectedRevision: number;
+  reason: string;
+  scopes?: MemoryScopeRef[];
+  evidence?: Array<{ kind: 'observation'; id: string }>;
+} & (
+  | { operation: 'add_alias'; nodeId: string; alias: string }
+  | { operation: 'merge'; survivorId: string; memberIds: string[] }
+  | {
+      operation: 'split';
+      parentId: string;
+      children: Array<{ clientKey: string; name: string; aliases?: string[] }>;
+      assignments: Array<{ edgeId: string; endpoint: 'from' | 'to'; childKey: string }>;
+    }
+  | {
+      operation: 'assign_refs';
+      parentId: string;
+      assignments: Array<{
+        edgeId: string;
+        endpoint: 'from' | 'to';
+        targetNodeId: string | null;
+      }>;
+    }
+);
+
+export interface IdentityCorrectionReceipt {
+  commandId: string;
+  identityRevision: number;
+  children: Array<{ clientKey: string; ref: { kind: 'registry'; id: string } }>;
+  changedSlots: Array<{ edgeId: string; endpoint: 'from' | 'to' }>;
+  unresolved: Array<{ edgeId: string; endpoint: 'from' | 'to' }>;
+}
+
+export interface WorkGraphQuery {
+  seeds?: WorkReference[];
+  search?: { text: string; kinds?: WorkReference['kind'][] };
+  view: 'overview' | 'neighbors' | 'timeline' | 'paths' | 'detail';
+  section?: 'summary' | 'reasoning' | 'payload';
+  textOffset?: number;
+  textLimit?: number;
+  from?: WorkReference;
+  to?: WorkReference;
+  maxDepth?: number;
+  direction?: 'in' | 'out' | 'both';
+  relations?: string[];
+  history?: 'current' | 'all';
+  eventRange?: { start?: number; end?: number };
+  recordedRange?: { start?: number; end?: number };
+  asOf?: number;
+  limit?: number;
+  cursor?: string;
+}
+
+export type WorkGraphNodeData =
+  | {
+      kind: 'memory';
+      recordKind: 'judgment' | 'commitment';
+      topic: string;
+      summary: string;
+      recordedAt: number;
+      appliesFrom: number | null;
+      appliesUntil: number | null;
+      stateAtSnapshot: 'current' | 'replaced' | 'withdrawn' | 'not_yet_effective' | 'expired';
+      replaces: string[];
+      payload: Record<string, JsonValue>;
+    }
+  | {
+      kind: 'registry';
+      nodeKind: 'item' | 'person' | 'client';
+      name: string;
+      visibleAliases: string[];
+      identityRevision: number;
+      visibleChildren: Array<{ kind: 'registry'; id: string }>;
+      unresolvedSlots: Array<{ edgeId: string; endpoint: 'from' | 'to' }>;
+    }
+  | {
+      kind: 'observation';
+      connector: string;
+      sourceId: string;
+      sourceAt: number | null;
+      observedAt: number;
+      contentHash: string;
+    }
+  | {
+      kind: 'case' | 'entity' | 'report' | 'edge' | 'raw';
+      data: Record<string, JsonValue>;
+    };
+
+export interface WorkGraphPage {
+  nodes: Array<{
+    ref: WorkReference;
+    resolvedRef: WorkReference;
+    label: string;
+    data: WorkGraphNodeData;
+  }>;
+  edges: Array<{
+    id: string;
+    relation: string;
+    from: WorkReference;
+    to: WorkReference;
+    resolvedFrom: WorkReference;
+    resolvedTo: WorkReference;
+    attrs: JsonValue;
+  }>;
+  coverage: { returned: number; total: number | null; complete: boolean; reasons: string[] };
+  snapshot: { judgmentWatermark: number; identityRevision: number; asOf: number };
+  nextCursor: string | null;
+}

--- a/packages/mama-core/tests/cases/migration-runner-duplicate-column.test.ts
+++ b/packages/mama-core/tests/cases/migration-runner-duplicate-column.test.ts
@@ -1695,7 +1695,7 @@ describe('TG-03/04/05: migration 068 runtime scope overlap recovery', () => {
         evidence_json: null,
       });
       expect(db.prepare('SELECT MAX(version) AS version FROM schema_version').get()).toEqual({
-        version: 74,
+        version: 76,
       });
       db.close();
     });

--- a/packages/mama-core/tests/memory/judgment-atomic-write.test.ts
+++ b/packages/mama-core/tests/memory/judgment-atomic-write.test.ts
@@ -110,6 +110,23 @@ describe('Story R1/TG-03/TG-04/TG-05/TG-06: atomic agent judgment writes', () =>
     expect(getAdapter().prepare('SELECT COUNT(*) AS n FROM decisions').get()).toEqual({ n: 1 });
   });
 
+  it('AC #3 binds an implicit access scope into the command replay identity', async () => {
+    const command = {
+      commandId: 'cmd-scope-bound',
+      topic: 'synthetic-topic',
+      summary: 'scope-bound payload',
+      recordKind: 'judgment' as const,
+    };
+    await appendJudgment(command, access);
+    await expect(
+      appendJudgment(command, {
+        ...access,
+        scopes: [{ kind: 'project', id: 'other-scope' }],
+      })
+    ).rejects.toMatchObject({ code: 'COMMAND_CONFLICT' });
+    expect(getAdapter().prepare('SELECT COUNT(*) AS n FROM decisions').get()).toEqual({ n: 1 });
+  });
+
   it('AC #3 refuses an embedder failure before opening the judgment transaction', async () => {
     await expect(
       appendJudgment(

--- a/packages/mama-core/tests/memory/judgment-atomic-write.test.ts
+++ b/packages/mama-core/tests/memory/judgment-atomic-write.test.ts
@@ -1,0 +1,193 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { getAdapter } from '../../src/db-manager.js';
+import { appendJudgment } from '../../src/knowledge/judgments.js';
+import { cleanupTestDB, initTestDB } from '../../src/test-utils.js';
+
+describe('Story R1/TG-03/TG-04/TG-05/TG-06: atomic agent judgment writes', () => {
+  let dbPath = '';
+  const access = {
+    principalId: 'principal-test',
+    agentId: 'agent-test',
+    scopes: [{ kind: 'project' as const, id: 'scope-test' }],
+  };
+
+  beforeAll(async () => {
+    dbPath = await initTestDB('judgment-atomic-write');
+  });
+
+  beforeEach(() => {
+    const db = getAdapter();
+    db.prepare('DELETE FROM commitment_assignments').run();
+    db.prepare('DELETE FROM commitments').run();
+    db.prepare('DELETE FROM judgment_commands').run();
+    db.prepare('DELETE FROM command_bindings').run();
+    db.prepare('DELETE FROM twin_edges').run();
+    db.prepare('DELETE FROM memory_events').run();
+    db.prepare('DELETE FROM memory_scope_bindings').run();
+    db.prepare('DELETE FROM memory_scopes').run();
+    db.prepare('DELETE FROM embeddings').run();
+    db.prepare('DELETE FROM decisions').run();
+  });
+
+  afterAll(async () => cleanupTestDB(dbPath));
+
+  it('AC #1 rejects an invisible reference without writing a judgment', async () => {
+    await expect(
+      appendJudgment(
+        {
+          commandId: 'cmd-missing',
+          topic: 'synthetic-launch',
+          summary: 'Ship after evidence review',
+          recordKind: 'judgment',
+          links: [{ relation: 'mentions', target: { kind: 'registry', id: 'missing' } }],
+        },
+        access
+      )
+    ).rejects.toMatchObject({ code: 'REFERENCE_NOT_FOUND' });
+    expect(getAdapter().prepare('SELECT COUNT(*) AS n FROM decisions').get()).toEqual({ n: 0 });
+  });
+
+  it('AC #2 commits explicit links and returns the original receipt on replay', async () => {
+    const db = getAdapter();
+    db.prepare(
+      `INSERT INTO decisions (id, topic, decision, status, created_at, updated_at)
+       VALUES ('memory-old', 'synthetic-launch', 'old view', 'active', 1000, 1000)`
+    ).run();
+    db.prepare(
+      `INSERT INTO memory_scopes (id, kind, external_id)
+       VALUES ('scope_project_c2NvcGUtdGVzdA', 'project', 'scope-test')`
+    ).run();
+    db.prepare(
+      `INSERT INTO memory_scope_bindings (memory_id, scope_id, is_primary)
+       VALUES ('memory-old', 'scope_project_c2NvcGUtdGVzdA', 1)`
+    ).run();
+    const command = {
+      commandId: 'cmd-revise',
+      topic: 'synthetic-launch',
+      summary: 'new view',
+      reasoning: 'new observation',
+      recordKind: 'judgment' as const,
+      links: [
+        { relation: 'builds_on' as const, target: { kind: 'memory' as const, id: 'memory-old' } },
+      ],
+      replaces: [{ id: 'memory-old', reason: 'new evidence' }],
+      scopes: access.scopes,
+    };
+    const receipt = await appendJudgment(command, access);
+    expect(await appendJudgment(command, access)).toEqual(receipt);
+    expect(
+      db
+        .prepare(
+          'SELECT edge_type, object_id FROM twin_edges WHERE subject_id = ? ORDER BY edge_type'
+        )
+        .all(receipt.recordId)
+    ).toEqual([
+      { edge_type: 'builds_on', object_id: 'memory-old' },
+      { edge_type: 'supersedes', object_id: 'memory-old' },
+    ]);
+    expect(
+      db.prepare("SELECT superseded_by, decision FROM decisions WHERE id = 'memory-old'").get()
+    ).toEqual({
+      superseded_by: receipt.recordId,
+      decision: 'old view',
+    });
+    expect(db.prepare('SELECT COUNT(*) AS n FROM decisions').get()).toEqual({ n: 2 });
+  });
+
+  it('AC #3 rejects a different payload for the same command without a second row', async () => {
+    const command = {
+      commandId: 'cmd-idempotent',
+      topic: 'synthetic-topic',
+      summary: 'first payload',
+      recordKind: 'judgment' as const,
+      scopes: access.scopes,
+    };
+    await appendJudgment(command, access);
+    await expect(
+      appendJudgment({ ...command, summary: 'different payload' }, access)
+    ).rejects.toMatchObject({ code: 'COMMAND_CONFLICT' });
+    expect(getAdapter().prepare('SELECT COUNT(*) AS n FROM decisions').get()).toEqual({ n: 1 });
+  });
+
+  it('AC #3 refuses an embedder failure before opening the judgment transaction', async () => {
+    await expect(
+      appendJudgment(
+        {
+          commandId: 'cmd-embedder-failure',
+          topic: 'synthetic-topic',
+          summary: 'must not persist',
+          recordKind: 'judgment',
+          scopes: access.scopes,
+        },
+        access,
+        {
+          embedder: {
+            embed: async () => {
+              throw new Error('synthetic embedder failure');
+            },
+          },
+        }
+      )
+    ).rejects.toThrow('synthetic embedder failure');
+    expect(getAdapter().prepare('SELECT COUNT(*) AS n FROM decisions').get()).toEqual({ n: 0 });
+    expect(getAdapter().prepare('SELECT COUNT(*) AS n FROM command_bindings').get()).toEqual({
+      n: 0,
+    });
+  });
+
+  it('AC #4 advances a commitment revision and rejects stale CAS', async () => {
+    const create = await appendJudgment(
+      {
+        commandId: 'cmd-create',
+        topic: 'synthetic-task',
+        summary: 'own launch',
+        recordKind: 'commitment',
+        work: {
+          operation: 'create',
+          creationKey: 'synthetic-launch-task',
+          set: { title: 'Launch', roles: [] },
+        },
+        scopes: access.scopes,
+      },
+      access
+    );
+    const commitmentId = create.work!.commitmentId;
+    const revised = await appendJudgment(
+      {
+        commandId: 'cmd-r1',
+        topic: 'synthetic-task',
+        summary: 'revise',
+        recordKind: 'commitment',
+        work: {
+          operation: 'revise',
+          commitmentId,
+          expectedRevision: 1,
+          set: { status: 'active' },
+        },
+        scopes: access.scopes,
+      },
+      access
+    );
+    expect(revised.work?.revision).toBe(2);
+    await expect(
+      appendJudgment(
+        {
+          commandId: 'cmd-stale',
+          topic: 'synthetic-task',
+          summary: 'stale',
+          recordKind: 'commitment',
+          work: {
+            operation: 'revise',
+            commitmentId,
+            expectedRevision: 1,
+            set: { status: 'done' },
+          },
+          scopes: access.scopes,
+        },
+        access
+      )
+    ).rejects.toMatchObject({ code: 'STALE_REVISION' });
+    expect(getAdapter().prepare('SELECT COUNT(*) AS n FROM decisions').get()).toEqual({ n: 2 });
+  });
+});


### PR DESCRIPTION
## What changed

Core now has an explicit command-bound judgment foundation. `appendJudgment` validates the admitted principal and scopes, rejects unavailable references before writing, prepares an optional local embedder before the transaction, and atomically stores the judgment, links, scope bindings, command binding, receipt, and memory event. Replaying the same command returns the stored receipt; a different payload or authority returns `COMMAND_CONFLICT` without a second row. Commitment create/revise/withdraw uses a Core-owned revision and CAS.

Migrations 075 and 076 add command bindings, judgment receipts, commitment heads/assignments, decision record bounds, and explicit checkpoint scope bindings. Existing migrations 001–074 and raw observation pending storage remain unchanged.

## Scope

This PR is 10 changed files and stays well below the 100-file review limit. It intentionally does not switch the existing public `saveMemory` callers, host extraction, polling auto-save, or the Operator task ledger yet; those consumers need a separate failure-first boundary review before they can be moved without leaving competing writers.

## Validation

- Core full suite with `MAMA_FORCE_TIER_3=true`: 109 files, 819 tests passed.
- Repository pre-commit: six turbo tasks successful; standalone 424 files / 5,923 tests with 7 skips and 1 todo; MCP and plugin suites passed.
- Core typecheck/build, ESLint, Prettier, diff check, PII-pattern scan, and gitleaks passed.
- Fixtures and public text use synthetic identifiers only; no credentials, local paths, or private project content are included.
