### PR TITLE
fix: close judgment writer idempotency gaps

### DIFF
--- a/docs/development/intent-checks.md
+++ b/docs/development/intent-checks.md
@@ -790,3 +790,20 @@
   서비스, 실제 모델 판단, 실제 Telegram 전달, 장기 raw 평가와 실제 파일 업무는 아직 검증하지 않았다.
 - 다음 단계: PR4에서 현재 원장의 지식 저장·조회와 업무 약속 writer 전환 후보를 main 기준으로
   failure-first 인벤토리하고, 100파일 이하의 실제 소비자 범위를 확정한다.
+
+## 2026-09-13 — PR4A CodeRabbit CLI 리뷰와 judgment writer closure
+
+- 리뷰 범위 / 근거: CodeRabbit CLI의 `--agent --base origin/main --type committed` 실행으로
+  PR4A의 Core judgment foundation을 검토했다. CLI가 반환한 구조화 지적은 현재 소스·계약·실제
+  Core 테스트와 대조했으며, 결과가 없는 외부 효과나 개인정보를 리뷰 입력·기록에 넣지 않았다.
+- 유효한 결함과 수정: 알 수 없는 reference kind의 허용, 기존 decisions의 judgment 오인, 같은
+  commandId의 동시 경쟁, 철회 후 revise 허용, create의 clear 유실을 수정했다. 계획에서 제거한
+  creationKey도 타입·테스트에서 제거했다. 기존 DB는 새 077 recovery에서 명시적 `legacy`로
+  분류하고 command receipt가 있는 기록은 보존한다. 별도 fallback runtime·승인 큐·업무 원장은
+  추가하지 않았다.
+- 검증: migration recovery 42개와 atomic judgment 9개를 포함한 Core 전체 825개 테스트와
+  typecheck/build가 통과했다. 저장·재시도·scope·약속 revision은 실제 SQLite adapter를 사용했다.
+  전체 workspace lint/format에는 이번 범위 밖 기존 오류가 남아 있어 성공 근거로 사용하지 않았다.
+- 의도 판정: **부분 부합**. 한 거래의 명령·판단·약속 경계와 legacy 구분은 강화됐지만, 공개
+  save/ingest writer 전환, 조회 graph, runtime/CLI/MCP 연결, 실제 모델·Telegram·파일 업무는
+  후속 PR에서 검증해야 한다. 최상위 목표는 미완료다.

--- a/packages/mama-core/db/migrations/075-agent-judgments.sql
+++ b/packages/mama-core/db/migrations/075-agent-judgments.sql
@@ -1,8 +1,8 @@
 -- Core-owned judgment and commitment command bindings.
 -- Existing decisions, registry, observations, edges, and effect receipts remain authoritative.
 
-ALTER TABLE decisions ADD COLUMN record_kind TEXT NOT NULL DEFAULT 'judgment'
-  CHECK (record_kind IN ('judgment', 'commitment'));
+ALTER TABLE decisions ADD COLUMN record_kind TEXT NOT NULL DEFAULT 'legacy'
+  CHECK (record_kind IN ('legacy', 'judgment', 'commitment'));
 ALTER TABLE decisions ADD COLUMN payload_json TEXT NOT NULL DEFAULT '{}'
   CHECK (json_valid(payload_json));
 ALTER TABLE decisions ADD COLUMN applies_from INTEGER;

--- a/packages/mama-core/db/migrations/077-legacy-record-kind.sql
+++ b/packages/mama-core/db/migrations/077-legacy-record-kind.sql
@@ -1,0 +1,6 @@
+-- Existing decisions are legacy memory records until an explicit judgment command
+-- binds them to a judgment receipt. Migration recovery in the adapter preserves
+-- the same distinction for databases that already applied migration 075.
+
+INSERT OR IGNORE INTO schema_version (version, description)
+VALUES (77, 'Distinguish legacy memory records from agent judgments');

--- a/packages/mama-core/src/db-adapter/node-sqlite-adapter.ts
+++ b/packages/mama-core/src/db-adapter/node-sqlite-adapter.ts
@@ -471,6 +471,14 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
   }
 
   transaction<T>(fn: () => T): T {
+    return this.runTransaction(fn, 'deferred');
+  }
+
+  transactionImmediate<T>(fn: () => T): T {
+    return this.runTransaction(fn, 'immediate');
+  }
+
+  private runTransaction<T>(fn: () => T, mode: 'deferred' | 'immediate'): T {
     if (!this.isConnected()) {
       throw new Error('Database not connected');
     }
@@ -479,7 +487,13 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
     const topicSnapshot = new Map(this.topicCache);
     const statusSnapshot = new Map(this.statusCache);
     const savepoint = `mama_nested_${depth}`;
-    this.exec(depth === 0 ? 'BEGIN TRANSACTION' : `SAVEPOINT ${savepoint}`);
+    this.exec(
+      depth === 0
+        ? mode === 'immediate'
+          ? 'BEGIN IMMEDIATE'
+          : 'BEGIN TRANSACTION'
+        : `SAVEPOINT ${savepoint}`
+    );
     this.transactionDepth += 1;
     try {
       const result = fn();
@@ -663,6 +677,14 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
     ) {
       this.recoverWorkGraphRefsMigration074();
     }
+    if (
+      currentVersion >= 77 &&
+      this.tableExists('decisions') &&
+      fs.existsSync(path.join(migrationsDir, '077-legacy-record-kind.sql')) &&
+      !this.legacyRecordKindShape077()
+    ) {
+      this.recoverLegacyRecordKindMigration077();
+    }
 
     for (const file of migrationFiles) {
       const versionMatch = file.match(/^(\d+)-/);
@@ -724,6 +746,12 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
           continue;
         }
         this.recoverWorkGraphRefsMigration074();
+        info(`[node-sqlite-adapter] Migration ${file} reconciled successfully`);
+        continue;
+      }
+
+      if (version === 77) {
+        this.recoverLegacyRecordKindMigration077();
         info(`[node-sqlite-adapter] Migration ${file} reconciled successfully`);
         continue;
       }
@@ -2772,6 +2800,115 @@ export class NodeSQLiteAdapter extends DatabaseAdapter {
         this.prepare(
           'INSERT OR IGNORE INTO schema_version (version, description) VALUES (?, ?)'
         ).run(74, 'Registry and observation work graph references');
+      });
+    } finally {
+      this.exec(`PRAGMA foreign_keys = ${previousForeignKeys ? 'ON' : 'OFF'}`);
+    }
+  }
+
+  private legacyRecordKindShape077(): boolean {
+    if (!this.tableExists('decisions')) {
+      return false;
+    }
+    const clauses = splitCreateTableClauses(this.tableSql('decisions'));
+    const recordKindClause = clauses.find(
+      (clause) => !clauseIsTableConstraint(clause) && clauseColumnName(clause) === 'record_kind'
+    );
+    return Boolean(
+      recordKindClause &&
+      normalizeSqlText(recordKindClause) ===
+        normalizeSqlText(
+          "record_kind TEXT NOT NULL DEFAULT 'legacy' CHECK (record_kind IN ('legacy', 'judgment', 'commitment'))"
+        ) &&
+      !clauses.some((clause) => clauseIsTableConstraint(clause) && /\brecord_kind\b/i.test(clause))
+    );
+  }
+
+  private recoverLegacyRecordKindMigration077(): void {
+    if (!this.tableExists('decisions')) {
+      throw new Error('Migration 077 recovery failed: missing decisions');
+    }
+    if (this.legacyRecordKindShape077()) {
+      this.transaction(() => {
+        this.prepare(
+          'INSERT OR IGNORE INTO schema_version (version, description) VALUES (?, ?)'
+        ).run(77, 'Distinguish legacy memory records from agent judgments');
+      });
+      return;
+    }
+
+    const clauses = splitCreateTableClauses(this.tableSql('decisions'));
+    if (clauses.length === 0) {
+      throw new Error('Migration 077 recovery failed: unreadable decisions');
+    }
+    const existingColumns: string[] = [];
+    const columns: string[] = [];
+    const constraints: string[] = [];
+    let hasRecordKind = false;
+    for (const clause of clauses) {
+      if (clauseIsTableConstraint(clause)) {
+        if (/\brecord_kind\b/i.test(clause)) {
+          throw new Error('Migration 077 cannot safely preserve conflicting record_kind CHECK');
+        }
+        constraints.push(clause);
+        continue;
+      }
+      const name = clauseColumnName(clause);
+      existingColumns.push(name);
+      if (name === 'record_kind') {
+        hasRecordKind = true;
+        columns.push(
+          "record_kind TEXT NOT NULL DEFAULT 'legacy' CHECK (record_kind IN ('legacy', 'judgment', 'commitment'))"
+        );
+      } else {
+        columns.push(clause);
+      }
+    }
+    if (!hasRecordKind) {
+      throw new Error('Migration 077 recovery failed: record_kind column is missing');
+    }
+
+    const objects = this.storedObjectsForTable('decisions');
+    const previousForeignKeys = this.readForeignKeysEnabled();
+    this.exec('PRAGMA foreign_keys = OFF');
+    if (this.readForeignKeysEnabled()) {
+      throw new Error('Migration 077 recovery failed: could not disable foreign_keys');
+    }
+    try {
+      this.transaction(() => {
+        this.exec(
+          `CREATE TABLE decisions_077_new (\n  ${[...columns, ...constraints].join(',\n  ')}\n)`
+        );
+        const names = existingColumns.map(quoteSqlIdentifier).join(', ');
+        const source = existingColumns
+          .map((name) =>
+            name === 'record_kind'
+              ? `CASE WHEN ${this.tableExists('judgment_commands') ? 'EXISTS (SELECT 1 FROM judgment_commands jc WHERE jc.record_id = decisions.id)' : '0'} THEN record_kind ELSE 'legacy' END`
+              : quoteSqlIdentifier(name)
+          )
+          .join(', ');
+        this.exec(`INSERT INTO decisions_077_new (${names}) SELECT ${source} FROM decisions`);
+        this.exec('DROP TABLE decisions');
+        this.exec('ALTER TABLE decisions_077_new RENAME TO decisions');
+        for (const sql of objects.indexes) {
+          this.exec(sql);
+        }
+        for (const sql of objects.triggers) {
+          this.exec(sql);
+        }
+        if (!this.legacyRecordKindShape077()) {
+          throw new Error('Migration 077 recovery failed: incomplete record_kind shape');
+        }
+        for (const table of this.tablesInForeignKeyGraph('decisions')) {
+          if (this.prepare('SELECT 1 FROM pragma_foreign_key_check(?)').all(table).length > 0) {
+            throw new Error(
+              `Migration 077 recovery failed: foreign key violations after rebuild (${table})`
+            );
+          }
+        }
+        this.prepare(
+          'INSERT OR IGNORE INTO schema_version (version, description) VALUES (?, ?)'
+        ).run(77, 'Distinguish legacy memory records from agent judgments');
       });
     } finally {
       this.exec(`PRAGMA foreign_keys = ${previousForeignKeys ? 'ON' : 'OFF'}`);

--- a/packages/mama-core/src/db-manager.ts
+++ b/packages/mama-core/src/db-manager.ts
@@ -39,6 +39,7 @@ export interface DatabaseAdapter {
   runMigrations: (dir: string) => void;
   prepare: (sql: string) => PreparedStatement;
   transaction: <T>(fn: () => T) => T;
+  transactionImmediate?: <T>(fn: () => T) => T;
   insertEmbedding: (rowid: number, embedding: Float32Array | number[]) => void;
   vectorSearch: (
     embedding: Float32Array | number[],

--- a/packages/mama-core/src/knowledge/judgments.ts
+++ b/packages/mama-core/src/knowledge/judgments.ts
@@ -148,7 +148,7 @@ function referenceExists(
       adapter.prepare('SELECT 1 FROM twin_edges WHERE edge_id = ?').get(reference.id) !== undefined
     );
   }
-  return true;
+  return false;
 }
 
 function validateLinks(
@@ -316,7 +316,25 @@ async function appendJudgmentOnAdapter(
     : null;
   const edgeIds: string[] = [];
   let workReceipt: JudgmentReceipt['work'];
-  adapter.transaction(() => {
+  let replayedReceipt: JudgmentReceipt | null = null;
+  const transaction = adapter.transactionImmediate
+    ? adapter.transactionImmediate.bind(adapter)
+    : adapter.transaction.bind(adapter);
+  transaction(() => {
+    const bindingResult = adapter
+      .prepare(
+        `INSERT OR IGNORE INTO command_bindings
+         (command_id, principal_id, action, payload_hash, receipt_kind, receipt_key, created_at)
+         VALUES (?, ?, 'judgment.append', ?, 'judgment', ?, ?)`
+      )
+      .run(command.commandId, access.principalId, hash, recordId, now);
+    if (bindingResult.changes === 0) {
+      replayedReceipt = assertReplay(adapter, command, access, hash);
+      if (!replayedReceipt) {
+        throw new Error('Command binding was not readable after a conflict-free insert');
+      }
+      return;
+    }
     const decisionRowId = insertPreparedDecision(
       adapter,
       {
@@ -395,19 +413,31 @@ async function appendJudgmentOnAdapter(
           .prepare(
             `INSERT INTO commitment_assignments
              (commitment_id, revision, record_id, operation, set_json, clear_json, created_at)
-             VALUES (?, 1, ?, 'create', ?, '[]', ?)`
+            VALUES (?, 1, ?, 'create', ?, ?, ?)`
           )
-          .run(commitmentId, recordId, canonicalizeJSON(workPatch(work)), now);
+          .run(
+            commitmentId,
+            recordId,
+            canonicalizeJSON(workPatch(work)),
+            canonicalizeJSON(work.clear ?? []),
+            now
+          );
         workReceipt = { commitmentId, revision: 1 };
       } else {
         const current = adapter
-          .prepare('SELECT current_revision FROM commitments WHERE commitment_id = ?')
-          .get(work.commitmentId) as { current_revision: number } | undefined;
+          .prepare('SELECT current_revision, withdrawn FROM commitments WHERE commitment_id = ?')
+          .get(work.commitmentId) as { current_revision: number; withdrawn: number } | undefined;
         if (!current) {
           throw new JudgmentError('REFERENCE_NOT_FOUND', 'Commitment is unavailable');
         }
         if (current.current_revision !== work.expectedRevision) {
           throw new JudgmentError('STALE_REVISION', 'Commitment revision is stale');
+        }
+        if (work.operation === 'revise' && current.withdrawn === 1) {
+          throw new JudgmentError(
+            'COMMITMENT_WITHDRAWN',
+            'Withdrawn commitments cannot be revised'
+          );
         }
         const revision = current.current_revision + 1;
         adapter
@@ -425,9 +455,6 @@ async function appendJudgmentOnAdapter(
             canonicalizeJSON(work.clear ?? []),
             now
           );
-        if (work.operation === 'withdraw') {
-          adapter.prepare("UPDATE decisions SET status = 'withdrawn' WHERE id = ?").run(recordId);
-        }
         adapter
           .prepare(
             'UPDATE commitments SET current_revision = ?, head_record_id = ?, withdrawn = ?, updated_at = ? WHERE commitment_id = ?'
@@ -456,18 +483,14 @@ async function appendJudgmentOnAdapter(
     };
     adapter
       .prepare(
-        `INSERT INTO command_bindings
-         (command_id, principal_id, action, payload_hash, receipt_kind, receipt_key, created_at)
-         VALUES (?, ?, 'judgment.append', ?, ?, ?, ?)`
-      )
-      .run(command.commandId, access.principalId, hash, 'judgment', recordId, now);
-    adapter
-      .prepare(
         `INSERT INTO judgment_commands (command_id, record_id, committed_watermark, receipt_json, created_at)
          VALUES (?, ?, ?, ?, ?)`
       )
       .run(command.commandId, recordId, receipt.watermark, canonicalizeJSON(receipt), now);
   });
+  if (replayedReceipt) {
+    return replayedReceipt;
+  }
   return {
     status: 'committed',
     recordId,

--- a/packages/mama-core/src/memory/judgment-types.ts
+++ b/packages/mama-core/src/memory/judgment-types.ts
@@ -47,7 +47,7 @@ export type WorkAssignment = {
   set?: OwnerWorkPatch;
   clear?: Array<keyof OwnerWorkPatch>;
 } & (
-  | { operation: 'create'; creationKey: string }
+  | { operation: 'create' }
   | { operation: 'revise' | 'withdraw'; commitmentId: string; expectedRevision: number }
 );
 
@@ -133,7 +133,7 @@ export interface WorkGraphQuery {
 export type WorkGraphNodeData =
   | {
       kind: 'memory';
-      recordKind: 'judgment' | 'commitment';
+      recordKind: 'legacy' | 'judgment' | 'commitment';
       topic: string;
       summary: string;
       recordedAt: number;

--- a/packages/mama-core/tests/cases/migration-runner-duplicate-column.test.ts
+++ b/packages/mama-core/tests/cases/migration-runner-duplicate-column.test.ts
@@ -108,6 +108,69 @@ describe('Story M2.1: Migration 032 duplicate-column recovery', () => {
   });
 });
 
+describe('Story PR4: migration 077 legacy record-kind recovery', () => {
+  afterEach(cleanupTempDir);
+
+  it('relabels pre-command decisions while preserving explicit judgment records', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'mama-migration-077-'));
+    const dbPath = join(tempDir, 'legacy-record-kind.db');
+    const setup = new Database(dbPath);
+    applyThrough(setup, 74);
+    setup
+      .prepare(
+        `INSERT INTO decisions (id, topic, decision, status, created_at, updated_at)
+         VALUES ('legacy-memory', 'legacy', 'historical', 'active', 1, 1)`
+      )
+      .run();
+    const legacy075 = readFileSync(join(MIGRATIONS_DIR, '075-agent-judgments.sql'), 'utf8')
+      .replace("DEFAULT 'legacy'", "DEFAULT 'judgment'")
+      .replace("('legacy', 'judgment', 'commitment')", "('judgment', 'commitment')");
+    setup.exec(legacy075);
+    setup.exec(readFileSync(join(MIGRATIONS_DIR, '076-scoped-checkpoint-bindings.sql'), 'utf8'));
+    setup
+      .prepare('INSERT INTO schema_version (version, description) VALUES (77, ?)')
+      .run('legacy record-kind stamp');
+    setup
+      .prepare(
+        `INSERT INTO decisions (id, topic, decision, status, created_at, updated_at, record_kind)
+         VALUES ('explicit-judgment', 'new', 'new judgment', 'active', 2, 2, 'judgment')`
+      )
+      .run();
+    setup
+      .prepare(
+        `INSERT INTO command_bindings
+         (command_id, principal_id, action, payload_hash, receipt_kind, receipt_key, created_at)
+         VALUES ('explicit-command', 'principal', 'judgment.append', 'hash', 'judgment', 'explicit-judgment', 2)`
+      )
+      .run();
+    setup
+      .prepare(
+        `INSERT INTO judgment_commands
+         (command_id, record_id, committed_watermark, receipt_json, created_at)
+         VALUES ('explicit-command', 'explicit-judgment', 2, '{}', 2)`
+      )
+      .run();
+    setup.close();
+
+    const adapter = new NodeSQLiteAdapter({ dbPath });
+    adapter.connect();
+    adapter.runMigrations(MIGRATIONS_DIR);
+    adapter.disconnect();
+
+    const db = new Database(dbPath);
+    expect(
+      db.prepare('SELECT record_kind FROM decisions WHERE id = ?').get('legacy-memory')
+    ).toEqual({ record_kind: 'legacy' });
+    expect(
+      db.prepare('SELECT record_kind FROM decisions WHERE id = ?').get('explicit-judgment')
+    ).toEqual({ record_kind: 'judgment' });
+    expect(db.prepare('SELECT MAX(version) AS version FROM schema_version').get()).toEqual({
+      version: 77,
+    });
+    db.close();
+  });
+});
+
 describe('Story T4: stamped registry identity migration recovery', () => {
   afterEach(cleanupTempDir);
 
@@ -1695,7 +1758,7 @@ describe('TG-03/04/05: migration 068 runtime scope overlap recovery', () => {
         evidence_json: null,
       });
       expect(db.prepare('SELECT MAX(version) AS version FROM schema_version').get()).toEqual({
-        version: 76,
+        version: 77,
       });
       db.close();
     });

--- a/packages/mama-core/tests/memory/judgment-atomic-write.test.ts
+++ b/packages/mama-core/tests/memory/judgment-atomic-write.test.ts
@@ -48,6 +48,26 @@ describe('Story R1/TG-03/TG-04/TG-05/TG-06: atomic agent judgment writes', () =>
     expect(getAdapter().prepare('SELECT COUNT(*) AS n FROM decisions').get()).toEqual({ n: 0 });
   });
 
+  it('AC #1 rejects an unsupported reference kind instead of accepting it', async () => {
+    const unsupported = { kind: 'case', id: 'case-not-implemented' } as unknown as {
+      kind: 'memory';
+      id: string;
+    };
+    await expect(
+      appendJudgment(
+        {
+          commandId: 'cmd-unsupported-ref',
+          topic: 'synthetic-topic',
+          summary: 'unsupported reference',
+          recordKind: 'judgment',
+          links: [{ relation: 'mentions', target: unsupported }],
+        },
+        access
+      )
+    ).rejects.toMatchObject({ code: 'REFERENCE_NOT_FOUND' });
+    expect(getAdapter().prepare('SELECT COUNT(*) AS n FROM decisions').get()).toEqual({ n: 0 });
+  });
+
   it('AC #2 commits explicit links and returns the original receipt on replay', async () => {
     const db = getAdapter();
     db.prepare(
@@ -77,7 +97,7 @@ describe('Story R1/TG-03/TG-04/TG-05/TG-06: atomic agent judgment writes', () =>
     const receipt = await appendJudgment(command, access);
     expect(await appendJudgment(command, access)).toEqual(receipt);
     expect(
-      db
+      getAdapter()
         .prepare(
           'SELECT edge_type, object_id FROM twin_edges WHERE subject_id = ? ORDER BY edge_type'
         )
@@ -153,6 +173,25 @@ describe('Story R1/TG-03/TG-04/TG-05/TG-06: atomic agent judgment writes', () =>
     });
   });
 
+  it('AC #3 returns one receipt for concurrent retries of the same command', async () => {
+    const command = {
+      commandId: 'cmd-concurrent-retry',
+      topic: 'synthetic-topic',
+      summary: 'concurrent payload',
+      recordKind: 'judgment' as const,
+      scopes: access.scopes,
+    };
+    const embedder = {
+      embed: async () => new Float32Array(384),
+    };
+    const [first, second] = await Promise.all([
+      appendJudgment(command, access, { embedder }),
+      appendJudgment(command, access, { embedder }),
+    ]);
+    expect(second).toEqual(first);
+    expect(getAdapter().prepare('SELECT COUNT(*) AS n FROM decisions').get()).toEqual({ n: 1 });
+  });
+
   it('AC #4 advances a commitment revision and rejects stale CAS', async () => {
     const create = await appendJudgment(
       {
@@ -162,8 +201,8 @@ describe('Story R1/TG-03/TG-04/TG-05/TG-06: atomic agent judgment writes', () =>
         recordKind: 'commitment',
         work: {
           operation: 'create',
-          creationKey: 'synthetic-launch-task',
           set: { title: 'Launch', roles: [] },
+          clear: ['status'],
         },
         scopes: access.scopes,
       },
@@ -187,6 +226,13 @@ describe('Story R1/TG-03/TG-04/TG-05/TG-06: atomic agent judgment writes', () =>
       access
     );
     expect(revised.work?.revision).toBe(2);
+    expect(
+      getAdapter()
+        .prepare(
+          'SELECT clear_json FROM commitment_assignments WHERE commitment_id = ? AND revision = 1'
+        )
+        .get(commitmentId)
+    ).toEqual({ clear_json: '["status"]' });
     await expect(
       appendJudgment(
         {
@@ -206,5 +252,44 @@ describe('Story R1/TG-03/TG-04/TG-05/TG-06: atomic agent judgment writes', () =>
       )
     ).rejects.toMatchObject({ code: 'STALE_REVISION' });
     expect(getAdapter().prepare('SELECT COUNT(*) AS n FROM decisions').get()).toEqual({ n: 2 });
+  });
+
+  it('AC #4 rejects revising a withdrawn commitment', async () => {
+    const create = await appendJudgment(
+      {
+        commandId: 'cmd-withdraw-create',
+        topic: 'synthetic-task',
+        summary: 'create then withdraw',
+        recordKind: 'commitment',
+        work: { operation: 'create', set: { title: 'Withdraw me' } },
+        scopes: access.scopes,
+      },
+      access
+    );
+    const commitmentId = create.work!.commitmentId;
+    await appendJudgment(
+      {
+        commandId: 'cmd-withdraw',
+        topic: 'synthetic-task',
+        summary: 'withdraw',
+        recordKind: 'commitment',
+        work: { operation: 'withdraw', commitmentId, expectedRevision: 1 },
+        scopes: access.scopes,
+      },
+      access
+    );
+    await expect(
+      appendJudgment(
+        {
+          commandId: 'cmd-after-withdraw',
+          topic: 'synthetic-task',
+          summary: 'revise after withdraw',
+          recordKind: 'commitment',
+          work: { operation: 'revise', commitmentId, expectedRevision: 2 },
+          scopes: access.scopes,
+        },
+        access
+      )
+    ).rejects.toMatchObject({ code: 'COMMITMENT_WITHDRAWN' });
   });
 });


### PR DESCRIPTION
## Summary

PR4A's initial judgment writer left six contract gaps: unsupported reference kinds were accepted, legacy decisions were labeled as new judgments, concurrent retries could race, withdrawn commitments could be revised, create assignments dropped `clear`, and the removed `creationKey` contract had reappeared.

This closure makes unsupported references fail closed, distinguishes legacy records through migration 077 recovery, reserves command bindings inside an immediate transaction for idempotent retries, preserves create clears, rejects revisions after withdrawal, and keeps commandId as the sole create identity. It does not add a second writer, runtime fallback, approval queue, or host-controlled action loop.

## Validation

- Core: 109 test files, 825 tests passed with `MAMA_FORCE_TIER_3=true`
- Migration recovery: 42 tests passed
- Atomic judgment contract: 9 tests passed
- Core typecheck and build passed
- Commit hook: changed-package tests, standalone typecheck, lint-staged, gitleaks passed
- CodeRabbit CLI final review: 0 findings
- Added-line privacy scan and gitleaks scan: clean

## Scope

9 files; no public save/ingest, runtime, CLI, MCP, or Telegram migration is included. Those remain the next bounded PR4 work after this writer contract is landed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate judgment records when the same command is submitted concurrently; retries now return the original result.
  - Unsupported references are correctly rejected instead of being treated as valid.
  - Commitment updates now preserve requested fields to clear.
  - Withdrawn commitments can no longer be revised.
  - Existing records are preserved and correctly classified as legacy during database upgrades.

- **Documentation**
  - Added development notes covering judgment validation, migration recovery, and verification results.

- **Tests**
  - Expanded coverage for migration recovery, atomic writes, concurrency, reference validation, and commitment lifecycle rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->